### PR TITLE
chore(identity): replace stephenlutar2@gmail.com with stephen@szlholdings.com (Doctrine V6 D1)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -15,4 +15,4 @@
 # Use the `custom` field to point investors and partners to the right place.
 custom:
   - "https://github.com/szl-holdings"
-  - "mailto:stephenlutar2@gmail.com?subject=SZL%20Holdings%20%E2%80%94%20Inquiry"
+  - "mailto:stephen@szlholdings.com?subject=SZL%20Holdings%20%E2%80%94%20Inquiry"

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,8 +10,8 @@ SZL Holdings is a private company building governed AI decision infrastructure f
 | **Bug in the published research / DOI claim** | Open an issue in [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis/issues). |
 | **Bug in the runtime / platform code** | Open an issue on the relevant repo. Please include reproduction steps. |
 | **Question about a published paper** | Cite the relevant Zenodo DOI and email the author at the address listed in `CITATION.cff`. |
-| **Commercial licensing or partnership** | Email [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com). |
-| **Press, investment, or general business** | Email [stephenlutar2@gmail.com](mailto:stephenlutar2@gmail.com). |
+| **Commercial licensing or partnership** | Email [stephen@szlholdings.com](mailto:stephen@szlholdings.com). |
+| **Press, investment, or general business** | Email [stephen@szlholdings.com](mailto:stephen@szlholdings.com). |
 
 ## Response expectations
 


### PR DESCRIPTION
Doctrine V6 D1 — identity sweep (Wave A).

  Replaces `stephenlutar2@gmail.com` with the canonical `stephen@szlholdings.com` per Doctrine V6.

  **Audit reference:** `ORG_AUDIT_ROLLUP` 2026-05-14, defect D1 (Tier 1 — moralGrounding + measurabilityHonesty, identity).

  **Files touched:** `SUPPORT.md`, `.github/FUNDING.yml`

  **Diff:**
  ```
  - stephenlutar2@gmail.com
  + stephen@szlholdings.com
  ```

  Mechanical, atomic, byte-verifiable. No semantic changes.