### PR TITLE
chore: add canonical .zenodo.json (Series A audit metadata)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,35 @@
+{
+  "title": ".github \u2014 SZL Holdings organization profile and community files.",
+  "description": "SZL Holdings organization profile and community files.",
+  "upload_type": "other",
+  "creators": [
+    {
+      "name": "Lutar, Stephen P.",
+      "affiliation": "SZL Holdings",
+      "orcid": "0009-0001-0110-4173"
+    }
+  ],
+  "access_right": "open",
+  "license": "cc-by-4.0",
+  "keywords": [
+    "branding",
+    "community",
+    "organization",
+    "profile",
+    "szl-holdings",
+    "ai-governance",
+    "ouroboros"
+  ],
+  "communities": [
+    {
+      "identifier": "open-science"
+    }
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.5281/zenodo.19944926",
+      "relation": "isSupplementTo",
+      "scheme": "doi"
+    }
+  ]
+}


### PR DESCRIPTION
Adds canonical Zenodo deposit metadata so future Zenodo backfills auto-populate author/ORCID/affiliation correctly.

Canonical fields:
- Author: Lutar, Stephen P.
- ORCID: 0009-0001-0110-4173
- Affiliation: SZL Holdings
- Community: open-science
- Related: supplements Ouroboros Thesis concept DOI 10.5281/zenodo.19944926

Closes one of the gaps surfaced by the deep gap audit (/home/user/workspace/deep_gap_audit.json).
