### PR TITLE
docs(profile): reconcile org-card header to honest live status + add verifiable Series-A badge row

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,9 @@
 
 **Provable by math, signed by receipts, runs on your hardware.**
 
-### 5/5 flagships live · 5/5 cosign-signed via Sigstore Rekor · 749 declarations · 14 axioms · 163 sorries · Doctrine v11 LOCKED
+### 4/5 flagship Spaces live (a11oy rebuilding) · cosign-signed images on GHCR · 749 declarations · 14 axioms · 163 sorries · Doctrine v11 LOCKED
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![Doctrine v11 LOCKED 749/14/163](https://img.shields.io/badge/Doctrine-v11_LOCKED_749%2F14%2F163-2a3550)](https://github.com/szl-holdings/lutar-lean/commit/c7c0ba17c2ea) [![Λ = Conjecture 1](https://img.shields.io/badge/%CE%9B-Conjecture_1_(not_a_theorem)-3a2f0f)](https://github.com/szl-holdings/szl-papers/tree/main/thesis/ouroboros/papers/v22) [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20434276-blue)](https://doi.org/10.5281/zenodo.20434276) [![DCO](https://img.shields.io/badge/DCO-sign--off_required-green)](https://developercertificate.org/)
 
 [Quickstart](https://docs.szlholdings.com/quickstart) · [Docs](https://docs.szlholdings.com) · [Cookbook](https://github.com/szl-holdings/szl-cookbook) · [Verify](https://github.com/szl-holdings/szl-cookbook/blob/main/recipes/01-verify-a-receipt-end-to-end.md) · [Cite](#citation) · [Releases](https://github.com/orgs/szl-holdings/repositories)
 


### PR DESCRIPTION
## Series-A polish — honesty reconciliation + verifiable badges

This PR makes two surgical, **honesty-first** changes to `profile/README.md`. It introduces
no new claims; it removes an over-claim and adds only badges whose values are independently verifiable.

### 1. Reconcile the header banner with the body
The header read **"5/5 flagships live · 5/5 cosign-signed via Sigstore Rekor"**, which contradicts
this same README's own honest sections:
- The mesh section marks **a11oy as roadmap / not-live**, and the live HF runtime is `BUILD_ERROR`
  (verified against `huggingface.co/api/spaces/SZLHOLDINGS/a11oy` on 2026-06-03 — 4/5 Spaces `RUNNING`).
- "What is honest right now" states DSSE receipts are **currently unsigned** and the stack is **SLSA L1 honest**.

New header: **"4/5 flagship Spaces live (a11oy rebuilding) · cosign-signed images on GHCR"** — matches the
body and the team's `MASTER_DASHBOARD.md` honest-gaps section. A Series-A diligence reviewer reading both
the header and the body would otherwise catch the inconsistency.

### 2. Add a verifiable badge row (no fabricated compliance claims)
All five badges resolve to real values (each shields.io URL returns HTTP 200 SVG, verified this session):
- **License: Apache-2.0** — matches the repos' license.
- **Doctrine v11 LOCKED 749/14/163** — links to the real kernel commit `c7c0ba17` in `lutar-lean`.
- **Λ = Conjecture 1 (not a theorem)** — links to thesis v22; preserves the honest "conjecture, not theorem" framing.
- **DOI 10.5281/zenodo.20434276** — the real concept DOI.
- **DCO sign-off required** — links to developercertificate.org.

**Deliberately NOT added:** "SLSA L2 attested", "Cosign signed", and "Section 889 compliant" badges.
Per this org's own honest gaps, SLSA L2 is still in roadmap (`/healthz` reports "L2 in roadmap"),
real cosign signing is blocked on the founder `SZL_COSIGN_PRIVATE_PEM` secret (receipts are HMAC-stub
today), and a blanket Section 889 *compliance* badge is an unverifiable federal-procurement claim
(the README already states the honest, narrower vendor-exclusion fact). Adding those would be exactly
the kind of fabrication the org-wide no-mock sweep exists to prevent.

Generated by the Series-A Polish + No-Mock Sweep pass. See `team/series-a-polish/NO_MOCK_REPORT.md`.
