### PR TITLE
feat(data): canonical locked_formula_count=8 in lean_numbers.json (P2)

### DIFF
--- a/.github/data/lean_numbers.json
+++ b/.github/data/lean_numbers.json
@@ -28,6 +28,19 @@
     "sorries_raw": 163,
     "sorries_noncomment": 146,
     "sorries_putnam": 51,
-    "sorries_baseline": 112
-  }
+    "sorries_baseline": 112,
+    "locked_formula_count": 8,
+    "locked_formula_ids": [
+      "F1",
+      "F4",
+      "F7",
+      "F11",
+      "F12",
+      "F18",
+      "F19",
+      "F22"
+    ],
+    "locked_formula_theorem": "Lutar.Wave8.AxiomDisclosure.locked_count_eight"
+  },
+  "locked_formulas_note": "locked_formula_count is the single canonical source for the locked-proven formula count across all SZL surfaces. Enforced in lutar-lean by locked_count_eight (no axioms). Grew 5->8 on 2026-06-10 (F4/F7 upgraded to genuine non-vacuous proofs, joining F22). Lambda uniqueness stays Conjecture 1."
 }


### PR DESCRIPTION
Proposal P2 from the Forge payload. Adds a **single canonical source** for the locked-proven formula count to `.github/data/lean_numbers.json` so every surface reads one file — killing the 5/8 drift that caused this week's split-brain.

Additive fields: `locked_formula_count: 8`, `locked_formula_ids: {F1,F4,F7,F11,F12,F18,F19,F22}`, `locked_formula_theorem: locked_count_eight` (the no-axiom Lean theorem that enforces it). Verified against lutar-lean main. Λ stays Conjecture 1; no other numbers touched.