### PR TITLE
fix(domain): migrate a11oy.net -> a-11-oy.com (.net retiring)

### DIFF
--- a/.github/scripts/anatomy_map_drift.py
+++ b/.github/scripts/anatomy_map_drift.py
@@ -15,7 +15,7 @@ independently-deployed surfaces:
                     (NS-aware; the killinchu variant legitimately drops the
                     trailing `NS=` footer line).
   * HF Space     SZLHOLDINGS/anatomy       data.js + index.html
-                 -> the standalone static deck (a11oy.net/anatomy-map mirror),
+                 -> the standalone static deck (a-11-oy.com/anatomy-map mirror),
                     a DIFFERENT rendering of the same honest doctrine.
 
 Because each is edited and shipped on its own pipeline, the honesty doctrine can

--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -4,7 +4,7 @@ name: Anatomy-map cross-surface drift
 # independently-deployed surfaces -- the a11oy /console tab (szl-holdings/a11oy
 # pages/console.html), the killinchu /elite tab (szl-holdings/killinchu
 # killinchu_elite_console.py) and the standalone HF static Space
-# SZLHOLDINGS/anatomy (data.js + index.html, the a11oy.net/anatomy-map mirror).
+# SZLHOLDINGS/anatomy (data.js + index.html, the a-11-oy.com/anatomy-map mirror).
 # Each has its own pipeline, so the honesty doctrine can silently DRIFT between
 # them. This sweep fetches all three and fails LOUD the moment they diverge on:
 #   * the canonical locked-8 ladder {F1,F4,F7,F11,F12,F18,F19,F22}, and
@@ -16,7 +16,7 @@ name: Anatomy-map cross-surface drift
 # Reading the a11oy / killinchu sources needs repo read access; the built-in
 # Actions token covers same-org repos, with SZL_GITHUB_TOKEN as a fallback. The
 # HF Space is public. On real drift (exit 1) an ntfy alert is pushed through the
-# team's shared relay (SLACK_WEBHOOK_URL -> a11oy.net/relay -> a11oy-uptime).
+# team's shared relay (SLACK_WEBHOOK_URL -> a-11-oy.com/relay -> a11oy-uptime).
 # A fetch/auth failure is exit 2 (ERROR), never a silent pass.
 
 on:

--- a/.github/workflows/code-security-drift.yml
+++ b/.github/workflows/code-security-drift.yml
@@ -94,7 +94,7 @@ jobs:
         continue-on-error: true
         env:
           # Slack-compatible {"text":...} webhook pointed at the box alert relay
-          # (https://a11oy.net/relay/ntfy/<token>), same channel as the other
+          # (https://a-11-oy.com/relay/ntfy/<token>), same channel as the other
           # org guards. The relay flattens the payload to clean ntfy text.
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/.github/workflows/lockfile-registry-check.yml
+++ b/.github/workflows/lockfile-registry-check.yml
@@ -31,7 +31,7 @@ name: Lockfile Registry Check
 # A coverage GAP previously only surfaced as a red scheduled run, which nobody is
 # guaranteed to notice. This workflow now also PAGES a human: when the sweep finds
 # a NEW coverage gap it pushes an actionable alert to the team's shared a11oy-uptime
-# ntfy topic (the same SLACK_WEBHOOK_URL -> a11oy.net/relay -> a11oy-uptime-notify
+# ntfy topic (the same SLACK_WEBHOOK_URL -> a-11-oy.com/relay -> a11oy-uptime-notify
 # channel the other org guards use), naming each offending repo and the piece it is
 # missing. The alert is edge-triggered: the dedup baseline (the set of repos we
 # have already paged for) is persisted in a small DEDICATED state file
@@ -122,7 +122,7 @@ jobs:
         # commits a lockfile but is missing its per-repo caller workflow and/or
         # the required status check, so a *.replit.local-poisoned lockfile could
         # merge unblocked. Routed through the shared relay (SLACK_WEBHOOK_URL ->
-        # a11oy.net/relay -> a11oy-uptime-notify), the same channel the box uptime
+        # a-11-oy.com/relay -> a11oy-uptime-notify), the same channel the box uptime
         # monitor uses, so it pages immediately instead of only being a red run.
         # Rising-edge + dedup are computed by the unit-tested helper (--new-gaps),
         # so a gap already on the baseline does NOT re-alert (no spam on a standing

--- a/.github/workflows/required-check-drift.yml
+++ b/.github/workflows/required-check-drift.yml
@@ -18,7 +18,7 @@ name: Required-check Drift (security-load-bearing merge blocks)
 # `branches/<default>/protection/required_status_checks`) and fails if the
 # context is no longer required via either. On drift it also pushes a clean
 # ntfy alert through the team's shared relay (SLACK_WEBHOOK_URL ->
-# a11oy.net/relay -> a11oy-uptime-notify), the same channel the box uptime
+# a-11-oy.com/relay -> a11oy-uptime-notify), the same channel the box uptime
 # monitor uses, so the team is paged immediately rather than only seeing a red
 # scheduled run.
 #

--- a/FORGE_BUILD_BRIEF.md
+++ b/FORGE_BUILD_BRIEF.md
@@ -30,7 +30,7 @@
    authority signs the chain with **Ed25519**. These are two distinct layers —
    do not "unify" them without proving cross-verification first.
 4. **Deploy boundary.** Work lives in **GitHub + Hugging Face + Replit**. Do **NOT**
-   push to Hetzner, `a11oy.net` DNS, or any production host without an explicit
+   push to Hetzner, `a-11-oy.com` DNS, or any production host without an explicit
    human approval gate. Open PRs; let CI/CD deploy. No prod changes from a
    one-line mandate.
 5. **Repo conventions (from `.github/AGENTS.md`).**


### PR DESCRIPTION
## Summary
Migrate all `a11oy.net` references to canonical `a-11-oy.com` (.net retiring). Subdomains preserved.

## Testing
- [x] grep `a11oy.net` returns 0 (no emails in this repo)