### PR TITLE
doctrine: CITATION.cff add name-suffix "Jr."

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,7 @@ title: "szl-holdings/.github — Organization-wide reusable workflows and securi
 authors:
   - family-names: Lutar
     given-names: "Stephen P."
+    name-suffix: "Jr."
 
     email: stephen@szlholdings.com
     affiliation: SZL Holdings
@@ -30,6 +31,7 @@ keywords:
 contact:
   - family-names: Lutar
     given-names: "Stephen P."
+    name-suffix: "Jr."
 
     email: stephen@szlholdings.com
     email: "stephen@szlholdings.com"


### PR DESCRIPTION
Adds `name-suffix: "Jr."` to author block in CITATION.cff.

Aligns this repo with canonical author identity used across all SZL Holdings repos and Zenodo deposits.

- Canonical: Stephen P. Lutar Jr.
- ORCID: 0009-0001-0110-4173
- Affiliation: SZL Holdings
- Email: stephen@szlholdings.com

No code changes. Documentation-only.