### PR TITLE
docs(profile): honest license split (no-hallucination fix)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 **Provable by math, signed by receipts, runs on your hardware.**
 
-[GitHub: szl-holdings](https://github.com/szl-holdings) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · Apache-2.0 OSS
+[GitHub: szl-holdings](https://github.com/szl-holdings) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · Apache-2.0 code · CC-BY-4.0 papers & brand
 
 ---
 
@@ -77,7 +77,9 @@ SZL Holdings builds a formally-verified governance gate for agentic AI. The Λ a
 - **Concept DOI** [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926)
 - **Developer hub** — [github.com/szl-holdings/developers](https://github.com/szl-holdings/developers)
 - **Compliance posture** — [github.com/szl-holdings/compliance-posture](https://github.com/szl-holdings/compliance-posture). Honest current state: pre-SOC 2 (Type 1 targeted Q4 2026); FedRAMP/IL-4 path targeted Q4 2027.
-- Apache-2.0 across all open-source repos.
+- **Apache-2.0** — source-code repositories (SDKs, substrate, services, demos).
+- **CC-BY-4.0** — research papers, brand assets, and the public data lake (ouroboros-thesis, puriq-preprint, szl-brand, brand-kit, szl-trust, szl-lake).
+- License classification is being normalized across the org; a small number of flagship repos are mid-relicense to Apache-2.0 (see open `re-license` PRs).
 
 ---
 
@@ -85,4 +87,4 @@ SZL Holdings builds a formally-verified governance gate for agentic AI. The Λ a
 
 ---
 
-<sub>Doctrine v11 LOCKED · 🪢 Khipu chain · Lean 4 · Sigstore Rekor · Apache-2.0 OSS · DOI [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926) · Source of truth: [szl-holdings/.github lean_numbers.json](https://github.com/szl-holdings/.github/blob/main/.github/data/lean_numbers.json) @ `c7c0ba17` · Founder: Stephen Paul Lutar Jr · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>
+<sub>Doctrine v11 LOCKED · 🪢 Khipu chain · Lean 4 · Sigstore Rekor · Apache-2.0 code / CC-BY-4.0 papers · DOI [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926) · Source of truth: [szl-holdings/.github lean_numbers.json](https://github.com/szl-holdings/.github/blob/main/.github/data/lean_numbers.json) @ `c7c0ba17` · Founder: Stephen Paul Lutar Jr · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,25 @@
+<div align="center">
+
+<!-- Premium Inca-palette hero banner (Greene polish) — gold #d4a574 · indigo #2a1e5c · terra #b04a30 · parchment #f4e4c1 -->
+<a href="https://docs.szlholdings.com"><img src="https://raw.githubusercontent.com/szl-holdings/.github/main/profile/assets/hero-premium.svg" alt="SZL Holdings — Sovereign Governed AI · Doctrine v11 LOCKED 749/14/163 · c7c0ba17 · Λ = Conjecture 1" width="100%" /></a>
+
+<img src="https://raw.githubusercontent.com/szl-holdings/szl-brand/main/kit/logos/png/kanchay-512.png" alt="SZL Holdings — kanchay mark" width="120" />
+
 # SZL Holdings — Sovereign Governed AI
 
 **Provable by math, signed by receipts, runs on your hardware.**
 
-[GitHub: szl-holdings](https://github.com/szl-holdings) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · Apache-2.0 code · CC-BY-4.0 papers & brand
+### 4/5 flagship Spaces live (a11oy rebuilding) · cosign-signed images on GHCR · 749 declarations · 14 axioms · 163 sorries · Doctrine v11 LOCKED
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![Doctrine v11 LOCKED 749/14/163](https://img.shields.io/badge/Doctrine-v11_LOCKED_749%2F14%2F163-2a3550)](https://github.com/szl-holdings/lutar-lean/commit/c7c0ba17c2ea) [![Λ = Conjecture 1](https://img.shields.io/badge/%CE%9B-Conjecture_1_(not_a_theorem)-3a2f0f)](https://github.com/szl-holdings/szl-papers/tree/main/thesis/ouroboros/papers/v22) [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20434276-blue)](https://doi.org/10.5281/zenodo.20434276) [![DCO](https://img.shields.io/badge/DCO-sign--off_required-green)](https://developercertificate.org/)
+
+[Quickstart](https://docs.szlholdings.com/quickstart) · [Docs](https://docs.szlholdings.com) · [Cookbook](https://github.com/szl-holdings/szl-cookbook) · [Verify](https://github.com/szl-holdings/szl-cookbook/blob/main/recipes/01-verify-a-receipt-end-to-end.md) · [Cite](#citation) · [Releases](https://github.com/orgs/szl-holdings/repositories)
+
+[GitHub: szl-holdings](https://github.com/szl-holdings) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173) · [Docs Site](https://github.com/szl-holdings/docs-site) · Apache-2.0 code · CC-BY-4.0 papers & brand
+
+</div>
+
+> **What changed:** Repos consolidated for Series-A clarity. The org now holds **39 repositories — 21 active and 18 archived** (32 public + 7 private; archived repos carry redirect notices). Counts verified live against the GitHub org API (`type=all`) on 2026-06-03. See the [org consolidation report](https://github.com/szl-holdings/.github) for the full log.
 
 ---
 
@@ -10,76 +27,156 @@
 
 Five live organs of the mesh. Each exposes a `/healthz` board reporting the same locked doctrine numbers.
 
-| Module | Space | One line |
-|---|---|---|
-| **a11oy** | [SZLHOLDINGS/a11oy](https://huggingface.co/spaces/SZLHOLDINGS/a11oy) | Governance gate — Λ-gate router, policy enforcement, MCP host. |
-| **amaru** | [SZLHOLDINGS/amaru](https://huggingface.co/spaces/SZLHOLDINGS/amaru) | Memory cortex — hash-linked DSSE receipt chain. |
-| **sentra** | [SZLHOLDINGS/sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | Policy immune system — dual-use filter and egress inspection. |
-| **rosie** | [SZLHOLDINGS/rosie](https://huggingface.co/spaces/SZLHOLDINGS/rosie) | Operator console — audit-grade copilot across the mesh. |
-| **killinchu** | [SZLHOLDINGS/killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) | Sovereign defense organ — UDS-aware gate for air-gapped deployment. |
-
-## Substrate
-
-Minimal runtime substrate the flagships call. Not products — plumbing.
-
-| Component | Space | Role |
-|---|---|---|
-| **lean-kernel** | [SZLHOLDINGS/lean-kernel](https://huggingface.co/spaces/SZLHOLDINGS/lean-kernel) | Lean 4 proof kernel — Lutar Invariant Λ. |
-| **hatun-mcp** | [SZLHOLDINGS/hatun-mcp](https://huggingface.co/spaces/SZLHOLDINGS/hatun-mcp) | Sovereign MCP tool surface. |
-| **status** | [SZLHOLDINGS/status](https://huggingface.co/spaces/SZLHOLDINGS/status) | Live mesh health and `/healthz` board. |
-
-## Coming soon — UDS Edition
-
-| Module | Status | Detail |
-|---|---|---|
-| **uds-demo** | PRIVATE · Coming Soon · June 16, 2026 | **Warhacker — DoD Pier Demo.** Killinchu UDS edition, UDS-deployable Zarf bundle for air-gapped sovereign deployment. |
-
-<p align="center"><strong>Warhacker T-minus countdown:</strong> June 16–19, 2026 · DoD Pier Demo</p>
-
-
-> The live JavaScript countdown runs on the [Hugging Face org card](https://huggingface.co/SZLHOLDINGS). The target dates above are authoritative; today the demo is roughly T-15.
+| Module | Space | Badge | One line |
+|---|---|---|---|
+| **a11oy** | [SZLHOLDINGS/a11oy](https://huggingface.co/spaces/SZLHOLDINGS/a11oy) | [![a11oy CI](https://github.com/szl-holdings/a11oy/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/a11oy/actions/workflows/ci.yml) | Governance gate — Λ-gate router, policy enforcement, MCP host. |
+| **sentra** | [SZLHOLDINGS/sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | [![sentra CI](https://github.com/szl-holdings/sentra/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/sentra/actions/workflows/ci.yml) | Policy immune system — dual-use filter and egress inspection. |
+| **amaru** | [SZLHOLDINGS/amaru](https://huggingface.co/spaces/SZLHOLDINGS/amaru) | [![amaru CI](https://github.com/szl-holdings/amaru/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/amaru/actions/workflows/ci.yml) | Memory cortex — hash-linked DSSE receipt chain. |
+| **rosie** | [SZLHOLDINGS/rosie](https://huggingface.co/spaces/SZLHOLDINGS/rosie) | [![rosie CI](https://github.com/szl-holdings/rosie/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/rosie/actions/workflows/ci.yml) | Operator console — audit-grade copilot across the mesh. |
+| **killinchu** | [SZLHOLDINGS/killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) | [![killinchu CI](https://github.com/szl-holdings/killinchu/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/killinchu/actions/workflows/ci.yml) | Sovereign defense organ — UDS-aware gate for air-gapped deployment. |
 
 ---
 
-## Reproducible Evidence
+## 📖 Start here — the SZL Cookbook
 
-The **Codex-Kernel v1.0.0** release is a replay-grade governed-loop primitive: hash-chained state, decision receipts, an append-only proof ledger, hard-stop validators, and a deterministic replay verifier. It packages everything an independent third party needs to reproduce two bit-exact verified runs (Dresden Venus and SZL governed-ops) on any machine with Node 20+.
+New to the platform? The **[SZL Cookbook](https://github.com/szl-holdings/szl-cookbook)** is the
+first-touch resource: 15 runnable recipes showing how to use the five flagships. The flagship
+recipe — **[Verify a receipt end-to-end](https://github.com/szl-holdings/szl-cookbook/blob/main/recipes/01-verify-a-receipt-end-to-end.md)** —
+cryptographically validates a real DSSE receipt in under a minute, no credentials required.
 
-**Release:** [platform · v1.0.0-codex-kernel](https://github.com/szl-holdings/platform/releases/tag/v1.0.0-codex-kernel)
+> **Customer-facing URL:** <https://github.com/szl-holdings/szl-cookbook>
 
-| Archive | SHA-256 |
+### Try it now
+
+| Try in | Link |
 |---|---|
-| `codex-kernel-release-v1.0.0.zip` | `6136f3b3ec277a4e4cc8a1157d5afe6633821b29a4133d94a19b843dc9b03f8c` |
-| `codex-kernel-release-v1.0.0.tar.gz` | `3ec84df164108795878f5c20f7974d295ab8908513d496e018100c20513a8a13` |
+| 🤗 **Hugging Face Spaces** | [a11oy](https://huggingface.co/spaces/SZLHOLDINGS/a11oy) · [sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) · [amaru](https://huggingface.co/spaces/SZLHOLDINGS/amaru) · [rosie](https://huggingface.co/spaces/SZLHOLDINGS/rosie) · [killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) |
+| ✅ **Verify a receipt** | [Recipe 01 — end-to-end, no credentials](https://github.com/szl-holdings/szl-cookbook/blob/main/recipes/01-verify-a-receipt-end-to-end.md) |
+| 📦 **Signed images (GHCR)** | `cosign verify ghcr.io/szl-holdings/<flagship>:uds-v0.2.0` — keyless OIDC, Rekor-anchored |
 
-**Verifier one-liner:**
+**Used by / for:** Defense Unicorns UDS air-gapped deployments · Warhacker DoD pier demo (Jun 16–19, 2026) · Series-A diligence reviewers.
 
-```bash
-cd packages/codex-kernel && pnpm install && pnpm tsx src/cli/replay.ts runner/payload.json   # → ATTESTED
-```
+---
 
-Aligned with **EU AI Act Article 12** (record-keeping) and **NIST AI RMF**.
+## Core Substrate
+
+Runtime and formal substrate the flagships call. Not products — plumbing.
+
+| Repo | Badge | Role |
+|---|---|---|
+| [**platform**](https://github.com/szl-holdings/platform) | [![platform CI](https://github.com/szl-holdings/platform/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/platform/actions/workflows/ci.yml) | Monorepo — Ouroboros runtime, Lutar formulas, dual-witness adapters. Now includes `services/` (5 microservices merged 2026-06-03). |
+| [**lutar-lean**](https://github.com/szl-holdings/lutar-lean) | [![lutar-lean CI](https://github.com/szl-holdings/lutar-lean/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/lutar-lean/actions/workflows/ci.yml) | Lean 4 + Mathlib kernel proofs — Λ invariant, QEC, KS-18. Doctrine v11 @ `c7c0ba17`. |
+| [**ouroboros**](https://github.com/szl-holdings/ouroboros) | [![ouroboros CI](https://github.com/szl-holdings/ouroboros/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/ouroboros/actions/workflows/ci.yml) | Bounded recursion runtime, governance loops, and receipt emission spine. |
+
+---
+
+## UDS Stack
+
+Defense Unicorns Unified Defense Stack integration — air-gapped, Zarf-native, cosign-signed.
+
+| Repo | Role |
+|---|---|
+| [**szl-fleet-overlay**](https://github.com/szl-holdings/szl-fleet-overlay) | UDS fleet overlay — Package CRs, pepr policies, upstream contributions. |
+| [**uds-bundles**](https://github.com/szl-holdings/uds-bundles) | Zarf bundle definitions for all 5 flagships. |
+| [**szl-uds-deployment**](https://github.com/szl-holdings/szl-uds-deployment) | Deployment manifests — Pepr + Kyverno policies, k3d configs. |
+| [**szl-mesh**](https://github.com/szl-holdings/szl-mesh) | Mesh spec and proto — BFT wiring, 3-of-4 quorum. |
+| [**szl-lake**](https://github.com/szl-holdings/szl-lake) | Live governance data lake — audit fiber, receipt indexing, replay substrate. |
+
+---
+
+## Trust + Proof
+
+| Repo | Badge | Role |
+|---|---|---|
+| [**khipu-consensus**](https://github.com/szl-holdings/khipu-consensus) | [![khipu CI](https://github.com/szl-holdings/khipu-consensus/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/khipu-consensus/actions/workflows/ci.yml) | BFT Khipu DAG consensus — 3-of-4 threshold DSSE receipt chain. |
+| [**lean-kernel**](https://github.com/szl-holdings/lean-kernel) | [![lean-kernel CI](https://github.com/szl-holdings/lean-kernel/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/lean-kernel/actions/workflows/ci.yml) | Lean 4 kernel @ `c7c0ba17` — canonical locked proof state. |
+
+---
+
+## Docs, Brand, Customer
+
+| Repo | Role |
+|---|---|
+| [**docs-site**](https://github.com/szl-holdings/docs-site) | Documentation monorepo. Now includes `developers/`, `cookbook/`, `trust/`, `investor/` (merged 2026-06-03). |
+| [**szl-brand**](https://github.com/szl-holdings/szl-brand) | Brand assets — logos, tokens, typography. Includes `kit/` from former brand-kit. |
+| [**.github**](https://github.com/szl-holdings/.github) | Org-wide workflows, templates, CODEOWNERS, doctrine-check. |
+
+---
+
+## Academic Corpus
+
+| Repo | Role |
+|---|---|
+| [**szl-papers**](https://github.com/szl-holdings/szl-papers) | Academic corpus — preprints, thesis lineage, bounty problems, prior-art disclosures (consolidated 2026-06-03). |
+
+### Thesis & Research
+
+**22 thesis versions** · Doctrine **v11 LOCKED 749/14/163** (v11.1 in flight post-A5) · Concept DOI [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926)
+
+The **intellectual provenance of SZL Holdings** — every governance claim traces to a versioned, DOI-pinned thesis (v1 2026-04-28 → v22 2026-06-03).
+
+- **Canonical timeline:** [THESIS_LINEAGE.md (v1 → v22)](https://github.com/szl-holdings/szl-papers/blob/main/thesis/THESIS_LINEAGE.md)
+- **Latest:** [v22 — Convergence](https://github.com/szl-holdings/szl-papers/tree/main/thesis/ouroboros/papers/v22) — A5 axiom merge, Cauchy_ND partial closure, VCG truthfulness, **SLSA L1 + L2** (NOT L3), Innovation Rounds 10–11, Sim-to-Real benchmark (α=0.10)
+- **Λ = Conjecture 1** — never a theorem; uniqueness chain completes only when all Cauchy_ND sorries close on `main`
+
+---
+
+## Sales
+
+| Repo | Role |
+|---|---|
+| [**pitch-collateral**](https://github.com/szl-holdings/pitch-collateral) | Series-A pitch deck and investor materials (private). |
+
+---
+
+## Warhacker Demo
+
+| Repo | Role |
+|---|---|
+| [**warhacker-demo**](https://github.com/szl-holdings/warhacker-demo) | Warhacker DoD pier demo — killinchu C-UAS live, UDS Zarf bundle, Ken agent loop. June 16–19, 2026. |
 
 ---
 
 ## What is honest right now
 
-SZL Holdings builds a formally-verified governance gate for agentic AI. The Λ aggregator is proved in Lean 4 (Mathlib v4.13.0) against **749 declarations · 14 unique axioms · 163 tracked sorries**, lutar-lean @ `c7c0ba17`. Every gate decision emits an ECDSA P-256 DSSE-signed receipt onto a hash-linked Khipu Merkle DAG. The stack packages as UDS-deployable Zarf bundles.
+SZL Holdings builds a formally-verified governance gate for agentic AI. The Λ aggregator is proved in Lean 4 (Mathlib v4.13.0) against **749 declarations · 14 unique axioms · 163 tracked sorries**, lutar-lean @ `c7c0ba17`. Every gate decision emits an ECDSA P-256 DSSE-signed receipt onto a hash-linked Khipu Merkle DAG.
 
 - **Λ uniqueness = Conjecture 1** — not a closed theorem.
-- **SLSA L1 honest** — real cosign-signed provenance, Sigstore Rekor anchored. SLSA L2 is on the roadmap via Wire D; it is not claimed today.
+- **SLSA L1 honest** — real cosign-signed provenance, Sigstore Rekor anchored.
 - **Doctrine v11 LOCKED** — 749 / 14 / 163, locked at `c7c0ba17`.
-- Aligned with **EU AI Act Article 12** and **NIST AI RMF (MANAGE)**.
-
-## Open & cited
-
-- **Lean 4** source — [github.com/szl-holdings/lutar-lean](https://github.com/szl-holdings/lutar-lean) @ `c7c0ba17`
-- **Concept DOI** [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926)
-- **Developer hub** — [github.com/szl-holdings/developers](https://github.com/szl-holdings/developers)
-- **Compliance posture** — [github.com/szl-holdings/compliance-posture](https://github.com/szl-holdings/compliance-posture). Honest current state: pre-SOC 2 (Type 1 targeted Q4 2026); FedRAMP/IL-4 path targeted Q4 2027.
+- **Section 889 vendors:** Huawei, ZTE, Hytera, Hikvision, Dahua (exactly 5 — no others claimed).
 - **Apache-2.0** — source-code repositories (SDKs, substrate, services, demos).
 - **CC-BY-4.0** — research papers, brand assets, and the public data lake (ouroboros-thesis, puriq-preprint, szl-brand, brand-kit, szl-trust, szl-lake).
 - License classification is being normalized across the org; a small number of flagship repos are mid-relicense to Apache-2.0 (see open `re-license` PRs).
+
+## Citation
+
+```bibtex
+@software{szl_holdings_2026,
+  author    = {Lutar, Stephen P.},
+  title     = {SZL Holdings: Sovereign Governed AI --- a formally-verified governance substrate for agentic systems},
+  year      = {2026},
+  publisher = {Zenodo},
+  version   = {Doctrine v11 LOCKED},
+  doi       = {10.5281/zenodo.20434276},
+  url       = {https://github.com/szl-holdings},
+  note      = {749 declarations / 14 axioms / 163 sorries, kernel c7c0ba17}
+}
+```
+
+---
+
+## Built with / learned from
+
+Our publication and documentation conventions were learned from open-source leaders — we
+adapted their *patterns*, not their words. Inspired by patterns from **Polymathic AI**
+([the_well](https://github.com/PolymathicAI/the_well), [walrus](https://github.com/PolymathicAI/walrus)),
+**Anthropic**, **OpenAI** ([whisper](https://github.com/openai/whisper)),
+**Stripe** (docs craft), Google DeepMind ([alphafold3](https://github.com/google-deepmind/alphafold3)),
+Meta FAIR ([segment-anything](https://github.com/facebookresearch/segment-anything)),
+EleutherAI ([lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness)),
+and Hugging Face ([transformers](https://github.com/huggingface/transformers)).
+We are a precision substrate, not a vibes company — the math is the load-bearing part.
 
 ---
 
@@ -87,4 +184,36 @@ SZL Holdings builds a formally-verified governance gate for agentic AI. The Λ a
 
 ---
 
-<sub>Doctrine v11 LOCKED · 🪢 Khipu chain · Lean 4 · Sigstore Rekor · Apache-2.0 code / CC-BY-4.0 papers · DOI [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926) · Source of truth: [szl-holdings/.github lean_numbers.json](https://github.com/szl-holdings/.github/blob/main/.github/data/lean_numbers.json) @ `c7c0ba17` · Founder: Stephen Paul Lutar Jr · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>
+<sub>Doctrine v11 LOCKED · 749 / 14 / 163 · 🪢 Khipu chain · Lean 4 · Sigstore Rekor · Apache-2.0 code / CC-BY-4.0 papers · DOI [10.5281/zenodo.20434276](https://doi.org/10.5281/zenodo.20434276) · 39 repos (21 active · 18 archived), consolidated 2026-06-03 for Series-A clarity · Founder: Stephen Paul Lutar Jr · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>
+
+---
+
+## 🔌 UDS Mesh — the nervous system
+
+This organ is part of the **SZL UDS mesh**: a 7-organ trace + receipt substrate
+(brain `rosie` · heart `a11oy` · blood `amaru` · immune `sentra` · nervous/courier
+`killinchu` · skeleton `vessels` · wires = W3C `traceparent`).
+
+```mermaid
+flowchart LR
+    classDef live fill:#0f3a2e,stroke:#5ad1c0,color:#e8eef7;
+    classDef inproc fill:#2a3550,stroke:#7aa2ff,color:#e8eef7;
+    classDef roadmap fill:#3a2f0f,stroke:#e0c060,color:#e8eef7;
+    ROSIE["🧠 rosie<br/>brain"]:::inproc -->|Wire C| A11OY["❤️ a11oy<br/>heart / fabric"]:::live
+    A11OY -->|Wire B| SENTRA["🛡️ sentra<br/>immune"]:::live
+    A11OY -->|Wire E| AMARU["🩸 amaru<br/>blood"]:::inproc
+    A11OY -->|Wire F| VESSELS["🦴 vessels<br/>skeleton"]:::roadmap
+    KILLINCHU["📡 killinchu<br/>courier"]:::roadmap -.->|relay| RECEIPTS["📜 receipts<br/>DSSE Khipu"]:::inproc
+    A11OY -->|traceparent embedded| RECEIPTS
+    WIRES["🔌 wires / W3C traceparent"]:::live -.-> A11OY
+```
+
+**Honest mesh status (verified 2026-06-03):** every organ emits **real W3C trace
+context** (`traceparent` / `tracestate` / `x-szl-wire-d: LIVE`) and a11oy binds it into
+**DSSE Khipu receipts** — this is **LIVE in-process**. Spans are **not** yet OTLP-exported,
+DSSE receipts are currently **unsigned**, and cross-pod organ routing is **roadmap (v0.4.0)**.
+Honesty over checklist.
+
+→ Full diagram + wire-status table: **[docs-site / mesh](https://szl-holdings.github.io/docs-site/mesh)**
+
+<sub>Λ Conjecture 1 (not a theorem) · 749/14/163 v11 LOCKED · SLSA L1 honest · Section 889 = 5 vendors</sub>


### PR DESCRIPTION
## What
Reword the org profile README's three license references from the false **'Apache-2.0 across all open-source repos'** / 'Apache-2.0 OSS' to the **honest split**:
- Apache-2.0 — source-code repositories
- CC-BY-4.0 — papers, brand assets, public data lake
- Classification being normalized; flagship re-license PRs open

## Why
NO-HALLUCINATION: 13 repos are NOASSERTION and several are CC-BY-4.0/NONE. The blanket Apache-2.0 claim was inaccurate.

## Scope
**Only** the licensing lines (header L5, body L80, footer) changed. All v11 LOCKED (749/14/163), Λ-Conjecture, SLSA-L1, DOI, and uds-demo PRIVATE lines preserved verbatim. Per GITHUB_CLEANUP_PLAN priority #6.