### PR TITLE
fix(r3): remove .github invalid Scorecard badge from org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,7 +16,6 @@
 <p>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/ouroboros"><img alt="OpenSSF Scorecard — ouroboros" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/ouroboros/badge"></a>
   <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/ouroboros-thesis"><img alt="OpenSSF Scorecard — thesis" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/ouroboros-thesis/badge"></a>
-  <a href="https://securityscorecards.dev/viewer/?uri=github.com/szl-holdings/.github"><img alt="OpenSSF Scorecard — .github" src="https://api.securityscorecards.dev/projects/github.com/szl-holdings/.github/badge"></a>
   <a href="https://github.com/szl-holdings/.github/security/policy"><img alt="Security policy" src="https://img.shields.io/badge/security-policy-01696F?style=flat-square&logo=github&logoColor=white"></a>
 </p>
 


### PR DESCRIPTION
The .github org-profile repo is not indexed by OpenSSF Scorecard's publishing system - the badge URL https://api.securityscorecards.dev/projects/github.com/szl-holdings/.github/badge returns 'invalid repo path' when rendered via shields.io. The badge displayed as a broken/no-data tile on the org landing page at https://github.com/szl-holdings, visible to anyone viewing the org. The ouroboros and ouroboros-thesis Scorecard badges (which DO resolve correctly to scores 6.4 and 6.7 respectively) are retained. Verification path: visit https://github.com/szl-holdings after merge — only the two valid badges should render.