### PR TITLE
fix: strip fabricated claims from org profile and root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,60 @@
 # SZL Holdings
 
-  > Governed AI decision infrastructure for organizations that cannot afford silent failures, invisible risk, or unaccountable AI.
+  > Governed runtime infrastructure for AI-assisted decisions.
 
-  [![szlholdings.com](https://img.shields.io/badge/web-szlholdings.com-0a0a0a?style=flat-square)](https://szlholdings.com)
-  [![CodeQL](https://img.shields.io/badge/CodeQL-passing-2da44e?style=flat-square&logo=github)](https://github.com/szl-holdings/szl-holdings-platform/actions)
-  [![Ouroboros tests](https://img.shields.io/badge/ouroboros%20tests-133%2F133-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
-  [![Government Readiness](https://img.shields.io/badge/NYSTEC%20audit-2026--04--30-2b6cb0?style=flat-square)](https://github.com/szl-holdings/ouroboros/blob/main/docs/audit/szl-government-readiness.md)
-  [![License](https://img.shields.io/badge/license-Proprietary-red?style=flat-square)](https://github.com/szl-holdings/szl-holdings-platform/blob/master/LICENSE.md)
+  [![Ouroboros tests](https://img.shields.io/badge/ouroboros%20tests-150%20declared-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
+  [![Paper v3](https://img.shields.io/badge/paper-v3.0.0%20Lutar%20Invariant-c4356b?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis/tree/main/papers/v3)
+  [![Zenodo v3](https://zenodo.org/badge/DOI/10.5281/zenodo.19951520.svg)](https://doi.org/10.5281/zenodo.19951520)
 
   ---
 
-  ## What we build
+  ## What is here
 
-  A **three-platform stack** — A11oy (orchestration), Sentra (security), Amaru (data sync) — plus four product surfaces (Counsel, Terra, Vessels, Carlota Jo) on top of a shared, replay-safe runtime: the **Ouroboros loop kernel** and **Codex decision-receipt kernel**.
+  The shipped, open-source piece is the **Ouroboros runtime** — `@szl-holdings/ouroboros` v6.1.0 — a bounded-loop runtime that implements the **Lutar Invariant Λ**, a closed-form scalar in [0, 1] that aggregates nine independent runtime-trust axes (Cleanliness, Horizon, Resonance, Frustum, Geometry, Invariance, Moral, Being, Non-measurability) into a single auditable number.
 
-  Every agent action produces a cryptographically traceable receipt, an append-only log, and a primary-source hash. Human approval is enforced at risk tiers R3/R4. Every conclusion can be replayed and verified.
+  The companion thesis ([`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis)) carries the v1 position paper, the v2 empirical companion, and the v3 closed-form scalar law with its uniqueness proof under four axioms. Each version has a Zenodo DOI.
 
-  ## Government readiness scorecard
-
-  April 30, 2026 NYSTEC pre-briefing audit — Empire APEX Accelerator (Mercy McInnis, Procurement Counselor). Full report: [`docs/audit/szl-government-readiness.md`](https://github.com/szl-holdings/ouroboros/blob/main/docs/audit/szl-government-readiness.md).
-
-  | Platform | Governance | Proof Chain | Auditability | Human Oversight | Cert Path | Overall |
-  |---|---|---|---|---|---|---|
-  | **A11oy**  | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ In progress | **72/100** |
-  | **Sentra** | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ Needs SOC 2 | **68/100** |
-  | **Amaru**  | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ Needs privacy docs | **65/100** |
-
-  ### NIST AI RMF — full coverage across all four functions
-
-  | Function | A11oy | Sentra | Amaru |
-  |---|---|---|---|
-  | **GOVERN**  | Validator registry, loop policy, operator modes | Risk tier governance | Source priority + merge safety |
-  | **MAP**     | Domain pack router, task-type routing | Threat loop profiles | Schema variant mapping |
-  | **MEASURE** | Delta, consistency, uncertainty per step | Risk tier scoring | Consistency scoring |
-  | **MANAGE**  | Approval gate, halt conditions, replay | Evidence packs, escalation | Conflict reconciliation |
-
-  ### DoD Responsible AI Tenets — 4 of 5 covered
-
-  | Tenet | Status |
-  |---|---|
-  | Responsible | ✅ Human approval at R3/R4, validator hard stops |
-  | Equitable   | ⚠️ Bias-testing methodology in 30-day roadmap |
-  | Traceable   | ✅ Full trace runtime, append-only logs, receipts |
-  | Reliable    | ✅ Golden runs, replay verification, consistency gates |
-  | Governable  | ✅ Approval gate, halt conditions, operational modes |
-
-  ### GSAR 552.239-7001 (proposed) — 5 of 10 covered, 5 documented gaps
-
-  Covered: human oversight, summarized intermediate processing, model routing rationale, RAG source attribution, complete audit trail. Gaps (all documentation, no architectural rework needed): NIST AI RMF written documentation, 72-hour incident reporting procedure, no-cross-customer-training contractual commitment, American AI Systems vendor disclosure, formal bias audit plan.
+  Everything else in this org is at varying earlier stages of work.
 
   ---
 
   ## Repositories
 
-  ### Runtime + thesis
+  ### Runtime + thesis (shipped, open-source)
 
   | Repo | Purpose | Status |
   |---|---|---|
-  | [`ouroboros`](https://github.com/szl-holdings/ouroboros) | `@workspace/ouroboros` — bounded-loop runtime, v6 ecosystem layer, government readiness module | **133/133 tests** passing |
-  | [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis) | Architectural rationale + v6 operational contract JSON | v6 published |
+  | [`ouroboros`](https://github.com/szl-holdings/ouroboros) | `@szl-holdings/ouroboros` v6.1.0 — bounded-loop runtime implementing the Lutar Invariant Λ | **150 declared Vitest tests** in the single `ouroboros` package |
+  | [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis) | v1 position paper, v2 empirical companion, v3 closed-form scalar law + v6 operational contract JSON | v3 published 2026-05-01 ([DOI](https://doi.org/10.5281/zenodo.19951520)) |
 
-  ### Three-platform stack
+  ### Product surfaces (varying stages)
 
-  | Repo | Purpose | Readiness |
-  |---|---|---|
-  | [`a11oy`](https://github.com/szl-holdings/a11oy)   | Orchestration control plane — agent ecosystem brain, validator registry, approval gate | **72/100** |
-  | [`sentra`](https://github.com/szl-holdings/sentra) | Governed security and threat intelligence — recursive threat modeling, evidence packs | **68/100** |
-  | [`amaru`](https://github.com/szl-holdings/amaru)   | Convergent data sync and reconciliation — append-only delta log, consistency gates | **65/100** |
-
-  ### Domain product surfaces
-
-  | Repo | Purpose |
+  | Repo | Stage |
   |---|---|
-  | [`counsel`](https://github.com/szl-holdings/counsel)       | Legal matter command — policy-gated human review |
-  | [`terra`](https://github.com/szl-holdings/terra)           | NYC distress pipeline + AI-assisted real-estate workflow |
-  | [`vessels`](https://github.com/szl-holdings/vessels)       | Maritime fleet intelligence — sanctions screening, dark-vessel detection |
-  | [`carlota-jo`](https://github.com/szl-holdings/carlota-jo) | Premium UHNW advisory operations portal with Proof-Chain delivery |
+  | [`a11oy`](https://github.com/szl-holdings/a11oy) | Public repo, README-stage |
+  | [`sentra`](https://github.com/szl-holdings/sentra) | Public repo, README-stage |
+  | [`amaru`](https://github.com/szl-holdings/amaru) | Public repo, README-stage |
+  | [`counsel`](https://github.com/szl-holdings/counsel) | Public repo, README-stage |
+  | [`terra`](https://github.com/szl-holdings/terra) | Public repo, README-stage |
+  | [`vessels`](https://github.com/szl-holdings/vessels) | Public repo, README-stage |
+  | [`carlota-jo`](https://github.com/szl-holdings/carlota-jo) | Public repo, README-stage |
 
   ### Platform monorepo
 
-  [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) — full monorepo. Latest release: [`v1.0.2-codex-kernel`](https://github.com/szl-holdings/szl-holdings-platform/releases) (2026-04-30).
+  [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) — public monorepo, in active development. CI is currently flaky on master.
 
   ---
 
-  ## Security & supply-chain posture
+  ## Architecture principles
 
-  - **Dependabot alerts**: 0 open across all 11 org repositories.
-  - **CodeQL**: enabled on the platform monorepo, all checks passing.
-  - **Dependency hygiene**: 3 dependabot PRs merged this cycle (react-ecosystem, vite-build, ui-components in progress).
-  - **CMMC / FedRAMP / SOC 2**: roadmap items, disclosed in audit; NIST SP 800-171 gap assessment scoped.
+  - **AI governance by design.** Advisory agents cannot execute consequential actions without explicit human confirmation.
+  - **Evidence-backed decisions.** Every recommendation includes source citations and retrieval provenance.
+  - **Explicit over implicit.** Platform state is visible. No silent fallbacks. Failures surface.
 
   ---
 
   ## Contact
 
-  [szlholdings.com](https://szlholdings.com) · [stephen@szlholdings.com](mailto:stephen@szlholdings.com) · [LinkedIn](https://linkedin.com/in/stephen-l-279315240)
+  [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · [LinkedIn](https://linkedin.com/in/stephen-l-279315240)
 
-  © 2026 SZL Holdings. All rights reserved.
-  
+  © 2026 SZL Holdings.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,102 +1,60 @@
 # SZL Holdings
 
-  > Governed AI decision infrastructure for organizations that cannot afford silent failures, invisible risk, or unaccountable AI.
+  > Governed runtime infrastructure for AI-assisted decisions.
 
-  [![szlholdings.com](https://img.shields.io/badge/web-szlholdings.com-0a0a0a?style=flat-square)](https://szlholdings.com)
-  [![CodeQL](https://img.shields.io/badge/CodeQL-passing-2da44e?style=flat-square&logo=github)](https://github.com/szl-holdings/szl-holdings-platform/actions)
-  [![Ouroboros tests](https://img.shields.io/badge/ouroboros%20tests-1%2C372%2F1%2C372-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
+  [![Ouroboros tests](https://img.shields.io/badge/ouroboros%20tests-150%20declared-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
   [![Paper v3](https://img.shields.io/badge/paper-v3.0.0%20Lutar%20Invariant-c4356b?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis/tree/main/papers/v3)
   [![Zenodo v3](https://zenodo.org/badge/DOI/10.5281/zenodo.19951520.svg)](https://doi.org/10.5281/zenodo.19951520)
-  [![Government Readiness](https://img.shields.io/badge/NYSTEC%20audit-2026--04--30-2b6cb0?style=flat-square)](https://github.com/szl-holdings/ouroboros/blob/main/docs/audit/szl-government-readiness.md)
-  [![License](https://img.shields.io/badge/license-Proprietary-red?style=flat-square)](https://github.com/szl-holdings/szl-holdings-platform/blob/master/LICENSE.md)
 
   ---
 
-  ## What we build
+  ## What is here
 
-  A **three-platform stack** — A11oy (orchestration), Sentra (security), Amaru (data sync) — plus four product surfaces (Counsel, Terra, Vessels, Carlota Jo) on top of a shared, replay-safe runtime: the **Ouroboros loop kernel** and **Codex decision-receipt kernel**.
+  The shipped, open-source piece is the **Ouroboros runtime** — `@szl-holdings/ouroboros` v6.1.0 — a bounded-loop runtime that implements the **Lutar Invariant Λ**, a closed-form scalar in [0, 1] that aggregates nine independent runtime-trust axes (Cleanliness, Horizon, Resonance, Frustum, Geometry, Invariance, Moral, Being, Non-measurability) into a single auditable number.
 
-  Every agent action produces a cryptographically traceable receipt, an append-only log, and a primary-source hash. Human approval is enforced at risk tiers R3/R4. Every conclusion can be replayed and verified.
+  The companion thesis ([`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis)) carries the v1 position paper, the v2 empirical companion, and the v3 closed-form scalar law with its uniqueness proof under four axioms. Each version has a Zenodo DOI.
 
-  ## Government readiness scorecard
-
-  April 30, 2026 NYSTEC pre-briefing audit — Empire APEX Accelerator (Mercy McInnis, Procurement Counselor). Full report: [`docs/audit/szl-government-readiness.md`](https://github.com/szl-holdings/ouroboros/blob/main/docs/audit/szl-government-readiness.md).
-
-  | Platform | Governance | Proof Chain | Auditability | Human Oversight | Cert Path | Overall |
-  |---|---|---|---|---|---|---|
-  | **A11oy**  | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ In progress | **72/100** |
-  | **Sentra** | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ Needs SOC 2 | **68/100** |
-  | **Amaru**  | ✅ Strong | ✅ Strong | ✅ Strong | ✅ Strong | ⚠️ Needs privacy docs | **65/100** |
-
-  ### NIST AI RMF — full coverage across all four functions
-
-  | Function | A11oy | Sentra | Amaru |
-  |---|---|---|---|
-  | **GOVERN**  | Validator registry, loop policy, operator modes | Risk tier governance | Source priority + merge safety |
-  | **MAP**     | Domain pack router, task-type routing | Threat loop profiles | Schema variant mapping |
-  | **MEASURE** | Delta, consistency, uncertainty per step | Risk tier scoring | Consistency scoring |
-  | **MANAGE**  | Approval gate, halt conditions, replay | Evidence packs, escalation | Conflict reconciliation |
-
-  ### DoD Responsible AI Tenets — 4 of 5 covered
-
-  | Tenet | Status |
-  |---|---|
-  | Responsible | ✅ Human approval at R3/R4, validator hard stops |
-  | Equitable   | ⚠️ Bias-testing methodology in 30-day roadmap |
-  | Traceable   | ✅ Full trace runtime, append-only logs, receipts |
-  | Reliable    | ✅ Golden runs, replay verification, consistency gates |
-  | Governable  | ✅ Approval gate, halt conditions, operational modes |
-
-  ### GSAR 552.239-7001 (proposed) — 5 of 10 covered, 5 documented gaps
-
-  Covered: human oversight, summarized intermediate processing, model routing rationale, RAG source attribution, complete audit trail. Gaps (all documentation, no architectural rework needed): NIST AI RMF written documentation, 72-hour incident reporting procedure, no-cross-customer-training contractual commitment, American AI Systems vendor disclosure, formal bias audit plan.
+  Everything else in this org is at varying earlier stages of work.
 
   ---
 
   ## Repositories
 
-  ### Runtime + thesis
+  ### Runtime + thesis (shipped, open-source)
 
   | Repo | Purpose | Status |
   |---|---|---|
-  | [`ouroboros`](https://github.com/szl-holdings/ouroboros) | `@szl-holdings/ouroboros` v6.1.0 — bounded-loop runtime implementing the Lutar Invariant Λ across nine axes | **1,372/1,372 tests** passing (925 TS + 447 Py) |
-  | [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis) | Architectural rationale + v6 operational contract JSON. **v3 paper** — [The Lutar Invariant](https://doi.org/10.5281/zenodo.19951520) | v3 published 2026-05-01 |
+  | [`ouroboros`](https://github.com/szl-holdings/ouroboros) | `@szl-holdings/ouroboros` v6.1.0 — bounded-loop runtime implementing the Lutar Invariant Λ | **150 declared Vitest tests** in the single `ouroboros` package |
+  | [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis) | v1 position paper, v2 empirical companion, v3 closed-form scalar law + v6 operational contract JSON | v3 published 2026-05-01 ([DOI](https://doi.org/10.5281/zenodo.19951520)) |
 
-  ### Three-platform stack
+  ### Product surfaces (varying stages)
 
-  | Repo | Purpose | Readiness |
-  |---|---|---|
-  | [`a11oy`](https://github.com/szl-holdings/a11oy)   | Orchestration control plane — agent ecosystem brain, validator registry, approval gate | **72/100** |
-  | [`sentra`](https://github.com/szl-holdings/sentra) | Governed security and threat intelligence — recursive threat modeling, evidence packs | **68/100** |
-  | [`amaru`](https://github.com/szl-holdings/amaru)   | Convergent data sync and reconciliation — append-only delta log, consistency gates | **65/100** |
-
-  ### Domain product surfaces
-
-  | Repo | Purpose |
+  | Repo | Stage |
   |---|---|
-  | [`counsel`](https://github.com/szl-holdings/counsel)       | Legal matter command — policy-gated human review |
-  | [`terra`](https://github.com/szl-holdings/terra)           | NYC distress pipeline + AI-assisted real-estate workflow |
-  | [`vessels`](https://github.com/szl-holdings/vessels)       | Maritime fleet intelligence — sanctions screening, dark-vessel detection |
-  | [`carlota-jo`](https://github.com/szl-holdings/carlota-jo) | Premium UHNW advisory operations portal with Proof-Chain delivery |
+  | [`a11oy`](https://github.com/szl-holdings/a11oy) | Public repo, README-stage |
+  | [`sentra`](https://github.com/szl-holdings/sentra) | Public repo, README-stage |
+  | [`amaru`](https://github.com/szl-holdings/amaru) | Public repo, README-stage |
+  | [`counsel`](https://github.com/szl-holdings/counsel) | Public repo, README-stage |
+  | [`terra`](https://github.com/szl-holdings/terra) | Public repo, README-stage |
+  | [`vessels`](https://github.com/szl-holdings/vessels) | Public repo, README-stage |
+  | [`carlota-jo`](https://github.com/szl-holdings/carlota-jo) | Public repo, README-stage |
 
   ### Platform monorepo
 
-  [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) — full monorepo. Latest release: [`v1.0.2-codex-kernel`](https://github.com/szl-holdings/szl-holdings-platform/releases) (2026-04-30).
+  [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) — public monorepo, in active development. CI is currently flaky on master.
 
   ---
 
-  ## Security & supply-chain posture
+  ## Architecture principles
 
-  - **Dependabot alerts**: 0 open across all 11 org repositories.
-  - **CodeQL**: enabled on the platform monorepo, all checks passing.
-  - **Dependency hygiene**: 3 dependabot PRs merged this cycle (react-ecosystem, vite-build, ui-components in progress).
-  - **CMMC / FedRAMP / SOC 2**: roadmap items, disclosed in audit; NIST SP 800-171 gap assessment scoped.
+  - **AI governance by design.** Advisory agents cannot execute consequential actions without explicit human confirmation.
+  - **Evidence-backed decisions.** Every recommendation includes source citations and retrieval provenance.
+  - **Explicit over implicit.** Platform state is visible. No silent fallbacks. Failures surface.
 
   ---
 
   ## Contact
 
-  [szlholdings.com](https://szlholdings.com) · [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com) · [LinkedIn](https://linkedin.com/in/stephen-l-279315240)
+  [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · [LinkedIn](https://linkedin.com/in/stephen-l-279315240)
 
-  © 2026 SZL Holdings. All rights reserved.
-  
+  © 2026 SZL Holdings.


### PR DESCRIPTION
Mirror of the personal-profile fix and the ouroboros / ouroboros-thesis cleanups.

## Stripped

- 133/133 tests (root) and 1,372/1,372 tests (profile) badges and inline numbers -> 150 declared (the real ouroboros surface at v6.1.0)
- NYSTEC audit badge — 2026-04-30 was Empire APEX counseling, not an audit
- Government readiness scorecard with A11oy 72/100, Sentra 68/100, Amaru 65/100 (self-prepared, not external)
- NIST AI RMF 'full coverage' claims, DoD '4 of 5 covered', GSAR '5 of 10 covered'
- Three-platform stack framing for A11oy/Sentra/Amaru (they are README-stage public repos)
- Product-readiness language for Counsel/Terra/Vessels/Carlota Jo
- 'Dependabot alerts 0 across 11 org repositories' and '3 dependabot PRs merged' (unverified)
- 'CodeQL all checks passing' (CI on platform monorepo is currently flaky on master)
- szlholdings.com badge (no live site)
- stephen@szlholdings.com -> stephenlutar2@gmail.com (canonical)