### PR TITLE
fix(ci): drop workflow-level read-all in reusable-scorecard

### DIFF
--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -17,7 +17,10 @@ on:
         type: boolean
         default: true
 
-permissions: read-all
+# Workflow-level permissions deliberately omitted: GitHub clamps job-level
+# permissions to the workflow ceiling, and the analysis job below needs
+# 'security-events: write' and 'id-token: write'. Setting 'read-all' here
+# produces a startup_failure for every caller.
 
 jobs:
   analysis:


### PR DESCRIPTION
Root cause of the `startup_failure` on every Scorecard run in caller repos (ouroboros, ouroboros-thesis):

GitHub clamps job permissions to the workflow-level ceiling. With `permissions: read-all` at the workflow level, the analysis job's `security-events: write` and `id-token: write` are silently downgraded, and the runner refuses to start.

Removing the workflow-level grant lets the job-level grants apply unhindered.