### PR TITLE
docs: canonical SZL alignment header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **SZL Holdings** · Doctrine v11 · Λ = Conjecture 1 (advisory, never "green"/theorem) · canonical [a-11-oy.com](https://a-11-oy.com)
+
 <div align="center">
 
 # 🧬 .github


### PR DESCRIPTION
Adds the canonical SZL Holdings alignment header to the top of the README so this repo is consistent with the rest of the org.

**Header added:**

> SZL Holdings · Doctrine v11 · Λ = Conjecture 1 (advisory) · canonical a-11-oy.com

This change is **purely additive** — no existing README content was removed or rewritten.

Doctrine v11 LOCKED · Λ = Conjecture 1 (never "green"/theorem) · honest labels.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>