### PR TITLE
fix(honesty): org profile reverts to SLSA L1 honest (L2 roadmap)

### DIFF
--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -85,12 +85,12 @@ jobs:
           # actions/attest-build-provenance attestation in GHCR/GitHub Attestations API.
           # Unverified L2 claims and all L3 claims are banned.
           #
-          # Verification evidence: all five flagships (a11oy, sentra, amaru, rosie,
-          # killinchu) have actions/attest-build-provenance@v2.4.0 wired in their
-          # ghcr-build-push.yml workflows and have produced Sigstore-signed SLSA
-          # Provenance v1 attestations (predicate type https://slsa.dev/provenance/v1)
-          # verified via the GitHub attestations API (2026-06-04).
-          # Doctrine upgrade: L1 honest -> L2 verified (2026-06-04, slsa_l2.md).
+          # Posture: SLSA L1 honest (L2 roadmap via Wire D). All five flagships have
+          # actions/attest-build-provenance@v2.4.0 wired in their ghcr-build-push.yml
+          # workflows, BUT the L2 attestation is NOT yet earned on the deployed images:
+          # `cosign verify-attestation --type slsaprovenance ghcr.io/szl-holdings/<organ>`
+          # returns "no matching attestations" (verified 2026-06-04). L2 is not claimed
+          # anywhere until that command passes (likely needs org-level attestations:write).
 
           # RULE 1: L3 is never allowed (requires isolated/reusable-workflow builder)
           M3_L3=$(grep -rE "SLSA.*L3|SLSA Level 3" \

--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -5,7 +5,7 @@ name: SLSA Provenance (L1 honest)
 # SLSA L2/L3 provenance — do not claim L3 anywhere.
 #
 # Real build provenance for release artifacts is produced per-repo by
-# actions/attest-build-provenance@v2 (SLSA L2 attested, verifiable via
+# actions/attest-build-provenance@v2 (SLSA L2 roadmap — NOT yet earned; verifiable via
 # `gh attestation verify` / slsa-verifier). See each flagship's
 # .github/workflows for the actual attestation step.
 
@@ -31,4 +31,4 @@ jobs:
       - name: SLSA L1 supply-chain baseline (SBOM + DCO; honest — not L3)
         run: |
           echo "SLSA Build L1 baseline (SBOM + DCO). No L3 claim."
-          echo "Release-artifact provenance is SLSA L2 (attest-build-provenance@v2)."
+          echo "Release-artifact provenance: attest-build-provenance@v2 wired (SLSA L2 roadmap via Wire D); L2 NOT yet earned until cosign verify-attestation passes on the deployed image."

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,5 +1,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
-<!-- © 2026 Lutar, Stephen P. — SZL Holdings · ORCID 0009-0001-0110-4173 · Doctrine v11 LOCKED 749/14/163 · Λ Conjecture 1 · SLSA L1+L2 -->
+<!-- © 2026 Lutar, Stephen P. — SZL Holdings · ORCID 0009-0001-0110-4173 · Doctrine v11 LOCKED 749/14/163 · Λ Conjecture 1 · SLSA L1 honest (L2 roadmap) -->
 
 # SZL Holdings — Cosign Public Key for DSSE Verification
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -35,7 +35,7 @@ Six live Three.js/WebGL explorations of the proof architecture. Static. No login
 
 ## The proof layer — verify it yourself
 
-[![SLSA L2 Verified](https://img.shields.io/badge/SLSA-L2%20Verified-2C5F2D?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDMgN3YxMGwxNiAxMFY3TDEyIDJ6Ii8+PC9zdmc+)](https://github.com/szl-holdings/a11oy/attestations)
+[![SLSA L1 honest](https://img.shields.io/badge/SLSA-L1%20honest%20(L2%20roadmap)-2C5F2D?style=flat-square)](https://github.com/szl-holdings/.github/blob/main/PROVENANCE_NOTICE.md)
 [![cosign signed](https://img.shields.io/badge/cosign-keyless%20signed-blueviolet?style=flat-square)](https://docs.sigstore.dev/cosign/signing/overview/)
 [![Rekor](https://img.shields.io/badge/Rekor-transparency%20log-blue?style=flat-square)](https://search.sigstore.dev/)
 [![UDS bundle](https://img.shields.io/badge/UDS%20bundle-szl--mesh%3Av0.4.0-4a4a8a?style=flat-square)](https://github.com/szl-holdings/uds-mesh)
@@ -53,13 +53,19 @@ cosign verify oci://ghcr.io/szl-holdings/szl-mesh:v0.4.0 \
   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 ```
 
-### Verify SLSA Build L2 provenance (all 5 flagships)
+### Verify SLSA Build provenance
 
 ```bash
-# Any of the five flagships — all have GitHub-hosted runner attestations
-gh attestation verify oci://ghcr.io/szl-holdings/a11oy@sha256:1cfd28e03e6f1fb4b0827f2281f5016ebde8122d8c9ecb00d73145c77dd02cd7 \
-  --repo szl-holdings/a11oy
-# Expected: ✓ Verification succeeded — SLSA Provenance v1, github-hosted runner
+# SLSA L1 (honest) — PASSES today: every flagship image is cosign keyless-signed:
+cosign verify ghcr.io/szl-holdings/a11oy:uds-v0.2.0 \
+  --certificate-identity-regexp="^https://github.com/szl-holdings/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+
+# SLSA L2 build-provenance attestation — roadmap via Wire D, NOT yet earned
+# (currently returns "no matching attestations"; do not claim L2 until it passes):
+# cosign verify-attestation --type slsaprovenance ghcr.io/szl-holdings/a11oy:uds-v0.2.0 \
+#   --certificate-identity-regexp="^https://github.com/szl-holdings/" \
+#   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
 
 # Rekor transparency-log entries (public Sigstore instance):
 # a11oy:   https://search.sigstore.dev/?logIndex=1723769508
@@ -85,7 +91,7 @@ uds-cli bundle deploy szl-mesh-v0.4.0.tar.zst --confirm
 | Claim | Status | Verify |
 |---|---|---|
 | 5 live HF demos | ✅ All HTTP 200 | curl any `/healthz` |
-| SLSA Build L2 | ✅ Verified — a11oy/sentra/amaru/rosie (Public Sigstore); killinchu (GitHub Sigstore, private repo) | `gh attestation verify` above |
+| SLSA Build L1 honest (L2 roadmap) | ✅ L1 — all 5 organs cosign-signed + Rekor-logged. L2 attestation NOT yet earned (`cosign verify-attestation` returns "no matching attestations") | `cosign verify` above |
 | cosign keyless signed | ✅ All 5 organs, Public Good Rekor | `cosign verify` above |
 | UDS bundle published | ✅ `szl-mesh:v0.4.0` on GHCR | `uds deploy oci://ghcr.io/szl-holdings/szl-mesh:v0.4.0` |
 | Lean kernel | ✅ 749 decl / 14 axioms / 163 sorries @ `c7c0ba17` | [`lutar-lean@main`](https://github.com/szl-holdings/lutar-lean) |
@@ -126,7 +132,7 @@ graph LR
 
 ### Supply-chain posture
 
-- **SLSA Build L2 verified** — all 5 flagship images have `actions/attest-build-provenance@v2.4.0` wired in `ghcr-build-push.yml`; `runner_environment: github-hosted`; DSSE-signed SLSA Provenance v1 predicate stored in GitHub Attestations API + pushed to registry
+- **SLSA Build L1 honest (L2 roadmap via Wire D)** — every flagship image is cosign keyless-signed and Rekor-logged (`cosign verify` PASSES). All 5 build workflows have `actions/attest-build-provenance@v2.4.0` wired in `ghcr-build-push.yml`, but the **L2 attestation is NOT yet earned** on the deployed images (`cosign verify-attestation --type slsaprovenance` returns "no matching attestations" — likely org-level `attestations: write` is the remaining founder step). L2 is not claimed until that command passes.
 - **cosign keyless signed** — every image signed via Fulcio OIDC short-lived cert bound to the GitHub Actions workflow identity; entries in public Sigstore Rekor transparency log (indexes above)
 - **UDS bundle `szl-mesh:v0.4.0`** — real baked images (SBOM-only regression fixed); keyless cosign-signed; deployable via `uds deploy oci://...` into any UDS Core cluster
 - **DCO required** on every commit; OpenSSF Scorecard monitored; Trivy + Grype + Gitleaks in CI
@@ -162,6 +168,6 @@ graph LR
 
 ---
 
-<sub>Doctrine v11 LOCKED · 749/14/163 · kernel `c7c0ba17` · Λ = Conjecture 1 (F23 open bounty, not a theorem) · SLSA L2 verified (a11oy/sentra/amaru/rosie public; killinchu GitHub Sigstore) · Apache-2.0 code / CC-BY-4.0 papers · DOI [10.5281/zenodo.20434276](https://doi.org/10.5281/zenodo.20434276) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>
+<sub>Doctrine v11 LOCKED · 749/14/163 · kernel `c7c0ba17` · Λ = Conjecture 1 (F23 open bounty, not a theorem) · SLSA L1 honest (L2 roadmap via Wire D — not yet earned) · Apache-2.0 code / CC-BY-4.0 papers · DOI [10.5281/zenodo.20434276](https://doi.org/10.5281/zenodo.20434276) · [ORCID 0009-0001-0110-4173](https://orcid.org/0009-0001-0110-4173)</sub>
 
 Signed-off-by: stephenlutar2-hash <stephenlutar2@gmail.com>

--- a/profile/assets/hero-premium.svg
+++ b/profile/assets/hero-premium.svg
@@ -58,7 +58,7 @@
     <rect width="392" height="92" rx="12" fill="#211a4a" stroke="#8a6d44" stroke-opacity="0.7"/>
     <text x="20" y="34" font-size="15" font-weight="700" font-family="'JetBrains Mono', monospace" fill="#d4a574">v11 LOCKED · 749/14/163 · c7c0ba17</text>
     <text x="20" y="58" font-size="13" font-family="'JetBrains Mono', monospace" fill="#b9add6">Λ = Conjecture 1 (NOT a theorem)</text>
-    <text x="20" y="78" font-size="13" font-family="'JetBrains Mono', monospace" fill="#b9add6">SLSA L1 honest + L2 attested · Apache-2.0</text>
+    <text x="20" y="78" font-size="13" font-family="'JetBrains Mono', monospace" fill="#b9add6">SLSA L1 honest (L2 roadmap) · Apache-2.0</text>
   </g>
 
   <!-- flagship chips -->


### PR DESCRIPTION
## Summary
Live verification (2026-06-04): `cosign verify` PASSES for every flagship (genuine **SLSA L1**), but `cosign verify-attestation --type slsaprovenance` returns **"no matching attestations"** on all deployed `ghcr.io/szl-holdings/*` images (a11oy/sentra/amaru/rosie verified). **SLSA L2 is NOT yet earned.** This aligns the org profile with the already-honest `PROVENANCE_NOTICE.md`.

## Surfaces reverted (5 files)
- `profile/README.md` — L2 badge → L1 honest badge; supply-chain posture bullet; "Verify SLSA Build L2 provenance" section → cosign verify + commented-out verify-attestation; status-table row; footer
- `profile/assets/hero-premium.svg` — hero strapline
- `keys/README.md` — header comment
- `.github/workflows/slsa.yml` — echo + comment now say "L2 roadmap (not yet earned)"
- `.github/workflows/doctrine-check.yml` — reverts the false "Doctrine upgrade: L1 honest -> L2 verified" comment to honest L1 posture. **CI grep rules (RULE 1 L3 ban, RULE 2 L2-evidence gate) still pass** — verified locally; honest "L2 roadmap / not yet earned" wording is excluded by the existing filters.

## Net state
Every public org surface now says **SLSA L1 honest (L2 roadmap via Wire D)**, consistent with what `cosign verify` actually proves and with `PROVENANCE_NOTICE.md`.

L3 never claimed. Λ = Conjecture 1. Doctrine v11 LOCKED 749/14/163. File count unchanged (197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)