### PR TITLE
fix(doctrine): run authoritative checker against caller tree in reusable workflow

### DIFF
--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -21,6 +21,20 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The authoritative honesty checker (doctrine_check.py) lives ONLY in the
+      # szl-holdings/.github repo, not in leaf repos. When a leaf repo calls this
+      # reusable workflow, the checkout above pulls the CALLER tree (which has no
+      # script), so we fetch the script's home repo into a separate subpath here.
+      # `--local .` below still scans the CALLER tree (default workspace root);
+      # this second checkout only supplies the script binary. persist-credentials
+      # is disabled — we only need the tree, no token stays on disk.
+      - name: Fetch org doctrine checker
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: szl-holdings/.github
+          path: _szl_doctrine
+          persist-credentials: false
+
       # ---------------------------------------------------------------------
       # AUTHORITATIVE, LINE-WRAP-TOLERANT honesty invariants (Inv 1/2/3/5/6).
       #
@@ -46,7 +60,7 @@ jobs:
       - name: SZL Doctrine Invariants (line-wrap tolerant, Inv 1/2/3/5/6)
         run: |
           set -eu
-          python3 .github/scripts/doctrine_check.py \
+          python3 _szl_doctrine/.github/scripts/doctrine_check.py \
             --local . --repo "${GITHUB_REPOSITORY:-}"
 
       - name: SZL Doctrine Invariants (bash — jq-based Inv 4/7/8/9 + legacy echo)


### PR DESCRIPTION
## Summary

The org reusable workflow `doctrine-check.yml` was hardened on 2026-07-07 to run the authoritative, line-wrap-tolerant honesty checker `doctrine_check.py`. But that script lives **only** in `szl-holdings/.github` — not in leaf repos. When a leaf repo (`szl-router`, `szl-lake`, …) calls the reusable workflow, `actions/checkout` pulls the **caller** tree, the script path 404s, and the step dies:

```
python3: can't open file '.../.github/scripts/doctrine_check.py': [Errno 2] No such file → exit 2
```

This reddens the doctrine gate on **every** leaf repo org-wide that calls the reusable workflow (confirmed on `szl-router` PR #13 → `Doctrine / doctrine` = failure). `main` on those repos only *looks* green because it hasn't re-run since the workflow change landed.

### Fix (additive / surgical — no bandaid, no gate weakening)

- Keep the existing `actions/checkout` of the **caller** repo at the default workspace path, so `--local .` still scans the caller's tree (that is what must be checked).
- Add a **second** SHA-pinned `actions/checkout` (same pinned `actions/checkout@9c091bb…` # v7.0.0 already in the file) of `szl-holdings/.github` into `_szl_doctrine/`, with `persist-credentials: false`.
- Invoke the script from that path: `python3 _szl_doctrine/.github/scripts/doctrine_check.py --local . --repo "${GITHUB_REPOSITORY:-}"`.

**What is NOT changed:** `doctrine_check.py` logic is untouched; the bash Inv-4/7/8/9 block is untouched; the pinned `test_doctrine_check.py` self-test is untouched. The script is **not** vendored into leaf repos (would drift), and the gate is **not** weakened or skipped. Doctrine v11 LOCKED, Λ = Conjecture 1 — unchanged.

Net: a 15-line additive change to a single workflow file.

## Testing

Verified locally before opening (details in the Wave P gate-fix result file):

- **Leaf-repo simulation** — caller = `szl-router` @ `align/canonical-readme-header`, with `.github` checked out into `_szl_doctrine/`:
  `python3 _szl_doctrine/.github/scripts/doctrine_check.py --local . --repo szl-holdings/szl-router` → `All doctrine invariants satisfied (line-wrap tolerant).` **exit 0**
- **`.github`-as-caller simulation** — `_szl_doctrine` is a second copy of itself; `--local .` scans the caller root → **exit 0** (no double-count / no break).
- **`actionlint`** on `doctrine-check.yml` → clean (0 errors).
- **`test_doctrine_check.py`** self-test → 13/13 pass (unchanged, network-free).

## Unblocks (re-run CI after merge)

Once merged to `main`, re-running CI turns the doctrine gate green on the 20 Wave-P README PRs + affected leaf repos, including: szl-router#13, szl-lake#21, szl-receipt#4, szl-substrate#9, szl-governed-norm#9, szl-lambda-gate#10, szl-energy-attest#11, khipu-consensus#11, khipu-sda-core#7, immune#5, governed-inference-meter#6, platform#429, developers#16, david-leads#26, szl-brand#72, szl-cookbook#79, szl-trust#53, vsp-otel#85, yarqa#13, and .github#187.

Branch-protected — leaving merge to the founder (no self-merge).