### PR TITLE
fix(profile): honest surface count, remove dead links, canonical domain note

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: [stephenlutar2]
-custom: ["https://szl-holdings.github.io/founder-page/"]
+custom: ["https://a-11-oy.com"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **org doctrine**
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20434276.svg)](https://doi.org/10.5281/zenodo.20434276) [![ORCID](https://img.shields.io/badge/ORCID-0009--0001--0110--4173-a6ce39?style=flat-square&logo=orcid&logoColor=white)](https://orcid.org/0009-0001-0110-4173) [![Doctrine](https://img.shields.io/badge/Doctrine-v11-3b82f6?style=flat-square)](https://github.com/szl-holdings/.github/blob/main/DOCTRINE_V11.md) [![SLSA](https://img.shields.io/badge/SLSA-L1_honest-22c55e?style=flat-square)](https://slsa.dev/spec/v1.0/levels)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20434276.svg)](https://doi.org/10.5281/zenodo.20434276) [![ORCID](https://img.shields.io/badge/ORCID-0009--0001--0110--4173-a6ce39?style=flat-square&logo=orcid&logoColor=white)](https://orcid.org/0009-0001-0110-4173) [![Doctrine](https://img.shields.io/badge/Doctrine-v11-3b82f6?style=flat-square)](https://github.com/szl-holdings/.github/blob/main/doctrine/DOCTRINE_V11.md) [![SLSA](https://img.shields.io/badge/SLSA-L1_honest-22c55e?style=flat-square)](https://slsa.dev/spec/v1.0/levels)
 
 [Hugging Face](https://huggingface.co/SZLHOLDINGS) · [Demo](https://szlholdings-readme.static.hf.space/) · [GitHub Org](https://github.com/szl-holdings)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
     Locked-proven = EXACTLY 8 {F1,F4,F7,F11,F12,F18,F19,F22}.
     Λ-uniqueness = Conjecture 1 (unconditional machine-checked FALSE; conditional Theorem U proven, axiom-free).
     SLSA = L1 honest · L2 build-attested · L3 roadmap. No FedRAMP/ATO/CMMC without "roadmap".
-  KANCHAY palette only (void #080c14 · proof #3af4c8 · lattice #5b8dee · gold #d7b96b). No purple. No a11oy.net (sunset).
+  KANCHAY palette only (void #080c14 · proof #3af4c8 · lattice #5b8dee · gold #d7b96b). No purple. Canonical domain is a-11-oy.com (with hyphens); the pre-sunset domain must never appear on any surface.
 -->
 
 <div align="center">
@@ -36,10 +36,9 @@
 | Space | What it is | Open |
 |---|---|---|
 | **a11oy** — flagship | Governed-AI Command Center: ask-and-act behind deny-by-default gates, a live decision feed, and a signed receipt for every action. | **[a-11-oy.com](https://a-11-oy.com)** |
-| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — ~50 live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D. 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
+| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 56 live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D. 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
 | **killinchu** | Counter-UAS & maritime command *demonstration* — multi-sensor fusion with signed engagement receipts (effector link is a labeled simulation). | [demo →](https://szlholdings-killinchu.hf.space/elite) |
 | **anatomy** | Living anatomy map — the locked-8 ladder and the four honesty tiers, visualized. | [view →](https://szlholdings-anatomy.hf.space) |
-| **energy** | a11oy energy surface — joules MEASURED when a GPU lung is reachable, honest SAMPLE otherwise. | [view →](https://szlholdings-energy.hf.space) |
 | **david-leads** | Sovereign insurance intelligence — audit-defensible lead intelligence from public data only. | [view →](https://szlholdings-david-leads.hf.space) |
 
 ---


### PR DESCRIPTION
## Doctrine v11 audit — org profile repo (szl-holdings/.github)

Estate-wide audit of the highly-visible ORG PROFILE repo against the 6-point doctrine-v11 checklist. Root-cause fixes only; no invented content.

### Audited + fixed
- **profile/README.md (org landing page)**
  - Holographic Estate: `~50 live surfaces` -> `56 live surfaces` — the verified estate fact is 56 surfaces (all 56 modules load 200); `~50` under-claimed it (doctrine bans under- and over-claiming).
  - Removed the **energy** row: `https://szlholdings-energy.hf.space` returns **404** and `SZLHOLDINGS/energy` HF page **401** — a dead link on the public landing page. The energy surface remains described inside the Holographic Estate row, so no concept is lost.
  - Reworded the doctrine comment that literally contained the sunset domain string; replaced with a canonical-domain note (blind replace would have produced the false statement "a-11-oy.com (sunset)").
- **README.md**
  - Doctrine badge linked to `/blob/main/DOCTRINE_V11.md` (**404**); corrected to real path `doctrine/DOCTRINE_V11.md`.
- **.github/FUNDING.yml**
  - `custom` funding link `szl-holdings.github.io/founder-page/` returned **404** (Pages not published); repointed to the live canonical domain `https://a-11-oy.com`.

### Verified clean (no change needed)
- All other profile/README links resolve 200 (a-11-oy.com, /holographic, lutar-lean, HF SZLHOLDINGS, slsa.dev, anatomy, david-leads, killinchu/elite).
- No purple in the rendered landing page — badges use proof-teal/lattice-blue/grey/gold only. (Purple/codename-bearing SVGs exist under `profile/assets/` but are unreferenced by any rendered markdown/HTML — dormant, not on any surface; flagged for follow-up rather than edited.)
- Locked-8 `{F1,F4,F7,F11,F12,F18,F19,F22}` and Λ = Conjecture 1 stated correctly; `749/14/163` consistent; SLSA "L1 honest · L2 attested · L3 roadmap" matches doctrine G4 (not upgraded).
- Reusable workflows: all external action refs SHA-pinned; no secrets; `.replit.local` mentions are inside a detection GATE (not weakened).
- Community-health files present; contacts on owned domain `security@szlholdings.com`.

### Still open (needs account/infra access — not fakeable here)
- `github: [stephenlutar2]` Sponsors profile 404s — requires enabling GitHub Sponsors on the account.
- HF dataset `SZLHOLDINGS/doctrine-v11` returns 401 (gated/private) — confirm intended visibility.
- Dormant purple + codename SVGs under `profile/assets/` (e.g. hero-premium.svg) — recolor or delete in a follow-up if they will ever be rendered.

Do not merge — main agent handles protected-branch merge.