### PR TITLE
chore(security): SBOM + Trivy + Gitleaks + Dependabot + SECURITY.md — Doctrine v11

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,27 @@
+name: gitleaks
+
+# Secret scanning via gitleaks-action. PR + nightly.
+# Allow-list in .gitleaks.toml (cosign.pub PEM blocks). ADDITIVE. Doctrine v11 LOCKED 749/14/163 locked_at c7c0ba17
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '7 1 * * *'   # nightly 01:07 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,45 @@
+name: trivy
+
+# Trivy filesystem vulnerability scan. PR + weekly cron. SARIF -> Code Scanning.
+# Fails on CRITICAL+HIGH. ADDITIVE. Doctrine v11 LOCKED 749/14/163 locked_at c7c0ba17
+
+on:
+  pull_request:
+  schedule:
+    - cron: '41 3 * * 1'   # weekly Monday 03:41 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy filesystem scan (SARIF)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Trivy fail gate (CRITICAL+HIGH)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+# Gitleaks config for SZL Holdings. Extends defaults; allow-lists known false positives.
+# Doctrine v11 LOCKED 749/14/163 locked_at c7c0ba17
+title = "SZL Gitleaks Config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "SZL known false-positives"
+# cosign / sigstore PUBLIC keys are safe to commit (public verification material).
+regexes = [
+  '''-----BEGIN PUBLIC KEY-----[\s\S]*?-----END PUBLIC KEY-----''',
+]
+paths = [
+  '''cosign\.pub''',
+  '''.*\.pub$''',
+  '''.*cosign.*\.pem$''',
+]


### PR DESCRIPTION
## OPS WAVE A — Security hygiene

Additive only. Adds the following (missing) files:

- `.github/workflows/trivy.yml`
- `.github/workflows/gitleaks.yml`
- `.gitleaks.toml`

**Item 5** Syft SBOM (PR+nightly, artifact + attestations branch).
**Item 6** Trivy fs scan (PR+weekly, SARIF→Code Scanning, fail CRITICAL+HIGH).
**Item 7** Gitleaks (PR+nightly) + `.gitleaks.toml` allow-list (cosign.pub PEM).
**Item 8** `SECURITY.md` (disclosure stephenlutar2@gmail.com, 90-day window, cosign verify, compliance link).
**Item 9** Dependabot (pip, npm, github-actions; weekly; security auto-PRs).

Doctrine v11 LOCKED · 749/14/163 · locked_at `c7c0ba17`.

Co-Authored-By: Perplexity Computer Agent