### PR TITLE
docs(profile): cross-link Λ Conjecture 1 bounty

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -70,6 +70,8 @@ Runtime and formal substrate the flagships call. Not products — plumbing.
 | [**lutar-lean**](https://github.com/szl-holdings/lutar-lean) | [![lutar-lean CI](https://github.com/szl-holdings/lutar-lean/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/lutar-lean/actions/workflows/ci.yml) | Lean 4 + Mathlib kernel proofs — Λ invariant, QEC, KS-18. Doctrine v11 @ `c7c0ba17`. |
 | [**ouroboros**](https://github.com/szl-holdings/ouroboros) | [![ouroboros CI](https://github.com/szl-holdings/ouroboros/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/ouroboros/actions/workflows/ci.yml) | Bounded recursion runtime, governance loops, and receipt emission spine. |
 
+- **🏆 [Λ-Uniqueness Bounty — Conjecture 1 (OPEN)](https://github.com/szl-holdings/lutar-lean/blob/main/BOUNTY.md)** — a founder-set monetary award for a complete, machine-checked Lean 4 proof that the 9-axis Λ-aggregator (PURIQ F23) is unique under axioms A1–A4. Conjecture 1 is **NOT a theorem**; `verify-proof` CI on [`lambda-bounty`](https://github.com/szl-holdings/lambda-bounty) is the sole, no-bypass arbiter. Working intake + webhook surface: [`lambda-bounty/webhook`](https://github.com/szl-holdings/lambda-bounty/tree/main/webhook).
+
 ---
 
 ## UDS Stack


### PR DESCRIPTION
## Cross-link the Λ Conjecture 1 bounty from the org profile

Adds **one additive bullet** to `profile/README.md` under the proof-kernel section,
linking:
- `lutar-lean/BOUNTY.md` (the bounty declaration), and
- `lambda-bounty` + its working `webhook/` intake surface.

### Honesty posture (unchanged)
- Conjecture 1 is labeled **NOT a theorem** (consistent with the existing "Λ uniqueness is a Conjecture" disclosure already in this README).
- `verify-proof` CI on `lambda-bounty` is named as the sole, no-bypass arbiter.
- No other lines touched. Doctrine disclosure block preserved verbatim.

Signed-off-by: Yachay <yachay@szlholdings.dev>

Sign: Yachay
Co-Authored-By: Perplexity Computer Agent
