### PR TITLE
docs(trust): add TRUST.md — Tier 1 verifiable trust posture

### DIFF
--- a/TRUST.md
+++ b/TRUST.md
@@ -1,0 +1,95 @@
+# Trust
+
+This document records the verifiable trust posture of SZL Holdings. Every claim
+below resolves to a link, a commit SHA, or a CI workflow run. Claims that are not
+yet verifiable are marked as roadmap items, not as current state.
+
+This file is governed by [SZL Doctrine v7](doctrine/DOCTRINE_V7.md), in
+particular §2 (No Hallucinations / No Fake Green) and §7 (Every Claim Citable).
+
+## Doctrine v7
+
+Governance doctrine, including the banned-token policy and the honesty rules
+that bind this document: [`doctrine/DOCTRINE_V7.md`](doctrine/DOCTRINE_V7.md).
+
+## Provenance — SLSA Level 1 (honest)
+
+Provenance is documented at SLSA Level 1: source and build steps are recorded.
+The truth pass that set this level honestly (rather than asserting an
+unverifiable higher level) is recorded in
+[PR szl-holdings/.github#103](https://github.com/szl-holdings/.github/pull/103).
+
+Levels 2 and 3 (Sigstore signing + isolated, hardened builders) are roadmap
+items and are NOT claimed here.
+
+## Signed commits (DCO)
+
+Commits carry a Developer Certificate of Origin sign-off
+(`Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>`), enforced by
+the DCO check. This requirement is set in
+[Doctrine v7 §5](doctrine/DOCTRINE_V7.md#5--signed-commits-dco).
+
+## CODEOWNERS coverage
+
+Default code ownership for the org is declared in
+[`.github/CODEOWNERS`](.github/CODEOWNERS). Repositories that do not define
+their own CODEOWNERS inherit this default; per-repo files override it.
+
+## CodeQL
+
+CodeQL static analysis runs in CI. A recent completed run with a `success`
+conclusion on the `.github` repository (commit `d304951`):
+[run 26699048618](https://github.com/szl-holdings/.github/actions/runs/26699048618).
+
+A recent completed CodeQL run with a `success` conclusion on the `platform`
+repository (commit `90ad450`):
+[run 26699466180](https://github.com/szl-holdings/platform/actions/runs/26699466180).
+
+CodeQL status reflects the run linked above at the SHA shown. It is not a
+standing guarantee about later commits.
+
+## SSRF guards
+
+Server-side request forgery protection: an SSRF allowlist validation on webhook
+delivery was added to the platform in
+[PR szl-holdings/platform#252](https://github.com/szl-holdings/platform/pull/252).
+
+## No-marketing-token policy
+
+Public artifacts are screened against a banned-token list (marketing
+superlatives). The policy and the token list are defined in
+[Doctrine v7 §1 — No Marketing Superlatives](doctrine/DOCTRINE_V7.md#1--no-marketing-superlatives).
+
+## Founder identity
+
+- Founder and CEO: Stephen P. Lutar Jr.
+- ORCID: [0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)
+- GitHub: [stephenlutar2-hash](https://github.com/stephenlutar2-hash) and
+  [betterwithage](https://github.com/betterwithage)
+- Corporate email: stephen@szlholdings.com
+- DCO sign-off email: stephenlutar2@gmail.com
+
+## Live numbers
+
+The following Lean proof-corpus numbers were verified at a specific commit. They
+may drift as the corpus changes; re-verify against current HEAD before reuse.
+
+Verified at commit
+[`3de37e5`](https://github.com/szl-holdings/lutar-lean/commit/3de37e5258648cbd1263ade1a6f36f54d3a79ae3)
+(`lutar-lean`):
+
+- Declarations: 626
+- Unique axioms: 14
+- Sorries: 189
+
+Caveat: these counts are accurate as of `3de37e5` and may drift on later
+commits. A reproducibility script that regenerates these counts from a clean
+checkout is a TODO and is not yet present in the repository.
+
+## Deliberately NOT claimed
+
+To stay within Doctrine v7 §2, this document does NOT assert:
+
+- SOC 2, ISO 27001, or any external audit certification (none held).
+- A "trusted by" customer or logo list.
+- Any badge or status not backed by a resolving link or SHA above.


### PR DESCRIPTION
## What this adds

`TRUST.md` at the repo root — a Tier 1 verifiable trust posture document. Every claim resolves to a link, a commit SHA, or a CI workflow run:

- **Doctrine v7** → `doctrine/DOCTRINE_V7.md`
- **Provenance — SLSA L1 (honest)** → PR #103
- **Signed commits (DCO)** → Doctrine v7 §5
- **CODEOWNERS coverage** → `.github/CODEOWNERS`
- **CodeQL** → completed `success` runs: .github run 26699048618 (`d304951`) and platform run 26699466180 (`90ad450`)
- **SSRF guards** → platform PR #252
- **No-marketing-token policy** → Doctrine v7 §1
- **Founder identity** → Stephen P. Lutar Jr., ORCID 0009-0001-0110-4173, GitHub stephenlutar2-hash + betterwithage, stephen@szlholdings.com
- **Live numbers** → Lean 626 declarations / 14 unique axioms / 189 sorries, verified at `3de37e5` (lutar-lean), with an explicit drift caveat and a reproducibility-script TODO

## What was deliberately NOT added

- No SOC 2, ISO 27001, or any external certification (none held).
- No "trusted by" / logo wall.
- No badges that do not resolve to a verifiable current status.
- No fabricated PGP fingerprint or invented run links.

## Banned-token grep result

Ran the §1 banned-token grep (plus the fuller doctrine list incl. first/only/leading/Putnam/Bo11y/Bolly/Boss/Jarvis) on `TRUST.md`:

```
grep -inE 'revolutionary|unprecedented|world-class|seamless|industry-leading|cutting-edge|game-changing|breakthrough|premier|leading|best-in-class|immaculate|state-of-the-art' TRUST.md
→ CLEAN (no matches)
```

Do not auto-merge — left open for parent to merge via temp-lift.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>
