### PR TITLE
docs(doctrine-v7): honest Putnam framing in §11 canonical-number example

### DIFF
--- a/doctrine/DOCTRINE_V7.md
+++ b/doctrine/DOCTRINE_V7.md
@@ -115,8 +115,10 @@ Source: `/home/user/workspace/szl/audit_2026-05-29_evening/hf_truth_audit/REPORT
 
 **Rule:** When a canonical numeric value is updated (benchmark score, sorry count, tool count, theorem count, or any other metric cited across multiple files), all affected files must reflect the updated value within 48 hours of the canonical update. After 48 hours, a stale numeric is a doctrine violation in any file that still carries the old value. The owner of the canonical number must maintain an inventory of all files where the number appears; that inventory is a required artifact of the update.
 
-**Rationale:** The Putnam percentage `8.3% (1/12)` lingered on 31 HF assets after the canonical value was updated to `83.3% (10/12)` on 2026-10-12. The stale figure persisted as a 10× magnitude error on investor-facing assets.  
-Source: `/home/user/workspace/szl/audit_2026-05-29_evening/hf_truth_audit/REPORT.md`, LIE #1: "This is a 10x magnitude error on a key investor-facing metric" affecting "ALL 29 datasets + ALL 2 models = 31 files."
+**Rationale:** The Putnam percentage `8.3% (1/12)` lingered on 31 HF assets after a canonical-value update on 2026-10-12. The stale figure persisted on investor-facing assets.  
+Source: `/home/user/workspace/szl/audit_2026-05-29_evening/hf_truth_audit/REPORT.md`, LIE #1, affecting "ALL 29 datasets + ALL 2 models = 31 files."
+
+> **Honesty correction (PhD-verified, 2026-05-30):** The `83.3% (10/12)` figure used in the original example above counts files with structural scaffolding, **not** proved problems, and is itself misleading. Per the PhD Math audit, **0/12** Putnam 2025 problems are fully proved: 2/12 files are sorry-token-free (A1, A3) but stated as `→ True` shells, and A5/B4/B6 carry root-level sorries. Two files previously encoded the wrong official answer (P_B6: r=1/2 vs official 1/4; P_A3: Alice vs official Bob), corrected in lutar-lean. Official answers verified against the [86th Putnam official solutions](https://kskedlaya.org/putnam-archive/2025s.pdf). This §11 example is retained only to illustrate the staleness-propagation rule; the `10/12` value must not be cited as a progress metric.
 
 **Enforcement:**  
 - Canonical numbers are declared in a `canonical_numbers.json` file at the `.github` repo root.  


### PR DESCRIPTION
## Summary

Doctrine v7 (`doctrine/DOCTRINE_V7.md`) lives in this `.github` repo (referenced by the lutar-lean README badge). Its §11 "Canonical-Number Propagation Deadline" example cited the Putnam value **`83.3% (10/12)`** as the canonical/correct figure.

That figure counts files with structural scaffolding, **not** proved problems, and is itself misleading. Per the PhD Math audit:

- **0/12** Putnam 2025 problems are fully proved.
- A1, A3 are sorry-token-free but stated as `→ True` shells.
- A5, B4, B6 carry root-level sorries on the main theorem.
- Two files previously encoded the **wrong official answer** (P_B6: r=1/2 vs official 1/4; P_A3: Alice vs official Bob), corrected in lutar-lean.

## Change

Adds an **honesty-correction note** to §11. The historical example (the 1/12 staleness bug) is retained to illustrate the propagation rule, but the `10/12` value is explicitly forbidden as a progress metric.

## Source verification

Official answers verified against the **86th Putnam official solutions** (https://kskedlaya.org/putnam-archive/2025s.pdf): "B6. The largest such constant is r = 1/4" and "A3. Bob has a winning strategy for all n ≥ 1".

## Notes

- Docs-only, single-file change.
- No `canonical_numbers.json` exists yet in this repo, so the doctrine doc is the authoritative location for this number.
- Out of scope this round: several `coordination/` and `cursor-directives/` files also cite 10/12-style Putnam numbers; flagged for a later pass.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>
