### PR TITLE
fix(doctrine): make honesty gate line-wrap tolerant + add its first self-test

### DIFF
--- a/.github/scripts/doctrine_check.py
+++ b/.github/scripts/doctrine_check.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""SZL Doctrine Invariants — line-wrap-tolerant, testable port of doctrine-check.yml.
+
+WHY THIS FILE EXISTS
+--------------------
+The org-wide honesty gate (`.github/workflows/doctrine-check.yml`) was, for its
+whole history, ~200 lines of inline bash `grep` pipelines. Two structural
+problems made it the single most fragile load-bearing check in the org:
+
+  1. LINE-BASED. `grep` matches one physical line at a time. Every honesty
+     invariant is really "TRIGGER token X is present AND no governance-safe
+     qualifier Y is nearby". Bash implements that as
+     `grep TRIGGER | grep -v QUALIFIER`, so the qualifier MUST live on the SAME
+     physical line as the trigger. A cosmetic text reflow that splits one honest
+     sentence across two lines (so the trigger lands on a line without its
+     qualifier) turns an honest doc into a FALSE-POSITIVE doctrine failure.
+     This actually happened: a 2-line wrap in `szl_kc_atlas.py` broke
+     `check / doctrine` on `main` AND every open PR org-wide (a11oy PR #768 was
+     needed just to re-flow the sentence back onto one line — a bandaid that
+     leaves the NEXT reflow free to break the org again).
+
+  2. UNTESTED. Every OTHER org guard (overclaim-sweep, energy-provenance,
+     receipt-shape, codename, anatomy-map, ...) ships a network-free self-test
+     wired into tests.yml so a refactor can't weaken it into a false-green
+     no-op. The most important gate — doctrine — had NONE, because its logic
+     was un-importable inline bash. So a weakening (or a false positive) could
+     land with no signal.
+
+THE FIX (no bandaid)
+--------------------
+Port the invariant logic to Python and make the honesty qualifiers WINDOW-scoped
+instead of single-line-scoped: when a TRIGGER matches, we test the governance
+qualifier against a whitespace-normalized window (the trigger line joined with a
+few neighbouring lines). A soft-wrap can no longer hide the qualifier from the
+check, so a cosmetic reflow can never again break the org. A genuine unqualified
+overclaim (no qualifier anywhere in the window) still FAILS.
+
+This is kept behaviour-compatible with the bash gate's INTENT (same triggers,
+same exemptions, same repo-scoping for the a11oy/killinchu verified-L2 banner),
+and is pinned by test_doctrine_check.py.
+
+Modes:
+  --local DIR   scan a local checkout (network-free; used by CI + the self-test)
+Exit code 0 = all invariants satisfied; 1 = at least one violation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# File selection (mirrors the bash gate's --include / --exclude-dir set).
+# ---------------------------------------------------------------------------
+SCAN_EXT = {".md", ".json", ".yaml", ".yml", ".py", ".ts", ".go", ".lean"}
+EXCLUDE_DIRS = {
+    ".git", ".lake", "node_modules", "dist", "build", "coordination",
+    "cursor-directives", "replit-sync", "corpus", "resilience_observability",
+    "__tests__",
+}
+# Files the bash gate excluded by name (generated snapshots / self-referential
+# guard sources that quote banned strings on purpose).
+EXCLUDE_BASENAMES = {
+    "governed_loop.json", "wayra_snapshot.json", "all_open_prs.json",
+    "cto_prs_opened_recent.json", "szl_math_corpus.py", "szl_chaski.py",
+    "szl_hub.py", "run_all_json.py", "OUROBOROS_RUN_ALL.py", "szlBreaker.ts",
+    "szl_breaker.py", "serve.py", "szl_wire.py", "_live_serve.py",
+    "YACHAY_SYSTEM_PROMPT.md", "doctrine_check.py", "test_doctrine_check.py",
+}
+EXCLUDE_GLOBS = ("governed_loop", "wayra_snapshot")
+
+
+def _excluded_basename(name: str) -> bool:
+    if name in EXCLUDE_BASENAMES:
+        return True
+    return any(name.startswith(g) for g in EXCLUDE_GLOBS)
+
+
+def iter_files(root: str, exts=None):
+    exts = exts or SCAN_EXT
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for fn in filenames:
+            ext = os.path.splitext(fn)[1]
+            if ext not in exts:
+                continue
+            if _excluded_basename(fn):
+                continue
+            yield os.path.join(dirpath, fn)
+
+
+def _iter_dockerfiles(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for fn in filenames:
+            if fn.startswith("Dockerfile"):
+                yield os.path.join(dirpath, fn)
+
+
+def read_lines(path: str):
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as fh:
+            return fh.read().splitlines()
+    except Exception:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# The window primitive — the heart of the line-wrap fix.
+# ---------------------------------------------------------------------------
+def window_text(lines, idx: int, radius: int = 2, rel: str = "") -> str:
+    """Whitespace-normalized join of line[idx] with `radius` neighbours each side.
+
+    This is what defeats the reflow-breaks-the-org failure: an honesty qualifier
+    that a soft-wrap pushed onto an adjacent physical line is still visible to
+    the exemption test, because we test the exemption against this joined window
+    rather than against the single physical trigger line.
+    """
+    lo = max(0, idx - radius)
+    hi = min(len(lines), idx + radius + 1)
+    # Prefix the relative path so PATH-based exemptions work in byte-parity with
+    # the bash gate, whose `grep` output lines are `path:content` and whose
+    # `grep -v knowledge\.json` etc. therefore match on the path segment too.
+    joined = (rel + ": " if rel else "") + " ".join(lines[lo:hi])
+    return re.sub(r"\s+", " ", joined).strip()
+
+
+def _search(patterns, text: str) -> bool:
+    return any(re.search(p, text, re.IGNORECASE) for p in patterns)
+
+
+# ---------------------------------------------------------------------------
+# Invariant definitions. Each honesty invariant = (trigger, exemptions).
+# A line FAILS iff the trigger matches AND NO exemption matches the WINDOW.
+# ---------------------------------------------------------------------------
+
+INV1_TRIGGER = r"doctrine.*v(9|10|12|13)"
+INV1_EXEMPT = [
+    r"additive", r"proposed", r"planned.*release", r"roadmap",
+    r"not yet promoted", r"future", r"historical", r"deprecated",
+    r"archived", r"out of scope", r"not pursuing", r"rejected",
+    r"v10.*v11|v11.*v10|v10-v11|additive over|edge organ|4th organ",
+    r"v12.*v11|v11.*v12|puriq|chaski|organ.*v1[23]|v1[23].*organ",
+    r"§[0-9]|doctrine_state|doctrine-v|doctrine v[0-9].*locked|v1[12].*locked",
+]
+INV1_EXT = {".md", ".json", ".yaml", ".yml", ".py", ".ts", ".go"}
+
+INV2_TRIGGER = r"Λ.*theorem|Lambda.*theorem|lambda.*Theorem|lambdaUniqueness[^C]"
+INV2_EXEMPT = [
+    r"conjecture", r"not a proven theorem|not a theorem|never a theorem",
+    r"never claim|do ?n['o]t claim", r"do ?n['o]t call|never call",
+    r"gate.*theorem|theorem.*enforced|readme.*theorem|gates/readme",
+    r"lambdacategory|lambdamonotonicity|composability|minmaxbounds",
+    r"theoremu_lambdaunique|theoremu_|lutar/uniqueness/theoremu",
+    r"knowledge\.json|lean.*theorem|lean 4.*theorem",
+    r"does ?n['o]t assert|do not assert|not assert.*theorem",
+    r"[0-9]+ theorems|all [0-9]+ theorem|theorems '|every theorem|theorem carries",
+    r"ks_theorem|_theorem_[0-9]|theorem_ref|theorem [0-9]",
+    r"→ ?theorem|theorem ?→|receipt.*theorem|provenance.*theorem|theorem.*doi",
+    r"uniqueness theorem is conditional|theorem is conditional-only|conditional.*not claimed",
+    r"dress .*up as a theorem|conditional Λ theorem|conditional lambda theorem",
+]
+INV2_EXT = {".md", ".json", ".py", ".ts", ".lean"}
+
+INV3_L3_TRIGGER = r"SLSA.*L3|SLSA Level 3"
+INV3_L3_EXEMPT = [
+    r"not l3|no.*l3|l3.*not|banned|prohibited|forbidden|out of scope",
+    r"roadmap|future|planned|historical|archived|rejected|path to",
+    r"staged|awaiting|mis-?claimed|corrected|previously",
+    r"flags bare|appears only inside|quoted prohibition|overclaim grep",
+]
+INV3_L2_TRIGGER = r"SLSA.*L2|SLSA Level 2"
+INV3_L2_EXEMPT_BASE = [
+    r"ghcr-build-push\.yml|ghcr\.io/szl-holdings/(a11oy|killinchu)",
+    r"verified|attested|attestation.*(exists|created|uploaded)",
+    r"(a11oy|killinchu)\.slsa-provenance|szl-(a11oy|killinchu)|l2 on organ images",
+    r"bundle-level.*not.*earned|no bundle-level",
+    r"roadmap|future|planned|historical|archived|rejected|path to|not yet",
+    r"not l2|no.*l2|l2.*not|banned|prohibited",
+]
+INV3_L2_BANNER_EXEMPT = [
+    r"SLSA L1 ?\+ ?L2|SLSA L1\+L2|L1 ?\+ ?L2|SLSA Build L2 provenance attestation",
+]
+INV3_EXT = {".md", ".json", ".yaml"}
+
+INV5_TRIGGER = r"Iron Bank|FedRAMP (High|Moderate)|CMMC L[2-5]|SWFT certified|Mission Owner"
+INV5_EXEMPT = [
+    r"out of scope|not pursuing|historical|archived|rejected|deprecated|proposed|roadmap",
+    r"no iron bank|not.*iron bank|no fedramp|not.*fedramp|no cmmc|not.*cmmc|gap|vanilla|approved base|citation|nist",
+    r"not claimed|❌|not pursued|not held|no.*authorization",
+    r"customer.*requirement|policy.*map|compliance.*map|does not|cannot|without",
+    r"upstream|ecosystem|respective.*polic|their.*polic|contribute to",
+]
+INV5_EXT = {".md", ".json", ".yaml"}
+INV5_EXCLUDE_BASENAMES = {"OPS_NOTES.md"}
+INV5_EXCLUDE_GLOBS = ("defense",)
+INV5_EXCLUDE_DIRS = {"vertical"}
+
+
+def _verified_l2_repo(repo: str) -> bool:
+    return (repo or "").split("/")[-1] in {"a11oy", "killinchu"}
+
+
+def scan_local(root: str, repo: str = ""):
+    """Return list of (invariant, path, lineno, line) violations."""
+    violations = []
+    is_verified_l2 = _verified_l2_repo(repo)
+
+    for path in iter_files(root):
+        ext = os.path.splitext(path)[1]
+        base = os.path.basename(path)
+        rel = os.path.relpath(path, root)
+        # skip anything under a .git/.lake path that os.walk pruning missed
+        if re.search(r"(^|/)(\.git|\.lake|node_modules|dist|build)/", rel):
+            continue
+        lines = read_lines(path)
+
+        for i, line in enumerate(lines):
+            win = None  # computed lazily
+
+            # --- Invariant 1: doctrine version drift ---
+            # TRIGGER is case-SENSITIVE (byte-parity with the bash gate's
+            # `grep -rE`, which has no -i on the trigger — only the exclusions
+            # are -i). Capitalised prose like "Doctrine v10" is intentionally
+            # NOT a trigger; only lower-case `doctrine v1x` fires.
+            if ext in INV1_EXT and re.search(INV1_TRIGGER, line):
+                win = win or window_text(lines, i, rel=rel)
+                if not _search(INV1_EXEMPT, win):
+                    violations.append(("Inv1", rel, i + 1, line.strip()))
+
+            # --- Invariant 2: Λ must be Conjecture 1, never a theorem ---
+            if ext in INV2_EXT and re.search(INV2_TRIGGER, line):
+                win = window_text(lines, i, rel=rel)
+                if not _search(INV2_EXEMPT, win):
+                    violations.append(("Inv2", rel, i + 1, line.strip()))
+
+            # --- Invariant 3: SLSA honesty ---
+            if ext in INV3_EXT:
+                # base64 blobs stripped like the bash `sed`
+                clean = re.sub(r";base64,[A-Za-z0-9+/=]+", "", line)
+                if re.search(INV3_L3_TRIGGER, clean):
+                    w = window_text(lines, i, rel=rel)
+                    if not _search(INV3_L3_EXEMPT, w):
+                        violations.append(("Inv3-L3", rel, i + 1, line.strip()))
+                if re.search(INV3_L2_TRIGGER, clean):
+                    w = window_text(lines, i, rel=rel)
+                    exempts = list(INV3_L2_EXEMPT_BASE)
+                    if is_verified_l2:
+                        exempts += INV3_L2_BANNER_EXEMPT
+                    if not _search(exempts, w):
+                        violations.append(("Inv3-L2", rel, i + 1, line.strip()))
+
+            # --- Invariant 5: banned compliance positive claims ---
+            if ext in INV5_EXT:
+                if base in INV5_EXCLUDE_BASENAMES:
+                    pass
+                elif any(base.startswith(g) for g in INV5_EXCLUDE_GLOBS):
+                    pass
+                elif any(("/%s/" % d) in ("/" + rel) for d in INV5_EXCLUDE_DIRS):
+                    pass
+                elif re.search(INV5_TRIGGER, line):
+                    w = window_text(lines, i, rel=rel)
+                    if not _search(INV5_EXEMPT, w):
+                        violations.append(("Inv5", rel, i + 1, line.strip()))
+
+    # --- Invariant 6: no `COPY . .` in Dockerfiles (extension-less, scanned separately) ---
+    for path in _iter_dockerfiles(root):
+        rel = os.path.relpath(path, root)
+        for i, line in enumerate(read_lines(path)):
+            if re.match(r"^COPY \. \.", line):
+                violations.append(("Inv6", rel, i + 1, line.strip()))
+
+    return violations
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="SZL Doctrine invariant check (line-wrap tolerant).")
+    ap.add_argument("--local", default=".", help="root dir of a local checkout to scan")
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""),
+                    help="owner/name — enables the verified-L2 (a11oy/killinchu) banner exemption")
+    ap.add_argument("--json", action="store_true", help="emit JSON report")
+    args = ap.parse_args(argv)
+
+    repo = args.repo
+    print(f"repo={repo.split('/')[-1] or '?'} verified_L2={int(_verified_l2_repo(repo))}")
+    violations = scan_local(args.local, repo=repo)
+
+    if args.json:
+        print(json.dumps([
+            {"invariant": inv, "path": p, "line": ln, "text": t}
+            for inv, p, ln, t in violations
+        ], indent=2))
+    else:
+        for inv, p, ln, t in violations:
+            print(f"::error file={p},line={ln}::[{inv}] {t}")
+
+    if violations:
+        by_inv = {}
+        for inv, *_ in violations:
+            by_inv[inv] = by_inv.get(inv, 0) + 1
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(by_inv.items()))
+        print(f"::error::Doctrine check FAILED ({len(violations)} violation(s): {summary}).")
+        return 1
+    print("All doctrine invariants satisfied (line-wrap tolerant).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_doctrine_check.py
+++ b/.github/scripts/test_doctrine_check.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Self-test for the line-wrap-tolerant SZL doctrine check.
+
+`doctrine_check.py` is the testable port of the org-wide honesty gate. Its whole
+reason to exist is that the previous inline-bash gate was LINE-BASED: a cosmetic
+reflow that split an honest sentence across two lines (trigger on one line,
+qualifier on the next) produced a FALSE-POSITIVE doctrine failure org-wide (the
+`szl_kc_atlas.py` incident that needed a11oy PR #768 just to re-flow text).
+
+This network-free self-test PINS the contract so a future refactor can neither
+(a) reintroduce the line-based fragility, nor (b) weaken an invariant into a
+false-green no-op. Following the org convention (test_overclaim_sweep.py etc.),
+it drives the REAL scan_local() path against synthetic fixtures.
+
+Contract pinned:
+  1. A genuine UNQUALIFIED overclaim  -> FAIL (gate is substantive).
+  2. The SAME honest sentence, but soft-wrapped so the qualifier lands on an
+     ADJACENT line (the exact break that took down the org)  -> PASS.
+  3. A clean tree  -> PASS.
+  4. The verified-L2 (a11oy/killinchu) repo-scoped banner exemption still works
+     AND still fails a bare L2 claim on a non-verified repo.
+  5. `COPY . .` Dockerfile invariant still fires.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_PATH = os.path.join(_HERE, "doctrine_check.py")
+_spec = importlib.util.spec_from_file_location("doctrine_check", _MODULE_PATH)
+assert _spec and _spec.loader
+dc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dc)
+
+
+def _write(root: str, rel: str, text: str) -> None:
+    p = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(p) or root, exist_ok=True)
+    with open(p, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _invs(root: str, repo: str = ""):
+    return {v[0] for v in dc.scan_local(root, repo=repo)}
+
+
+class DoctrineWrapTolerance(unittest.TestCase):
+
+    def test_unqualified_lambda_theorem_overclaim_fails(self):
+        """A bare 'Λ is a proven theorem' with NO qualifier anywhere -> Inv2 fail."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "claim.md",
+                   "The aggregator Λ is a proven theorem and always will be.\n"
+                   "This paragraph says nothing else about it.\n")
+            self.assertIn("Inv2", _invs(d),
+                          "an unqualified Λ-theorem overclaim must still FAIL")
+
+    def test_softwrapped_honest_sentence_passes(self):
+        """THE REGRESSION: honest sentence wrapped so the qualifier lands on the
+        NEXT line. The old line-based grep FALSE-POSITIVED here and broke the org.
+        The window-scoped check must PASS it."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "szl_kc_atlas.py",
+                   "# no bare 'Λ...theorem' claim without the qualifier: it is\n"
+                   "# not asserted as a proven theorem here; Λ remains\n"
+                   "# Conjecture 1 (never a theorem, advisory only).\n")
+            self.assertNotIn("Inv2", _invs(d),
+                             "a soft-wrapped honest Λ sentence must PASS — a "
+                             "cosmetic reflow must never break the org again")
+
+    def test_inline_honest_sentence_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "ok.md",
+                   "Λ = Conjecture 1, never a theorem (advisory only).\n")
+            self.assertNotIn("Inv2", _invs(d))
+
+    def test_clean_tree_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "README.md", "# A11oy\nHonest labels. Doctrine v11 LOCKED.\n")
+            self.assertEqual(_invs(d), set())
+
+    def test_doctrine_version_drift_wrapped_qualifier_passes(self):
+        """Inv1: a v12 mention that is ADDITIVE/roadmap must pass even when the
+        'additive' qualifier is wrapped onto an adjacent line."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "notes.md",
+                   "We discuss doctrine v12 here as a purely\n"
+                   "proposed, additive roadmap item — not promoted.\n")
+            self.assertNotIn("Inv1", _invs(d))
+
+    def test_doctrine_version_drift_unqualified_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "bad.md", "We are now on doctrine v12 in production.\n"
+                                "Full stop.\n")
+            self.assertIn("Inv1", _invs(d))
+
+    def test_slsa_l3_claim_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "x.md", "This image has achieved SLSA L3 in production.\nWe are proud of it.\n")
+            self.assertIn("Inv3-L3", _invs(d))
+
+    def test_slsa_l2_verified_repo_banner_passes(self):
+        """a11oy/killinchu may carry the honest 'SLSA L1 + L2' banner."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "footer.md", "Posture: SLSA L1 + L2 (roadmap).\n")
+            self.assertNotIn("Inv3-L2", _invs(d, repo="szl-holdings/a11oy"))
+
+    def test_slsa_l2_nonverified_repo_bare_claim_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "footer.md", "This repo is SLSA L2.\nDone.\n")
+            self.assertIn("Inv3-L2", _invs(d, repo="szl-holdings/some-lib"))
+
+    def test_banned_compliance_claim_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "compliance.md", "We are FedRAMP High authorized.\nToday.\n")
+            self.assertIn("Inv5", _invs(d))
+
+    def test_banned_compliance_negated_wrapped_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "compliance.md",
+                   "We are NOT pursuing FedRAMP High; it is\n"
+                   "explicitly out of scope for this release.\n")
+            self.assertNotIn("Inv5", _invs(d))
+
+    def test_dockerfile_copy_dot_fails(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "Dockerfile", "FROM scratch\nCOPY . .\n")
+            self.assertIn("Inv6", _invs(d))
+
+    def test_main_exit_codes(self):
+        """The exit-code contract: 0 clean, 1 on violation (mirrors org guards)."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "README.md", "Doctrine v11 LOCKED. Λ = Conjecture 1.\n")
+            self.assertEqual(dc.main(["--local", d]), 0)
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "bad.md", "Λ is a proven theorem.\nEnd.\n")
+            self.assertEqual(dc.main(["--local", d]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -16,10 +16,52 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: SZL Doctrine Invariants
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      # ---------------------------------------------------------------------
+      # AUTHORITATIVE, LINE-WRAP-TOLERANT honesty invariants (Inv 1/2/3/5/6).
+      #
+      # WHY: the historical inline-bash block below is LINE-BASED (grep tests
+      # one physical line at a time), so a cosmetic reflow that split an honest
+      # sentence across two lines (trigger on one line, qualifier on the next)
+      # produced a FALSE-POSITIVE doctrine failure ORG-WIDE. That actually
+      # happened (a 2-line wrap in a11oy szl_kc_atlas.py broke check/doctrine on
+      # main and every open PR; a11oy PR #768 was needed just to re-flow text
+      # back onto one line — a bandaid the next reflow re-breaks). It was also
+      # the ONLY org guard with no self-test, because its logic was un-importable
+      # inline bash.
+      #
+      # FIX (no bandaid): doctrine_check.py ports the SAME triggers/exemptions/
+      # repo-scoping but evaluates each honesty qualifier over a WHITESPACE-
+      # NORMALIZED WINDOW (the trigger line joined with its neighbours), so a
+      # soft-wrap can never again hide a qualifier from the check — while a
+      # genuine unqualified overclaim still FAILS. It is pinned by the network-
+      # free test_doctrine_check.py in tests.yml (the org's self-test-the-guard
+      # convention), which includes the exact szl_kc_atlas line-wrap regression.
+      # This step is the AUTHORITATIVE fatal gate for Inv 1/2/3/5/6.
+      # ---------------------------------------------------------------------
+      - name: SZL Doctrine Invariants (line-wrap tolerant, Inv 1/2/3/5/6)
+        run: |
+          set -eu
+          python3 .github/scripts/doctrine_check.py \
+            --local . --repo "${GITHUB_REPOSITORY:-}"
+
+      - name: SZL Doctrine Invariants (bash — jq-based Inv 4/7/8/9 + legacy echo)
         run: |
           set -eu
           FAIL=0
+          # NOTE (2026-07-07 hardening): the line-wrap-prone honesty invariants
+          # (Inv 1/2/3/5/6) are now enforced AUTHORITATIVELY and line-wrap-
+          # tolerantly by the doctrine_check.py step ABOVE (pinned by
+          # test_doctrine_check.py). Their bash counterparts below are kept for
+          # transparency but NO LONGER SET FAIL (see the `# [migrated]` markers)
+          # so a soft-wrap can't reintroduce the org-wide false positive. The
+          # jq/numeric invariants that were never line-wrap-sensitive (Inv 4
+          # Section-889 vendor count, Inv 7 kernel-commit lock, Inv 8 SBOM/
+          # signing warning, Inv 9 DSSE receipt shape) remain fatal here.
 
           # Repo-scoped SLSA L2 evidence gate. SLSA posture is L1 honest / L2 roadmap.
           # Only the two SHIPPING products (a11oy, killinchu) wire
@@ -93,8 +135,7 @@ jobs:
               || true)
           if [ -n "$M1" ]; then
             echo "$M1" | head -10
-            echo "::error::Doctrine version drift detected — only v11 allowed (ADDITIVE/proposed/roadmap/historical labels are exempt)"
-            FAIL=1
+            echo "::notice::[migrated] Inv1 now enforced line-wrap-tolerantly by doctrine_check.py above (this bash echo is advisory only)."
           fi
 
           echo "=== Invariant 2: Λ = Conjecture 1 (NEVER theorem) ==="
@@ -120,8 +161,7 @@ jobs:
               || true)
           if [ -n "$M2" ]; then
             echo "$M2" | head -10
-            echo "::error::Λ described as theorem or lambdaUniqueness used without Conjecture suffix — must be Conjecture 1"
-            FAIL=1
+            echo "::notice::[migrated] Inv2 now enforced line-wrap-tolerantly by doctrine_check.py above (this bash echo is advisory only)."
           fi
 
           echo "=== Invariant 3: SLSA claims must be honest and evidence-gated ==="
@@ -152,8 +192,7 @@ jobs:
               || true)
           if [ -n "$M3_L3" ]; then
             echo "$M3_L3" | head -10
-            echo "::error::SLSA L3 claim detected — L3 is NOT achieved (requires isolated builder/reusable workflow). Remove or scope as future roadmap."
-            FAIL=1
+            echo "::notice::[migrated] Inv3-L3 now enforced line-wrap-tolerantly by doctrine_check.py above (this bash echo is advisory only)."
           fi
 
           # RULE 2: L2 claims require evidence (attestation). Verified repos:
@@ -196,8 +235,7 @@ jobs:
               || true)
           if [ -n "$M3_L2_UNVERIFIED" ]; then
             echo "$M3_L2_UNVERIFIED" | head -10
-            echo "::error::SLSA L2 claim without evidence — only a11oy/killinchu (the two shipping products) have verified L2 attestations. Add evidence reference or remove the claim."
-            FAIL=1
+            echo "::notice::[migrated] Inv3-L2 now enforced line-wrap-tolerantly by doctrine_check.py above (this bash echo is advisory only)."
           fi
 
           echo "=== Invariant 4: Section 889 = exactly 5 vendors ==="
@@ -235,8 +273,7 @@ jobs:
           M6=$(grep -rE "^COPY \. \." --include="Dockerfile*" . 2>/dev/null || true)
           if [ -n "$M6" ]; then
             echo "$M6" | head -5
-            echo "::error::COPY . . in Dockerfile — must be per-file COPY"
-            FAIL=1
+            echo "::notice::[migrated] Inv6 now enforced by doctrine_check.py above (this bash echo is advisory only)."
           fi
 
           echo "=== Invariant 7: kernel commit c7c0ba17 not bumped ==="

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,22 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Pins the org-wide DOCTRINE honesty gate — the single most load-bearing
+      # check in the org, and (until now) the ONLY guard with no self-test.
+      # Its logic used to be inline LINE-BASED bash grep: a cosmetic 2-line
+      # reflow that split an honest sentence so the trigger landed on a line
+      # without its qualifier produced a FALSE-POSITIVE doctrine failure
+      # org-wide (the szl_kc_atlas incident; a11oy PR #768 was a bandaid reflow).
+      # doctrine_check.py ports the SAME triggers/exemptions but evaluates the
+      # qualifier over a whitespace-normalized WINDOW so a soft-wrap can never
+      # again break the org, while a genuine unqualified overclaim still FAILS.
+      # This network-free unit test pins that contract — including the exact
+      # szl_kc_atlas line-wrap regression and the verified-L2 repo-scoping — so a
+      # refactor can neither reintroduce the line fragility nor weaken an
+      # invariant into a false-green no-op.
+      - name: Doctrine check (line-wrap tolerant) self-test
+        run: python3 .github/scripts/test_doctrine_check.py
+
       # Pins the HF license-consistency private-coverage safety net (task #383):
       # the "valid token but private_seen < floor" false-green branch can't be
       # exercised with a live restricted token, so this stubbed, network-free


### PR DESCRIPTION
## Problem
The org-wide required `check / doctrine` gate was ~200 lines of inline **line-based** bash `grep`. Every honesty invariant is really "TRIGGER present AND no qualifier nearby", implemented as `grep TRIGGER | grep -v QUALIFIER` — so the qualifier had to live on the **same physical line** as the trigger.

A cosmetic **2-line reflow** in `a11oy/szl_kc_atlas.py` split an honest sentence so the `Λ…theorem` trigger landed on a line without its `Conjecture` qualifier, turning an honest doc into a **false-positive doctrine failure on `main` and every open PR org-wide**. a11oy PR #768 was a bandaid re-flow that the next wrap simply re-breaks. It was also the **only** org guard with no self-test, because its logic was un-importable inline bash.

## Fix (no bandaid — hardens the check itself)
Mirrors this repo's established "self-test the guard so a refactor can't weaken it" pattern (overclaim-sweep, energy-provenance, receipt-shape, …):

- **`.github/scripts/doctrine_check.py`** — ports the **same** triggers / exemptions / repo-scoping (Inv 1/2/3/5/6) but evaluates each qualifier over a **whitespace-normalized window** (the trigger line joined with its neighbours). A soft-wrap can no longer hide a qualifier; a genuine **unqualified** overclaim still **fails**. Triggers stay **case-sensitive** and **path-aware** for byte-parity with the bash gate.
- **`.github/scripts/test_doctrine_check.py`** — network-free self-test pinning the contract, including the **exact szl_kc_atlas line-wrap regression** (honest sentence wrapped across two lines → must PASS) and the a11oy/killinchu verified-L2 repo-scoping.
- **`doctrine-check.yml`** — `doctrine_check.py` is now the **authoritative fatal gate** for the line-wrap-prone invariants; their bash counterparts are demoted to advisory echoes. The jq/numeric invariants (Inv 4 §889 count, Inv 7 kernel-commit lock, Inv 8 SBOM warning, Inv 9 DSSE receipt shape) — which were never line-wrap sensitive — stay fatal in bash.
- **`tests.yml`** — wires the self-test into `Run tests`.

## Parity evidence
- `test_doctrine_check.py`: **13/13 pass**.
- `doctrine_check.py --local <a11oy> --repo szl-holdings/a11oy`: **exit 0 / all invariants satisfied** — **0 new false positives** vs the bash gate on current a11oy main.

## Impact
A line-wrap can never again break `check / doctrine` org-wide, and any future weakening of the gate is caught by its own pinned self-test.

Doctrine v11 LOCKED (749/14/163). Λ = Conjecture 1 (advisory). locked-8 untouched. — DCO-signed.