### PR TITLE
fix(doctrine): exempt SKELETON honesty-organ Λ self-disclosures in Invariant 2

### DIFF
--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -115,6 +115,7 @@ jobs:
               grep -vE "KS_theorem|_theorem_[0-9]|theorem_ref|Theorem [0-9]|theorem [0-9]" | \
               grep -vE "→ ?theorem|theorem ?→|receipt.*theorem|provenance.*theorem|theorem.*DOI" | \
               grep -vE "uniqueness theorem is conditional|theorem is conditional-only|conditional.*not claimed" | \
+              grep -viE "conjecture 1|never a theorem|dress .*up as a theorem|conditional Λ theorem|conditional lambda theorem" | \
               grep -vE "^(\./)?\.git/|\.lake/|node_modules/" \
               || true)
           if [ -n "$M2" ]; then


### PR DESCRIPTION
## What
The shared `Doctrine` reusable workflow's **Invariant 2** (Λ = Conjecture 1, NEVER theorem) was self-flagging `apps/agentic-gpu/skeleton_spine.py` in **platform** main, leaving the `Doctrine` required check RED across multiple consecutive commits.

`skeleton_spine.py` is the SKELETON organ — the claim→theorem traceability map whose entire purpose is to enforce that Λ-uniqueness is **never** asserted as a theorem. Three honest, doctrine-compliant lines were flagged because the existing exclusions are case-sensitive while the file uses uppercase tokens:
- `Λ = CONJECTURE 1 — intentionally NEVER a theorem`
- `no caller can dress Λ-uniqueness up as a theorem to justify a stronger claim`
- `the CONDITIONAL Λ theorem is honestly distinct (with hypotheses)`

## Fix
Adds **one** case-insensitive exclusion line recognizing these honest-disclosure phrasings. Same class of fix as the pre-existing `OUROBOROS_RUN_ALL.py` / `YACHAY_SYSTEM_PROMPT.md` file exemptions, but surgical (keeps the gate live on every other line of the file).

## Not weakened — verified
With the fix applied, the three honest lines are exempt **and** a real violation still FAILS:
```
Λ uniqueness is a proven theorem.            -> still flagged (FAIL)
lambdaUniqueness is established as a Theorem  -> still flagged (FAIL)
```
No honest source text was reworded; no threshold/gate disabled.

Doctrine: v11, locked=8, Λ=Conjecture 1.