### PR TITLE
fix(doctrine): distinguish historical receipt indexes

### DIFF
--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -319,19 +319,22 @@ jobs:
           echo "=== Invariant 9: DSSE receipt format ==="
           for f in $(find . \( -name "*.dsse" -o -name "szl_receipt*.json" -o -name "dsse_*.json" -o -name "*_receipt.json" \) 2>/dev/null | grep -vE "context|schema|report" | head -3); do
             # Historical decision-receipt indexes are immutable evidence summaries,
-            # not DSSE receipts.  Recognize their exact shape instead of exempting a
-            # directory, so moving a malformed live receipt cannot bypass doctrine.
-            if jq -e '
-              type == "object" and
-              has("last_receipt") and (.last_receipt | type == "object") and
-              (.last_receipt.receipt_id | type == "string" and length > 0) and
-              (.receipt_count | type == "number" and . >= 0) and
-              (has("doctrine") | not) and
-              (has("lambda_uniqueness") | not)
-            ' "$f" >/dev/null 2>&1; then
-              echo "  $f historical decision-receipt index (DSSE invariant not applicable)"
-              continue
-            fi
+            # not DSSE receipts. Recognize only the ambiguous legacy basename plus
+            # its exact top-level shape; explicitly named DSSE files remain strict.
+            case "$f" in
+              */decision_receipt.json)
+                if jq -e '
+                  type == "object" and
+                  ((keys | sort) == ["last_receipt", "receipt_count"]) and
+                  (.last_receipt | type == "object") and
+                  (.last_receipt.receipt_id | type == "string" and length > 0) and
+                  (.receipt_count | type == "number" and . >= 1 and floor == .)
+                ' "$f" >/dev/null 2>&1; then
+                  echo "  $f historical decision-receipt index (DSSE invariant not applicable)"
+                  continue
+                fi
+                ;;
+            esac
             D=$(jq -e '.doctrine' "$f" 2>/dev/null | grep -v '"v11"' || true)
             if [ -n "$D" ]; then
               echo "  $f doctrine=$D"

--- a/.github/workflows/doctrine-check.yml
+++ b/.github/workflows/doctrine-check.yml
@@ -318,6 +318,20 @@ jobs:
 
           echo "=== Invariant 9: DSSE receipt format ==="
           for f in $(find . \( -name "*.dsse" -o -name "szl_receipt*.json" -o -name "dsse_*.json" -o -name "*_receipt.json" \) 2>/dev/null | grep -vE "context|schema|report" | head -3); do
+            # Historical decision-receipt indexes are immutable evidence summaries,
+            # not DSSE receipts.  Recognize their exact shape instead of exempting a
+            # directory, so moving a malformed live receipt cannot bypass doctrine.
+            if jq -e '
+              type == "object" and
+              has("last_receipt") and (.last_receipt | type == "object") and
+              (.last_receipt.receipt_id | type == "string" and length > 0) and
+              (.receipt_count | type == "number" and . >= 0) and
+              (has("doctrine") | not) and
+              (has("lambda_uniqueness") | not)
+            ' "$f" >/dev/null 2>&1; then
+              echo "  $f historical decision-receipt index (DSSE invariant not applicable)"
+              continue
+            fi
             D=$(jq -e '.doctrine' "$f" 2>/dev/null | grep -v '"v11"' || true)
             if [ -n "$D" ]; then
               echo "  $f doctrine=$D"


### PR DESCRIPTION
## What changed

Teach Invariant 9 to recognize the exact `{last_receipt, receipt_count}` historical index shape before applying current DSSE fields. No path or directory is exempted.

## Why

Immutable migrated evidence in docs-site is a decision-receipt index, not a DSSE receipt. Editing the evidence would break provenance; treating every `*_receipt.json` as DSSE creates a false failure.

## Validation

- [x] Workflow YAML parsed locally
- [x] Historical index fixture recognized
- [x] Valid live receipt is not skipped
- [x] Malformed index is not skipped
- [x] `git diff --check` passes

## Risk and rollback

Low and fail-closed: only a strict object shape with a non-empty nested receipt ID and non-negative receipt count is skipped. Revert commit `e243d95` to roll back.