### PR TITLE
docs: bump holographic surface floor to 70+ to match live count

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,7 +36,7 @@
 | Space | What it is | Open |
 |---|---|---|
 | **a11oy** — flagship | Governed-AI Command Center: ask-and-act behind deny-by-default gates, a live decision feed, and a signed receipt for every action. | **[a-11-oy.com](https://a-11-oy.com)** |
-| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 60+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D, the exact live count self-verifiable at [`/api/a11oy/v1/frontier/surfaces`](https://a-11-oy.com/api/a11oy/v1/frontier/surfaces). 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
+| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 70+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D, the exact live count self-verifiable at [`/api/a11oy/v1/frontier/surfaces`](https://a-11-oy.com/api/a11oy/v1/frontier/surfaces). 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
 | **killinchu** | Counter-UAS & maritime command *demonstration* — multi-sensor fusion with signed engagement receipts (effector link is a labeled simulation). | [demo →](https://szlholdings-killinchu.hf.space/elite) |
 | **anatomy** | Living anatomy map — the locked-8 ladder and the four honesty tiers, visualized. | [view →](https://szlholdings-anatomy.hf.space) |
 | **david-leads** | Sovereign insurance intelligence — audit-defensible lead intelligence from public data only. | [view →](https://szlholdings-david-leads.hf.space) |


### PR DESCRIPTION
## Summary

The org profile card advertised **"60+ live surfaces"** for the Holographic Estate. The live, self-verifying endpoint now reports **71**:

```
GET https://a-11-oy.com/api/a11oy/v1/frontier/surfaces  →  {"ok":true,"count":71,...}
```

`60+` was a stale floor. This raises it to `70+` — still a durable floor (never higher than the live count), and the card already links to the live endpoint so the exact number stays self-verifiable.

No other doctrine claims changed. Verified consistent with live/canonical on this card:
- Canonical domain `a-11-oy.com` (with hyphens) throughout — unchanged.
- Λ = Conjecture 1 (never green) — unchanged.
- Exactly 8 formulas locked-proven `{F1,F4,F7,F11,F12,F18,F19,F22}` — unchanged.
- Trust ceiling 0.97, never 100% — unchanged.

## Testing

- `curl -s https://a-11-oy.com/api/a11oy/v1/frontier/surfaces` → `count: 71` (floor `70+` holds, no overclaim).
- `git diff` confirms a single-line change; no code, `.js`, `serve.py`, or manifest touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)