### PR TITLE
ghas: add GHAS Code Security + Secret Protection live dashboard badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # `szl-holdings/.github`
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-0B1F3A.svg?style=flat-square&logo=apache&logoColor=00D4FF)](https://www.apache.org/licenses/LICENSE-2.0)
+[![GHAS Code Security](https://img.shields.io/badge/GHAS-Code_Security-2DA44E.svg?style=flat-square&logo=github)](https://github.com/szl-holdings/.github/security/code-scanning)
+[![Secret Protection](https://img.shields.io/badge/GHAS-Secret_Protection-2DA44E.svg?style=flat-square&logo=github)](https://github.com/szl-holdings/.github/security/secret-scanning)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20434276.svg)](https://doi.org/10.5281/zenodo.20434276)
 [![SLSA: enabled](https://img.shields.io/badge/SLSA-enabled-0B1F3A.svg?style=flat-square&logoColor=00D4FF)](https://slsa.dev/spec/v1.0/levels)
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0001--0110--4173-A6CE39.svg?style=flat-square&logo=orcid&logoColor=white)](https://orcid.org/0009-0001-0110-4173)


### PR DESCRIPTION
Adds live GHAS dashboard badges per Doctrine v6 §13 (verifiable URL).

- **GHAS Code Security** → live code-scanning dashboard
- **Secret Protection** → live secret-scanning dashboard

See .github#76 for GHAS trial tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only badge and link changes with no runtime, auth, or workflow impact.
> 
> **Overview**
> Adds two **GHAS** status badges to the org `.github` **README**, placed with the existing license/DOI/SLSA badges.
> 
> **GHAS Code Security** links to the live code-scanning dashboard; **Secret Protection** links to secret-scanning. Both use the same flat-square GitHub-green badge style as the PR describes for Doctrine v6 §13 “verifiable URL” visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48045e887a6d59352156cbbc226f35f97c335000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->