### PR TITLE
fix(readme): remove broken CII PENDING badge (half-state)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # 🧬 .github
 
-<!-- CII-BEST-PRACTICES-BADGE: PENDING — replace 'PENDING' with the project id once founder registers this repo at https://bestpractices.coreinfrastructure.org/ -->
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/PENDING/badge)](https://bestpractices.coreinfrastructure.org/)
+<!-- CII Best Practices badge (founder-action required): register at https://bestpractices.coreinfrastructure.org/ then add the live badge here. -->
 
 **org doctrine**
 


### PR DESCRIPTION
## Summary
The org profile README contains a badge that renders as a broken image:
`[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/PENDING/badge)]`

`PENDING` is not a valid project ID — the CII badge service returns an error image for this URL. This is a half-state visible to investors, partners, and GitHub visitors.

## Change
Replace with an HTML comment that documents the founder-action needed (register the org at bestpractices.coreinfrastructure.org).

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>