### PR TITLE
fix(hf): verify LFS content in drift guard

### DIFF
--- a/.github/scripts/hf_module_drift_check.py
+++ b/.github/scripts/hf_module_drift_check.py
@@ -13,9 +13,12 @@ newer v1.1 of a module that GitHub never received.
 
 This script parses every `COPY` source in the Dockerfile, expands directories
 and globs, then compares each file's content between the two sides by git-blob
-SHA (no full download needed for the comparison -- HF's tree API and GitHub's
-git-tree both expose the git blob OID (sha1), identical iff content is
-identical). For every drifted file it fetches the last-commit DATE on both sides
+SHA. HF's tree API and GitHub's git-tree expose the same blob OID for normal
+files. When HF stores a large file through LFS, the guard compares HF's LFS
+SHA-256 with a streamed local SHA-256 (CI mode) or a bounded GitHub raw-file
+SHA-256 (registry mode) instead of failing merely because the storage
+representation changed. For every drifted file it fetches the last-commit DATE
+on both sides
 and NAMES which side is ahead -- it deliberately does NOT auto-overwrite, because
 drift can run either direction.
 
@@ -70,6 +73,7 @@ GH_API = "https://api.github.com"
 GH_RAW = "https://raw.githubusercontent.com"
 
 UA = {"User-Agent": "hf-module-drift-check/1.0"}
+MAX_REMOTE_LFS_COMPARE_BYTES = 128 * 1024 * 1024
 
 
 # --------------------------------------------------------------------------- #
@@ -284,6 +288,28 @@ def github_tree_remote(github_repo, ref="main"):
         if e.get("type") == "blob":
             out[e["path"]] = e["sha"]
     return out
