### PR TITLE
docs: make holographic surface count self-verifying against live frontier API

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,7 +36,7 @@
 | Space | What it is | Open |
 |---|---|---|
 | **a11oy** — flagship | Governed-AI Command Center: ask-and-act behind deny-by-default gates, a live decision feed, and a signed receipt for every action. | **[a-11-oy.com](https://a-11-oy.com)** |
-| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 60+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D. 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
+| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 60+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D, the exact live count self-verifiable at [`/api/a11oy/v1/frontier/surfaces`](https://a-11-oy.com/api/a11oy/v1/frontier/surfaces). 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
 | **killinchu** | Counter-UAS & maritime command *demonstration* — multi-sensor fusion with signed engagement receipts (effector link is a labeled simulation). | [demo →](https://szlholdings-killinchu.hf.space/elite) |
 | **anatomy** | Living anatomy map — the locked-8 ladder and the four honesty tiers, visualized. | [view →](https://szlholdings-anatomy.hf.space) |
 | **david-leads** | Sovereign insurance intelligence — audit-defensible lead intelligence from public data only. | [view →](https://szlholdings-david-leads.hf.space) |


### PR DESCRIPTION
## Summary

Org-wide honest-count consistency sweep (docs only, no backend).

The live holographic surface count keeps growing — 56 → 63 → **65 today** (verified via `GET https://a-11-oy.com/api/a11oy/v1/frontier/surfaces` → `count: 65`). Rather than chase an exact number that drifts stale, this makes the profile card's `60+ live surfaces` claim **self-verifying**: it now links directly to the authoritative frontier endpoint so any reader can confirm the exact live count.

- `60+` remains an honest **floor** (65 ≥ 60) that stays true as the estate grows — never overclaims, never underclaims (Doctrine v11).
- Adds a pointer to `/api/a11oy/v1/frontier/surfaces` as the single source of truth.

### Sweep results (this repo)
- `profile/README.md` was the **only** surface-count claim in the repo — already at the durable `60+` band; this PR anchors it to the live source.
- **No** brain-node-count claims present (the "brain" mentions are the anatomy-organ metaphor, not the harvested-artifact graph — nothing to correct here).

### Follow-ups found on other org surfaces (read-only check)
- **docs-site** `README.md`: `~50 governed surfaces` is a **stale underclaim** vs live 65 — separate follow-up PR.
- **a11oy** `README.md`: "Live surfaces" is a curated 5-endpoint table with no numeric count — nothing stale.
- **killinchu** `README.md`: no numeric surface-count claim — nothing stale.

## Testing
- `curl -s https://a-11-oy.com/api/a11oy/v1/frontier/surfaces` → `"count":65` (link target verified live).
- No workflow/YAML touched; markdown-only change.