### PR TITLE
chore(numbers): canonical Lean corpus counter + workflow (Trust Tier 1 reproducibility)

### DIFF
--- a/.github/data/lean_numbers.json
+++ b/.github/data/lean_numbers.json
@@ -1,0 +1,33 @@
+{
+  "schema": "szl.lean_numbers/v1",
+  "repo": "szl-holdings/lutar-lean",
+  "ref": "main",
+  "sha": "3de37e5258648cbd1263ade1a6f36f54d3a79ae3",
+  "measured_at_utc": "2026-05-31T02:31:06Z",
+  "method": "see .github/scripts/lean_numbers.py docstring (fixed grep-equivalent regexes)",
+  "numbers": {
+    "declarations": 752,
+    "axioms_raw": 15,
+    "axioms_unique": 14,
+    "axiom_names": [
+      "MomentSubGaussian",
+      "audit_reidemeister_invariance",
+      "canonicalReceipt",
+      "chromotopology_code_bijection",
+      "gleason_length_mod_8",
+      "klDivergence_nonneg",
+      "lambda_schur_concave_n_axis",
+      "lambda_stationary_unique",
+      "liu_hui_pi_converges",
+      "pinsker",
+      "r1_invariance",
+      "r2_invariance",
+      "sha256",
+      "sha256_collision_resistant"
+    ],
+    "sorries_raw": 160,
+    "sorries_noncomment": 146,
+    "sorries_putnam": 51,
+    "sorries_baseline": 109
+  }
+}

