### PR TITLE
fix(ci): harden HF deploy and reusable workflow pins

### DIFF
--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -32,9 +32,11 @@ Design notes:
     with a warning rather than silently expanded.
   * Directory COPY sources expand to every tracked file under them; globs expand
     by fnmatch; explicit files are taken as-is.
-  * README front-matter is PRESERVED (the GitHub README already carries the HF
-    `sdk: docker` / `app_port` card). HF's flaky server-side `_validate_yaml` is
-    monkeypatched non-fatal (the documented a11oy `_safe_validate` shim).
+  * README is deployed iff `--include-readme` is true, even when a Dockerfile
+    explicitly COPYs it. When included, its front-matter is PRESERVED (the
+    GitHub README already carries the HF `sdk: docker` / `app_port` card). HF's
+    flaky server-side `_validate_yaml` is monkeypatched non-fatal (the documented
+    a11oy `_safe_validate` shim).
   * stdlib-only for derivation + attestation, so --dry-run and --attest run on a
     bare runner; huggingface_hub is imported lazily only for an actual push.
 """
@@ -281,6 +283,17 @@ def derive(args):
     tree = local_tree(args.repo_root)
     targets, unresolved = expand_sources(sources, tree)
 
+    # include-readme is authoritative. A README may already be in the derived
+    # set because the Dockerfile explicitly COPYs it; remove that exact path
+    # when the caller owns the Space card separately. Normalize the CLI path to
+    # the forward-slash form used by local_tree/expand_sources, without filtering
+    # unrelated nested README files.
+    readme_path = args.readme_path.replace("\\", "/")
+    while readme_path.startswith("./"):
+        readme_path = readme_path[2:]
+    if not args.include_readme:
+        targets.pop(readme_path, None)
+
     if unresolved:
         for u in unresolved:
             print(f"::warning::COPY source not found in checkout (skipped): {u}")
@@ -299,10 +312,10 @@ def derive(args):
 
     readme_rel = None
     if args.include_readme:
-        rp = os.path.join(args.repo_root, args.readme_path)
+        rp = os.path.join(args.repo_root, readme_path)
         if os.path.exists(rp):
             data = load_readme(rp)
-            readme_rel = args.readme_path
+            readme_rel = readme_path
             files[readme_rel] = {
                 "git_blob_sha1": git_blob_sha1(data),
                 "sha256": sha256(data),

--- a/.github/scripts/reusable_workflow_target_check.py
+++ b/.github/scripts/reusable_workflow_target_check.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Verify remote reusable-workflow calls are pinned and resolvable.
+
+GitHub accepts a syntactically valid 40-character commit SHA even when the
+referenced workflow file does not exist at that commit. Such a caller fails at
+workflow startup, before any job can explain the problem. This guard scans
+``uses: owner/repo/.github/workflows/file.yml@ref`` entries, requires an
+immutable full SHA, and verifies the exact file through the GitHub Contents API.
+
+Exit codes:
+  0 -- every remote reusable-workflow target exists at its pinned SHA
+  1 -- an unpinned, malformed, or missing target was found
+  2 -- target verification could not complete (network/auth/API failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Callable, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*(?P<value>.+?)\s*$")
+REMOTE_REUSABLE_RE = re.compile(
+    r"^(?P<owner>[A-Za-z0-9_.-]+)/"
+    r"(?P<repo>[A-Za-z0-9_.-]+)/\.github/workflows/"
+    r"(?P<workflow>[A-Za-z0-9_.-]+\.ya?ml)@(?P<ref>[^\s@]+)$"
+)
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class WorkflowCall:
+    source: Path
+    line: int
+    value: str
+    owner: str
+    repo: str
+    workflow: str
+    ref: str
+
+    @property
+    def target(self) -> str:
+        return (
+            f"{self.owner}/{self.repo}/.github/workflows/"
+            f"{self.workflow}@{self.ref}"
+        )
+
+    @property
+    def target_key(self) -> tuple[str, str, str, str]:
+        return self.owner, self.repo, self.workflow, self.ref
+
+
+@dataclass(frozen=True)
+class Finding:
+    source: Path
+    line: int
+    value: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    checked_targets: int
+    violations: tuple[Finding, ...]
+    unavailable: tuple[Finding, ...]
+
+    @property
+    def exit_code(self) -> int:
+        if self.unavailable:
+            return 2
+        if self.violations:
+            return 1
+        return 0
+
+
+class VerificationUnavailable(RuntimeError):
+    """The remote target could not be classified as present or missing."""
+
+
+def _uses_value(line: str) -> str | None:
+    """Return a scalar ``uses`` value, excluding comments and YAML quotes."""
+
+    if line.lstrip().startswith("#"):
+        return None
+    match = USES_RE.match(line)
+    if not match:
+        return None
+
+    value = match.group("value").strip()
+    if value.startswith(("'", '"')):
+        quote_char = value[0]
+        end = value.find(quote_char, 1)
+        if end < 0:
+            return value
+        return value[1:end].strip()
+
+    # A '#' inside a GitHub reference is invalid, so only the ordinary YAML
+    # trailing-comment form needs to be preserved here.
+    return re.split(r"\s+#", value, maxsplit=1)[0].strip()
+
+
+def scan_workflows(workflow_dir: Path) -> tuple[list[WorkflowCall], list[Finding]]:
+    calls: list[WorkflowCall] = []
+    findings: list[Finding] = []
+    paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
+
+    for path in paths:
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            value = _uses_value(line)
+            if not value or value.startswith("./"):
+                continue
+            if "/.github/workflows/" not in value:
+                continue
+
+            match = REMOTE_REUSABLE_RE.fullmatch(value)
+            if not match:
+                findings.append(
+                    Finding(
+                        source=path,
+                        line=line_number,
+                        value=value,
+                        message="Malformed remote reusable-workflow reference",
+                    )
+                )
+                continue
+
+            calls.append(
+                WorkflowCall(
+                    source=path,
+                    line=line_number,
+                    value=value,
+                    owner=match.group("owner"),
+                    repo=match.group("repo"),
+                    workflow=match.group("workflow"),
+                    ref=match.group("ref"),
+                )
+            )
+
+    return calls, findings
+
+
+def github_target_exists(
+    call: WorkflowCall,
+    *,
+    token: str = "",
+    api_base: str = "https://api.github.com",
+    timeout: float = 15.0,
+) -> bool:
+    """Return whether the exact workflow path exists at the pinned revision."""
+
+    workflow_path = f".github/workflows/{call.workflow}"
+    url = (
+        f"{api_base.rstrip('/')}/repos/{quote(call.owner, safe='')}/"
+        f"{quote(call.repo, safe='')}/contents/{quote(workflow_path, safe='/')}?"
+        f"{urlencode({'ref': call.ref})}"
+    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "szl-reusable-workflow-target-check",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        with urlopen(Request(url, headers=headers), timeout=timeout) as response:
+            status = getattr(response, "status", response.getcode())
+            if status == 200:
+                return True
+            raise VerificationUnavailable(f"GitHub API returned HTTP {status}")
+    except HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise VerificationUnavailable(
+            f"GitHub API returned HTTP {exc.code}"
+        ) from exc
+    except (URLError, TimeoutError, OSError) as exc:
+        raise VerificationUnavailable(f"GitHub API request failed: {exc}") from exc
+
+
+def validate_workflows(
+    workflow_dir: Path,
+    probe: Callable[[WorkflowCall], bool],
+) -> ValidationResult:
+    calls, scan_findings = scan_workflows(workflow_dir)
+    violations = list(scan_findings)
+    unavailable: list[Finding] = []
+    unique: dict[tuple[str, str, str, str], WorkflowCall] = {}
+
+    for call in calls:
+        if not FULL_SHA_RE.fullmatch(call.ref):
+            violations.append(
+                Finding(
+                    source=call.source,
+                    line=call.line,
+                    value=call.value,
+                    message=(
+                        "Remote reusable workflow must be pinned to a full "
+                        "40-character lowercase commit SHA"
+                    ),
+                )
+            )
+            continue
+        unique.setdefault(call.target_key, call)
+
+    for call in unique.values():
+        try:
+            exists = probe(call)
+        except VerificationUnavailable as exc:
+            unavailable.append(
+                Finding(
+                    source=call.source,
+                    line=call.line,
+                    value=call.value,
+                    message=f"Could not verify pinned target: {exc}",
+                )
+            )
+            continue
+        if not exists:
+            violations.append(
+                Finding(
+                    source=call.source,
+                    line=call.line,
+                    value=call.value,
+                    message="Reusable workflow does not exist at the pinned SHA",
+                )
+            )
+
+    return ValidationResult(
+        checked_targets=len(unique),
+        violations=tuple(violations),
+        unavailable=tuple(unavailable),
+    )
+
+
+def _annotation(finding: Finding) -> str:
+    path = finding.source.as_posix()
+    message = f"{finding.message}: {finding.value}"
+    for old, new in (("%", "%25"), ("\r", "%0D"), ("\n", "%0A")):
+        message = message.replace(old, new)
+    return f"::error file={path},line={finding.line}::{message}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflow-dir",
+        type=Path,
+        default=Path(".github/workflows"),
+        help="Directory containing caller workflow YAML files",
+    )
+    parser.add_argument(
+        "--api-base",
+        default=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        help="GitHub API base URL (defaults to GITHUB_API_URL)",
+    )
+    parser.add_argument("--timeout", type=float, default=15.0)
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not args.workflow_dir.is_dir():
+        print(
+            f"::error::{args.workflow_dir.as_posix()} is not a workflow directory",
+            file=sys.stderr,
+        )
+        return 2
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    result = validate_workflows(
+        args.workflow_dir,
+        lambda call: github_target_exists(
+            call,
+            token=token,
+            api_base=args.api_base,
+            timeout=args.timeout,
+        ),
+    )
+
+    for finding in (*result.violations, *result.unavailable):
+        print(_annotation(finding))
+
+    if result.exit_code == 0:
+        print(
+            "PASS: Verified "
+            f"{result.checked_targets} unique remote reusable-workflow "
+            "target(s) at pinned SHAs."
+        )
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import tempfile
+import types
 import unittest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -145,6 +147,68 @@ class TestExpandSources(unittest.TestCase):
         targets, unresolved = dep.expand_sources(["missing/thing.py"], self.tree)
         self.assertEqual(targets, {})
         self.assertEqual(unresolved, ["missing/thing.py"])
+
+
+class TestDeriveReadmePolicy(unittest.TestCase):
+    def _derive(self, dockerfile, files, *, include_readme, readme_path="README.md"):
+        with tempfile.TemporaryDirectory() as repo_root:
+            for rel, content in {"Dockerfile": dockerfile, **files}.items():
+                path = os.path.join(repo_root, *rel.split("/"))
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as fh:
+                    fh.write(content.encode("utf-8"))
+            args = types.SimpleNamespace(
+                repo_root=repo_root,
+                dockerfile_path="Dockerfile",
+                include_readme=include_readme,
+                readme_path=readme_path,
+                github_repo="szl-holdings/example",
+                hf_repo="SZLHOLDINGS/example",
+                ref="main",
+            )
+            return dep.derive(args)
+
+    def test_include_readme_false_filters_explicit_copy(self):
+        manifest, files = self._derive(
+            "FROM scratch\n"
+            "COPY README.md /app/README.md\n"
+            "COPY serve.py /app/serve.py\n",
+            {"README.md": "# GitHub-only README\n", "serve.py": "pass\n"},
+            include_readme=False,
+            readme_path="./README.md",
+        )
+
+        self.assertEqual(set(files), {"serve.py"})
+        self.assertEqual(manifest["files_resolved"], 1)
+        self.assertIsNone(manifest["readme"])
+
+    def test_include_readme_false_keeps_unrelated_nested_readme(self):
+        manifest, files = self._derive(
+            "FROM scratch\n"
+            "COPY README.md /app/README.md\n"
+            "COPY docs /app/docs\n",
+            {
+                "README.md": "# Space-card-owned README\n",
+                "docs/README.md": "# App documentation\n",
+            },
+            include_readme=False,
+        )
+
+        self.assertEqual(set(files), {"docs/README.md"})
+        self.assertEqual(manifest["files_resolved"], 1)
+
+    def test_include_readme_true_merges_derived_entry_as_readme(self):
+        readme = "---\nsdk: docker\napp_port: 7860\n---\n# Space card\n"
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY README.md /app/README.md\n",
+            {"README.md": readme},
+            include_readme=True,
+        )
+
+        self.assertEqual(set(files), {"README.md"})
+        self.assertEqual(files["README.md"]["copy_source"], "(readme)")
+        self.assertEqual(files["README.md"]["sha256"], dep.sha256(readme.encode()))
+        self.assertEqual(manifest["readme"], "README.md")
 
 
 class TestContentIdentity(unittest.TestCase):

--- a/.github/scripts/test_reusable_workflow_target_check.py
+++ b/.github/scripts/test_reusable_workflow_target_check.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Network-free tests for reusable_workflow_target_check.py."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, redirect_stdout
+from io import BytesIO, StringIO
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from urllib.error import HTTPError
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT = os.path.join(_HERE, "reusable_workflow_target_check.py")
+_SPEC = importlib.util.spec_from_file_location("reusable_workflow_target_check", _SCRIPT)
+assert _SPEC and _SPEC.loader
+check = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = check
+_SPEC.loader.exec_module(check)
+
+
+PIN = "a" * 40
+
+
+class TestReusableWorkflowTargetCheck(unittest.TestCase):
+    @contextmanager
+    def workflow_dir(self, files):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name, content in files.items():
+                (root / name).write_text(content, encoding="utf-8")
+            yield root
+
+    def test_valid_pinned_target_passes_and_is_probed_once(self):
+        target = f"szl-holdings/.github/.github/workflows/doctrine-check.yml@{PIN}"
+        with self.workflow_dir(
+            {
+                "one.yml": f"jobs:\n  check:\n    uses: {target}\n",
+                "two.yaml": f"jobs:\n  check:\n    uses: \"{target}\" # pinned\n",
+            }
+        ) as root:
+            probed = []
+            result = check.validate_workflows(
+                root, lambda call: probed.append(call.target) or True
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.checked_targets, 1)
+        self.assertEqual(probed, [target])
+
+    def test_branch_ref_fails_without_network_probe(self):
+        target = "szl-holdings/.github/.github/workflows/doctrine-check.yml@main"
+        with self.workflow_dir({"caller.yml": f"jobs:\n  check:\n    uses: {target}\n"}) as root:
+            result = check.validate_workflows(
+                root, lambda _call: self.fail("unpinned ref must not be probed")
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("40-character", result.violations[0].message)
+
+    def test_missing_target_fails_at_pinned_sha(self):
+        target = f"szl-holdings/.github/.github/workflows/missing.yml@{PIN}"
+        with self.workflow_dir({"caller.yml": f"jobs:\n  check:\n    uses: {target}\n"}) as root:
+            result = check.validate_workflows(root, lambda _call: False)
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.checked_targets, 1)
+        self.assertIn("does not exist", result.violations[0].message)
+
+    def test_api_failure_is_unavailable_not_missing(self):
+        target = f"szl-holdings/.github/.github/workflows/check.yml@{PIN}"
+
+        def unavailable(_call):
+            raise check.VerificationUnavailable("HTTP 403")
+
+        with self.workflow_dir({"caller.yml": f"jobs:\n  check:\n    uses: {target}\n"}) as root:
+            result = check.validate_workflows(root, unavailable)
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertFalse(result.violations)
+        self.assertIn("HTTP 403", result.unavailable[0].message)
+
+    def test_ordinary_actions_local_calls_and_comments_are_ignored(self):
+        content = f"""
+jobs:
+  check:
+    # uses: szl-holdings/.github/.github/workflows/ignored.yml@{PIN}
+    steps:
+      - uses: actions/checkout@{PIN}
+  local:
+    uses: ./.github/workflows/local.yml
+"""
+        with self.workflow_dir({"caller.yml": content}) as root:
+            result = check.validate_workflows(
+                root, lambda _call: self.fail("no remote target should be probed")
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.checked_targets, 0)
+
+    def test_malformed_remote_workflow_reference_fails(self):
+        value = f"szl-holdings/.github/.github/workflows/nested/check.yml@{PIN}"
+        with self.workflow_dir({"caller.yml": f"jobs:\n  check:\n    uses: {value}\n"}) as root:
+            result = check.validate_workflows(root, lambda _call: True)
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Malformed", result.violations[0].message)
+
+    def test_contents_api_maps_404_to_missing_and_other_errors_to_unavailable(self):
+        call = check.WorkflowCall(
+            source=Path("caller.yml"),
+            line=3,
+            value="unused",
+            owner="szl-holdings",
+            repo=".github",
+            workflow="doctrine-check.yml",
+            ref=PIN,
+        )
+        not_found = HTTPError("https://api.github.com", 404, "Not Found", {}, BytesIO())
+        forbidden = HTTPError("https://api.github.com", 403, "Forbidden", {}, BytesIO())
+
+        with mock.patch.object(check, "urlopen", side_effect=not_found):
+            self.assertFalse(check.github_target_exists(call))
+        with mock.patch.object(check, "urlopen", side_effect=forbidden):
+            with self.assertRaises(check.VerificationUnavailable):
+                check.github_target_exists(call)
+
+    def test_successful_cli_output_is_ascii_safe(self):
+        with self.workflow_dir({}) as root:
+            output = StringIO()
+            with redirect_stdout(output):
+                exit_code = check.main(["--workflow-dir", str(root)])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("PASS: Verified 0", output.getvalue())
+        output.getvalue().encode("ascii")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pin-check-reusable.yml
+++ b/.github/workflows/pin-check-reusable.yml
@@ -23,14 +23,23 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout
+      - name: Checkout caller
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: caller
+
+      - name: Checkout exact reusable-workflow revision (shared validator)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: tools
 
       - name: Verify SHA-pins
         shell: bash
         run: |
           set -euo pipefail
-          WORKFLOW_DIR=".github/workflows"
+          WORKFLOW_DIR="caller/.github/workflows"
           VIOLATIONS=$(mktemp)
           for file in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
             [ -f "$file" ] || continue
@@ -38,7 +47,7 @@ jobs:
               ref=$(echo "$line" | sed -n 's/.*uses:[[:space:]]*\([^[:space:]#]*\).*/\1/p')
               [ -z "$ref" ] && continue
               [[ "$ref" == ./* ]] && continue
-              # Reusable workflows live in this org and may use @main — allow that
+              # Org reusable-workflow calls are validated by the next step.
               [[ "$ref" == szl-holdings/* ]] && continue
               after_at="${ref##*@}"
               if ! echo "$after_at" | grep -qE '^[0-9a-f]{40}$'; then
@@ -52,3 +61,10 @@ jobs:
             exit 1
           fi
           echo "✓ All action refs are SHA-pinned."
+
+      - name: Verify reusable-workflow targets at pinned SHAs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 tools/.github/scripts/reusable_workflow_target_check.py
+          --workflow-dir caller/.github/workflows

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -8,10 +8,14 @@ name: Pin Check
 on:
   push:
     branches: [main]
-    paths: ['.github/workflows/**']
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/reusable_workflow_target_check.py'
   pull_request:
     branches: [main]
-    paths: ['.github/workflows/**']
+    paths:
+      - '.github/workflows/**'
+      - '.github/scripts/reusable_workflow_target_check.py'
 
 permissions:
   contents: read
@@ -42,7 +46,7 @@ jobs:
               ref=$(echo "$line" | sed -n 's/.*uses:[[:space:]]*\([^[:space:]#]*\).*/\1/p')
               [ -z "$ref" ] && continue
               [[ "$ref" == ./* ]] && continue
-              # Reusable workflows live in this org and may use @main — allow that
+              # Org reusable-workflow calls are validated by the next step.
               [[ "$ref" == szl-holdings/* ]] && continue
               after_at="${ref##*@}"
               if ! echo "$after_at" | grep -qE '^[0-9a-f]{40}$'; then
@@ -56,3 +60,10 @@ jobs:
             exit 1
           fi
           echo "✓ All action refs are SHA-pinned."
+
+      - name: Verify reusable-workflow targets at pinned SHAs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 .github/scripts/reusable_workflow_target_check.py
+          --workflow-dir .github/workflows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      # A full 40-character ref is not enough for a reusable workflow: the
+      # target file can be absent at that exact commit (the a11oy/docs-site
+      # pre-merge-pin startup_failure). This network-free test locks three
+      # distinct outcomes: present=0, missing=1, API/auth unavailable=2.
+      - name: Reusable-workflow pinned-target validator self-test
+        run: python3 .github/scripts/test_reusable_workflow_target_check.py
+
       # Pins the org-wide DOCTRINE honesty gate — the single most load-bearing
       # check in the org, and (until now) the ONLY guard with no self-test.
       # Its logic used to be inline LINE-BASED bash grep: a cosmetic 2-line


### PR DESCRIPTION
## What changed

- honor `include_readme: false` even when a Dockerfile explicitly copies the root README, while preserving unrelated nested README files
- validate every pinned reusable-workflow `uses:` target at the exact 40-character SHA before callers can rely on it
- make the reusable pin check inspect its own exact repository and workflow revision
- add focused regression coverage and wire both suites into the control-plane test workflow

## Why

The estate audit found callers pinned to commits where the referenced reusable workflow path did not exist. The prior pin check validated SHA syntax but not the target at that immutable revision. The HF deploy helper could also reintroduce a root README despite an explicit exclusion policy.

## How was this tested

- [x] 23/23 HF deploy tests
- [x] 8/8 reusable-workflow target tests
- [x] Python compilation for all four implementation/test modules
- [x] YAML parse for all three edited workflows
- [x] `git show --check`
- [x] retained `step-security/harden-runner` v2.20.0 exact SHA after rebasing onto current main

## Risk & rollback

The validator performs read-only GitHub Contents API checks and returns a distinct unavailable status for API/auth/network failures. Roll back by reverting this PR; no data migration or secret change is involved.

## Checklist

- [x] Conventional commit title
- [x] No secrets, tokens, or PII committed
- [x] Tests added and updated
- [x] Signed-off-by line included