### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is an **org-level `.github` governance repository** — it contains no
+application code, no package managers, and no build steps. The "product" is
+a set of reusable GitHub Actions workflows, markdown documentation, issue/PR
+templates, and community health files.
+
+### Linting (the only local checks)
+
+| Tool | Command | What it checks |
+|---|---|---|
+| `markdownlint-cli2` | `markdownlint-cli2 "**/*.md"` | All 15+ markdown files (mirrors CI job in `.github/workflows/ci.yml`) |
+| `actionlint` | `actionlint` | All GitHub Actions workflow YAML files in `.github/workflows/` |
+
+- The CI workflow runs `markdownlint-cli2` with `continue-on-error: true`,
+  so lint findings do **not** block merges. The existing codebase has ~400
+  findings (mostly line-length and indentation).
+- `actionlint` passes clean (0 errors) on all 15 workflow files.
+
+### There is no build / run / test step
+
+- No `package.json`, `requirements.txt`, `Makefile`, or any dependency manifest exists.
+- No services to start. No database. No backend / frontend.
+- Reusable workflows (`.github/workflows/reusable-*.yml`) are consumed by
+  other repos via `uses:` and run on GitHub Actions, not locally.
+
+### Conventions
+
+- Conventional Commits required (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`).
+- Squash-merge into `main`.
+- All Actions must be SHA-pinned (enforced by `pin-check.yml`).
+- DCO sign-off required on all commits (`git commit -s`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Added `AGENTS.md` with Cursor Cloud specific instructions documenting the development environment setup for this governance repository.

## Why

Future Cursor Cloud agents need context about how to work with this repo — specifically that it has no application code, no build steps, and only markdown/YAML linting as local checks.

## How was this tested

- [x] Manual verification (describe steps)
- [x] CI is green

Ran both lint tools locally and verified they produce expected results:

- `markdownlint-cli2 "**/*.md"` — lints all 15 markdown files (398 findings, matching CI which uses `continue-on-error: true`)
- `actionlint` — validates all 15 workflow YAML files with 0 errors

Lint output:
[lint_results.log](https://cursor.com/agents/bc-9204fc6d-cb86-45e1-b007-d24847f724a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flint_results.log)

## Risk & rollback

Zero risk — adds a new documentation file only. Revert by deleting `AGENTS.md`.

## Checklist

- [x] Conventional commit title (`feat:`, `fix:`, `chore:`, `docs:`, etc.)
- [x] No secrets, tokens, or PII committed
- [x] Public-facing copy reviewed for accuracy
- [ ] CHANGELOG updated if user-visible
- [ ] Linked issue closed via `Closes #<n>` if applicable

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9204fc6d-cb86-45e1-b007-d24847f724a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9204fc6d-cb86-45e1-b007-d24847f724a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

