### PR TITLE
chore(hygiene): add .gitignore (no logic change)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Byte-compiled / optimized / cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/
+
+# Secrets / keys — NEVER commit (Doctrine v11)
+*.pem
+!*.pub
+*.key
+.env
+.secret/
+
+# Local temp / OS cruft
+*.tmp
+.DS_Store
+.pytest_cache/
+
+# NOTE: coordination/**/*.log are intentional evidence-run artifacts and are
+# tracked on purpose — not ignored here.


### PR DESCRIPTION
Repo-hygiene alignment for the Warhacker submission (REPO HYGIENE lane only — no code/logic changes, no shared szl_*.py / serve.py / tab modules touched).

- Adds missing docs/.gitignore as listed in the commit.
- All claims kept honest: Λ = Conjecture 1, locked-proven = 8 {F1,F4,F7,F11,F12,F18,F19,F22} @ c7c0ba17, SLSA L1 honest, counts 749/14/163.
- No keys committed; no gate weakened.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>