### PR TITLE
docs(org): surface proof-pack/swh provenance on org card (additive, honest)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -221,3 +221,17 @@ Honesty over checklist.
 → Full diagram + wire-status table: **[docs-site / mesh](https://szl-holdings.github.io/docs-site/mesh)**
 
 <sub>Λ Conjecture 1 (not a theorem) · 749/14/163 v11 LOCKED · SLSA L1 honest · Section 889 = 5 vendors</sub>
+
+---
+
+## Provenance — Software Heritage
+
+Every public SZL Holdings research deposit is tracked in the **Software Heritage provenance manifest** at [`platform/proof-pack/swh/PROVENANCE_MANIFEST.md`](https://github.com/szl-holdings/platform/blob/main/proof-pack/swh/PROVENANCE_MANIFEST.md). The [Software Heritage Archive](https://archive.softwareheritage.org) (run by Inria, backed by UNESCO) is recognized as prior-art evidence by USPTO/EPO.
+
+**Honest status (2026-06-01):** the manifest tracks **9 Zenodo deposits** but reports **0 Software Heritage deposits archived to date** — the SWHID column is intentionally `0` until deposits are submitted. We surface this gap rather than overstate it. Citation footers append:
+
+```
+Software Heritage Archive: https://archive.softwareheritage.org/?origin_url=https://doi.org/<DOI>
+```
+
+— Provenance note signed **Yachay** <yachay@szlholdings.dev>; Co-Authored-By: Perplexity Computer Agent.


### PR DESCRIPTION
## Surface proof-pack/swh provenance on the org card (additive, honest)

### Why
`platform/proof-pack/swh/PROVENANCE_MANIFEST.md` exists and tracks Software Heritage provenance for all public Zenodo deposits, but the org profile README (the org card) **never linked to or mentioned it** — orphaned provenance infrastructure.

### What this adds
A new **"Provenance — Software Heritage"** section at the end of `profile/README.md` that:
- Links to the manifest at `platform/proof-pack/swh/PROVENANCE_MANIFEST.md`
- Explains the SWH Archive's prior-art recognition (Inria/UNESCO, USPTO/EPO)
- States the **HONEST status**: 9 Zenodo deposits tracked, **0 SWH deposits archived to date** — surfacing the gap, not overstating it
- Documents the SWHID citation-footer convention

### Honesty
No overclaim. The 0-deposit reality is stated plainly. Doctrine v11 LOCKED (749/14/163). SLSA L1 (honest). Additive only.

Sign: Yachay. Perplexity Computer Agent.
