### PR TITLE
fix(hf-drift): separate revision namespaces and fail honest

### DIFF
--- a/.github/scripts/hf_module_drift_check.py
+++ b/.github/scripts/hf_module_drift_check.py
@@ -509,7 +509,21 @@ def classify_lineage(gh_sha, hf_oid, canonical_shas, date_ahead):
 # --------------------------------------------------------------------------- #
 # Main comparison (single GitHub<->HF pair)
 # --------------------------------------------------------------------------- #
+def effective_refs(args):
+    """Return independent GitHub and Hugging Face refs.
+
+    ``--ref`` remains the backwards-compatible common default. A pull-request
+    head SHA belongs to GitHub's revision namespace and must never be sent to
+    the Hugging Face tree API as though it were a Space revision.
+    """
+    common = getattr(args, "ref", None) or "main"
+    github_ref = getattr(args, "github_ref", None) or common
+    hf_ref = getattr(args, "hf_ref", None) or common
+    return github_ref, hf_ref
+
+
 def compare(args, allow=None):
+    github_ref, hf_ref = effective_refs(args)
     if allow is None:
         allow = load_allow_file(args.allow)
     accepted = allow.get("accepted_divergences", {})
@@ -530,6 +544,9 @@ def compare(args, allow=None):
             tree = _sibling_tree_cache.get(s)
             if tree is None:
                 try:
+                    # A commit SHA is repository-local. Sibling canonical repos
+                    # keep using the common ref (normally main), not the primary
+                    # repository's PR-head override.
                     tree = github_tree_remote(s, args.ref)
                 except RuntimeError:
                     tree = {}
@@ -542,7 +559,7 @@ def compare(args, allow=None):
 
     if args.github_remote:
         status, body, _ = gh_get(
-            f"{GH_RAW}/{args.github_repo}/{args.ref}/Dockerfile")
+            f"{GH_RAW}/{args.github_repo}/{github_ref}/Dockerfile")
         if status != 200:
             raise RuntimeError(f"fetch remote Dockerfile: HTTP {status}")
         dockerfile_text = body.decode("utf-8", "replace")
@@ -552,11 +569,11 @@ def compare(args, allow=None):
     sources = parse_copy_sources(dockerfile_text)
 
     if args.github_remote:
-        gh_files = github_tree_remote(args.github_repo, args.ref)
+        gh_files = github_tree_remote(args.github_repo, github_ref)
     else:
         gh_files = github_tree_local(args.repo_root)
 
-    hf_files = hf_tree(args.hf_repo, args.ref)
+    hf_files = hf_tree(args.hf_repo, hf_ref)
 
     targets = sorted(expand_targets(sources, gh_files, hf_files, allow))
 
@@ -607,10 +624,10 @@ def compare(args, allow=None):
             continue  # byte-identical -> in sync
 
         # Content drift -> name which side is ahead by last-commit date.
-        gh_date = github_file_date(args.github_repo, path, args.ref)
+        gh_date = github_file_date(args.github_repo, path, github_ref)
         d = os.path.dirname(path)
         if d not in _hf_date_cache:
-            _hf_date_cache[d] = hf_dir_dates(args.hf_repo, d, args.ref)
+            _hf_date_cache[d] = hf_dir_dates(args.hf_repo, d, hf_ref)
         hf_date = _hf_date_cache[d].get(path)
         if gh_date and hf_date:
             ahead = "github" if gh_date > hf_date else ("huggingface" if hf_date > gh_date else "tied")
@@ -641,6 +658,8 @@ def compare(args, allow=None):
         "github_repo": args.github_repo,
         "hf_repo": args.hf_repo,
         "ref": args.ref,
+        "github_ref": github_ref,
+        "hf_ref": hf_ref,
         "copy_sources": len(sources),
         "files_compared": len(targets),
         "error_count": len(errors),
@@ -677,7 +696,10 @@ def fmt(entry):
 
 
 def print_pair(report, errors, warns, github_repo, hf_repo, ref):
