### PR TITLE
feat(profile): add Anatomy section linking to szl-brand PDFs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -30,6 +30,28 @@
 
 ---
 
+## Anatomy of the SZL Agent Body
+
+The SZL Agent Body is the canonical anatomy of an audit-closure AI agent — Heart (yuyay_v3, 13-axis conjunctive AND), Brain (5 cortical regions + Quantum Mind), Blood (YAWAR append-only receipt bus, 20 SLOC), Immune (SENTRA inline + HUKLLA 10 tripwires).
+
+[![Heart](https://img.shields.io/badge/anatomy-heart-01696F?style=flat-square)](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/heart.pdf)
+[![Brain](https://img.shields.io/badge/anatomy-brain-01696F?style=flat-square)](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/brain.pdf)
+[![Wires](https://img.shields.io/badge/anatomy-wires-01696F?style=flat-square)](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/wires.pdf)
+[![Full Body](https://img.shields.io/badge/anatomy-full--body-01696F?style=flat-square)](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/full_body.pdf)
+
+| Series | Title | PDF |
+|--------|-------|-----|
+| Anatomy 1/4 | The SZL Agent Body — v3, drawn from the disk up | [full_body.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/full_body.pdf) |
+| Anatomy 2/4 | Blood and Immune — the wiring under the agent | [wires.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/wires.pdf) |
+| Anatomy 3/4 | Inside the Head — what an AI agent's brain actually is | [brain.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/brain.pdf) |
+| Anatomy 4/4 | The Heart — yuyay_v3, the gate every cycle clears | [heart.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/heart.pdf) |
+
+Originals with richer diagrams: [brain_original.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/brain_original.pdf) · [wires_original.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/wires_original.pdf) · [full_body_original.pdf](https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/full_body_original.pdf)
+
+**Author:** Lutar, Stephen P. · ORCID [0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)
+
+---
+
 ## The thesis
 
 Every enterprise AI deployment fails the same diligence question: **"prove what your model decided, why, and that it was within policy."** Most can't. We can. Our runtime emits a **proof-chain receipt** for every decision — bounded loop trace, policy gates traversed, evidence cited, convergence verified — recorded against an audit-closure operator (Λ) with sub-millisecond per-request overhead. The receipt is the deliverable. The loop is the product.

--- a/profile/README.md
+++ b/profile/README.md
@@ -191,7 +191,7 @@ Three flagship payloads ship with the standard — covering the cross-domain sha
 
 <div align="center">
 
-**SZL Holdings, LLC** · Founded by [Stephen P. Lutar Jr.](https://orcid.org/0009-0001-0110-4173) · [szlholdings.com](https://szlholdings.com)
+**SZL Holdings, LLC** · Founded by [Lutar, Stephen P.](https://orcid.org/0009-0001-0110-4173) · [szlholdings.com](https://szlholdings.com)
 
 [![CITATION.cff](https://img.shields.io/badge/cite-CITATION.cff-blue?style=flat-square)](https://github.com/szl-holdings/ouroboros-thesis/blob/main/CITATION.cff)
 [![Software Heritage](https://archive.softwareheritage.org/badge/origin/https://github.com/szl-holdings/ouroboros-thesis/)](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/szl-holdings/ouroboros-thesis)


### PR DESCRIPTION
## Summary

Adds an **Anatomy of the SZL Agent Body** section to the org profile README (`profile/README.md`).

### Changes
- Synopsis paragraph: "The SZL Agent Body is the canonical anatomy of an audit-closure AI agent — Heart (yuyay_v3, 13-axis conjunctive AND), Brain (5 cortical regions + Quantum Mind), Blood (YAWAR append-only receipt bus, 20 SLOC), Immune (SENTRA inline + HUKLLA 10 tripwires)."
- 4 shields.io badges (heart, brain, wires, full-body) linking to raw PDFs in szl-brand
- Table of all 4 anatomy PDFs (Anatomy 1/4 through 4/4) with absolute raw.githubusercontent.com URLs
- Links to richer originals (brain_original, wires_original, full_body_original)

### PDF URLs (absolute)
- `https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/heart.pdf`
- `https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/brain.pdf`
- `https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/wires.pdf`
- `https://raw.githubusercontent.com/szl-holdings/szl-brand/main/anatomy/full_body.pdf`

**Author:** Lutar, Stephen P.  
**ORCID:** https://orcid.org/0009-0001-0110-4173

Depends on: szl-holdings/szl-brand#12