### PR TITLE
docs(readme): refresh org-readme footer Doctrine v6 -> v7 + axiom count

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ The 13 substrate repos cross-link reciprocally. This footer is maintained by GH 
 - [`agi-forecast`](https://github.com/szl-holdings/agi-forecast) — PAC-Bayes + Bekenstein governance-trajectory forecasts
 - [`vsp-otel`](https://github.com/szl-holdings/vsp-otel) — OpenTelemetry exporter for Λ-axis spans
 
-Org page: [github.com/szl-holdings](https://github.com/szl-holdings) · Doctrine v6 · 11 axioms · 32 GREEN modules · v18.0 DOI [`10.5281/zenodo.20434276`](https://doi.org/10.5281/zenodo.20434276)
+Org page: [github.com/szl-holdings](https://github.com/szl-holdings) · Doctrine v7 · 15 axioms (14 unique) · 32 GREEN modules · v18.0 DOI [`10.5281/zenodo.20434276`](https://doi.org/10.5281/zenodo.20434276)


### PR DESCRIPTION
## What changed
Updates the org-readme footer in `.github/README.md`:
`Doctrine v6 · 11 axioms` → `Doctrine v7 · 15 axioms (14 unique)`.

## Why
Doctrine v7 is canonical (supersedes v6) and the Lean axiom count is 15 raw / 14 unique (verified @ `lutar-lean` HEAD `3de37e5`). The rendered org profile (`profile/README.md`) was already correct; this repo `README.md` footer was stale.

## Scope / safety
- One footer line, single concern. Banned-token grep: clean. DCO sign-off present. Do **not** auto-merge.

## Evidence
- `github_full_audit/DOCTRINE_HITS.jsonl`.