### PR TITLE
chore(align): locked-proven count 5 -> 8 {F1,F4,F7,F11,F12,F18,F19,F22}

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The SZL substrate repos cross-link reciprocally. Two live products (a11oy + kill
 
 - [`a11oy`](https://github.com/szl-holdings/a11oy) — command platform; signed-receipt substrate with built-in reasoning, policy & operator capabilities (TypeScript packages, MCP server)
 - [`killinchu`](https://github.com/szl-holdings/killinchu) — drones & vessels field tool; counter-UAS + maritime picture; DSSE receipt per engagement
-- [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) — Lean 4 + Mathlib proofs of the Λ aggregator (749 decl / 14 axioms / 163 sorries; 5 formulas proven, Λ = Conjecture 1)
+- [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) — Lean 4 + Mathlib proofs of the Λ aggregator (749 decl / 14 axioms / 163 sorries; 8 formulas proven {F1,F4,F7,F11,F12,F18,F19,F22}, Λ = Conjecture 1)
 - [`szl-papers`](https://github.com/szl-holdings/szl-papers) — DOI-pinned thesis lineage (v1 → v23)
 - [`ouroboros`](https://github.com/szl-holdings/ouroboros) — bounded-recursion runtime
 - [`platform`](https://github.com/szl-holdings/platform) — composing monorepo for the substrate runtime


### PR DESCRIPTION
## What

Aligns the org-profile README's stale **5 formulas proven** lutar-lean one-liner to the already-proven **locked count of EXACTLY 8 → {F1, F4, F7, F11, F12, F18, F19, F22}**.

Tracks lutar-lean `Lutar.Wave8.AxiomDisclosure.locked_count_eight` (proven **2026-06-10**, by `decide`, **no axioms**). Kernel baseline UNCHANGED: `c7c0ba17`, 749 / 14 / 163.

## Files changed

- **`README.md`** — lutar-lean row: "5 formulas proven, Λ = Conjecture 1" → "8 formulas proven {F1,F4,F7,F11,F12,F18,F19,F22}, Λ = Conjecture 1". The `749 decl / 14 axioms / 163 sorries` figures and the Λ-line are preserved.

## Deliberately NOT changed (left for human review)

- **`.github/data/lean_numbers.json`** — schema `szl.lean_numbers/v1` carries only `declarations / axioms_raw / axioms_unique / axiom_names / sorries_*`. There is **no formula-count field** in the schema, so per the alignment rule ("only add if a formula-count field already exists; otherwise leave the data file alone and note it") this file is left untouched. A schema owner may wish to bump the schema to add a `locked_formula_count: 8` / `locked_ids` field — flagged for human decision.

## Honesty guardrails intact

- Λ stays **Conjecture 1**. Unchanged. No formulas invented.

Do not merge — opened for review only.