-    print(f"== HF module-drift guard: {github_repo}  <->  {hf_repo} ({ref}) ==")
+    github_ref = report.get("github_ref", ref)
+    hf_ref = report.get("hf_ref", ref)
+    print(f"== HF module-drift guard: {github_repo} ({github_ref})  <->  "
+          f"{hf_repo} ({hf_ref}) ==")
     print(f"   COPY sources: {report['copy_sources']}   files compared: {report['files_compared']}")
     print(f"   errors (drift): {len(errors)}   warnings (allowlisted/absent): {len(warns)}")
     if warns:
@@ -725,6 +747,7 @@ def _emit_inconclusive(args, exc):
     code = getattr(exc, "code", None)
     reason = "hf_api_429" if code == 429 else (
         f"api_http_{code}" if code else "api_unavailable")
+    github_ref, hf_ref = effective_refs(args)
     report = {
         "schema": 1,
         "status": "inconclusive",
@@ -733,6 +756,8 @@ def _emit_inconclusive(args, exc):
         "github_repo": getattr(args, "github_repo", None),
         "hf_repo": getattr(args, "hf_repo", None),
         "ref": getattr(args, "ref", None),
+        "github_ref": github_ref,
+        "hf_ref": hf_ref,
         "detail": str(exc),
         "error_count": 0,
         "warn_count": 0,
@@ -769,6 +794,8 @@ def run_registry(args):
         gh = ent.get("github")
         hf = ent.get("hf")
         ref = ent.get("ref", args.ref)
+        github_ref = ent.get("github_ref", ref)
+        hf_ref = ent.get("hf_ref", ref)
         if not gh or not hf:
             print(f"::warning::registry entry missing github/hf: {ent!r}")
             continue
@@ -776,13 +803,13 @@ def run_registry(args):
         # "...for each repo that HAS both a Dockerfile and a matching HF Space."
         # No Dockerfile -> nothing is COPY'd, so there's nothing to drift: skip.
         try:
-            dstatus, _, _ = gh_get(f"{GH_RAW}/{gh}/{ref}/Dockerfile")
+            dstatus, _, _ = gh_get(f"{GH_RAW}/{gh}/{github_ref}/Dockerfile")
         except RuntimeError as e:
             print(f"::warning::{gh}: could not reach Dockerfile ({e}); skipping.")
             skipped.append({"github": gh, "hf": hf, "reason": "dockerfile-unreachable"})
             continue
         if dstatus == 404:
-            print(f"-- {gh}: no Dockerfile at {ref}; skipping (nothing COPY'd).")
+            print(f"-- {gh}: no Dockerfile at {github_ref}; skipping (nothing COPY'd).")
             skipped.append({"github": gh, "hf": hf, "reason": "no-dockerfile"})
             continue
 
@@ -793,10 +820,11 @@ def run_registry(args):
                if e.get("github") and e.get("github") != gh]
         sub = argparse.Namespace(
             repo_root=args.repo_root, github_repo=gh, hf_repo=hf, ref=ref,
+            github_ref=github_ref, hf_ref=hf_ref,
             allow=None, github_remote=True, report_out="", warn_only=args.warn_only,
             siblings=sib,
         )
-        allow = fetch_remote_allow(gh, ref)
+        allow = fetch_remote_allow(gh, github_ref)
         try:
             report, errors, warns = compare(sub, allow)
         except TransientHTTPError as e:
