### PR TITLE
ci: daily HF dataset badge refresh — keep files/license badges honest

### DIFF
--- a/.github/scripts/hf_dataset_badge_refresh.mjs
+++ b/.github/scripts/hf_dataset_badge_refresh.mjs
@@ -1,0 +1,108 @@
+// Daily badge-drift refresher for SZLHOLDINGS dataset cards.
+// Recomputes each dataset's file count (recursive live tree) and license
+// (README front-matter) and rewrites ONLY the files/license badge values when
+// they drifted. Body text is never touched — the edit is a targeted regex on
+// the shields.io badge URL inside the existing badge row.
+//
+// Badge format matches .agents/estate-audit/hf-dataset-card-upgrade.mjs:
+//   files   -> 5b8dee, flat-square
+//   license -> 7e8aa3, flat-square
+//
+// FAIL-CLOSED: missing token, non-JSON tree, or a failed commit exits 1 —
+// drift is never silently left in place while the job reports green.
+//
+// Usage: HF_TOKEN=... node hf_dataset_badge_refresh.mjs [--publish]
+//   default = dry run (report drift, commit nothing)
+
+const TOKEN = process.env.HF_TOKEN || process.env.HUGGINGFACE_API_TOKEN;
+if (!TOKEN) {
+  console.error("FATAL: HF_TOKEN is not set — cannot audit private datasets or commit. Refusing to run public-only.");
+  process.exit(1);
+}
+const HF = { Authorization: "Bearer " + TOKEN };
+const PUBLISH = process.argv.includes("--publish");
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Same value-escaping as the upgrade builder (shields.io path segment)
+const esc = s => s.replace(/-/g, "--").replace(/ /g, "%20").replace(/·/g, "%C2%B7");
+
+const FILES_RE = /(\[!\[files\]\(https:\/\/img\.shields\.io\/badge\/files-)([^-]*(?:--[^-]*)*)(-5b8dee\?style=flat-square\))/;
+const LICENSE_RE = /(\[!\[license\]\(https:\/\/img\.shields\.io\/badge\/license-)([^-]*(?:--[^-]*)*)(-7e8aa3\?style=flat-square\))/;
+
+async function jfetch(url) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const r = await fetch(url, { headers: HF });
+    if (r.status === 429) { await sleep(2000 * (attempt + 1)); continue; }
+    return r;
+  }
+  throw new Error("429 persisted: " + url);
+}
+
+async function listDatasets() {
+  const out = [];
+  let url = "https://huggingface.co/api/datasets?author=SZLHOLDINGS&limit=100";
+  while (url) {
+    const r = await jfetch(url);
+    if (!r.ok) throw new Error(`dataset list HTTP ${r.status}`);
+    for (const d of await r.json()) out.push(d.id);
+    const link = r.headers.get("link");
+    url = link && link.includes('rel="next"') ? link.match(/<([^>]+)>;\s*rel="next"/)[1] : null;
+  }
+  return out;
+}
+
+// Recursive file count from the live tree (matches the original badge semantics)
+async function countFiles(id) {
+  let url = `https://huggingface.co/api/datasets/${id}/tree/main?limit=1000&recursive=true`;
+  let files = 0;
+  while (url) {
+    const r = await jfetch(url);
+    const j = await r.json();
+    if (!Array.isArray(j)) throw new Error(`tree ${id}: ${JSON.stringify(j).slice(0, 120)}`);
+    for (const e of j) if (e.type !== "directory") files++;
+    const link = r.headers.get("link");
+    url = link && link.includes('rel="next"') ? link.match(/<([^>]+)>;\s*rel="next"/)[1] : null;
+  }
+  return files;
+}
+
+let drifted = 0, checked = 0, skipped = 0, failed = 0;
+const ids = await listDatasets();
+console.log(`datasets: ${ids.length}`);
+for (const id of ids) {
+  const d = id.split("/")[1];
+  try {
+    const rr = await jfetch(`https://huggingface.co/datasets/${id}/raw/main/README.md`);
+    if (!rr.ok) { console.log(`SKIP ${d}: README HTTP ${rr.status}`); skipped++; continue; }
+    const txt = await rr.text();
+    if (!FILES_RE.test(txt)) { console.log(`SKIP ${d}: no house files badge`); skipped++; continue; }
+    checked++;
+    const nfiles = await countFiles(id);
+    const lic = (txt.match(/^license:\s*(\S+)/m) || [])[1] || "other";
+    let out = txt.replace(FILES_RE, (_, a, cur, z) => a + esc(String(nfiles)) + z);
+    out = out.replace(LICENSE_RE, (_, a, cur, z) => a + esc(lic) + z);
+    if (out === txt) { console.log(`ok   ${d}: files=${nfiles}, license=${lic}`); continue; }
+    drifted++;
+    const oldFiles = (txt.match(FILES_RE) || [])[2];
+    const oldLic = (txt.match(LICENSE_RE) || [])[2];
+    console.log(`DRIFT ${d}: files ${oldFiles} -> ${esc(String(nfiles))}, license ${oldLic} -> ${esc(lic)}${PUBLISH ? "" : " (dry run)"}`);
+    if (PUBLISH) {
+      const body = [
+        JSON.stringify({ key: "header", value: { summary: `docs: refresh badge stats (files=${nfiles}, license=${lic})`, description: "Automated badge-row refresh from the live tree; body preserved verbatim." } }),
+        JSON.stringify({ key: "file", value: { path: "README.md", content: Buffer.from(out).toString("base64"), encoding: "base64" } }),
+      ].join("\n");
+      const r = await fetch(`https://huggingface.co/api/datasets/${id}/commit/main`, {
+        method: "POST", headers: { ...HF, "Content-Type": "application/x-ndjson" }, body,
+      });
+      console.log(`  publish ${d}: ${r.status}${r.ok ? "" : " " + (await r.text()).slice(0, 200)}`);
+      if (!r.ok) failed++;
+      await sleep(400);
+    }
+  } catch (e) {
+    console.error(`ERROR ${d}: ${e.message}`);
+    failed++;
+  }
+  await sleep(200);
+}
+console.log(`summary: checked=${checked} drifted=${drifted} skipped=${skipped} failed=${failed}`);
+if (failed > 0) process.exit(1);

