### PR TITLE
fix(reusable-node-ci): support pnpm packageManager without version conflict

### DIFF
--- a/.github/workflows/reusable-node-ci.yml
+++ b/.github/workflows/reusable-node-ci.yml
@@ -105,8 +105,25 @@ jobs:
             echo "::warning::No $FILE found — cache disabled, install will not be frozen"
           fi
 
-      - name: Setup pnpm
+      - name: Detect packageManager in package.json
         if: steps.skip.outputs.enabled == 'true' && inputs.package-manager == 'pnpm'
+        id: pkgmgr
+        working-directory: ${{ inputs.working-directory }}
+        shell: bash
+        run: |
+          if [ -f package.json ] && grep -qE '"packageManager"\s*:\s*"pnpm@' package.json; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::package.json has packageManager — letting pnpm/action-setup read it"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup pnpm (from package.json packageManager)
+        if: steps.skip.outputs.enabled == 'true' && inputs.package-manager == 'pnpm' && steps.pkgmgr.outputs.present == 'true'
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v4.1.0
+
+      - name: Setup pnpm (from input version)
+        if: steps.skip.outputs.enabled == 'true' && inputs.package-manager == 'pnpm' && steps.pkgmgr.outputs.present != 'true'
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v4.1.0
         with:
           version: ${{ inputs.pnpm-version }}


### PR DESCRIPTION
## Series-A unblock for consumer pnpm migrations

When a consumer repo declares `packageManager: pnpm@X.Y.Z` in package.json AND the reusable workflow passes `version` to pnpm/action-setup, the action errors:

```
Error: Multiple versions of pnpm specified:
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

This blocks Series-A pnpm migrations on consumer repos adopting `packageManager` (the modern best practice for lockfile-bound pnpm).

### Fix

Detect `packageManager` in package.json before pnpm/action-setup, and call the action **without** `version` when present (so the action reads the version from package.json). Falls back to `inputs.pnpm-version` otherwise.

### Verified against

- ouroboros [`chore/series-a-pnpm-migration`](https://github.com/szl-holdings/ouroboros/pull/13) which has `packageManager: pnpm@10.26.1` and was failing with the conflict before this fix.

### Backward compatible

- Repos without `packageManager` keep using `inputs.pnpm-version` as before.
- No change to caller workflows required.