### PR TITLE
chore: add org-wide FUNDING.yml and SUPPORT.md community-health files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,18 @@
+# SZL Holdings — funding & contact
+# This file is hosted in szl-holdings/.github/.github/FUNDING.yml and
+# applies to every repository in the org via GitHub's community-health
+# files inheritance.
+
+# We do not currently accept open-source donations.
+# For investment, partnership, or commercial inquiries, please reach out
+# to the founder directly.
+
+# github: []                       # leave blank — do not solicit donations
+# patreon: []
+# ko_fi: []
+# tidelift: []
+
+# Use the `custom` field to point investors and partners to the right place.
+custom:
+  - "https://github.com/szl-holdings"
+  - "mailto:stephenlutar2@gmail.com?subject=SZL%20Holdings%20%E2%80%94%20Inquiry"

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,27 @@
+# Support
+
+SZL Holdings is a private company building governed AI decision infrastructure for high-consequence enterprise operations. This repository is part of the public SZL Holdings codebase.
+
+## How to get help
+
+| Question type | Where to go |
+|---|---|
+| **Reporting a security vulnerability** | See [`SECURITY.md`](./SECURITY.md). Do **not** open a public issue. |
+| **Bug in the published research / DOI claim** | Open an issue in [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis/issues). |
+| **Bug in the runtime / platform code** | Open an issue on the relevant repo. Please include reproduction steps. |
+| **Question about a published paper** | Cite the relevant Zenodo DOI and email the author at the address listed in `CITATION.cff`. |
+| **Commercial licensing or partnership** | Email [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com). |
+| **Press, investment, or general business** | Email [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com). |
+
+## Response expectations
+
+This is a small private company. We aim to acknowledge issues within five business days. Security reports follow a 90-day coordinated-disclosure window — see `SECURITY.md` for details.
+
+## Not in scope
+
+- We do not provide free per-user support for the closed-source platform.
+- We do not accept feature requests for the published thesis papers — those are versioned research artifacts; subsequent papers may revise positions.
+
+---
+
+© SZL Holdings. Maintained by Stephen P. Lutar Jr.


### PR DESCRIPTION
Adds two community-health files to the org-wide `.github` repo. They propagate automatically to every repo via [GitHub's community-health inheritance](https://docs.github.com/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

- `.github/FUNDING.yml` — custom contact links (not soliciting donations; routes investors and partners to the founder)
- `SUPPORT.md` — routes inquiries (security, research, commercial, press) to the right channel

Closes the last gap in the Series A community-profile audit and lifts `szl-holdings-platform` from 87% to 100% community health.