### PR TITLE
chore(citation): standardize affiliation to "SZL Holdings, Inc." in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     name-suffix: "Jr."
 
     email: stephen@szlholdings.com
-    affiliation: SZL Holdings
+    affiliation: "SZL Holdings, Inc."
     orcid: "https://orcid.org/0009-0001-0110-4173"
 date-released: "2026-05-29"
 version: "0.1.0"


### PR DESCRIPTION
## Summary

Doctrine 5x audit finding F: the org-level `.github` CITATION.cff uses bare `SZL Holdings` without the legal entity suffix `, Inc.`. This PR corrects the `affiliation:` field to use the canonical `"SZL Holdings, Inc."` form.

## Changes

- `CITATION.cff`: `affiliation: SZL Holdings` → `affiliation: "SZL Holdings, Inc."`

## Doctrine v7 self-scan

- DOCTRINE CLEAN
- MYTHOS CLEAN

## Agent authorship

Authored by Perplexity Computer Agent  
On-behalf-of: Stephen P. Lutar Jr. <stephen@szlholdings.com>

Signed-off-by: Perplexity Computer Agent <agent@perplexity.ai>