### PR TITLE
fix(slsa): correct sibling-commit f59e9f5e wording — SLSA L1 honest (Doctrine v11)

### DIFF
--- a/PROVENANCE_NOTICE.md
+++ b/PROVENANCE_NOTICE.md
@@ -1,0 +1,33 @@
+# Provenance NOTICE — SLSA L1 honest
+
+> **SLSA L1 honest.** SZL Holdings' verified supply-chain provenance posture is
+> **SLSA Level 1 (honest)**: source and build provenance are documented, and
+> DSSE/Cosign signing of Khipu receipts is live. **SLSA L2 (hardened
+> build-service provenance) is NOT yet attested** — it is a **roadmap item
+> delivered via Wire D**. SLSA L3 is not claimed.
+
+## Correction of sibling commit `f59e9f5e`
+
+The commit
+[`f59e9f5e`](https://github.com/szl-holdings/.github/commit/f59e9f5e)
+("Add SZLHOLDINGS Cosign public key for DSSE Khipu receipt verification") used
+the phrase **"SLSA L2 signed provenance"** in its message. **That wording was a
+misstatement.** Commit messages are immutable, so this NOTICE is the durable
+correction of record:
+
+- The Cosign public key ([`cosign.pub`](cosign.pub)) and DSSE-signed Khipu
+  receipts are **real** and verifiable with `cosign verify-blob`.
+- Their existence establishes **SLSA L1 (honest)** — documented provenance plus
+  signing. It does **not** by itself establish SLSA L2, which additionally
+  requires a hardened, isolated build service attesting the build.
+- SZL's posture therefore remains **SLSA L1 honest; L2 roadmap via Wire D**.
+
+This NOTICE supersedes any "SLSA L2" phrasing in `f59e9f5e` and aligns the
+provenance claim with the honest posture already stated in
+[`README.md`](README.md), [`profile/README.md`](profile/README.md), and
+[`TRUST.md`](TRUST.md).
+
+---
+Signed-off-by: Yachay <yachay@szlholdings.dev>
+Doctrine v11 — 749 / 14 / 163 — replay hash c7c0ba17 — SLSA L1 honest.
+Co-Authored-By: Perplexity Computer Agent

--- a/coordination/CURSOR_MASTER_DIRECTIVE_FINAL_2026-05-30.md
+++ b/coordination/CURSOR_MASTER_DIRECTIVE_FINAL_2026-05-30.md
@@ -401,7 +401,7 @@ gh release view uds-v0.3.0 --repo szl-holdings/vessels  # → 4 assets present
 
 ---
 
-### Founder Action C — git tag v0.3.1 in szl-uds-deployment (3 min — TRIGGERS SLSA L2+)
+### Founder Action C — git tag v0.3.1 in szl-uds-deployment (3 min — advances SLSA L2 roadmap via Wire D; posture remains L1 honest until attested)
 
 ```bash
 # In szl-holdings/szl-uds-deployment repo root:
@@ -409,7 +409,7 @@ git tag v0.3.1
 git push origin v0.3.1
 ```
 
-**Why:** Triggers `uds-package-release.yml`, which produces the first cosign-signed Zarf package and creates the first Rekor transparency log entry. Without this, the SLSA L2+ story has no actual signed artifact. This is required before the UDS Catalog sponsor application can be submitted.
+**Why:** Triggers `uds-package-release.yml`, which produces the first cosign-signed Zarf package and creates the first Rekor transparency log entry. Without this, the SLSA L2 roadmap (via Wire D) has no actual signed artifact; the verified posture remains SLSA L1 honest until a hardened build service attests it. This is required before the UDS Catalog sponsor application can be submitted.
 
 **STAGED-ADVISORY:** v0.3.1 is the first release that will have a CI-generated signed artifact. All references to "catalog-grade" status remain STAGED-ADVISORY until this tag triggers a successful workflow run and 4 assets appear on the release.
 


### PR DESCRIPTION
## SLSA L1 honest — correct sibling-commit `f59e9f5e` wording

Sibling commit [`f59e9f5e`](https://github.com/szl-holdings/.github/commit/f59e9f5e) described the Cosign public key as **"SLSA L2 signed provenance"**. Per **Doctrine v11** honesty rules, SZL's verified posture is **SLSA L1 honest** (signing live; L2 hardened build-service provenance is roadmap via **Wire D**, not yet attested).

Commit messages are immutable, so this PR:

1. Adds **`PROVENANCE_NOTICE.md`** — a prominent, durable correction of the `f59e9f5e` wording, stating **SLSA L1 honest** as the correction of record.
2. Clarifies the forward-looking "SLSA L2+" phrasing in the coordination directive as an explicit **roadmap** item (no current-state claim).

Additive / wording-only — no workflows, keys, or logic are changed.

---
Signed-off-by: Yachay <yachay@szlholdings.dev>
Doctrine v11 — 749 / 14 / 163 — replay hash c7c0ba17 — SLSA L1 honest.
Co-Authored-By: Perplexity Computer Agent
