### PR TITLE
fix(security): honest-degrade code-security-drift when token absent (#176)

### DIFF
--- a/.github/scripts/code_security_drift.py
+++ b/.github/scripts/code_security_drift.py
@@ -25,8 +25,16 @@ exceptions can be allowlisted with a reason.
 Auth: reads a token from $SZL_GITHUB_TOKEN / $GH_TOKEN / $GITHUB_TOKEN. The
 code-security configuration endpoints require org-admin, so the built-in
 GitHub Actions GITHUB_TOKEN is NOT sufficient — set the SZL_GITHUB_TOKEN PAT
-secret. A permission/auth/API failure is reported as an ERROR (exit 2) and
-never as a silent pass, so a missing token can never produce a false green.
+secret. Two failure modes are kept DISTINCT so a missing secret never looks
+like real drift and never looks like a pass:
+
+  * NO token configured at all -> exit 3 (NEUTRAL "not configured, skipped").
+    The check simply could not run; this is not a pass (coverage was NOT
+    verified) and not drift. The CI workflow surfaces this as a neutral/skipped
+    status, not a red failure.
+  * A token IS present but the API call fails (401/403 insufficient scope,
+    network, unexpected shape) -> exit 2 (ERROR). A configured-but-broken token
+    is a real misconfiguration and fails loudly, never a silent pass.
 
 Usage:
   python code_security_drift.py [--org szl-holdings] [--config-id 252588] \
@@ -35,7 +43,8 @@ Usage:
       [--include-archived] [--json]
 
 Exit code 0 = no drift (warnings allowed); 1 = drift detected; 2 = could not
-complete the check (auth/permission/API failure).
+complete the check (token present but auth/permission/API failure); 3 = no
+token configured (neutral skip — check did not run, NOT a pass).
 """
 from __future__ import annotations
 
@@ -49,6 +58,14 @@ from datetime import datetime, timezone
 
 API = "https://api.github.com"
 CANONICAL_CONFIG_ID = 252588
+
+# Exit-code contract (kept as named constants so the workflow and self-test
+# stay in lockstep): 0 no drift, 1 drift, 2 token-present-but-check-failed,
+# 3 no-token-configured (neutral skip — did not run, NOT a pass).
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_ERROR = 2
+EXIT_NO_TOKEN = 3
 # Repo is genuinely covered when the enforced org config reports it "enforced".
 OK_STATUSES = {"enforced"}
 # Briefly-in-flight states: warn (re-check next run) rather than fail.
@@ -59,6 +76,15 @@ class CheckError(RuntimeError):
     """Raised when the check cannot be completed (auth/permission/API)."""
 
 
+class MissingTokenError(CheckError):
+    """Raised when NO token is configured at all.
+
+    Distinct from a token that IS present but fails (401/403/network): a missing
+    secret is an honest NEUTRAL skip (exit 3), never a red failure and never a
+    pass. A present-but-broken token stays a loud error (exit 2).
+    """
+
+
 # --------------------------------------------------------------------------- #
 # GitHub helpers
 
@@ -67,9 +93,10 @@ def _token() -> str:
         v = os.environ.get(name)
         if v:
             return v
-    raise CheckError(
-        "No GitHub token found. Set SZL_GITHUB_TOKEN (an org-admin PAT) — the "
-        "built-in Actions GITHUB_TOKEN cannot read code-security configurations."
+    raise MissingTokenError(
+        "No GitHub token configured. Set SZL_GITHUB_TOKEN (an org-admin PAT) — "
+        "the built-in Actions GITHUB_TOKEN cannot read code-security "
+        "configurations. Skipping (neutral): coverage was NOT verified."
     )
 
 
@@ -294,10 +321,16 @@ def main() -> int:
 
     try:
         report = run_check(args)
+    except MissingTokenError as e:
+        # No token configured: honest NEUTRAL skip. Not a pass (coverage was not
+        # verified) and not drift. The workflow renders this as a skipped status.
+        print(f"::notice::{e}", file=sys.stderr)
+        return EXIT_NO_TOKEN
     except CheckError as e:
-        # Infrastructure/auth failure — fail loudly, never a silent pass.
+        # Token present but the check could not complete (auth/permission/API) —
+        # fail loudly, never a silent pass.
         print(f"::error::{e}", file=sys.stderr)
-        return 2
+        return EXIT_ERROR
 
     if args.report:
         os.makedirs(os.path.dirname(args.report) or ".", exist_ok=True)
@@ -325,7 +358,7 @@ def main() -> int:
             print(f"  ::error:: {e}")
         print(f"  -> {len(report['errors'])} error(s), {len(report['warnings'])} warning(s)")
 
-    return 1 if report["errors"] else 0
+    return EXIT_DRIFT if report["errors"] else EXIT_OK
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -21,7 +21,14 @@ contract of ``main()`` so a future refactor cannot quietly regress it:
   a new uncovered repo                           -> exit 1
   default-for-new-repos changed                  -> exit 1
   canonical configuration missing                -> exit 1
-  an auth/API failure (CheckError)               -> exit 2  (never a silent 0)
+  a present-but-failing token (auth/API error)   -> exit 2  (never a silent 0)
+  NO token configured at all                     -> exit 3  (neutral skip:
+                                                    not 0/pass, not 1/red)
+
+The exit-2 vs exit-3 split is the honest-degrade contract (task #176/#158): a
+MISSING secret is a neutral skip (the check could not run — CI surfaces it as a
+skipped/neutral status, not a red failure), while a token that IS present but
+fails auth/API stays a loud error. Neither is ever a silent pass.
 
 Stdlib ``unittest`` only — no third-party test framework, so CI needs only a
 github-owned ``actions/setup-python`` to run it.
@@ -98,7 +105,7 @@ def _run_main(configs, defaults, repos, attachments, *,
 
     ``token``          -> what ``_token()`` returns (None simulates a missing
                           token, which the real ``_token()`` turns into a
-                          CheckError -> exit 2).
+                          MissingTokenError -> exit 3 neutral skip).
     ``gh_json_error``  -> if set, the first ``gh_json`` call raises this
                           exception, simulating an auth/permission/API failure.
     Returns the ``main()`` exit code. Stdout/stderr are swallowed.
@@ -111,7 +118,7 @@ def _run_main(configs, defaults, repos, attachments, *,
     try:
         if token is None:
             def _no_token():
-                raise csd.CheckError("No GitHub token found (test).")
+                raise csd.MissingTokenError("No GitHub token configured (test).")
             csd._token = _no_token
         else:
             csd._token = lambda: token
@@ -197,17 +204,30 @@ class TestDriftCheckerExitContract(unittest.TestCase):
         rc = _run_main(configs, defaults, repos, attachments)
         self.assertEqual(rc, 1)
 
-    def test_missing_token_is_exit_2_not_0(self):
-        """A missing token must fail loudly (exit 2), never a silent green."""
-        rc = _run_main(*_clean_state(), token=None)
-        self.assertEqual(rc, 2)
+    def test_missing_token_is_neutral_skip_not_pass_not_red(self):
+        """No token configured -> exit 3 (neutral skip).
 
-    def test_api_failure_is_exit_2_not_0(self):
-        """An auth/permission/API failure must be exit 2, never swallowed -> 0."""
+        Honest degrade: a missing secret must NOT look like a pass (exit 0) and
+        must NOT look like drift/failure (exit 1). It is a distinct neutral code
+        so CI can render it as a skipped status.
+        """
+        rc = _run_main(*_clean_state(), token=None)
+        self.assertEqual(rc, csd.EXIT_NO_TOKEN)
+        self.assertEqual(rc, 3)
+        self.assertNotEqual(rc, 0)  # never a fake pass
+        self.assertNotEqual(rc, 1)  # never a false "drift" red
+
+    def test_present_but_failing_token_is_exit_2_not_0(self):
+        """A present token that hits an auth/API failure stays a loud error.
+
+        Distinct from a MISSING token (exit 3): a configured-but-broken token is
+        a real misconfiguration and must be exit 2, never swallowed to 0.
+        """
         rc = _run_main(
             *_clean_state(),
             gh_json_error=csd.CheckError("GitHub API 403 (simulated auth failure)"),
         )
+        self.assertEqual(rc, csd.EXIT_ERROR)
         self.assertEqual(rc, 2)
 
     def test_archived_uncovered_repo_passes(self):

--- a/.github/workflows/code-security-drift.yml
+++ b/.github/workflows/code-security-drift.yml
@@ -10,8 +10,17 @@ name: Code Security Config Drift
 #
 # The code-security configuration endpoints require org-admin, so the built-in
 # Actions GITHUB_TOKEN is NOT sufficient — the SZL_GITHUB_TOKEN PAT secret is
-# used. A missing/insufficient token is reported as an ERROR (exit 2), never a
-# silent pass, so coverage can't look green when the check could not run.
+# used. The two missing-vs-broken token cases are kept DISTINCT so a missing
+# secret never looks like real drift and never looks like a pass:
+#   * NO SZL_GITHUB_TOKEN configured -> the `check` job is SKIPPED (neutral) via
+#     the `preflight` gate below. This is honest degrade: the check did not run,
+#     so it is neither a red failure nor a green pass (coverage NOT verified).
+#   * A token IS present but the API call fails (401/403 insufficient scope,
+#     network) -> the checker exits 2 and this job FAILS loudly. A
+#     configured-but-broken token is a real misconfiguration, never a silent
+#     pass. A genuine drift (a repo not enforced under 252588) still FAILS.
+# Minimal token scope + the single founder step to add the secret are documented
+# in WORKFLOWS.md ("code-security-drift" section).
 
 on:
   schedule:
@@ -34,8 +43,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Honest-degrade gate. secrets.* cannot be referenced directly in a job-level
+  # `if:`, so this tiny job maps the secret to a boolean output. When the secret
+  # is absent the `check` job below is SKIPPED (neutral grey), not failed red and
+  # not passed green — the check simply did not run.
+  preflight:
+    name: Token preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      has_token: ${{ steps.detect.outputs.has_token }}
+    steps:
+      - name: Detect whether SZL_GITHUB_TOKEN is configured
+        id: detect
+        env:
+          SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+        run: |
+          if [ -n "${SZL_GITHUB_TOKEN:-}" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+            echo "SZL_GITHUB_TOKEN is configured — the drift check will run."
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=code-security-drift skipped::SZL_GITHUB_TOKEN is not configured. The org code-security drift check needs an org-admin PAT (fine-grained Administration:Read, or classic admin:org) to read the code-security configuration endpoints, so it is SKIPPED (neutral) rather than reported as drift. This is NOT a pass — org coverage was not verified. A founder must add the SZL_GITHUB_TOKEN secret to enable it (see WORKFLOWS.md)."
+          fi
+
   check:
     name: Managed security config attached + enforced everywhere
+    needs: preflight
+    if: needs.preflight.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -136,10 +171,17 @@ jobs:
               echo "::error::or add a reasoned entry to .github/data/code_security_allowlist.json."
               exit 1
               ;;
+            3)
+              # Defensive: this job only runs when the preflight gate saw a token,
+              # so exit 3 (no token) should not reach here. Treat it as a neutral
+              # skip rather than red — honest degrade, never a fake pass.
+              echo "::notice::SZL_GITHUB_TOKEN not configured; org code-security"
+              echo "::notice::drift check skipped (neutral). Coverage NOT verified."
+              ;;
             *)
               echo "::error::Could not complete the managed-security-config check"
-              echo "::error::(auth/API failure). The code-security endpoints need an"
-              echo "::error::org-admin token — set the SZL_GITHUB_TOKEN secret. This is"
+              echo "::error::(the token is present but the API call failed — likely"
+              echo "::error::insufficient scope; needs an org-admin PAT). This is"
               echo "::error::failed (not passed) so coverage can never look green when"
               echo "::error::the check could not actually run."
               exit 1

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -72,6 +72,48 @@ Both honor the repo's own `.github/hf-module-drift-allow.json` ratchet
 (known drift warns; new drift fails) and NEVER auto-overwrite — a human
 picks the source of truth, since drift can run in either direction.
 
+## Org code-security config drift (`code-security-drift.yml`)
+
+`code-security-drift.yml` verifies the org-level code security configuration
+"SZL Holdings Managed Security" (id `252588`) is still attached + **enforced**
+on every non-archived repo and is the default for new repos. Reading the
+code-security configuration endpoints (`/orgs/{org}/code-security/...`) requires
+**org-admin**, which the built-in Actions `GITHUB_TOKEN` does not have, so it
+uses the `SZL_GITHUB_TOKEN` repo (or org) secret.
+
+### Honest-degrade behavior
+
+The check distinguishes three states so a missing secret never masquerades as
+either drift or a clean pass:
+
+| State | Result | CI status |
+|---|---|---|
+| Every non-archived repo enforced under `252588` | exit 0 | ✅ pass |
+| A repo detached / on another config / new & uncovered | exit 1 | ❌ fail (real drift) |
+| `SZL_GITHUB_TOKEN` present but auth/API fails (bad scope, network) | exit 2 | ❌ fail (real misconfiguration) |
+| `SZL_GITHUB_TOKEN` **not configured** | check job skipped | ⏭️ neutral (did NOT run — not a pass) |
+
+The `preflight` job maps the secret to a boolean and gates the `check` job on
+it (`secrets.*` cannot be used in a job-level `if:` directly), so with no token
+the check is **skipped (neutral grey)** — not a red failure and not a green
+pass. A genuine drift still fails when the token IS present.
+
+### Founder step — enable the check (one time)
+
+1. Create a fine-grained **or** classic PAT owned by an org owner:
+   - **Fine-grained PAT** scoped to the `szl-holdings` org, with the
+     organization permission **"Administration" → Read** (this is what the
+     code-security configuration endpoints require).
+   - *(or)* **Classic PAT** with the **`admin:org`** scope (`read:org` alone is
+     **not** sufficient to read code-security configurations).
+2. Add it as a secret named `SZL_GITHUB_TOKEN`:
+   - Repo secret: `gh secret set SZL_GITHUB_TOKEN --repo szl-holdings/.github`
+   - *(or)* org secret visible to `.github`:
+     `gh secret set SZL_GITHUB_TOKEN --org szl-holdings --visibility selected --repos .github`
+
+Once the secret exists, re-run the workflow (`gh workflow run code-security-drift.yml
+--repo szl-holdings/.github`) and the neutral skip becomes a real pass/fail.
+
 ## Dependabot
 
 A default `.github/dependabot.yml` lives in this repo. Every repo without


### PR DESCRIPTION
## Summary

The org security posture is **correct** — 33/33 non-archived repos are attached + enforced under managed config `252588`, 0 drift. But the `code-security-drift` CI self-check was showing **RED** for one reason only: `SZL_GITHUB_TOKEN` (the org-admin PAT needed to *read* the code-security configuration endpoints) is unset, and a missing secret was being reported exactly like real drift.

This makes the check **degrade honestly** when the token is absent — a neutral/skipped status, **not** a red failure and **not** a fake pass. A genuine drift (or a present-but-broken token) still fails.

## Changes

- **`.github/scripts/code_security_drift.py`** — new `MissingTokenError` → **exit 3** (no token configured = neutral skip; check did not run, NOT a pass). A token that *is* present but fails auth/API stays **exit 2** (loud error). Genuine drift stays **exit 1**. Exit codes are now named constants (`EXIT_OK/DRIFT/ERROR/NO_TOKEN`).
- **`.github/workflows/code-security-drift.yml`** — new `preflight` job maps the secret to a boolean (`secrets.*` can't be used in a job-level `if:`) and gates the `check` job on it. With no token the `check` job is **skipped (neutral grey)** instead of failing red. With a token, real drift still fails.
- **`.github/scripts/test_code_security_drift.py`** — pins the new contract: missing token → exit 3 (asserts `!= 0` and `!= 1`, so never a fake pass and never false drift); present-but-failing token → exit 2.
- **`WORKFLOWS.md`** — documents the minimal token scope and the single founder step to add the secret.

### Honest-degrade truth table

| State | Result |
|---|---|
| Every non-archived repo enforced under `252588` | ✅ exit 0 |
| A repo detached / on another config / new & uncovered | ❌ exit 1 (real drift) |
| Token present but auth/API fails (bad scope/network) | ❌ exit 2 (real misconfig) |
| `SZL_GITHUB_TOKEN` **not configured** | ⏭️ check skipped (neutral, NOT a pass) |

This does **not** weaken a real gate: honest-degrade on a missing token is not weakening; a genuine drift and a present-but-broken token both still fail loudly.

## Founder step (to turn the neutral skip into a live pass)

1. Create an org-owner PAT: fine-grained with **Administration → Read** on the `szl-holdings` org, *or* classic with **`admin:org`** (`read:org` alone is not sufficient for code-security config endpoints).
2. `gh secret set SZL_GITHUB_TOKEN --repo szl-holdings/.github` (or as an org secret scoped to `.github`).
3. Re-run the workflow — the skip becomes a real 0-drift pass.

Refs #176, #158.

## Testing

- [x] `python3 .github/scripts/test_code_security_drift.py` → 11 tests OK
- [x] `python3 .github/scripts/test_build_drift_alert.py` → 14 tests OK (unaffected; alert step lives inside the token-gated `check` job)
- [x] `actionlint .github/workflows/code-security-drift.yml` → clean
- [x] `python3 .github/scripts/code_security_drift.py` with no token → prints neutral `::notice::`, exits 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)