### PR TITLE
docs: update live surface count to 60+ (verified 63)

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,7 +36,7 @@
 | Space | What it is | Open |
 |---|---|---|
 | **a11oy** — flagship | Governed-AI Command Center: ask-and-act behind deny-by-default gates, a live decision feed, and a signed receipt for every action. | **[a-11-oy.com](https://a-11-oy.com)** |
-| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 56 live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D. 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
+| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 60+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D. 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
 | **killinchu** | Counter-UAS & maritime command *demonstration* — multi-sensor fusion with signed engagement receipts (effector link is a labeled simulation). | [demo →](https://szlholdings-killinchu.hf.space/elite) |
 | **anatomy** | Living anatomy map — the locked-8 ladder and the four honesty tiers, visualized. | [view →](https://szlholdings-anatomy.hf.space) |
 | **david-leads** | Sovereign insurance intelligence — audit-defensible lead intelligence from public data only. | [view →](https://szlholdings-david-leads.hf.space) |


### PR DESCRIPTION
Holographic Estate now serves 63 live surfaces (all modules load 200). Durable 60+ phrasing.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>