### PR TITLE
ci(numbers): PR-based canonical-count refresh (clears red push)

### DIFF
--- a/.github/workflows/lean-numbers.yml
+++ b/.github/workflows/lean-numbers.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: lean-numbers-${{ github.ref }}
@@ -43,14 +44,31 @@ jobs:
           echo "----- canonical numbers -----"
           cat .github/data/lean_numbers.json
 
-      - name: Commit updated numbers if changed
+      # Open a PR instead of pushing straight to main: main is branch-protected
+      # (requires the "Run tests" status check), so a direct bot push is rejected
+      # with GH013. A PR lets the required check run, then we auto-merge it.
+      # The canonical JSON only changes when lutar-lean main actually drifts, so
+      # this is a no-op on a quiet day (the early-exit below handles that).
+      - name: Open/refresh PR with updated numbers if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet -- .github/data/lean_numbers.json; then
             echo "No change in canonical numbers; nothing to commit."
             exit 0
           fi
+          BR="chore/lean-numbers-refresh"
           git config user.name "Stephen P. Lutar Jr."
           git config user.email "stephenlutar2@gmail.com"
+          git checkout -B "$BR"
           git add .github/data/lean_numbers.json
-          git commit -s -m "chore(numbers): refresh canonical lutar-lean counts [skip ci]"
-          git push
+          git commit -s -m "chore(numbers): refresh canonical lutar-lean counts"
+          git push -f origin "$BR"
+          # Create the PR if one isn't already open for this branch.
+          if ! gh pr view "$BR" --json number >/dev/null 2>&1; then
+            gh pr create --base main --head "$BR" \
+              --title "chore(numbers): refresh canonical lutar-lean counts" \
+              --body "Automated canonical-count refresh from lutar-lean @ main. locked-proven stays 8; Λ stays Conjecture 1. No manual edits."
+          fi
+          # Best-effort auto-merge once the required check passes.
+          gh pr merge "$BR" --squash --auto || echo "auto-merge not enabled; PR left open for review."

--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -25,6 +25,16 @@ on:
         required: false
         type: string
         default: 'main'
+      config-file:
+        description: 'Path to a release-please-config.json (registers custom commit types so non-standard subjects like doctrine:/bundle:/compliance: do not crash the parser). Optional.'
+        required: false
+        type: string
+        default: ''
+      manifest-file:
+        description: 'Path to a .release-please-manifest.json. Optional; pair with config-file.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -48,6 +58,13 @@ jobs:
         with:
           release-type: ${{ inputs.release-type }}
           target-branch: ${{ inputs.target-branch }}
+          # When a config-file/manifest-file is supplied, release-please uses the
+          # manifest-driven mode: custom commit types declared in changelog-sections
+          # are parsed instead of crashing on non-standard subjects (the
+          # "unexpected token" error seen on doctrine:/bundle:/compliance: and
+          # double-scope chore(deps)(deps): commits).
+          config-file: ${{ inputs.config-file }}
+          manifest-file: ${{ inputs.manifest-file }}
           # Note: `package-name` removed (deprecated in v5; not in valid inputs list)
           # GitHub Actions PR creation requires `Allow GitHub Actions to create PRs`
           # enabled in Settings → Actions → General.


### PR DESCRIPTION
Lean Numbers job pushed straight to protected main and was rejected (GH013, 'Run tests' required), going red every run. Now opens a branch+PR with best-effort auto-merge. No data change. DCO signed-off.