### PR TITLE
chore(profile): R2 glow-up — Mermaid architecture, Scorecard badges, security_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Security vulnerability
+  - name: Security vulnerability (PRIVATE)
     url: https://github.com/szl-holdings/.github/security/policy
-    about: Please report security issues privately — do NOT file a public issue.
+    about: Report exploitable security issues privately. Do NOT file a public issue.
+  - name: security.txt (RFC 9116)
+    url: https://szlholdings.com/.well-known/security.txt
+    about: Canonical private-disclosure contact and PGP key.
+  - name: Ouroboros Thesis discussion
+    url: https://github.com/szl-holdings/ouroboros-thesis/discussions
+    about: Academic and methodology questions on the published papers.
   - name: General questions
     url: mailto:inquiries@szlholdings.com
-    about: For non-bug questions, email us directly.
+    about: Press, partnerships, hiring, and other non-bug inquiries.

--- a/.github/ISSUE_TEMPLATE/security_report.yml
+++ b/.github/ISSUE_TEMPLATE/security_report.yml
@@ -1,0 +1,44 @@
+name: Security report (low-sensitivity only)
+description: Use ONLY for low-sensitivity hardening suggestions. Real vulnerabilities must use the private disclosure path.
+title: "security: "
+labels: ["security", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Stop.** If this report contains exploitable details, do not file
+        > a public issue.
+        >
+        > Use one of these private channels instead:
+        > - GitHub Private Vulnerability Reporting on the affected repo
+        > - Email `security@szlholdings.com` (see `SECURITY.md`)
+        > - Web form at <https://szlholdings.com/.well-known/security.txt>
+        >
+        > Use this template only for non-exploitable hardening suggestions
+        > (e.g. "consider pinning this action by SHA", "add Scorecard badge").
+  - type: dropdown
+    id: confirm_public
+    attributes:
+      label: I confirm this report is safe to be public
+      options:
+        - "Yes — no exploitable details"
+        - "No — I should use the private channel"
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Hardening suggestion
+      description: A concise description of the improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: reference
+    attributes:
+      label: Reference (OpenSSF, CIS, NIST, etc.)
+      description: Link to the standard or guidance this is based on.
+  - type: input
+    id: repo
+    attributes:
+      label: Affected repository (optional)
+      placeholder: "szl-holdings/ouroboros"

--- a/README.md
+++ b/README.md
@@ -1,69 +1,79 @@
-# SZL Holdings
+<!-- Repo-level README for szl-holdings/.github -->
 
-  > Governed operational intelligence for regulated enterprises.
+# `szl-holdings/.github`
 
-  [![Ouroboros tests](https://img.shields.io/badge/runtime%20tests-172%2F172-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
-  [![Runtime](https://img.shields.io/badge/ouroboros-v6.2.0-2b6cb0?style=flat-square)](https://github.com/szl-holdings/ouroboros/releases/tag/v6.2.0)
-  [![DOI concept](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19944926-1f78b4?style=flat-square)](https://doi.org/10.5281/zenodo.19944926)
-  [![Innovations](https://img.shields.io/badge/sovereign%20innovations-34-e6522c?style=flat-square)](https://github.com/szl-holdings/szl-holdings-platform)
-  [![Papers](https://img.shields.io/badge/papers-v1--v10-805ad5?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis)
-  [![Endpoints](https://img.shields.io/badge/API%20endpoints-48%20tested-2da44e?style=flat-square)](https://github.com/szl-holdings/szl-holdings-platform)
+> Org-wide governance, reusable workflows, templates, and security policy for [SZL Holdings](https://github.com/szl-holdings).
 
-  ---
+<p>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/.github"><img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/.github/badge"></a>
+  <a href="./LICENSE"><img alt="License Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-01696F?style=flat-square"></a>
+  <a href="./SECURITY.md"><img alt="Security policy" src="https://img.shields.io/badge/security-policy-1B474D?style=flat-square&logo=github&logoColor=white"></a>
+  <a href="./CODE_OF_CONDUCT.md"><img alt="Contributor Covenant 2.1" src="https://img.shields.io/badge/conduct-Contributor%20Covenant%202.1-C8B26A?style=flat-square"></a>
+  <img alt="Workflows SHA-pinned" src="https://img.shields.io/badge/workflows-SHA--pinned-2DA44E?style=flat-square">
+</p>
 
-  ## Repositories
+---
 
-  ### Core infrastructure
+## What lives here
 
-  | Repository | What it is | Status |
-  |---|---|---|
-  | [**szl-holdings-platform**](https://github.com/szl-holdings/szl-holdings-platform) | TypeScript monorepo: 34 sovereign innovations, 48 API endpoints, 7 domain surfaces | Active development |
-  | [**ouroboros**](https://github.com/szl-holdings/ouroboros) | Bounded-loop runtime implementing the Lutar Invariant | v6.2.0, 172/172 tests |
-  | [**ouroboros-thesis**](https://github.com/szl-holdings/ouroboros-thesis) | 10 published papers (v1--v10) with Zenodo DOIs | All 10 versions minted, concept DOI active |
+| Path | Purpose |
+|---|---|
+| [`profile/README.md`](./profile/README.md) | Org profile shown at <https://github.com/szl-holdings> |
+| [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/) | Default issue templates cascaded to every repo without its own |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) | Default PR template |
+| [`.github/workflows/`](./.github/workflows/) | **11 reusable workflows** — see [`WORKFLOWS.md`](./WORKFLOWS.md) |
+| [`.github/dependabot.yml`](./.github/dependabot.yml) | Weekly dependency updates for this repo |
+| [`.github/CODEOWNERS`](./.github/CODEOWNERS) | Org-default ownership |
+| [`templates/`](./templates/) | Copy-paste templates for product repos (`README`, `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SECURITY`) |
+| [`security.txt`](./security.txt) | RFC 9116 disclosure record (canonical copy; deploy under `/.well-known/security.txt`) |
+| [`SECURITY.md`](./SECURITY.md) · [`CONTRIBUTING.md`](./CONTRIBUTING.md) · [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) · [`SUPPORT.md`](./SUPPORT.md) | Org-default community docs |
+| [`CITATION.cff`](./CITATION.cff) | Citation metadata |
+| [`assets/social/`](./assets/social/) | 1280×640 social-preview banners ready for upload via Settings → General → Social preview |
 
-  ### Product surfaces
+## Reusable workflows
 
-  | Product | Domain | Repository |
-  |---|---|---|
-  | [**A11oy**](https://github.com/szl-holdings/a11oy) | Brand orchestration and AI governance | Cross-domain agent fabric |
-  | [**Sentra**](https://github.com/szl-holdings/sentra) | Cyber resilience command | Threat modeling, posture drift |
-  | [**Amaru**](https://github.com/szl-holdings/amaru) | Convergent data sync | Append-only delta logs |
-  | [**Counsel**](https://github.com/szl-holdings/counsel) | Legal matter command | Policy-gated AI workflows |
-  | [**Terra**](https://github.com/szl-holdings/terra) | Real estate intelligence | Distress pipeline scoring |
-  | [**Vessels**](https://github.com/szl-holdings/vessels) | Maritime fleet intelligence | Sanctions, dark-vessel detection |
-  | [**Carlota Jo**](https://github.com/szl-holdings/carlota-jo) | UHNW advisory operations | Proof-chain delivery |
+Eleven SHA-pinned, harden-runner-protected workflows that every product repo can call:
 
-  ### Key numbers (verified 2026-05-06)
+```yaml
+jobs:
+  codeql:
+    uses: szl-holdings/.github/.github/workflows/reusable-codeql.yml@<commit-sha>
+```
 
-  | Metric | Value |
-  |---|---|
-  | Sovereign innovations | 34 (operational, API-served) |
-  | API endpoints tested | 48/48 passing |
-  | Runtime tests | 172/172 passing |
-  | Published papers | 10 (v1--v10) |
-  | Zenodo DOIs | 10 minted (v1–v10) + concept DOI |
-  | Domain verticals | 7 integrated products |
-  | Tech stack | TypeScript 5.9, React 19, Vite, Node.js, PostgreSQL |
+| Workflow | What it does |
+|---|---|
+| `reusable-codeql.yml` | CodeQL static analysis (JS, TS, Python) |
+| `reusable-dependency-review.yml` | Block PRs that introduce vulnerable deps |
+| `reusable-trivy.yml` | Filesystem + container vuln scanning |
+| `reusable-gitleaks.yml` | Secret scanning on every PR / push |
+| `reusable-secret-scan.yml` | TruffleHog-style verified-secret scan |
+| `reusable-sbom.yml` | CycloneDX SBOM per release |
+| `reusable-scorecard.yml` | OpenSSF Scorecard re-run + badge publish |
+| `reusable-workflow-lint.yml` | `actionlint` + zizmor lint on all workflows |
+| `reusable-release-please.yml` | Conventional-commits release automation |
+| `reusable-node-ci.yml` | Node lint + typecheck + test matrix |
+| `reusable-docs-ci.yml` | Markdown lint + link-check for docs repos |
 
-  ## Architecture
+All Actions are SHA-pinned and wrapped with [`step-security/harden-runner`](https://github.com/step-security/harden-runner) using a deny-by-default egress policy. See [`WORKFLOWS.md`](./WORKFLOWS.md) for inputs, secrets, and per-workflow examples.
 
-  - **Ouroboros Runtime** -- bounded loops with measurable convergence as a system primitive
-  - **Sovereign Engine** -- 34 innovations spanning AI governance, quantum-inspired optimization, active inference, sacred geometry coherence, and dynamical systems analysis
-  - **Lambda Engine** -- 9-axis Lutar Invariant pipeline producing formal trust scores
-  - **Proof Chain** -- tamper-evident, hash-chained decision receipts for every operation
-  - **A11oy Orchestrator** -- unified control plane routing decisions across all 7 domain surfaces
+## Security posture
 
-  ## Principles
+- Private vulnerability reporting: [security policy](https://github.com/szl-holdings/.github/security/policy)
+- Email: `security@szlholdings.com`
+- Canonical RFC 9116 record: [`security.txt`](./security.txt)
+- Org-wide: branch protection rulesets, signed-commit enforcement, CODEOWNERS, OpenSSF Scorecard
+- Live status: 0 open Dependabot · 0 open secret-scanning · 0 open CodeQL
 
-  1. **AI governance by design.** Agents cannot execute consequential actions without human confirmation.
-  2. **Evidence-backed decisions.** Every recommendation includes source citations and retrieval provenance.
-  3. **Explicit over implicit.** Platform state is visible. No silent fallbacks. Failures surface.
-  4. **Proof-carrying execution.** Every decision produces a tamper-evident receipt.
+## Tooling for contributors
 
-  ## Contact
+- Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`)
+- Squash-merge into `main`; release automation handled by `release-please`
+- All PRs run reusable security suite before merge
 
-  Stephen P. Lutar Jr. -- ORCID [0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) -- [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com) -- [LinkedIn](https://linkedin.com/in/stephen-l-279315240)
+## License
 
-  ---
+[Apache-2.0](./LICENSE) for this repo. Product repos under SZL Holdings may use different licenses — see each repo's `LICENSE`.
 
-  (c) 2026 SZL Holdings. Runtime Apache-2.0; platform BUSL-1.1 (converts to Apache-2.0 on 2030-05-06); thesis text under CC BY 4.0.
+---
+
+<sub>© 2026 SZL Holdings — [`szlholdings.com`](https://szlholdings.com) · ORCID [`0009-0001-0110-4173`](https://orcid.org/0009-0001-0110-4173)</sub>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,53 +1,148 @@
+<!-- Organization profile README — rendered at github.com/szl-holdings -->
+
 # SZL Holdings
 
-  > Sovereign decision intelligence. Bounded recursion as a system primitive.
+> Sovereign decision intelligence. **Bounded recursion** as a system primitive. Auditable AI by construction.
 
-  [![Ouroboros Thesis](https://img.shields.io/badge/research-Ouroboros%20Thesis%20v10-1f78b4?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis)
-  [![Runtime tests](https://img.shields.io/badge/runtime%20tests-172%2F172-2da44e?style=flat-square)](https://github.com/szl-holdings/ouroboros)
-  [![ORCID](https://img.shields.io/badge/ORCID-0009--0001--0110--4173-a6ce39?style=flat-square&logo=orcid&logoColor=white)](https://orcid.org/0009-0001-0110-4173)
-  [![License — research](https://img.shields.io/badge/research%20license-CC%20BY%204.0-blue?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis/blob/main/LICENSE)
+<p>
+  <a href="https://github.com/szl-holdings/ouroboros-thesis"><img alt="Ouroboros Thesis v10" src="https://img.shields.io/badge/research-Ouroboros%20Thesis%20v10-1F78B4?style=flat-square&logo=readthedocs&logoColor=white"></a>
+  <a href="https://github.com/szl-holdings/ouroboros"><img alt="Runtime tests 172/172" src="https://img.shields.io/badge/runtime%20tests-172%2F172-2DA44E?style=flat-square&logo=jest&logoColor=white"></a>
+  <a href="https://github.com/szl-holdings/szl-holdings-platform"><img alt="API 48/48" src="https://img.shields.io/badge/API%20endpoints-48%2F48-2DA44E?style=flat-square&logo=fastapi&logoColor=white"></a>
+  <a href="https://orcid.org/0009-0001-0110-4173"><img alt="ORCID" src="https://img.shields.io/badge/ORCID-0009--0001--0110--4173-A6CE39?style=flat-square&logo=orcid&logoColor=white"></a>
+  <a href="https://doi.org/10.5281/zenodo.19944926"><img alt="Concept DOI" src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19944926-01696F?style=flat-square&logo=doi&logoColor=white"></a>
+  <a href="https://github.com/szl-holdings/ouroboros-thesis/blob/main/LICENSE"><img alt="Research license CC BY 4.0" src="https://img.shields.io/badge/research%20license-CC%20BY%204.0-1F78B4?style=flat-square"></a>
+</p>
 
-  SZL Holdings builds **A11oy** and a portfolio of vertical operator surfaces (Sentra, Amaru, Vessels, Terra, Counsel, Carlota Jo) on top of a single research foundation: the **Ouroboros Thesis** — bounded loops with measurable convergence and machine-verifiable audit closure as a first-class primitive for auditable AI.
+<p>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/ouroboros"><img alt="OpenSSF Scorecard — ouroboros" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/ouroboros/badge"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/ouroboros-thesis"><img alt="OpenSSF Scorecard — thesis" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/ouroboros-thesis/badge"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/.github"><img alt="OpenSSF Scorecard — .github" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/.github/badge"></a>
+  <a href="https://github.com/szl-holdings/.github/security/policy"><img alt="Security policy" src="https://img.shields.io/badge/security-policy-01696F?style=flat-square&logo=github&logoColor=white"></a>
+</p>
 
-  ---
+---
 
-  ## Products
+SZL Holdings builds **A11oy** and a portfolio of vertical operator surfaces — Sentra, Amaru, Vessels, Terra, Counsel, Carlota Jo — on top of one research foundation: the **Ouroboros Thesis**. Bounded loops with measurable convergence and machine-verifiable audit closure as a first-class primitive for governed AI.
 
-  | Product | Domain | Repo |
-  |---|---|---|
-  | **A11oy** | Brand orchestration & governed intelligence | [`a11oy`](https://github.com/szl-holdings/a11oy) |
-  | **Sentra** | Cyber resilience command | [`sentra`](https://github.com/szl-holdings/sentra) |
-  | **Amaru** | Andean ouroboros — data convergence runtime | [`amaru`](https://github.com/szl-holdings/amaru) |
-  | **Vessels** | Maritime intelligence | [`vessels`](https://github.com/szl-holdings/vessels) |
-  | **Terra** | Real estate intelligence | [`terra`](https://github.com/szl-holdings/terra) |
-  | **Counsel** | Legal matter command | [`counsel`](https://github.com/szl-holdings/counsel) |
-  | **Carlota Jo** | Consulting practice | [`carlota-jo`](https://github.com/szl-holdings/carlota-jo) |
+## Architecture at a glance
 
-  All products run on the [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) monorepo with the [`ouroboros`](https://github.com/szl-holdings/ouroboros) runtime.
+```mermaid
+flowchart TD
+    classDef research fill:#28251D,stroke:#C8B26A,color:#F7F6F2,stroke-width:1.5px;
+    classDef runtime  fill:#1B474D,stroke:#01696F,color:#F7F6F2,stroke-width:1.5px;
+    classDef platform fill:#01696F,stroke:#C8B26A,color:#F7F6F2,stroke-width:1.5px;
+    classDef surface  fill:#F7F6F2,stroke:#01696F,color:#1B474D,stroke-width:1.5px;
 
-  ---
+    T["Ouroboros Thesis<br/>10 papers · 10 DOIs"]:::research
+    R["Ouroboros Runtime v6.2.0<br/>bounded loops · 172/172 tests"]:::runtime
+    L["Lambda Engine<br/>9-axis Lutar Invariant"]:::runtime
+    P["SZL Holdings Platform<br/>34 sovereign innovations · 48 endpoints"]:::platform
 
-  ## Research foundation — Ouroboros Thesis chain
+    A["A11oy<br/>brand & governance"]:::surface
+    S["Sentra<br/>cyber resilience"]:::surface
+    AM["Amaru<br/>convergent data sync"]:::surface
+    V["Vessels<br/>maritime intel"]:::surface
+    TE["Terra<br/>real estate intel"]:::surface
+    C["Counsel<br/>legal matter command"]:::surface
+    CJ["Carlota Jo<br/>UHNW advisory"]:::surface
 
-  Ten canonical papers, full DOI lineage, every formula bound to operational TypeScript code. The concept DOI [`10.5281/zenodo.19944926`](https://doi.org/10.5281/zenodo.19944926) always resolves to the latest version.
+    T --> R
+    R --> L
+    L --> P
+    P --> A
+    P --> S
+    P --> AM
+    P --> V
+    P --> TE
+    P --> C
+    P --> CJ
+```
 
-  | Version | Title | DOI |
-  |---|---|---|
-  | v10 | EXHAUSTIVE-AUDIT — Audit Closure Operator Λ₁₀ | [`10.5281/zenodo.20053163`](https://doi.org/10.5281/zenodo.20053163) |
-  | v9 | UNIFIED-OPERATIONAL — Lutar Family v1 → v7 + Ω with Bianchi closure | [`10.5281/zenodo.20053148`](https://doi.org/10.5281/zenodo.20053148) |
-  | v8 | Free-Energy Active Inference + Predictive Coding + Cognitive Maps | [`10.5281/zenodo.20020849`](https://doi.org/10.5281/zenodo.20020849) |
-  | v7 | Sefirot Memory + Hopfield Associative Retrieval | [`10.5281/zenodo.20020848`](https://doi.org/10.5281/zenodo.20020848) |
-  | v6 | Hermetic Safety + Chinchilla-Lutar Scaling + Bifurcation | [`10.5281/zenodo.20020845`](https://doi.org/10.5281/zenodo.20020845) |
-  | v5 | Prisca-GraphRAG + Tawa SAE Interpretability | [`10.5281/zenodo.20020846`](https://doi.org/10.5281/zenodo.20020846) |
-  | v4 | Omega Formalism + EPR-Bell + Sacred Geometry | [`10.5281/zenodo.20020841`](https://doi.org/10.5281/zenodo.20020841) |
-  | v3 | The Lutar Invariant — axiomatic trust aggregator | [`10.5281/zenodo.19983066`](https://doi.org/10.5281/zenodo.19983066) |
-  | v2 | Empirical companion — A11oy / Sentra / Amaru case studies | [`10.5281/zenodo.19934129`](https://doi.org/10.5281/zenodo.19934129) |
-  | v1 | Position paper — bounded looped computation | [`10.5281/zenodo.19867281`](https://doi.org/10.5281/zenodo.19867281) |
+---
 
-  ---
+## Repositories
 
-  ## Contact
+### Core infrastructure
 
-  **Stephen P. Lutar Jr.** — Principal · SZL Holdings · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)
+| Repository | What it is | Status |
+|---|---|---|
+| [**szl-holdings-platform**](https://github.com/szl-holdings/szl-holdings-platform) | TypeScript monorepo: 34 sovereign innovations, 48 API endpoints, 7 domain surfaces | Active development |
+| [**ouroboros**](https://github.com/szl-holdings/ouroboros) | Bounded-loop runtime implementing the Lutar Invariant | v6.2.0 · 172/172 tests |
+| [**ouroboros-thesis**](https://github.com/szl-holdings/ouroboros-thesis) | 10 published papers (v1 → v10) with Zenodo DOIs | All 10 minted · concept DOI active |
+| [**.github**](https://github.com/szl-holdings/.github) | Org-wide policy, reusable workflows, templates, SECURITY, SBOM, security.txt | 11 reusable workflows · SHA-pinned |
 
-  © 2026 SZL Holdings.
+### Product surfaces
+
+| Product | Domain | Repository |
+|---|---|---|
+| [**A11oy**](https://github.com/szl-holdings/a11oy) | Brand orchestration and AI governance | Cross-domain agent fabric |
+| [**Sentra**](https://github.com/szl-holdings/sentra) | Cyber resilience command | Threat modeling, posture drift |
+| [**Amaru**](https://github.com/szl-holdings/amaru) | Convergent data sync | Append-only delta logs |
+| [**Vessels**](https://github.com/szl-holdings/vessels) | Maritime fleet intelligence | Sanctions, dark-vessel detection |
+| [**Terra**](https://github.com/szl-holdings/terra) | Real-estate intelligence | Distress pipeline scoring |
+| [**Counsel**](https://github.com/szl-holdings/counsel) | Legal matter command | Policy-gated AI workflows |
+| [**Carlota Jo**](https://github.com/szl-holdings/carlota-jo) | UHNW advisory operations | Proof-chain delivery |
+
+---
+
+## Research foundation — Ouroboros Thesis
+
+Ten canonical papers, full DOI lineage, every formula bound to operational TypeScript code. The **concept DOI** [`10.5281/zenodo.19944926`](https://doi.org/10.5281/zenodo.19944926) always resolves to the latest version.
+
+| Version | Title | DOI |
+|---|---|---|
+| v10 | EXHAUSTIVE-AUDIT — Audit Closure Operator Λ₁₀ | [`10.5281/zenodo.20053163`](https://doi.org/10.5281/zenodo.20053163) |
+| v9 | UNIFIED-OPERATIONAL — Lutar Family v1 → v7 + Ω with Bianchi closure | [`10.5281/zenodo.20053148`](https://doi.org/10.5281/zenodo.20053148) |
+| v8 | Free-Energy Active Inference + Predictive Coding + Cognitive Maps | [`10.5281/zenodo.20020849`](https://doi.org/10.5281/zenodo.20020849) |
+| v7 | Sefirot Memory + Hopfield Associative Retrieval | [`10.5281/zenodo.20020848`](https://doi.org/10.5281/zenodo.20020848) |
+| v6 | Hermetic Safety + Chinchilla-Lutar Scaling + Bifurcation | [`10.5281/zenodo.20020845`](https://doi.org/10.5281/zenodo.20020845) |
+| v5 | Prisca-GraphRAG + Tawa SAE Interpretability | [`10.5281/zenodo.20020846`](https://doi.org/10.5281/zenodo.20020846) |
+| v4 | Omega Formalism + EPR-Bell + Sacred Geometry | [`10.5281/zenodo.20020841`](https://doi.org/10.5281/zenodo.20020841) |
+| v3 | The Lutar Invariant — axiomatic trust aggregator | [`10.5281/zenodo.19983066`](https://doi.org/10.5281/zenodo.19983066) |
+| v2 | Empirical companion — A11oy / Sentra / Amaru case studies | [`10.5281/zenodo.19934129`](https://doi.org/10.5281/zenodo.19934129) |
+| v1 | Position paper — bounded looped computation | [`10.5281/zenodo.19867281`](https://doi.org/10.5281/zenodo.19867281) |
+
+---
+
+## Key numbers
+
+| Metric | Value |
+|---|---|
+| Sovereign innovations | **34** operational, API-served |
+| API endpoints tested | **48 / 48** passing |
+| Runtime tests | **172 / 172** passing |
+| Published papers | **10** (v1 → v10) |
+| Zenodo DOIs | **10 + concept DOI** |
+| Domain verticals | **7** integrated products |
+| Reusable security workflows | **11** SHA-pinned |
+| Active rulesets | **33** |
+| Open Dependabot · Secret-scan · CodeQL | **0 · 0 · 0** |
+
+---
+
+## Principles
+
+1. **AI governance by design.** Agents cannot execute consequential actions without explicit human confirmation.
+2. **Evidence-backed decisions.** Every recommendation includes source citations and retrieval provenance.
+3. **Explicit over implicit.** Platform state is visible. No silent fallbacks. Failures surface.
+4. **Proof-carrying execution.** Every decision produces a tamper-evident, hash-chained receipt.
+5. **Supply-chain hygiene as a feature.** SHA-pinned actions, harden-runner egress policy, SBOM, OpenSSF Scorecard.
+
+---
+
+## Security & supply chain
+
+- Private vulnerability reporting: [security policy](https://github.com/szl-holdings/.github/security/policy) · `security@szlholdings.com` · [security.txt (RFC 9116)](https://szlholdings.com/.well-known/security.txt)
+- Org-wide CODEOWNERS, branch protection rulesets, signed commits required
+- Reusable workflows (SHA-pinned) for **CodeQL, dependency-review, Trivy, gitleaks, SBOM (CycloneDX), secret-scan, scorecard, workflow-lint, release-please, docs-CI, node-CI**
+- All third-party Actions SHA-pinned with `step-security/harden-runner` egress policy
+- Real-time security pulse: weekday net-new alert digest (8am ET)
+
+---
+
+## Contact
+
+**Stephen P. Lutar Jr.** — Principal · SZL Holdings
+[ORCID `0009-0001-0110-4173`](https://orcid.org/0009-0001-0110-4173) · [`inquiries@szlholdings.com`](mailto:inquiries@szlholdings.com) · [`szlholdings.com`](https://szlholdings.com) · [`@szlholdings`](https://twitter.com/szlholdings)
+
+<sub>© 2026 SZL Holdings. Runtime Apache-2.0 · Platform BUSL-1.1 (converts to Apache-2.0 on 2030-05-06) · Thesis text CC BY 4.0.</sub>


### PR DESCRIPTION
## Summary

Round 2 of the Series A overhaul: a top-tier visual + governance refresh of the public org face.

## What changed

### `profile/README.md` (the page shown at https://github.com/szl-holdings)
- Hydra Teal **Mermaid architecture diagram**: Thesis -> Runtime -> Lambda Engine -> Platform -> 7 surfaces
- **3 live OpenSSF Scorecard badges** (ouroboros, ouroboros-thesis, .github)
- Expanded badge strip with runtime/test/API/ORCID/DOI/research-license
- Repositories table now includes `.github` with workflow count
- Key-numbers table includes reusable-workflow count and rulesets count
- New "Security & supply chain" section calls out PVR, security.txt (RFC 9116), and the weekday security pulse

### `README.md` (repo-level)
- Full org-policy index with file-by-file purpose table
- Table of all **11 reusable workflows** with one-line descriptions
- Contributor tooling, license guidance
- OpenSSF Scorecard badge for this repo

### `.github/ISSUE_TEMPLATE/security_report.yml` (new)
- Low-sensitivity hardening suggestions ONLY
- Gated by an "I confirm this is safe to be public" dropdown
- Prominent redirect to private vulnerability reporting in the description

### `.github/ISSUE_TEMPLATE/config.yml`
- Adds RFC 9116 security.txt contact link
- Adds Ouroboros Thesis Discussions link
- Renames security entry to make private channel obvious

## Risk

Documentation + template only. No workflow or runtime change. Mermaid renders natively on GitHub.