+
+
+def github_file_sha256_local(repo_root, path):
+    """SHA-256 one checked-out file without loading a large artifact at once."""
+    full = os.path.join(repo_root, *path.split("/"))
+    digest = hashlib.sha256()
+    try:
+        with open(full, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def github_file_sha256_remote(github_repo, path, ref="main"):
+    """SHA-256 a GitHub raw file for registry mode; auth can fall back public."""
+    url = f"{GH_RAW}/{github_repo}/{ref}/{urllib.parse.quote(path)}"
+    status, body, _ = gh_get(url)
+    if status != 200:
+        return None
+    return hashlib.sha256(body).hexdigest()
 
 
 # --------------------------------------------------------------------------- #
@@ -582,6 +608,27 @@ def compare(args, allow=None):
     # BOTH sides -- the latter is dockerfile-copy-guard's domain, not drift).
     findings = []
     _hf_date_cache = {}
+    _github_lfs_sha256_cache = {}
+
+    def github_lfs_sha256(path, hf_size):
+        """Return GitHub-side content identity for one HF-LFS target.
+
+        Local CI hashes the exact checkout in a streaming pass. Registry mode
+        has no checkout, so it fetches the GitHub raw object only when the
+        HF-declared size is within a conservative bound. Unavailable or
+        oversized comparisons remain fail-closed as ``lfs-unverified``.
+        """
+        if path in _github_lfs_sha256_cache:
+            return _github_lfs_sha256_cache[path]
+        if (args.github_remote and isinstance(hf_size, int)
+                and hf_size > MAX_REMOTE_LFS_COMPARE_BYTES):
+            value = None
+        elif args.github_remote:
+            value = github_file_sha256_remote(args.github_repo, path, github_ref)
+        else:
+            value = github_file_sha256_local(args.repo_root, path)
+        _github_lfs_sha256_cache[path] = value
+        return value
 
     def add(entry, base_severity):
         if entry["path"] in accepted:
@@ -612,12 +659,25 @@ def compare(args, allow=None):
 
         # Both present.
         if hf.get("lfs_oid"):
-            # LFS on the Space: git-blob OID vs sha256 aren't comparable cheaply.
-            # Source modules are never LFS, so this only fires for un-excluded
-            # binary assets -> flag for manual review.
-            add({"path": path, "kind": "lfs",
-                 "detail": "stored as LFS on HF Space; not cheaply comparable "
-                           "-- exclude via ignore_paths if it is a vendored asset"}, "error")
+            # HF LFS exposes the content SHA-256 rather than the normal git blob
+            # OID. Compare it to the exact GitHub bytes: storage representation
+            # alone is not drift, and evidence files must not be ignored merely
+            # because the Hub selected LFS for them.
+            github_sha256 = github_lfs_sha256(path, hf.get("size"))
+            if github_sha256 == hf.get("lfs_oid"):
+                continue
+            if github_sha256 is None:
+                add({"path": path, "kind": "lfs-unverified",
+                     "hf_lfs_sha256": hf.get("lfs_oid"),
+                     "detail": "HF stores this path as LFS, but the GitHub-side "
+                               "SHA-256 could not be computed within the bounded "
+                               "comparison; equality is unverified"}, "error")
+            else:
+                add({"path": path, "kind": "lfs-drift",
+                     "github_sha256": github_sha256,
+                     "hf_lfs_sha256": hf.get("lfs_oid"),
+                     "detail": "GitHub bytes and HF LFS object have different "
+                               "SHA-256 content identities"}, "error")
             continue
 
         if gh_sha == hf.get("oid"):

--- a/.github/scripts/test_hf_module_drift_check.py
+++ b/.github/scripts/test_hf_module_drift_check.py
@@ -239,6 +239,125 @@ class TestIndependentRefs(unittest.TestCase):
         self.assertNotIn(("szl-holdings/killinchu", "github-pr-head"), calls)
 
 
+class TestLFSContentIdentity(unittest.TestCase):
+    """HF LFS is a storage representation, not evidence of content drift."""
+
+    def setUp(self):
+        self._saved = {key: getattr(drift, key) for key in (
+            "github_tree_remote", "hf_tree", "github_file_sha256_remote",
+            "gh_get",
+        )}
+        self._tmp = tempfile.mkdtemp()
+        self.path = "ledger.jsonl"
+        self.data = b'{"receipt":"measured"}\n' * 4096
+        with open(os.path.join(self._tmp, "Dockerfile"), "w") as fh:
+            fh.write("COPY ledger.jsonl /app/ledger.jsonl\n")
+        with open(os.path.join(self._tmp, self.path), "wb") as fh:
+            fh.write(self.data)
+        self.lfs_sha256 = drift.hashlib.sha256(self.data).hexdigest()
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            setattr(drift, key, value)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _args(self, github_remote=False):
+        return argparse.Namespace(
+            repo_root=self._tmp,
+            github_repo="szl-holdings/a11oy",
+            hf_repo="SZLHOLDINGS/a11oy",
+            ref="main",
+            github_ref="github-pr-head",
+            hf_ref="hf-candidate",
+            allow=None,
+            github_remote=github_remote,
+            report_out="",
+            warn_only=False,
+            siblings=[],
+        )
+
+    def test_local_lfs_sha256_match_is_in_sync(self):
+        drift.hf_tree = lambda *_a, **_k: {
+            self.path: {
+                "oid": "lfs-pointer-blob",
+                "lfs_oid": self.lfs_sha256,
+                "size": len(self.data),
+            }
+        }
+
+        report, errors, warns = drift.compare(self._args(), allow={})
+
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(errors, [])
+        self.assertEqual(warns, [])
+
+    def test_local_lfs_sha256_mismatch_fails_closed(self):
+        drift.hf_tree = lambda *_a, **_k: {
+            self.path: {
+                "oid": "lfs-pointer-blob",
+                "lfs_oid": "0" * 64,
+                "size": len(self.data),
+            }
+        }
+
+        _report, errors, _warns = drift.compare(self._args(), allow={})
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["kind"], "lfs-drift")
+        self.assertEqual(errors[0]["github_sha256"], self.lfs_sha256)
+
+    def test_remote_lfs_uses_github_ref_and_matching_sha256(self):
+        calls = []
+        git_blob = drift.git_blob_sha1(self.data)
+        drift.gh_get = lambda *_a, **_k: (
+            200, b"COPY ledger.jsonl /app/ledger.jsonl\n", None)
+        drift.github_tree_remote = lambda _repo, ref="main": {self.path: git_blob}
+        drift.hf_tree = lambda *_a, **_k: {
+            self.path: {
+                "oid": "lfs-pointer-blob",
+                "lfs_oid": self.lfs_sha256,
+                "size": len(self.data),
+            }
+        }
+
+        def remote_sha(repo, path, ref="main"):
+            calls.append((repo, path, ref))
+            return self.lfs_sha256
+
+        drift.github_file_sha256_remote = remote_sha
+        report, errors, warns = drift.compare(
+            self._args(github_remote=True), allow={})
+
+        self.assertEqual(report["status"], "ok")
+        self.assertEqual(errors, [])
+        self.assertEqual(warns, [])
+        self.assertEqual(
+            calls,
+            [("szl-holdings/a11oy", self.path, "github-pr-head")],
+        )
+
+    def test_oversized_remote_lfs_comparison_fails_closed_without_download(self):
+        git_blob = drift.git_blob_sha1(self.data)
+        drift.gh_get = lambda *_a, **_k: (
+            200, b"COPY ledger.jsonl /app/ledger.jsonl\n", None)
+        drift.github_tree_remote = lambda _repo, ref="main": {self.path: git_blob}
+        drift.hf_tree = lambda *_a, **_k: {
+            self.path: {
+                "oid": "lfs-pointer-blob",
+                "lfs_oid": self.lfs_sha256,
+                "size": drift.MAX_REMOTE_LFS_COMPARE_BYTES + 1,
+            }
+        }
+        drift.github_file_sha256_remote = lambda *_a, **_k: self.fail(
+            "oversized registry artifact must not be downloaded")
+
+        _report, errors, _warns = drift.compare(
+            self._args(github_remote=True), allow={})
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["kind"], "lfs-unverified")
+
+
 class TestTransientHTTPInconclusive(unittest.TestCase):
     """A persistent HF 429/5xx must go HONEST INCONCLUSIVE (report written,
     exit 0), never crash and never false-green. All network stubbed."""


### PR DESCRIPTION
## What changed

Teach the reusable Hugging Face module-drift guard to verify Git LFS-backed objects by comparing the computed content SHA-256 with the pointer’s `oid sha256:` value instead of rejecting every LFS target.

## Why

A11oy’s 13.4 MB Brain ingest ledger was byte-identical to the HF candidate, but the shared checker classified any LFS target as drift. The old behavior produced a false failure and prevented exact, content-addressed candidate verification.

## How was this tested

- [x] Shared guard regression suite: 22/22 passed
- [x] Exact A11oy candidate check: 489 COPY sources, 918 files, 0 errors, 0 warnings
- [x] HF candidate preserved 747 HF-only files and deleted none
- [x] HF main remained unchanged

## Risk & rollback

The change remains fail-closed: malformed pointers, missing OIDs, download failures, and digest mismatches still fail. Revert commit 4c5f39b to restore the previous behavior.

## Checklist

- [x] Conventional commit title
- [x] No secrets, tokens, or PII committed
- [x] Public-facing copy reviewed for accuracy
- [x] No live HF deployment or weight publication
