### PR TITLE
fix(attribution): replace Wayne Slaughter with Stephen P. Lutar Jr. as founder

### DIFF
--- a/coordination/CURSOR_MASTER_DIRECTIVE_FINAL_2026-05-30.md
+++ b/coordination/CURSOR_MASTER_DIRECTIVE_FINAL_2026-05-30.md
@@ -2,7 +2,7 @@
 **Date:** 2026-05-30 09:36 UTC  
 **Auditor:** Perplexity subagent (PhD Cursor Master Directive task)  
 **Doctrine:** v6 strict, v7 enacted  
-**Authority:** Founder — Wayne Slaughter  
+**Authority:** Founder — Stephen P. Lutar Jr.  
 **Tracking issue:** https://github.com/szl-holdings/.github/issues/76  
 **Prior directive superseded:** `.github/coordination/CURSOR_MASTER_DIRECTIVE.md` (all prior versions)  
 **Commit trail:** This file is the source of truth. All per-session workspace files in `/home/user/workspace/szl/audit_2026-05-29_evening/` feed this document.

--- a/docs/UDS_CATALOG_SPONSOR_APPLICATION.md
+++ b/docs/UDS_CATALOG_SPONSOR_APPLICATION.md
@@ -183,7 +183,7 @@ The sponsor handoff from Andrew Greene to a DU engineering reviewer follows this
 3. SZL provides dedicated review access:
    - Read access to szl-holdings/szl-uds-deployment (or DU fork)
    - Slack channel #szl-du-catalog-review (SZL workspace invite)
-   - Wayne Slaughter (wayne@szlholdings.com) as primary eng contact
+   - Stephen P. Lutar Jr. (stephen@szlholdings.com) as primary eng contact
 
 4. Andrew Greene → DU reviewer handoff brief:
    - Architecture walkthrough (30 min video call)
@@ -196,12 +196,12 @@ The sponsor handoff from Andrew Greene to a DU engineering reviewer follows this
 6. On approval: DU Catalog team adds uds-package-szl-organs to catalog
    OCI tag: ghcr.io/szl-holdings/uds-package-szl-organs:v0.4.0
 
-7. Ongoing: Wayne Slaughter maintains package; Andrew Greene is
+7. Ongoing: Stephen P. Lutar Jr. maintains package; Andrew Greene is
    "sponsor of record" at DU. Quarterly sync with DU Catalog team.
 ```
 
 ### Escalation
-If Andrew Greene is unavailable: escalate to Wayne Slaughter → SZL executive sponsor. SZL will seek a second DU sponsor if needed per DU policy.
+If Andrew Greene is unavailable: escalate to Stephen P. Lutar Jr. → SZL executive sponsor. SZL will seek a second DU sponsor if needed per DU policy.
 
 ---
 
@@ -305,7 +305,7 @@ echo "AIRGAP_TEST=PASS" >> $GITHUB_OUTPUT
 
 | Role | Name | Contact |
 |------|------|---------|
-| SZL Founder / Submitter | Wayne Slaughter | wayne@szlholdings.com |
+| SZL Founder / Submitter | Stephen P. Lutar Jr. | stephen@szlholdings.com |
 | DU Sponsor (internal) | Andrew Greene | andrew.greene@defenseunicorns.com |
 | SZL Eng Lead | [TBD v0.4.0] | eng@szlholdings.com |
 | SZL Legal | [TBD] | legal@szlholdings.com |

--- a/docs/WARHACKER_DEMO_V3.md
+++ b/docs/WARHACKER_DEMO_V3.md
@@ -1,6 +1,6 @@
 # Warhacker Demo v3 — Script
 **Event:** Warhacker, June 16–20, 2026
-**Presenter:** Wayne Slaughter (Stephen)
+**Presenter:** Stephen P. Lutar Jr.
 **Version:** v3 | 3 verifiable proof points per minute
 **Total runtime:** 15 minutes = 45 proof points
 **Classification:** UNCLASSIFIED//FOUO
@@ -460,7 +460,7 @@ cat UDS_CATALOG_SPONSOR_APPLICATION.md | head -30
 
 ## Segment 4 — "What's Next: v0.4.0" (11:00–14:00)
 
-**Narration:** Wayne returns to keyboard. "Here's where we're going."
+**Narration:** Stephen returns to keyboard. "Here's where we're going."
 
 ### Minute 12 (11:00–12:00)
 

--- a/doctrine/DOCTRINE_V7.md
+++ b/doctrine/DOCTRINE_V7.md
@@ -2,7 +2,7 @@
 
 **Status:** ENACTED — 2026-05-30  
 **Supersedes:** Doctrine v6 (session-locked 2026-05-29 evening)  
-**Authority:** Founder — Wayne Slaughter  
+**Authority:** Founder — Stephen P. Lutar Jr.  
 **Attestation:** This document was drafted under Doctrine v6 and must itself pass v6/v7 grep on every clause.  
 **Audit basis:** Lessons derived from `/home/user/workspace/szl/audit_2026-05-29_evening/` session artifacts.
 


### PR DESCRIPTION
Per founder directive 2026-05-30 ~20:34 EDT: Wayne Slaughter is the CEO of Defense Unicorns (our Warhacker audience), not the founder of SZL Holdings. The 4 templated files had the wrong name inserted.

**Scope of change:**

| File | Edit |
|---|---|
| `docs/UDS_CATALOG_SPONSOR_APPLICATION.md` | Wayne Slaughter (wayne@) → Stephen P. Lutar Jr. (stephen@) |
| `doctrine/DOCTRINE_V7.md` | `Founder — Wayne Slaughter` → `Founder — Stephen P. Lutar Jr.` |
| `docs/WARHACKER_DEMO_V3.md` | Presenter + narration name |
| `coordination/CURSOR_MASTER_DIRECTIVE_FINAL_2026-05-30.md` | Founder authority line |

**NOT touched:** the academic 'Wayne, G.' citations in `ouroboros-thesis` are references to Greg Wayne (DeepMind, Neural Turing Machines / Hybrid Computing / Experience Replay co-author), a separate person from Wayne Slaughter. Those are valid citations.

**Critical for Warhacker:** had this gone out unfixed, the UDS Catalog sponsor application would have arrived at Defense Unicorns claiming their own CEO as our founder.

Closes #104

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>