@@ -810,6 +838,7 @@ def run_registry(args):
                                  "detail": str(e)})
             pair_reports.append({
                 "github_repo": gh, "hf_repo": hf, "ref": ref,
+                "github_ref": github_ref, "hf_ref": hf_ref,
                 "status": "inconclusive", "error_count": 0, "warn_count": 0,
                 "findings": [{"path": "(pair)", "kind": "inconclusive",
                               "severity": "warn", "detail": str(e)}],
@@ -823,6 +852,7 @@ def run_registry(args):
             total_errors += 1
             pair_reports.append({
                 "github_repo": gh, "hf_repo": hf, "ref": ref,
+                "github_ref": github_ref, "hf_ref": hf_ref,
                 "error_count": 1, "warn_count": 0,
                 "findings": [{"path": "(pair)", "kind": "compare-failed",
                               "severity": "error", "detail": str(e)}],
@@ -871,7 +901,15 @@ def main():
     ap.add_argument("--repo-root", default=".", help="local checkout root (GitHub side in CI mode)")
     ap.add_argument("--github-repo", help="e.g. szl-holdings/a11oy (single-pair mode)")
     ap.add_argument("--hf-repo", help="e.g. SZLHOLDINGS/a11oy (single-pair mode)")
-    ap.add_argument("--ref", default="main")
+    ap.add_argument(
+        "--ref", default="main",
+        help="backwards-compatible common ref for both sides (default: main)")
+    ap.add_argument(
+        "--github-ref", default="",
+        help="GitHub checkout/API ref; overrides --ref for the GitHub side")
+    ap.add_argument(
+        "--hf-ref", default="",
+        help="Hugging Face revision; overrides --ref for the HF side")
     ap.add_argument("--allow", default=".github/hf-module-drift-allow.json")
     ap.add_argument("--report-out", default="")
     ap.add_argument("--registry", default="",

--- a/.github/scripts/hf_module_drift_check.py
+++ b/.github/scripts/hf_module_drift_check.py
@@ -804,6 +804,37 @@ def run_registry(args):
         # No Dockerfile -> nothing is COPY'd, so there's nothing to drift: skip.
         try:
             dstatus, _, _ = gh_get(f"{GH_RAW}/{gh}/{github_ref}/Dockerfile")
+        except TransientHTTPError as e:
+            # A transient failure during the Dockerfile eligibility preflight
+            # means this pair was never actually classified as scannable or
+            # safely skippable. Record it as INCONCLUSIVE, not as a benign skip,
+            # so the sweep's top-level status cannot false-green.
+            print(f"::warning title=HF module drift INCONCLUSIVE::{gh} <-> {hf}: "
+                  f"Dockerfile preflight unavailable ({e}); could NOT determine "
+                  "whether this pair required a drift comparison.")
+            inconclusive.append({
+                "github": gh,
+                "hf": hf,
+                "reason": "dockerfile-preflight-api-unavailable",
+                "detail": str(e),
+            })
+            pair_reports.append({
+                "github_repo": gh,
+                "hf_repo": hf,
+                "ref": ref,
+                "github_ref": github_ref,
+                "hf_ref": hf_ref,
+                "status": "inconclusive",
+                "error_count": 0,
+                "warn_count": 0,
+                "findings": [{
+                    "path": "Dockerfile",
+                    "kind": "inconclusive",
+                    "severity": "warn",
+                    "detail": str(e),
+                }],
+            })
+            continue
         except RuntimeError as e:
             print(f"::warning::{gh}: could not reach Dockerfile ({e}); skipping.")
             skipped.append({"github": gh, "hf": hf, "reason": "dockerfile-unreachable"})
@@ -892,6 +923,11 @@ def run_registry(args):
               "HF Space. A human must pick which side is the source of truth, "
               "reconcile, and commit -- the guard never auto-overwrites.")
         return 1
+    if not total_errors and inconclusive:
+        print("\nINCONCLUSIVE: the org sweep could not verify every GitHub <-> HF "
+              "pair. This is NOT a verified in-sync pass; re-run once the "
+              "transient remote outage or rate limit clears.")
+        return 0
     print("\nOK: no unaccepted module drift between GitHub and any live HF Space.")
     return 0
 

--- a/.github/scripts/test_hf_module_drift_check.py
+++ b/.github/scripts/test_hf_module_drift_check.py
@@ -152,6 +152,91 @@ class TestComparePropagatesLineage(unittest.TestCase):
         self.assertIn("md5-compare all 4 surfaces", rendered)
 
 
+class TestIndependentRefs(unittest.TestCase):
+    """A GitHub PR SHA and an HF deployment revision are different namespaces."""
+
+    def setUp(self):
+        self._saved = {k: getattr(drift, k) for k in (
+            "github_tree_remote", "hf_tree", "github_file_date",
+            "hf_dir_dates", "parse_copy_sources", "gh_get")}
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            setattr(drift, key, value)
+
+    def test_common_ref_remains_backwards_compatible(self):
+        args = argparse.Namespace(ref="release")
+        self.assertEqual(drift.effective_refs(args), ("release", "release"))
+
+    def test_compare_routes_each_side_to_its_own_ref(self):
+        path = "module.py"
+        calls = []
+        drift.parse_copy_sources = lambda _text: [path]
+        drift.gh_get = lambda *a, **k: (200, b"COPY module.py /app/", None)
+
+        def github_tree(repo, ref="main"):
+            calls.append(("github-tree", ref))
+            return {path: "same"}
+
+        def hf_tree(repo, ref="main"):
+            calls.append(("hf-tree", ref))
+            return {path: {"oid": "same", "lfs_oid": None, "size": 1}}
+
+        drift.github_tree_remote = github_tree
+        drift.hf_tree = hf_tree
+        drift.github_file_date = lambda repo, p, ref="main": None
+        drift.hf_dir_dates = lambda repo, d, ref="main": {}
+        args = argparse.Namespace(
+            repo_root=".", github_repo="szl-holdings/a11oy",
+            hf_repo="SZLHOLDINGS/a11oy", ref="main",
+            github_ref="github-pr-head", hf_ref="hf-live-revision",
+            allow=None, github_remote=True, report_out="", warn_only=False,
+            siblings=[],
+        )
+
+        report, errors, warns = drift.compare(args, allow={})
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warns, [])
+        self.assertIn(("github-tree", "github-pr-head"), calls)
+        self.assertIn(("hf-tree", "hf-live-revision"), calls)
+        self.assertEqual(report["github_ref"], "github-pr-head")
+        self.assertEqual(report["hf_ref"], "hf-live-revision")
+
+    def test_primary_pr_sha_is_not_reused_for_sibling_repositories(self):
+        path = "module.py"
+        calls = []
+        drift.parse_copy_sources = lambda _text: [path]
+        drift.gh_get = lambda *a, **k: (200, b"COPY module.py /app/", None)
+
+        def github_tree(repo, ref="main"):
+            calls.append((repo, ref))
+            if repo == "szl-holdings/a11oy":
+                return {path: "canonical"}
+            return {path: "canonical"}
+
+        drift.github_tree_remote = github_tree
+        drift.hf_tree = lambda repo, ref="main": {
+            path: {"oid": "stale", "lfs_oid": None, "size": 1}}
+        drift.github_file_date = lambda repo, p, ref="main": "2026-07-12T00:00:00Z"
+        drift.hf_dir_dates = lambda repo, d, ref="main": {
+            path: "2026-07-11T00:00:00Z"}
+        args = argparse.Namespace(
+            repo_root=".", github_repo="szl-holdings/a11oy",
+            hf_repo="SZLHOLDINGS/a11oy", ref="main",
+            github_ref="github-pr-head", hf_ref="hf-live-revision",
+            allow=None, github_remote=True, report_out="", warn_only=False,
+            siblings=["szl-holdings/killinchu"],
+        )
+
+        _report, errors, _warns = drift.compare(args, allow={})
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn(("szl-holdings/a11oy", "github-pr-head"), calls)
+        self.assertIn(("szl-holdings/killinchu", "main"), calls)
+        self.assertNotIn(("szl-holdings/killinchu", "github-pr-head"), calls)
+
+
 class TestTransientHTTPInconclusive(unittest.TestCase):
     """A persistent HF 429/5xx must go HONEST INCONCLUSIVE (report written,
     exit 0), never crash and never false-green. All network stubbed."""

--- a/.github/scripts/test_hf_module_drift_check.py
+++ b/.github/scripts/test_hf_module_drift_check.py
@@ -21,7 +21,9 @@ conflict actually surfaces in the run output. Runs with NO network.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -310,6 +312,122 @@ class TestTransientHTTPInconclusive(unittest.TestCase):
         report, errors, warns = drift.compare(args)
         self.assertEqual(report["status"], "ok")
         self.assertEqual(errors, [])
+
+
+class TestRegistryInconclusiveHonesty(unittest.TestCase):
+    """Registry mode must never give an inconclusive sweep a terminal OK."""
+
+    def setUp(self):
+        self._saved = {key: getattr(drift, key) for key in (
+            "gh_get", "fetch_remote_allow", "compare")}
+        self._tmp = tempfile.mkdtemp()
+        self.registry = os.path.join(self._tmp, "registry.json")
+        self.report = os.path.join(self._tmp, "report.json")
+        with open(self.registry, "w") as fh:
+            json.dump({"spaces": [{
+                "github": "szl-holdings/a11oy",
+                "hf": "SZLHOLDINGS/a11oy",
+            }]}, fh)
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            setattr(drift, key, value)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _args(self):
+        return argparse.Namespace(
+            registry=self.registry,
+            report_out=self.report,
+            repo_root=".",
+            ref="main",
+            warn_only=False,
+        )
+
+    def _run(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = drift.run_registry(self._args())
+        with open(self.report) as fh:
+            report = json.load(fh)
+        return rc, report, output.getvalue()
+
+    def test_inconclusive_only_sweep_ends_inconclusive_not_ok(self):
+        drift.gh_get = lambda *_a, **_k: (200, b"FROM python:3.12", None)
+        drift.fetch_remote_allow = lambda *_a, **_k: {}
+
+        def transient_compare(*_a, **_k):
+            raise drift.TransientHTTPError(
+                "https://huggingface.co/api/spaces/SZLHOLDINGS/a11oy/tree/main",
+                429,
+                8,
+            )
+
+        drift.compare = transient_compare
+
+        rc, report, output = self._run()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(len(report["pairs_inconclusive"]), 1)
+        self.assertIn("\nINCONCLUSIVE:", output)
+        self.assertNotIn("\nOK:", output)
+
+    def test_transient_dockerfile_preflight_is_inconclusive_not_skipped(self):
+        def transient_preflight(*_a, **_k):
+            raise drift.TransientHTTPError(
+                "https://raw.githubusercontent.com/szl-holdings/a11oy/main/Dockerfile",
+                503,
+                8,
+            )
+
+        drift.gh_get = transient_preflight
+        drift.fetch_remote_allow = lambda *_a, **_k: self.fail(
+            "allowlist fetch must not run after an inconclusive preflight")
+        drift.compare = lambda *_a, **_k: self.fail(
+            "compare must not run after an inconclusive preflight")
+
+        rc, report, output = self._run()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["pairs_skipped"], [])
+        self.assertEqual(len(report["pairs_inconclusive"]), 1)
+        self.assertEqual(
+            report["pairs_inconclusive"][0]["reason"],
+            "dockerfile-preflight-api-unavailable",
+        )
+        self.assertEqual(report["pairs"][0]["status"], "inconclusive")
+        self.assertEqual(report["pairs"][0]["findings"][0]["path"], "Dockerfile")
+        self.assertIn("Dockerfile preflight unavailable", output)
+        self.assertIn("\nINCONCLUSIVE:", output)
+        self.assertNotIn("\nOK:", output)
+
+    def test_nontransient_dockerfile_preflight_keeps_legacy_skip_policy(self):
+        def nontransient_preflight(*_a, **_k):
+            raise RuntimeError("permanent read failure")
+
+        drift.gh_get = nontransient_preflight
+        drift.fetch_remote_allow = lambda *_a, **_k: self.fail(
+            "allowlist fetch must not run after a skipped preflight")
+        drift.compare = lambda *_a, **_k: self.fail(
+            "compare must not run after a skipped preflight")
+
+        rc, report, output = self._run()
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(report["pairs_inconclusive"], [])
+        self.assertEqual(
+            report["pairs_skipped"],
+            [{
+                "github": "szl-holdings/a11oy",
+                "hf": "SZLHOLDINGS/a11oy",
+                "reason": "dockerfile-unreachable",
+            }],
+        )
+        self.assertIn("could not reach Dockerfile", output)
+        self.assertIn("\nOK:", output)
+        self.assertNotIn("\nINCONCLUSIVE:", output)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/reusable-hf-module-drift-check.yml
+++ b/.github/workflows/reusable-hf-module-drift-check.yml
@@ -18,7 +18,7 @@ name: Reusable — HF Module Drift Check
 # unless overridden):
 #   jobs:
 #     hf-drift:
-#       uses: szl-holdings/.github/.github/workflows/reusable-hf-module-drift-check.yml@main
+#       uses: szl-holdings/.github/.github/workflows/reusable-hf-module-drift-check.yml@<full-commit-sha>
 #   # or, for a non-conventional Space name:
 #       with:
 #         hf-repo: SZLHOLDINGS/some-other-name

--- a/.github/workflows/reusable-hf-module-drift-check.yml
+++ b/.github/workflows/reusable-hf-module-drift-check.yml
@@ -32,10 +32,20 @@ on:
         type: string
         default: ""
       ref:
-        description: "Branch/ref to compare on both sides."
+        description: "Backwards-compatible common ref for both sides."
         required: false
         type: string
         default: "main"
+      github-ref:
+        description: "GitHub checkout/API ref. Empty preserves the common ref."
+        required: false
+        type: string
+        default: ""
+      hf-ref:
+        description: "Hugging Face revision. Empty preserves the common ref."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -55,13 +65,16 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: caller
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.github-ref != '' && inputs.github-ref || inputs.ref }}
 
-      - name: Checkout szl-holdings/.github (shared checker)
+      - name: Checkout exact reusable-workflow revision (shared checker)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: szl-holdings/.github
-          ref: main
+          # A reusable workflow must run the checker shipped with the exact
+          # workflow revision the caller pinned, never mutable default-branch
+          # code. GitHub exposes both values in the reusable job context.
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: tools
 
       - name: Set up Python
@@ -75,20 +88,26 @@ jobs:
           GH_REPO: ${{ github.repository }}
           HF_REPO_IN: ${{ inputs.hf-repo }}
           REF: ${{ inputs.ref }}
+          GITHUB_REF_IN: ${{ inputs.github-ref }}
+          HF_REF_IN: ${{ inputs.hf-ref }}
         run: |
           set -euo pipefail
+          GH_SOURCE_REF="${GITHUB_REF_IN:-${REF}}"
+          HF_SOURCE_REF="${HF_REF_IN:-${REF}}"
           if [ -n "${HF_REPO_IN}" ]; then
             HF_REPO="${HF_REPO_IN}"
           else
             # Convention: szl-holdings/<x> -> SZLHOLDINGS/<x> (HF org is UPPERCASE).
             HF_REPO="SZLHOLDINGS/${GH_REPO##*/}"
           fi
-          echo "Comparing ${GH_REPO} (checkout) <-> ${HF_REPO} (live HF Space) @ ${REF}"
+          echo "Comparing ${GH_REPO} @ ${GH_SOURCE_REF} (checkout) <-> ${HF_REPO} @ ${HF_SOURCE_REF} (live HF Space)"
           python3 tools/.github/scripts/hf_module_drift_check.py \
             --repo-root caller \
             --github-repo "${GH_REPO}" \
             --hf-repo "${HF_REPO}" \
             --ref "${REF}" \
+            --github-ref "${GH_SOURCE_REF}" \
+            --hf-ref "${HF_SOURCE_REF}" \
             --allow caller/.github/hf-module-drift-allow.json \
             --report-out hf-module-drift-report.out.json
 


### PR DESCRIPTION
## Purpose

Prevent GitHub pull-request SHAs from being sent to Hugging Face as Space revisions, and ensure an unverified org sweep can never present itself as verified OK.

## Changes

- add optional github-ref and hf-ref workflow inputs while keeping ref as the backwards-compatible common default
- route GitHub checkout, tree, date, and allowlist lookups through the GitHub ref
- route Hugging Face tree and date lookups through the HF ref
- keep sibling repositories on their canonical common ref so repository-local PR SHAs never leak across repositories
- record both effective refs in success, drift, failure, and INCONCLUSIVE reports
- check out the co-located verifier from the exact called-workflow revision with job.workflow_repository and job.workflow_sha
- replace the mutable wiring example with an immutable full-SHA contract
- classify transient registry preflights as INCONCLUSIVE instead of benign skips
- print terminal INCONCLUSIVE, never OK, when any registry pair remains unverified

## Verification

- [x] exact current-main base audited before editing
- [x] YAML unique-key parse passes
- [x] Python compilation passes
- [x] Ubuntu Python 3.12 full suite: 247/247 pass
- [x] independent-ref, sibling-isolation, backward-compatibility, INCONCLUSIVE-report, and registry-honesty regressions pass
- [x] remote branch hashes exactly match the audited candidate for all three files

## Scope and safety

Three files only. The guard remains read-only and never reconciles or overwrites either source automatically. Existing callers that only pass ref remain compatible.
