### PR TITLE
showcase(email): unify contact to stephen@szlholdings.com

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,4 +30,4 @@ contact:
   - family-names: Lutar
     given-names: Stephen
     name-particle: P.
-    email: "inquiries@szlholdings.com"
+    email: "stephen@szlholdings.com"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
   - **Bug reports.** Open a [GitHub issue](../../issues/new) with reproduction steps, environment, and expected vs actual behavior.
   - **Security disclosures.** Do **not** open a public issue. Follow [`SECURITY.md`](./SECURITY.md) — preferred channel is [security@szlholdings.com](mailto:security@szlholdings.com) or a private GitHub security advisory.
-  - **Questions and feedback.** Email [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com) for product questions, integration requests, or partnership inquiries.
+  - **Questions and feedback.** Email [stephen@szlholdings.com](mailto:stephen@szlholdings.com) for product questions, integration requests, or partnership inquiries.
   - **Documentation corrections.** Small typo / link / factual fixes to public docs are welcome via PR. Please open an issue first describing the change.
 
   ## What we expect from contributors
@@ -29,7 +29,7 @@
   |---|---|
   | [GitHub issues](../../issues) | Bugs, documentation gaps, reproducible defects |
   | [security@szlholdings.com](mailto:security@szlholdings.com) | Security vulnerabilities (private) |
-  | [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com) | Product, partnership, licensing |
+  | [stephen@szlholdings.com](mailto:stephen@szlholdings.com) | Product, partnership, licensing |
 
   ---
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -142,6 +142,6 @@ Ten canonical papers, full DOI lineage, every formula bound to operational TypeS
 ## Contact
 
 **Stephen P. Lutar Jr.** — Principal · SZL Holdings
-[ORCID `0009-0001-0110-4173`](https://orcid.org/0009-0001-0110-4173) · [`inquiries@szlholdings.com`](mailto:inquiries@szlholdings.com) · [`szlholdings.com`](https://szlholdings.com) · [`@szlholdings`](https://twitter.com/szlholdings)
+[ORCID `0009-0001-0110-4173`](https://orcid.org/0009-0001-0110-4173) · [`stephen@szlholdings.com`](mailto:stephen@szlholdings.com) · [`szlholdings.com`](https://szlholdings.com) · [`@szlholdings`](https://twitter.com/szlholdings)
 
 <sub>© 2026 SZL Holdings. Runtime Apache-2.0 · Platform BUSL-1.1 (converts to Apache-2.0 on 2030-05-06) · Thesis text CC BY 4.0.</sub>

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
   - **Bug reports.** Open a [GitHub issue](../../issues/new) with reproduction steps, environment, and expected vs actual behavior.
   - **Security disclosures.** Do **not** open a public issue. Follow [`SECURITY.md`](./SECURITY.md) — preferred channel is [security@szlholdings.com](mailto:security@szlholdings.com) or a private GitHub security advisory.
-  - **Questions and feedback.** Email [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com) for product questions, integration requests, or partnership inquiries.
+  - **Questions and feedback.** Email [stephen@szlholdings.com](mailto:stephen@szlholdings.com) for product questions, integration requests, or partnership inquiries.
   - **Documentation corrections.** Small typo / link / factual fixes to public docs are welcome via PR. Please open an issue first describing the change.
 
   ## What we expect from contributors
@@ -29,7 +29,7 @@
   |---|---|
   | [GitHub issues](../../issues) | Bugs, documentation gaps, reproducible defects |
   | [security@szlholdings.com](mailto:security@szlholdings.com) | Security vulnerabilities (private) |
-  | [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com) | Product, partnership, licensing |
+  | [stephen@szlholdings.com](mailto:stephen@szlholdings.com) | Product, partnership, licensing |
 
   ---
 

--- a/templates/REPO_README.md
+++ b/templates/REPO_README.md
@@ -41,7 +41,7 @@
 
   ---
 
-  **[SZL Holdings](https://szlholdings.com)** · [Platform Repository](https://github.com/szl-holdings/szl-holdings-platform) · [inquiries@szlholdings.com](mailto:inquiries@szlholdings.com)
+  **[SZL Holdings](https://szlholdings.com)** · [Platform Repository](https://github.com/szl-holdings/szl-holdings-platform) · [stephen@szlholdings.com](mailto:stephen@szlholdings.com)
 
   (c) 2024–2026 SZL Holdings, LLC. All rights reserved.
   


### PR DESCRIPTION
Series-A showcase polish per Stephen's directive. Unified all public-facing contact emails from `inquiries@szlholdings.com` to `stephen@szlholdings.com` in README, CONTRIBUTING, CITATION.cff, profile pages, and template files.