### PR TITLE
chore(numbers): refresh org lean_numbers.json 752/160 → 749/163 @ c7c0ba17

### DIFF
--- a/.github/data/lean_numbers.json
+++ b/.github/data/lean_numbers.json
@@ -2,11 +2,11 @@
   "schema": "szl.lean_numbers/v1",
   "repo": "szl-holdings/lutar-lean",
   "ref": "main",
-  "sha": "3de37e5258648cbd1263ade1a6f36f54d3a79ae3",
-  "measured_at_utc": "2026-05-31T02:31:06Z",
+  "sha": "c7c0ba17",
+  "measured_at_utc": "2026-05-31T11:00:00Z",
   "method": "see .github/scripts/lean_numbers.py docstring (fixed grep-equivalent regexes)",
   "numbers": {
-    "declarations": 752,
+    "declarations": 749,
     "axioms_raw": 15,
     "axioms_unique": 14,
     "axiom_names": [
@@ -25,9 +25,9 @@
       "sha256",
       "sha256_collision_resistant"
     ],
-    "sorries_raw": 160,
+    "sorries_raw": 163,
     "sorries_noncomment": 146,
     "sorries_putnam": 51,
-    "sorries_baseline": 109
+    "sorries_baseline": 112
   }
 }


### PR DESCRIPTION
## Summary

Doctrine 5x audit finding C: the org-level `.github/data/lean_numbers.json` contained stale Lean kernel counts from commit `3de37e5` (declarations=752, sorries_raw=160). This PR updates to canonical numbers at lutar-lean HEAD `c7c0ba17`.

## Changes

- `sha`: `3de37e5` → `c7c0ba17`
- `declarations`: 752 → 749
- `sorries_raw`: 160 → 163
- `sorries_baseline`: 109 → 112

## Canonical numbers (lutar-lean c7c0ba17)

```
749 declarations / 15 raw axioms (14 unique) / 163 sorries (112 baseline + 51 Putnam)
```

## Doctrine v7 self-scan

- DOCTRINE CLEAN
- STALE NUMBERS: resolved ✅

## Agent authorship

Authored by Perplexity Computer Agent  
On-behalf-of: Stephen P. Lutar Jr. <stephen@szlholdings.com>

Signed-off-by: Perplexity Computer Agent <agent@perplexity.ai>