### PR TITLE
fix(doctrine): exempt intentional ORPO negative-training data from INV2

### DIFF
--- a/.github/scripts/doctrine_check.py
+++ b/.github/scripts/doctrine_check.py
@@ -163,6 +163,29 @@ INV2_EXEMPT = [
     r"dress .*up as a theorem|conditional Λ theorem|conditional lambda theorem",
 ]
 INV2_EXT = {".md", ".json", ".py", ".ts", ".lean"}
+# --- INV2 training-data exemption (NARROW, path-scoped — NOT a global disable) ---
+# a11oy's ORPO / preference-training corpus GENERATORS intentionally embed the
+# disallowed "Λ ... proven theorem" strings as the REJECTED half of contrastive
+# preference pairs: the model is trained to PREFER the honest "Λ = Conjecture 1,
+# never a theorem" completion and to REJECT the overclaim. These rejected strings
+# are negative-training FIXTURES, not product/serve/README claims, so they are
+# not real overclaims and must not trip the honesty gate.
+#
+# Scope is a tight relative-path allowlist under training/ (the ORPO generator
+# and the box run-doc that quotes the refusal smoke-test prompt). This exempts
+# ONLY those files, ONLY from INV2 — every other invariant still scans them, and
+# INV2 still fires on every non-training file. A planted real overclaim outside
+# training/ (or a non-INV2 overclaim inside it) still FAILS; see the negative
+# control in test_doctrine_check.py.
+INV2_TRAINING_EXEMPT_PREFIXES = (
+    "training/build_orpo",      # ORPO rejected/accepted preference-pair generator
+    "training/box/RUN_ON_BOX",  # box run-doc quoting the "Is Λ a theorem?" refusal test
+)
+
+
+def _inv2_training_exempt(rel: str) -> bool:
+    r = rel.replace(os.sep, "/")
+    return any(r.startswith(p) for p in INV2_TRAINING_EXEMPT_PREFIXES)
 
 INV3_L3_TRIGGER = r"SLSA.*L3|SLSA Level 3"
 INV3_L3_EXEMPT = [
@@ -231,7 +254,12 @@ def scan_local(root: str, repo: str = ""):
                     violations.append(("Inv1", rel, i + 1, line.strip()))
 
             # --- Invariant 2: Λ must be Conjecture 1, never a theorem ---
-            if ext in INV2_EXT and re.search(INV2_TRIGGER, line):
+            # Path-scoped skip for intentional ORPO negative-training data (the
+            # rejected half of preference pairs deliberately contains the banned
+            # overclaim). Only these training-data files, and only INV2, are
+            # exempt; see INV2_TRAINING_EXEMPT_PREFIXES.
+            if (ext in INV2_EXT and re.search(INV2_TRIGGER, line)
+                    and not _inv2_training_exempt(rel)):
                 win = window_text(lines, i, rel=rel)
                 if not _search(INV2_EXEMPT, win):
                     violations.append(("Inv2", rel, i + 1, line.strip()))

--- a/.github/scripts/test_doctrine_check.py
+++ b/.github/scripts/test_doctrine_check.py
@@ -72,6 +72,42 @@ class DoctrineWrapTolerance(unittest.TestCase):
                              "a soft-wrapped honest Λ sentence must PASS — a "
                              "cosmetic reflow must never break the org again")
 
+    def test_orpo_negative_training_data_exempt(self):
+        """INV2 training-data exemption: the ORPO generator and the box run-doc
+        intentionally embed the banned 'Λ ... proven theorem' string as the
+        REJECTED half of contrastive preference pairs. These negative-training
+        fixtures must be exempt from INV2 (only)."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "training/build_orpo.py",
+                   '# ORPO rejected/accepted preference-pair generator\n'
+                   'REJECTED = "Yes, Λ-uniqueness is a fully proven theorem."\n'
+                   'ACCEPTED = "No. Λ = Conjecture 1, never a theorem."\n')
+            _write(d, "training/box/RUN_ON_BOX.md",
+                   'Smoke test the refusal:\n'
+                   'ollama run szl-sovereign-qwen "Is Lambda a theorem?"\n')
+            self.assertNotIn("Inv2", _invs(d, repo="szl-holdings/a11oy"),
+                             "intentional ORPO negative-training data must be "
+                             "exempt from INV2")
+
+    def test_negative_control_overclaim_outside_training_still_fails(self):
+        """NEGATIVE CONTROL: the SAME bare overclaim in a non-training file must
+        still FAIL — the exemption is path-scoped, it does NOT weaken INV2."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "serve_notes.md",
+                   "Yes, Λ-uniqueness is a fully proven theorem.\nEnd.\n")
+            self.assertIn("Inv2", _invs(d, repo="szl-holdings/a11oy"),
+                          "a real overclaim outside training/ must still FAIL")
+
+    def test_training_exemption_is_tight_not_whole_dir(self):
+        """The allowlist is tight: an overclaim in a training/ file that is NOT
+        an ORPO negative-data generator (e.g. build_seed.py) still FAILS, so the
+        exemption cannot be abused to hide overclaims anywhere under training/."""
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "training/build_seed.py",
+                   'X = "Λ is a proven theorem, full stop."\n')
+            self.assertIn("Inv2", _invs(d, repo="szl-holdings/a11oy"),
+                          "non-ORPO training files are NOT exempt from INV2")
+
     def test_inline_honest_sentence_passes(self):
         with tempfile.TemporaryDirectory() as d:
             _write(d, "ok.md",


### PR DESCRIPTION
## Summary

The org honesty gate `doctrine_check.py` (INV2: "Λ must be Conjecture 1, never a theorem") was flagging **intentional ORPO negative-training data** in a11oy:

- `training/build_orpo.py` (×4) — the ORPO/preference-pair generator. Its **rejected** completions deliberately contain the banned `Λ ... proven theorem` overclaim so the model learns to *avoid* it and prefer the honest `Λ = Conjecture 1, never a theorem` completion.
- `training/box/RUN_ON_BOX.md` (×1) — a box run-doc quoting the `"Is Lambda a theorem?"` refusal smoke-test prompt.

These are negative-training fixtures, not product/serve/README claims, but they turned `check / doctrine` **RED** on a11oy `main` and PR #842.

## The fix (narrow, not a weakening)

- New `INV2_TRAINING_EXEMPT_PREFIXES = ("training/build_orpo", "training/box/RUN_ON_BOX")` — a tight relative-path allowlist, applied **only to INV2**, via the existing `rel`/byte-parity path convention.
- INV2 is **not** globally disabled: every other file still scans for INV2, and every other invariant (INV1/3/5/6) still scans these files.
- Documented in-code explaining these are ORPO rejected/negative examples that intentionally contain the disallowed string for contrastive training.

## Testing

`test_doctrine_check.py` (required self-test gate) — **16 tests pass** (13 existing + 3 new):

- `test_orpo_negative_training_data_exempt` — the ORPO generator + box run-doc are exempt from INV2.
- `test_negative_control_overclaim_outside_training_still_fails` — **negative control**: the same bare overclaim in a non-training file still **FAILS** INV2.
- `test_training_exemption_is_tight_not_whole_dir` — a non-ORPO training file (`build_seed.py`) still **FAILS** INV2 (allowlist is tight, not whole-dir).

Verified against the real a11oy tree: the 5 prior INV2 violations clear, and planted overclaims outside `training/build_orpo`/`RUN_ON_BOX` still fail. No honesty gate weakened; Doctrine v11 LOCKED, Λ = Conjecture 1 intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)