### PR TITLE
fix(ci): least-privilege permissions in sbom.yml (TokenPermissionsID)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,8 +10,10 @@ on:
   release:
     types: [published]
 
+# Least-privilege: checkout only needs read; upload-artifact does not require
+# contents: write. Lowered from write to read to satisfy Scorecard TokenPermissionsID.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sbom:


### PR DESCRIPTION
## Summary

Resolves Scorecard TokenPermissionsID alert #64 in `.github`.

**Problem:** `.github/workflows/sbom.yml` declared `permissions: contents: write` at the top level, but the workflow contains only:
- `actions/checkout` (needs `contents: read`)
- `install Syft` (no token needed)
- `syft` SBOM generation (no token needed)
- `actions/upload-artifact` (no `contents` token needed — uses its own internal scope)

There is no git-commit or git-push step. `contents: write` was over-privileged.

**Fix:** Lowered top-level `permissions.contents` from `write` → `read`.

## Test plan
- Workflow still checks out (read ✓)
- Syft installs and generates SBOM (no token ✓)
- Upload-artifact completes (does not require contents: write ✓)

## Alert closed
- `.github` Scorecard alert #64 (TokenPermissionsID, sbom.yml line 14)

---
_Dev B security sweep — do not merge until reviewed. Dev A handles merges._

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>