### PR TITLE
chore(coordination): proxy Cursor's daily-status to .github

### DIFF
--- a/coordination/CURSOR_DAILY_STATUS_2026-05-29.md
+++ b/coordination/CURSOR_DAILY_STATUS_2026-05-29.md
@@ -1,0 +1,62 @@
+# Cursor Daily Status — 2026-05-29
+
+## Done today
+
+- Verified `a11oy` PR #89 merged at `6aca5bbd373430a5ab0024af5e569bdb024d47b0` and is live on `main`.
+- Verified `a11oy` PR #92 merged at `663e7c3eb11ca5e299f04f7619e926f962620b91`, resolving the PhD Lens 1 + Lens 3 adversarial-robustness clarification in the real gate file.
+- Confirmed stale `a11oy` PRs #90/#91 are superseded by #92; #57 remains an intentional relicense/legal HOLD.
+- Confirmed `a11oy/main` latest checks are green: DCO, Tests, Doctrine Build, Operational Validation, Docs CI, SBOM/Trivy, CodeQL, Scorecard.
+- Read `.github` coordination PRs #71/#72/#73/#75 and captured the Phase 1, UDS v0.3.0, and agi-forecast directives.
+
+## Phase 1 — Anatomy-alive instillation
+
+- Track 1: A11oy Layer 6 formula gates are merged and test-covered.
+- Track 2: Sentra witnessed forecasting, Amaru adversarial regression, and Rosie receipt replay require repo-specific implementation PRs.
+- Track 3: A11oy test stub was replaced by a real policy-gate test lane; Lutar-Lean Mathlib drift remains a proof-substrate blocker outside this a11oy workspace.
+
+## pnpm test:anatomy-alive
+
+- Not yet present as a single cross-repo command.
+- Current closest a11oy evidence:
+  - `npm run test:policy-gates`
+  - `pnpm test:doctrine`
+  - `bash scripts/validate-operational.sh`
+
+## uds-v0.3.0 release cut
+
+- a11oy: source readiness landed on `main`; no release was cut by Cursor because signed release assets require the actual tarball/cosign workflow and owner-controlled release credentials.
+- sentra: not cut in this loop.
+- amaru: not cut in this loop.
+- rosie: not cut in this loop.
+- vessels: not cut in this loop.
+- uds-mesh: not cut in this loop.
+- cosign verify: not run for v0.3.0 because no v0.3.0 assets exist yet.
+
+## In progress
+
+- GitHub-side directives are understood.
+- Direct writes to `.github` and `agi-forecast` were attempted but blocked by repository permissions for `cursor[bot]`.
+
+## Blocked
+
+- `.github` daily status branch push failed with `403 Permission to szl-holdings/.github.git denied to cursor[bot]`.
+- `agi-forecast` implementation branch dry-run push failed with `403 Permission to szl-holdings/agi-forecast.git denied to cursor[bot]`.
+- Hugging Face live publish remains user/Perplexity-owned from GitHub-backed source.
+- Do not fake `uds-v0.3.0`: signed assets must exist before the release can be claimed.
+
+## Tomorrow plan
+
+- Continue repo-specific operationalization when write access/workspace is available:
+  1. `agi-forecast`: FG-S1→S4 TypeScript pipeline, DSSE-shaped receipts, Putnam wiring, and real runtime tests.
+  2. `sentra`: witnessed forecast output with formula witness fields.
+  3. `amaru`: adversarial regression against historical receipts.
+  4. `rosie`: receipt replay proof point.
+  5. `uds-mesh`: v0.3.0 pointer manifest once organ payload releases exist.
+- Keep claims evidence-gated: no UDS v0.3.0 release is claimed until signed assets exist and verify.
+
+## What I need from Perplexity / owner
+
+- Keep HF mirror publish downstream of GitHub merges.
+- Provide write access or owner-side PR creation for `.github`, `agi-forecast`, `sentra`, `amaru`, `rosie`, `vessels`, and `uds-mesh` if Cursor is expected to push directly there.
+- Provide actual cosign keys/workflow outputs needed for release assets; Cursor will not invent signed releases.
+- Keep `a11oy#57`, `amaru#46`, and `sentra#45` on legal/IP HOLD unless founder explicitly changes that.


### PR DESCRIPTION
Cursor Agent wrote a full daily-status file in commit `f782d70e3b` on `szl-holdings/a11oy` branch `cursor/coordination-status-2026-05-29-2f18`, but his `cursor[bot]` account got `403 Permission denied` trying to push to `szl-holdings/.github` directly.

This PR proxies the file to its canonical location (`coordination/CURSOR_DAILY_STATUS_2026-05-29.md`) so future Cursor loops and Perplexity loops can read it. Co-authored-by Cursor Agent.

## What the file says

- a11oy #89 + #92 merged and verified at specific SHAs
- Phase 1 anatomy-alive: a11oy L6 gates merged + test-covered; Tracks 2-3 require per-repo PRs
- UDS v0.3.0 release-cut: **NOT cut** — Cursor explicitly refused to fake signed releases without actual cosign assets (doctrine v6 alignment)
- Blockers: cursor[bot] lacks write access to `.github`, `agi-forecast`, `sentra`, `amaru`, `rosie`, `uds-mesh`, `vessels`
- Cursor's tomorrow plan covers per-repo operationalization once access is granted or PRs proxied

This is the doctrine v6 handshake working as designed.