--- a/.github/workflows/hf-dataset-badge-refresh.yml
+++ b/.github/workflows/hf-dataset-badge-refresh.yml
@@ -1,0 +1,69 @@
+name: HF Dataset Badge Refresh
+
+# Keeps the verified "files-N" / "license-X" badges on every SZLHOLDINGS
+# Hugging Face dataset card in sync with reality. Several datasets grow daily
+# (killinchu-osint-corpus adds one intel shard per day, szl-evidence one
+# envelope per day), so a static count silently drifts from the live tree —
+# the opposite of the honesty standard the badges exist to signal.
+#
+# The script recomputes each dataset's recursive file count and front-matter
+# license from the LIVE tree and rewrites ONLY the badge values inside the
+# existing badge row (targeted regex on the shields.io URL). Body text is
+# never touched; a README is re-committed only when a badge value changed.
+# Badge palette/format matches the estate house style (files 5b8dee,
+# license 7e8aa3, flat-square).
+#
+# Auth: needs the org-scoped HF_ORG_TOKEN (same secret hf-license-consistency
+# uses) so PRIVATE datasets are covered too. FAIL-CLOSED: a missing/expired
+# token, an unreadable tree, or a failed commit turns the run RED — coverage
+# never silently lapses while reporting green.
+
+on:
+  schedule:
+    # Daily at 08:37 UTC — after the daily shard/envelope publishers (08:00)
+    # so the recount sees the day's new files; offset to avoid a thundering herd.
+    - cron: "37 8 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (report drift, commit nothing)"
+        required: false
+        default: "false"
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/hf_dataset_badge_refresh.mjs"
+      - ".github/workflows/hf-dataset-badge-refresh.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-dataset-badge-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Badges match the live tree
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Refresh dataset badges from the live tree
+        env:
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN }}
+        run: |
+          # Push-triggered runs validate in dry-run; schedule/dispatch publish
+          # (unless dispatch asked for dry_run).
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            node .github/scripts/hf_dataset_badge_refresh.mjs
+          else
+            node .github/scripts/hf_dataset_badge_refresh.mjs --publish
+          fi


### PR DESCRIPTION
Scheduled daily job that recomputes each SZLHOLDINGS dataset's recursive file count and front-matter license from the live tree and re-commits the README via the NDJSON commit API ONLY when a badge value changed. Badge-row-only edits, house palette (files 5b8dee / license 7e8aa3, flat-square). Fail-closed on missing HF_ORG_TOKEN or any commit failure. Push-path runs are dry-run.