--- a/.github/scripts/lean_numbers.py
+++ b/.github/scripts/lean_numbers.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Canonical Lean corpus counter for szl-holdings/lutar-lean.
+
+Trust Tier 1 reproducibility script (TRUST.md TODO). Clones (or reads) the
+lutar-lean repo at its current `main` HEAD and emits a single canonical JSON of
+declaration / axiom / sorry counts so that public surfaces stop drifting.
+
+The methods here are *fixed and documented* so any agent or reviewer gets the
+same numbers from the same SHA. This file is the source of truth for the
+"Live numbers" line, replacing hand-maintained figures.
+
+Usage:
+  python lean_numbers.py --repo-path /path/to/lutar-lean [--out lean_numbers.json]
+  python lean_numbers.py --clone --out .github/data/lean_numbers.json
+
+Counting methods (documented, stable):
+  - declarations: lines in Lutar/ and Main.lean whose initial token is one of
+    {theorem, lemma, def, abbrev, instance, structure, inductive, class},
+    optionally preceded by the `noncomputable` and/or `private` modifier.
+  - axioms_raw: lines whose initial token is `axiom` (after optional modifiers).
+  - axioms_unique: distinct axiom names among those.
+  - sorries_raw: total `\\bsorry\\b` token occurrences across all .lean files.
+  - sorries_noncomment: occurrences excluding lines that are pure line-comments
+    (leading `--`) — i.e. `sorry` that is live proof text.
+  - sorries_putnam / sorries_baseline: split by whether the file is under Putnam/.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+LUTAR_LEAN_URL = "https://github.com/szl-holdings/lutar-lean.git"
+
+DECL_RE = re.compile(
+    r"^(?:private\s+)?(?:noncomputable\s+)?(?:private\s+)?"
+    r"(theorem|lemma|def|abbrev|instance|structure|inductive|class)\b"
+)
+AXIOM_RE = re.compile(r"^(?:private\s+)?axiom\s+([A-Za-z_][A-Za-z0-9_']*)")
+SORRY_RE = re.compile(r"\bsorry\b")
+COMMENT_LINE_RE = re.compile(r"^\s*--")
+
+
+def iter_lean_files(root: str):
+    base = os.path.join(root, "Lutar")
+    for dirpath, _dirs, files in os.walk(base):
+        for fn in files:
+            if fn.endswith(".lean"):
+                yield os.path.join(dirpath, fn)
+    main = os.path.join(root, "Main.lean")
+    if os.path.exists(main):
+        yield main
+
+
+def count(root: str) -> dict:
+    declarations = 0
+    axioms_raw = 0
+    axiom_names: set[str] = set()
+    sorries_raw = 0
+    sorries_noncomment = 0
+    sorries_putnam = 0
+    sorries_baseline = 0
+
+    for path in iter_lean_files(root):
+        is_putnam = f"{os.sep}Putnam{os.sep}" in path
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if DECL_RE.match(line):
+                    declarations += 1
+                m = AXIOM_RE.match(line)
+                if m:
+                    axioms_raw += 1
+                    axiom_names.add(m.group(1))
+                hits = len(SORRY_RE.findall(line))
+                if hits:
+                    sorries_raw += hits
+                    if not COMMENT_LINE_RE.match(line):
+                        sorries_noncomment += hits
+                    if is_putnam:
+                        sorries_putnam += hits
+                    else:
+                        sorries_baseline += hits
+
+    return {
+        "declarations": declarations,
+        "axioms_raw": axioms_raw,
+        "axioms_unique": len(axiom_names),
+        "axiom_names": sorted(axiom_names),
+        "sorries_raw": sorries_raw,
+        "sorries_noncomment": sorries_noncomment,
+        "sorries_putnam": sorries_putnam,
+        "sorries_baseline": sorries_baseline,
+    }
+
+
+def git_head_sha(root: str) -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", root, "rev-parse", "HEAD"], text=True
+        ).strip()
+        return out
+    except Exception:
+        return "unknown"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Canonical lutar-lean corpus counter.")
+    ap.add_argument("--repo-path", help="Path to an existing lutar-lean checkout.")
+    ap.add_argument("--clone", action="store_true", help="Shallow-clone main first.")
+    ap.add_argument("--ref", default="main", help="Branch/SHA to count (with --clone).")
+    ap.add_argument("--out", help="Write JSON here (default: stdout).")
+    args = ap.parse_args()
+
+    tmp = None
+    repo_path = args.repo_path
+    if args.clone or not repo_path:
+        tmp = tempfile.mkdtemp(prefix="lutar-lean-")
+        subprocess.check_call(
+            ["git", "clone", "--depth", "1", "--branch", args.ref, LUTAR_LEAN_URL, tmp]
+        )
+        repo_path = tmp
+
+    if not os.path.isdir(os.path.join(repo_path, "Lutar")):
+        print(f"error: {repo_path} has no Lutar/ directory", file=sys.stderr)
+        return 2
+
+    sha = git_head_sha(repo_path)
+    numbers = count(repo_path)
+    payload = {
+        "schema": "szl.lean_numbers/v1",
+        "repo": "szl-holdings/lutar-lean",
+        "ref": args.ref,
+        "sha": sha,
+        "measured_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "method": "see .github/scripts/lean_numbers.py docstring (fixed grep-equivalent regexes)",
+        "numbers": numbers,
+    }
+
+    out_json = json.dumps(payload, indent=2) + "\n"
+    if args.out:
+        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(out_json)
+        print(f"wrote {args.out} @ {sha}")
+    else:
+        sys.stdout.write(out_json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/lean-numbers.yml
+++ b/.github/workflows/lean-numbers.yml
@@ -1,0 +1,56 @@
+name: Lean Numbers (canonical corpus counts)
+
+# Trust Tier 1 reproducibility (TRUST.md TODO): recompute lutar-lean
+# declaration / axiom / sorry counts from the current main HEAD and commit the
+# canonical JSON so public surfaces stop drifting. Runs on push to main (when the
+# script changes) and on a manual/scheduled trigger that re-reads lutar-lean.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/lean_numbers.py"
+      - ".github/workflows/lean-numbers.yml"
+  workflow_dispatch: {}
+  schedule:
+    # Daily refresh so the JSON tracks lutar-lean main even when this repo is idle.
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: lean-numbers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  recount:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (.github)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Recount lutar-lean @ main and write canonical JSON
+        run: |
+          python3 .github/scripts/lean_numbers.py \
+            --clone --ref main \
+            --out .github/data/lean_numbers.json
+          echo "----- canonical numbers -----"
+          cat .github/data/lean_numbers.json
+
+      - name: Commit updated numbers if changed
+        run: |
+          if git diff --quiet -- .github/data/lean_numbers.json; then
+            echo "No change in canonical numbers; nothing to commit."
+            exit 0
+          fi
+          git config user.name "Stephen P. Lutar Jr."
+          git config user.email "stephenlutar2@gmail.com"
+          git add .github/data/lean_numbers.json
+          git commit -s -m "chore(numbers): refresh canonical lutar-lean counts [skip ci]"
+          git push


### PR DESCRIPTION
## What

Adds the Lean-corpus reproducibility script flagged as a TODO in Trust Tier 1's TRUST.md, plus a workflow that keeps a canonical numbers JSON current. This closes the "numbers drift" gap: public surfaces have been citing `626 declarations / 189 sorries` that did not reproduce from any single stated command.

### Files
- `.github/scripts/lean_numbers.py` — clones (or reads) `szl-holdings/lutar-lean` at `main`, counts declarations / axioms (raw + unique) / sorries with **fixed, documented regexes**, and emits a single JSON. The counting method is written into the docstring so any reviewer gets the same numbers from the same SHA.
- `.github/workflows/lean-numbers.yml` — runs on push to `main` (when the script changes), on `workflow_dispatch`, and daily; recomputes from `lutar-lean` HEAD and commits `.github/data/lean_numbers.json` only when it changes.
- `.github/data/lean_numbers.json` — initial canonical numbers, measured at the current cleanly-building `main` HEAD.

### Canonical numbers (initial JSON, @ `3de37e5`)

```
declarations:        752
axioms_raw:          15
axioms_unique:       14
sorries_raw:         160   (146 non-comment)
sorries_putnam:      51
sorries_baseline:    109
```

`3de37e5` is the current `main` HEAD of lutar-lean and its **Lean kernel check passed in CI** (run 26694228189, success, 3m18s). The axiom figure (15 raw / 14 unique) matches the long-standing canonical number exactly; the declaration and sorry figures supersede the drifted `626 / 189` (the old README's own decl command yields 586, a local non-main branch showed 642 — none reproduced cleanly, which is the whole reason for this script).

## Why "Putnam" appears in this PR

The script counts `sorry` tokens under `lutar-lean/Lutar/Putnam/` as a labeled split (`sorries_putnam`). "Putnam" is a banned **reintroduction** token for the `a11oy` repo (package removed in a11oy #159). This PR is in `szl-holdings/.github` and does not reintroduce anything — it measures the existing, tracked `lutar-lean` corpus directory. Suppressing the name would make the counter inaccurate.

## Doctrine
- v7 §2 (no fake green): the script reports real counts; no badges, no stubs.
- Banned-token grep on diff + body: clean (the `Putnam` occurrences are factual corpus references, justified above; no marketing superlatives).
- Scope: just the script, its workflow, and the initial JSON. No other repo changes.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>
