### PR TITLE
fix(doctrine): exempt TheoremU_LambdaUnique from Lambda-as-theorem gate

### DIFF
--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -108,6 +108,7 @@ jobs:
               grep -viE "do not call|don't call|never call|not call.*theorem" | \
               grep -vE "gate.*theorem|theorem.*enforced|README.*theorem|gates/README" | \
               grep -vE "lambdaCategory|lambdaMonotonicity|composability|MinMaxBounds" | \
+              grep -vE "TheoremU_LambdaUnique|TheoremU_|Lutar/Uniqueness/TheoremU" | \
               grep -vE "knowledge\.json|Lean.*theorem|lean 4.*theorem|Lean 4.*theorem" | \
               grep -viE "does not assert|doesn't assert|do not assert|not assert.*theorem" | \
               grep -vE "[0-9]+ theorems|all [0-9]+ theorem|theorems '|Every theorem|theorem carries|theorems carries" | \


### PR DESCRIPTION
The doctrine Inv-2 (Λ=Conjecture 1) grep false-positives on the identifier `TheoremU_LambdaUnique` (the proven, axiom-free CONDITIONAL Theorem U — NOT the unconditional Conjecture 1). Adds a precise exemption for `TheoremU_LambdaUnique|TheoremU_|Lutar/Uniqueness/TheoremU`. **Verified** it still catches real overclaims ('proven theorem', 'a theorem now', 'unconditionally as a theorem') — gate stays substantive. Unblocks lutar-lean #221/#223.