### PR TITLE
fix(hf): attest exact deployed Space revision + pin deployer to reviewed revision

### DIFF
--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -16,20 +16,17 @@ can never silently drift from what the image actually builds.
 
 Two modes:
   deploy  (default): parse Dockerfile COPY sources, expand to tracked files,
-                     push them (+ README with preserved HF front-matter) to the
-                     Space via huggingface_hub create_commit (add + optional
-                     prune of managed files gone from git). Emits a manifest
-                     (path -> {git_blob_sha1, sha256, size}).
-  attest  (--attest): re-fetch every manifest path from the live Space
-                      resolve/main URL and assert sha256 == the value pushed.
-                      Fails loudly on any mismatch. This is the "can never drift
-                      again" guard that runs after the Space finishes rebuilding.
+                     push them (+ the build Dockerfile at HF-root `Dockerfile`
+                     and optional README) to the Space via huggingface_hub
+                     create_commit. Emits a source-aware manifest.
+  attest  (--attest): require the Space API to report the exact pushed HF commit
+                      in RUNNING state, re-fetch every manifest path at that
+                      immutable commit, and probe declared same-host live routes.
 
 Design notes:
-  * EXCLUDES `COPY --from=<stage>` (build-stage artifacts, not repo files) and a
-    bare `COPY . <dest>` whole-context copy (the Dockerfiles deliberately never
-    use it; a whole-repo mirror is not a curated Space deploy). Both are skipped
-    with a warning rather than silently expanded.
+  * EXCLUDES `COPY --from=<stage>` (build-stage artifacts, not repo files). A
+    bare `COPY . <dest>` whole-context copy and every unresolved COPY source are
+    hard errors: the deployer never publishes a knowingly incomplete manifest.
   * Directory COPY sources expand to every tracked file under them; globs expand
     by fnmatch; explicit files are taken as-is.
   * README is deployed iff `--include-readme` is true, even when a Dockerfile
@@ -47,6 +44,7 @@ import fnmatch
 import hashlib
 import json
 import os
+import posixpath
 import random
 import re
 import sys
@@ -57,6 +55,49 @@ import urllib.request
 
 HF_HOST = "https://huggingface.co"
 UA = {"User-Agent": "hf-deploy-from-dockerfile/1.0"}
+TERMINAL_RUNTIME_STAGES = {"BUILD_ERROR", "CONFIG_ERROR", "RUNTIME_ERROR"}
+
+
+class DeployContractError(ValueError):
+    """The requested deployment cannot produce a complete, safe manifest."""
+
+
+def normalize_repo_path(path, *, label="repository path"):
+    """Return a safe forward-slash path contained by the repository root."""
+    value = str(path or "").replace("\\", "/")
+    while value.startswith("./"):
+        value = value[2:]
+    value = posixpath.normpath(value)
+    if (value in ("", ".") or value.startswith("/") or
+            re.match(r"^[A-Za-z]:/", value)):
+        raise DeployContractError(f"{label} must be a non-empty relative path: {path!r}")
+    if value == ".." or value.startswith("../"):
+        raise DeployContractError(f"{label} escapes the repository root: {path!r}")
+    return value
+
+
+def source_file(repo_root, source_path):
+    """Resolve a manifest source path and fail if it escapes the checkout."""
+    rel = normalize_repo_path(source_path, label="source_path")
+    root = os.path.realpath(repo_root)
+    full = os.path.realpath(os.path.join(root, *rel.split("/")))
+    try:
+        contained = os.path.commonpath((root, full)) == root
+    except ValueError:
+        contained = False
+    if not contained:
+        raise DeployContractError(f"source_path escapes the repository root: {rel!r}")
+    if not os.path.isfile(full):
+        raise DeployContractError(f"source_path is not a file in the checkout: {rel!r}")
+    return rel, full
+
+
+def read_source_bytes(repo_root, target_path, meta):
+    """Read the GitHub source mapped to an HF target path."""
+    source_path = meta.get("source_path") or target_path
+    _, full = source_file(repo_root, source_path)
+    with open(full, "rb") as fh:
+        return fh.read()
 
 
 # --------------------------------------------------------------------------- #
@@ -78,8 +119,9 @@ def sha256(data: bytes) -> str:
 # --------------------------------------------------------------------------- #
 def parse_copy_sources(dockerfile_text):
     """Return COPY/ADD *source* tokens. Joins line-continuations, handles the
-    JSON-array form, drops --flag options, SKIPS `--from=` build-stage copies and
-    a bare `.` whole-context source."""
+    JSON-array form, drops --flag options, and SKIPS `--from=` build-stage
+    copies. A whole-context source is rejected because it cannot be represented
+    as a curated, independently attestable deploy set."""
     logical = []
     buf = ""
     for raw in dockerfile_text.splitlines():
@@ -97,7 +139,6 @@ def parse_copy_sources(dockerfile_text):
         logical.append(buf)
 
     sources = []
-    skipped_whole_context = False
     for line in logical:
         m = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
         if not m:
@@ -106,10 +147,17 @@ def parse_copy_sources(dockerfile_text):
         if rest.startswith("["):
             try:
                 arr = json.loads(rest)
-            except json.JSONDecodeError:
-                continue
-            if len(arr) >= 2:
-                sources.extend(arr[:-1])
+            except json.JSONDecodeError as exc:
+                raise DeployContractError(
+                    f"malformed JSON-form Dockerfile instruction: {line.strip()}"
+                ) from exc
+            if not isinstance(arr, list) or len(arr) < 2 or not all(
+                isinstance(item, str) for item in arr
+            ):
+                raise DeployContractError(
+                    f"invalid JSON-form Dockerfile instruction: {line.strip()}"
+                )
+            sources.extend(arr[:-1])
             continue
         toks = rest.split()
         skip = False
@@ -120,13 +168,23 @@ def parse_copy_sources(dockerfile_text):
                     skip = True
                 continue
             clean.append(t)
-        if skip or len(clean) < 2:
+        if skip:
             continue
+        if len(clean) < 2:
+            raise DeployContractError(
+                f"COPY/ADD instruction has no complete source/destination pair: "
+                f"{line.strip()}"
+            )
         srcs = clean[:-1]
-        # Skip a whole-context copy (`COPY . <dest>`): not a curated Space deploy.
-        if any(s in (".", "./") for s in srcs):
-            skipped_whole_context = True
-            continue
+        for source in srcs:
+            normalized = source
+            while normalized.startswith("./"):
+                normalized = normalized[2:]
+            if normalized in ("", "."):
+                raise DeployContractError(
+                    "bare `COPY . <dest>` / `ADD . <dest>` is forbidden: "
+                    "the deployer requires an explicit curated source set"
+                )
         sources.extend(srcs)
 
     out, seen = [], set()
@@ -136,12 +194,14 @@ def parse_copy_sources(dockerfile_text):
         # chars, or a dotdir source like ".compliance/x" collapses to "compliance/x".
         while s.startswith("./"):
             s = s[2:]
+        if s in ("", "."):
+            raise DeployContractError(
+                "bare `COPY . <dest>` / `ADD . <dest>` is forbidden: "
+                "the deployer requires an explicit curated source set"
+            )
         if s and s not in seen:
             seen.add(s)
             out.append(s)
-    if skipped_whole_context:
-        print("::warning::skipped a bare `COPY . <dest>` whole-context copy "
-              "(deployer derives a curated per-file set, not a whole-repo mirror)")
     return out
 
 
@@ -216,21 +276,28 @@ def load_readme(path):
 
 
 # --------------------------------------------------------------------------- #
-# HF HTTP (stdlib, retry) -- for attestation + tree listing
+# HF HTTP (stdlib, retry) -- for attestation + live route closure
 # --------------------------------------------------------------------------- #
-def _http(url, headers=None, retries=6):
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _http(url, headers=None, retries=6, follow_redirects=True):
     last = None
     hdrs = dict(UA)
     if headers:
         hdrs.update(headers)
+    opener = (urllib.request.build_opener() if follow_redirects else
+              urllib.request.build_opener(_NoRedirect()))
     for attempt in range(retries):
         try:
             req = urllib.request.Request(url, headers=hdrs)
-            with urllib.request.urlopen(req, timeout=45) as resp:
+            with opener.open(req, timeout=45) as resp:
                 return resp.status, resp.read()
         except urllib.error.HTTPError as e:
-            if e.code in (401, 403, 404):
-                return e.code, b""
+            if 300 <= e.code < 500:
+                return e.code, e.read()
             last = e
             if e.code == 429 or 500 <= e.code < 600:
                 ra = (e.headers or {}).get("Retry-After")
@@ -256,27 +323,135 @@ def _auth_headers():
     return {"Authorization": f"Bearer {tok}"} if tok else {}
 
 
-def hf_runtime_stage(hf_repo):
+def hf_space_state(hf_repo):
+    """Return the public Space API's exact (stage, sha) deployment identity."""
     url = f"{HF_HOST}/api/spaces/{hf_repo}"
-    try:
-        status, body = _http(url, headers=_auth_headers())
-    except RuntimeError:
-        return None
+    status, body = _http(url, headers=_auth_headers())
     if status != 200:
-        return None
+        raise RuntimeError(f"Space API returned HTTP {status}: {url}")
     try:
-        return (json.loads(body).get("runtime") or {}).get("stage")
-    except json.JSONDecodeError:
-        return None
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Space API returned invalid JSON: {url}") from exc
+    return (payload.get("runtime") or {}).get("stage"), payload.get("sha")
+
+
+def normalize_smoke_paths(value=None):
+    """Validate relative live-app paths; callers can never select another host."""
+    if value is None or value == "":
+        raw_paths = ["/"]
+    elif isinstance(value, str):
+        try:
+            raw_paths = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise DeployContractError(
+                "--smoke-paths must be a JSON array of same-host absolute paths"
+            ) from exc
+    else:
+        raw_paths = value
+    if not isinstance(raw_paths, list) or not raw_paths:
+        raise DeployContractError("smoke_paths must be a non-empty JSON array")
+
+    paths, seen = [], set()
+    for raw in raw_paths:
+        if not isinstance(raw, str) or not raw:
+            raise DeployContractError("each smoke path must be a non-empty string")
+        if "\\" in raw or any(ord(ch) < 32 for ch in raw):
+            raise DeployContractError(f"unsafe smoke path: {raw!r}")
+        parsed = urllib.parse.urlsplit(raw)
+        if (parsed.scheme or parsed.netloc or not parsed.path.startswith("/") or
+                parsed.path.startswith("//") or parsed.fragment):
+            raise DeployContractError(
+                f"smoke path must be same-host, absolute-path-only, and fragment-free: {raw!r}"
+            )
+        normalized = urllib.parse.urlunsplit(("", "", parsed.path,
+                                              parsed.query, ""))
+        if normalized not in seen:
+            seen.add(normalized)
+            paths.append(normalized)
+    return paths
+
+
+def hf_live_origin(hf_repo):
+    parts = hf_repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise DeployContractError(
+            f"HF Space id must be exactly <owner>/<name>: {hf_repo!r}"
+        )
+    subdomain = re.sub(r"[^a-z0-9-]+", "-", "-".join(parts).lower()).strip("-")
+    if not subdomain:
+        raise DeployContractError(f"HF Space id has no usable app hostname: {hf_repo!r}")
+    return f"https://{subdomain}.hf.space"
+
+
+def wait_for_expected_runtime(hf_repo, expected_sha, timeout, poll_interval=15):
+    """Require the exact pushed commit to reach the exact RUNNING stage."""
+    timeout = max(0, int(timeout or 0))
+    deadline = time.monotonic() + timeout
+    first = True
+    last_stage = last_sha = None
+    last_error = None
+    while first or time.monotonic() < deadline:
+        first = False
+        try:
+            last_stage, last_sha = hf_space_state(hf_repo)
+            last_error = None
+            print(f"   runtime stage: {last_stage}   api sha: {last_sha}")
+            if last_stage == "RUNNING" and last_sha == expected_sha:
+                return True
+            if last_sha == expected_sha and last_stage in TERMINAL_RUNTIME_STAGES:
+                print(f"::error::Space {hf_repo}@{expected_sha} is in {last_stage}.")
+                return False
+        except RuntimeError as exc:
+            last_error = str(exc)
+            print(f"::warning::Space runtime identity unavailable: {last_error}")
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(float(poll_interval), remaining))
+
+    detail = (f"last stage={last_stage!r} sha={last_sha!r}" if not last_error
+              else f"last error={last_error}")
+    print(f"::error::Timed out waiting for {hf_repo} to report exact RUNNING "
+          f"commit {expected_sha}; {detail}")
+    return False
+
+
+def probe_smoke_routes(hf_repo, smoke_paths, retries=6, delay=5):
+    """Probe only the derived Space host; redirects and empty bodies fail."""
+    paths = normalize_smoke_paths(smoke_paths)
+    origin = hf_live_origin(hf_repo)
+    failures = []
+    for path in paths:
+        url = origin + path
+        last_status = None
+        last_detail = "not attempted"
+        for attempt in range(max(1, int(retries))):
+            try:
+                status, body = _http(
+                    url, headers=_auth_headers(), retries=1,
+                    follow_redirects=False,
+                )
+                last_status = status
+                last_detail = f"HTTP {status}, {len(body)} bytes"
+                if status == 200 and body:
+                    print(f"   smoke OK: {path} (HTTP 200, {len(body)} bytes)")
+                    break
+            except RuntimeError as exc:
+                last_detail = str(exc)
+            if attempt + 1 < max(1, int(retries)):
+                time.sleep(float(delay))
+        else:
+            failures.append((path, last_status, last_detail))
+    return failures
 
 
 # --------------------------------------------------------------------------- #
 # derive: Dockerfile -> deploy manifest (no network, no push)
 # --------------------------------------------------------------------------- #
 def derive(args):
-    df_path = args.dockerfile_path
-    if not os.path.isabs(df_path):
-        df_path = os.path.join(args.repo_root, df_path)
+    dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
     with open(df_path, "rb") as fh:
         dockerfile_text = fh.read().decode("utf-8", "replace")
     sources = parse_copy_sources(dockerfile_text)
@@ -288,54 +463,71 @@ def derive(args):
     # when the caller owns the Space card separately. Normalize the CLI path to
     # the forward-slash form used by local_tree/expand_sources, without filtering
     # unrelated nested README files.
-    readme_path = args.readme_path.replace("\\", "/")
-    while readme_path.startswith("./"):
-        readme_path = readme_path[2:]
+    readme_path = normalize_repo_path(args.readme_path, label="README source path")
     if not args.include_readme:
         targets.pop(readme_path, None)
 
     if unresolved:
-        for u in unresolved:
-            print(f"::warning::COPY source not found in checkout (skipped): {u}")
+        raise DeployContractError(
+            "Dockerfile COPY/ADD sources were not found in the checkout: "
+            + ", ".join(sorted(unresolved))
+        )
 
     files = {}
     for rel, src in sorted(targets.items()):
-        full = os.path.join(args.repo_root, rel)
-        with open(full, "rb") as fh:
-            data = fh.read()
+        data = read_source_bytes(args.repo_root, rel, {"source_path": rel})
         files[rel] = {
             "git_blob_sha1": git_blob_sha1(data),
             "sha256": sha256(data),
             "size": len(data),
             "copy_source": src,
+            "source_path": rel,
         }
 
     readme_rel = None
     if args.include_readme:
-        rp = os.path.join(args.repo_root, readme_path)
-        if os.path.exists(rp):
-            data = load_readme(rp)
-            readme_rel = readme_path
-            files[readme_rel] = {
-                "git_blob_sha1": git_blob_sha1(data),
-                "sha256": sha256(data),
-                "size": len(data),
-                "copy_source": "(readme)",
-            }
-        else:
-            print(f"::warning::--include-readme set but {rp} not found")
+        _, rp = source_file(args.repo_root, readme_path)
+        data = load_readme(rp)
+        readme_rel = readme_path
+        files[readme_rel] = {
+            "git_blob_sha1": git_blob_sha1(data),
+            "sha256": sha256(data),
+            "size": len(data),
+            "copy_source": "(readme)",
+            "source_path": readme_rel,
+        }
+
+    # The Space build always consumes an HF-root Dockerfile. It is therefore a
+    # first-class deployed artifact even though Dockerfiles do not COPY
+    # themselves. `source_path` preserves nested caller layouts such as yarqa's
+    # `space/Dockerfile` while the target remains exactly `Dockerfile` on HF.
+    dockerfile_bytes = read_source_bytes(
+        args.repo_root, "Dockerfile", {"source_path": dockerfile_rel}
+    )
+    files["Dockerfile"] = {
+        "git_blob_sha1": git_blob_sha1(dockerfile_bytes),
+        "sha256": sha256(dockerfile_bytes),
+        "size": len(dockerfile_bytes),
+        "copy_source": "(dockerfile)",
+        "source_path": dockerfile_rel,
+    }
+
+    smoke_paths = normalize_smoke_paths(getattr(args, "smoke_paths", None))
 
     manifest = {
-        "schema": 1,
+        "schema": 2,
         "generated_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "github_repo": args.github_repo,
         "hf_repo": args.hf_repo,
         "ref": args.ref,
-        "dockerfile": args.dockerfile_path,
+        "dockerfile": dockerfile_rel,
+        "dockerfile_target": "Dockerfile",
         "copy_sources": len(sources),
         "files_resolved": len(targets),
+        "files_deployed": len(files),
         "unresolved_sources": unresolved,
         "readme": readme_rel,
+        "smoke_paths": smoke_paths,
         "files": files,
     }
     return manifest, files
@@ -344,13 +536,36 @@ def derive(args):
 # --------------------------------------------------------------------------- #
 # deploy: push the derived set (add + optional prune) via huggingface_hub
 # --------------------------------------------------------------------------- #
+def build_add_operations(repo_root, files, operation_class):
+    """Build HF add operations from the exact source bytes the manifest hashed."""
+    operations = []
+    for target_path in sorted(files):
+        meta = files[target_path]
+        data = read_source_bytes(repo_root, target_path, meta)
+        # Re-hash the exact source bytes used for the operation. This closes the
+        # nested-Dockerfile class of bugs where the manifest hashed one path but
+        # the deploy operation opened another.
+        if sha256(data) != meta.get("sha256"):
+            raise DeployContractError(
+                f"source changed after manifest derivation: "
+                f"{meta.get('source_path', target_path)}"
+            )
+        operations.append(
+            operation_class(path_in_repo=target_path, path_or_fileobj=data)
+        )
+    return operations
+
+
 def deploy(args):
     manifest, files = derive(args)
     print(f"== HF deploy: {args.github_repo} -> {args.hf_repo} ({args.ref}) ==")
     print(f"   COPY sources: {manifest['copy_sources']}   files resolved: "
           f"{manifest['files_resolved']}   readme: {manifest['readme']}")
     for p in sorted(files):
-        print(f"   + {p}  ({files[p]['size']}B  blob {files[p]['git_blob_sha1'][:12]})")
+        source = files[p].get("source_path", p)
+        mapping = f"{source} -> {p}" if source != p else p
+        print(f"   + {mapping}  ({files[p]['size']}B  "
+              f"blob {files[p]['git_blob_sha1'][:12]})")
 
     if args.manifest_out:
         with open(args.manifest_out, "w") as fh:
@@ -383,23 +598,14 @@ def deploy(args):
     HfApi._validate_yaml = _safe_validate
 
     api = HfApi(token=token)
-    ops = []
-    for rel in sorted(files):
-        with open(os.path.join(args.repo_root, rel), "rb") as fh:
-            ops.append(CommitOperationAdd(path_in_repo=rel, path_or_fileobj=fh.read()))
+    ops = build_add_operations(args.repo_root, files, CommitOperationAdd)
 
     deleted = []
     if args.prune:
-        managed_dirs = {f["copy_source"] for f in files.values()
-                        if f["copy_source"] not in ("(readme)",)
-                        and "/" in f["copy_source"] + "/"  # any source
-                        }
         # Only prune within COPY sources that are DIRECTORIES (whole-dir managed),
         # never within file/glob sources -- avoids sweeping Space-only vendor blobs.
         dir_sources = set()
-        df_path = args.dockerfile_path
-        if not os.path.isabs(df_path):
-            df_path = os.path.join(args.repo_root, df_path)
+        _, df_path = source_file(args.repo_root, args.dockerfile_path)
         for src in parse_copy_sources(open(df_path, encoding="utf-8", errors="replace").read()):
             s = src.rstrip("/")
             # a dir source is one where the checkout has children under s/
@@ -441,30 +647,30 @@ def attest(args):
     with open(args.manifest) as fh:
         manifest = json.load(fh)
     hf_repo = args.hf_repo or manifest.get("hf_repo")
-    ref = args.ref or manifest.get("ref", "main")
     files = manifest.get("files", {})
     if not hf_repo or not files:
         print("::error::attest needs a manifest with hf_repo + files")
         return 2
 
-    # Wait for the Space to finish rebuilding before re-fetching.
-    if args.wait_running:
-        deadline = time.time() + args.wait_running
-        while time.time() < deadline:
-            stage = hf_runtime_stage(hf_repo)
-            print(f"   runtime stage: {stage}")
-            if stage in ("RUNNING", "RUNNING_APP_STARTING"):
-                break
-            if stage in ("BUILD_ERROR", "CONFIG_ERROR", "RUNTIME_ERROR"):
-                print(f"::error::Space {hf_repo} in {stage} -- deploy did not come up.")
-                return 1
-            time.sleep(15)
+    hf_commit_oid = str(manifest.get("hf_commit_oid") or "").lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", hf_commit_oid):
+        print("::error::attest requires manifest.hf_commit_oid as an exact "
+              "40-character commit SHA")
+        return 2
+    smoke_paths = normalize_smoke_paths(manifest.get("smoke_paths", ["/"]))
+
+    # A RUNNING old revision is not this deployment. Require both exact state
+    # and exact API identity before immutable content and live routes are tested.
+    if not wait_for_expected_runtime(
+        hf_repo, hf_commit_oid, args.wait_running
+    ):
+        return 1
 
     mism, missing, ok = [], [], 0
     for path, meta in sorted(files.items()):
         want = meta.get("sha256")
         try:
-            status, body = hf_resolve(hf_repo, path, ref)
+            status, body = hf_resolve(hf_repo, path, hf_commit_oid)
         except RuntimeError as e:
             missing.append((path, f"fetch-failed: {e}"))
             continue
@@ -477,7 +683,7 @@ def attest(args):
         else:
             mism.append((path, want, got))
 
-    print(f"\n== HF deploy attestation: {hf_repo} ({ref}) ==")
+    print(f"\n== HF deploy attestation: {hf_repo} ({hf_commit_oid}) ==")
     print(f"   verified OK: {ok}   mismatched: {len(mism)}   missing: {len(missing)}")
     for p, w, g in mism:
         print(f"::error title=HF deploy drift::{p}: sha256 mismatch "
@@ -487,7 +693,19 @@ def attest(args):
     if mism or missing:
         print("\nFAIL: live Space does not match the pushed git blobs.")
         return 1
-    print("\nOK: every pushed file is byte-identical on the live Space (attested).")
+
+    route_failures = probe_smoke_routes(
+        hf_repo, smoke_paths, retries=args.smoke_retries
+    )
+    for path, status, detail in route_failures:
+        print(f"::error title=HF live route failed::{path}: expected exact HTTP "
+              f"200 with non-empty body; status={status!r}; {detail}")
+    if route_failures:
+        print("\nFAIL: declared live Space routes did not close after deployment.")
+        return 1
+
+    print("\nOK: exact HF commit is RUNNING, every pushed file is byte-identical, "
+          "and every declared live route returns HTTP 200 with content.")
     return 0
 
 
@@ -500,6 +718,10 @@ def main():
     ap.add_argument("--dockerfile-path", default="Dockerfile")
     ap.add_argument("--readme-path", default="README.md")
     ap.add_argument("--include-readme", default="true")
+    ap.add_argument(
+        "--smoke-paths", default='["/"]',
+        help="JSON array of same-host live app paths to require after deploy",
+    )
     ap.add_argument("--manifest-out", default="")
     ap.add_argument("--prune", action="store_true",
                     help="delete Space files under directory COPY sources that are "
@@ -510,7 +732,9 @@ def main():
                          "Space and assert sha256 == pushed value")
     ap.add_argument("--manifest", default="", help="manifest path (attest mode)")
     ap.add_argument("--wait-running", type=int, default=0,
-                    help="attest: seconds to poll runtime stage for RUNNING first")
+                    help="attest: seconds to require exact API sha + RUNNING stage")
+    ap.add_argument("--smoke-retries", type=int, default=6,
+                    help="attest: attempts per declared live route")
     args = ap.parse_args()
 
     args.include_readme = str(args.include_readme).lower() not in ("false", "0", "no")
@@ -521,11 +745,15 @@ def main():
                 os.path.basename(os.path.abspath(args.repo_root)))
         args.hf_repo = f"SZLHOLDINGS/{name}"
 
-    if args.attest:
-        if not args.manifest:
-            ap.error("--attest requires --manifest")
-        return attest(args)
-    return deploy(args)
+    try:
+        if args.attest:
+            if not args.manifest:
+                ap.error("--attest requires --manifest")
+            return attest(args)
+        return deploy(args)
+    except DeployContractError as exc:
+        print(f"::error title=HF deploy contract::{exc}")
+        return 2
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -493,8 +493,14 @@ class TestReusableWorkflowContract(unittest.TestCase):
             cls.workflow = fh.read()
 
     def test_shared_deployer_checkout_is_exact_reusable_revision(self):
-        self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
-        self.assertIn("ref: ${{ job.workflow_sha }}", self.workflow)
+        # The reusable workflow must checkout ITS OWN reviewed revision --
+        # github.job_workflow_sha is the documented context for that; the
+        # job.workflow_* forms do not exist and resolve empty.
+        self.assertIn("repository: szl-holdings/.github", self.workflow)
+        self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
+        self.assertNotIn("${{ job.workflow_repository }}", self.workflow)
+        self.assertNotIn("${{ job.workflow_sha }}", self.workflow)
+        self.assertNotIn("ref: main", self.workflow)
         self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
 
     def test_shell_consumes_inputs_through_environment(self):

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -7,8 +7,7 @@ contract. These locks pin the parts that have already burned us:
 
   * `COPY --from=<stage>` must NOT contribute deploy files (build-stage
     artifacts are not repo source-of-truth files);
-  * a bare `COPY . <dest>` whole-context copy must be SKIPPED, not silently
-    expanded into a whole-repo mirror (the curated Space deploy is per-file);
+  * a bare `COPY . <dest>` whole-context copy must FAIL CLOSED;
   * a dotdir source like `.compliance/x` must survive parsing -- an earlier
     `lstrip("./")` collapsed it to `compliance/x` and dropped 5 killinchu files;
   * directory / glob / explicit-file COPY sources must each expand to the right
@@ -19,10 +18,12 @@ Runs with NO network (derivation + expansion are pure stdlib).
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _MODULE_PATH = os.path.join(_HERE, "hf_deploy_from_dockerfile.py")
@@ -49,13 +50,25 @@ class TestParseCopySources(unittest.TestCase):
         # The --from artifact must NOT appear; only the real repo source does.
         self.assertEqual(dep.parse_copy_sources(df), ["serve.py"])
 
-    def test_skips_bare_whole_context(self):
+    def test_rejects_bare_whole_context(self):
         df = "FROM python:3.12\nCOPY . /app\nCOPY serve.py /app/serve.py\n"
-        self.assertEqual(dep.parse_copy_sources(df), ["serve.py"])
+        with self.assertRaisesRegex(dep.DeployContractError, "explicit curated"):
+            dep.parse_copy_sources(df)
 
-    def test_skips_dot_slash_whole_context(self):
+    def test_rejects_dot_slash_whole_context(self):
         df = "FROM python:3.12\nCOPY ./ /app\n"
-        self.assertEqual(dep.parse_copy_sources(df), [])
+        with self.assertRaises(dep.DeployContractError):
+            dep.parse_copy_sources(df)
+
+    def test_rejects_json_form_whole_context(self):
+        df = 'FROM python:3.12\nCOPY [".", "/app"]\n'
+        with self.assertRaises(dep.DeployContractError):
+            dep.parse_copy_sources(df)
+
+    def test_rejects_malformed_json_form(self):
+        df = 'FROM python:3.12\nCOPY ["serve.py", "/app/"\n'
+        with self.assertRaisesRegex(dep.DeployContractError, "malformed JSON"):
+            dep.parse_copy_sources(df)
 
     def test_dotdir_source_preserved(self):
         # The killinchu trap: leading-dot dir must NOT be stripped to a non-dot dir.
@@ -150,21 +163,25 @@ class TestExpandSources(unittest.TestCase):
 
 
 class TestDeriveReadmePolicy(unittest.TestCase):
-    def _derive(self, dockerfile, files, *, include_readme, readme_path="README.md"):
+    def _derive(
+        self, dockerfile, files, *, include_readme, readme_path="README.md",
+        dockerfile_path="Dockerfile", smoke_paths=None,
+    ):
         with tempfile.TemporaryDirectory() as repo_root:
-            for rel, content in {"Dockerfile": dockerfile, **files}.items():
+            for rel, content in {dockerfile_path: dockerfile, **files}.items():
                 path = os.path.join(repo_root, *rel.split("/"))
                 os.makedirs(os.path.dirname(path), exist_ok=True)
                 with open(path, "wb") as fh:
                     fh.write(content.encode("utf-8"))
             args = types.SimpleNamespace(
                 repo_root=repo_root,
-                dockerfile_path="Dockerfile",
+                dockerfile_path=dockerfile_path,
                 include_readme=include_readme,
                 readme_path=readme_path,
                 github_repo="szl-holdings/example",
                 hf_repo="SZLHOLDINGS/example",
                 ref="main",
+                smoke_paths=smoke_paths,
             )
             return dep.derive(args)
 
@@ -178,9 +195,10 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             readme_path="./README.md",
         )
 
-        self.assertEqual(set(files), {"serve.py"})
+        self.assertEqual(set(files), {"Dockerfile", "serve.py"})
         self.assertEqual(manifest["files_resolved"], 1)
         self.assertIsNone(manifest["readme"])
+        self.assertEqual(files["Dockerfile"]["source_path"], "Dockerfile")
 
     def test_include_readme_false_keeps_unrelated_nested_readme(self):
         manifest, files = self._derive(
@@ -194,7 +212,7 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             include_readme=False,
         )
 
-        self.assertEqual(set(files), {"docs/README.md"})
+        self.assertEqual(set(files), {"Dockerfile", "docs/README.md"})
         self.assertEqual(manifest["files_resolved"], 1)
 
     def test_include_readme_true_merges_derived_entry_as_readme(self):
@@ -205,10 +223,303 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             include_readme=True,
         )
 
-        self.assertEqual(set(files), {"README.md"})
+        self.assertEqual(set(files), {"Dockerfile", "README.md"})
         self.assertEqual(files["README.md"]["copy_source"], "(readme)")
         self.assertEqual(files["README.md"]["sha256"], dep.sha256(readme.encode()))
         self.assertEqual(manifest["readme"], "README.md")
+
+    def test_nested_yarqa_dockerfile_maps_to_hf_root_and_hashes_source(self):
+        dockerfile = "FROM scratch\nCOPY space/app.py /app/app.py\n"
+        manifest, files = self._derive(
+            dockerfile,
+            {"space/app.py": "print('yarqa')\n"},
+            include_readme=False,
+            dockerfile_path="space/Dockerfile",
+        )
+
+        self.assertEqual(manifest["dockerfile"], "space/Dockerfile")
+        self.assertEqual(manifest["schema"], 2)
+        self.assertEqual(manifest["dockerfile_target"], "Dockerfile")
+        self.assertEqual(files["Dockerfile"]["source_path"], "space/Dockerfile")
+        self.assertEqual(files["Dockerfile"]["copy_source"], "(dockerfile)")
+        self.assertEqual(
+            files["Dockerfile"]["sha256"], dep.sha256(dockerfile.encode())
+        )
+
+    def test_unresolved_copy_source_fails_closed(self):
+        with self.assertRaisesRegex(dep.DeployContractError, "not found"):
+            self._derive(
+                "FROM scratch\nCOPY missing.py /app/missing.py\n",
+                {},
+                include_readme=False,
+            )
+
+    def test_manifest_smoke_paths_default_to_root(self):
+        manifest, _ = self._derive(
+            "FROM scratch\nCOPY app.py /app/app.py\n",
+            {"app.py": "pass\n"},
+            include_readme=False,
+        )
+        self.assertEqual(manifest["smoke_paths"], ["/"])
+
+    def test_manifest_records_valid_declared_smoke_paths(self):
+        manifest, _ = self._derive(
+            "FROM scratch\nCOPY app.py /app/app.py\n",
+            {"app.py": "pass\n"},
+            include_readme=False,
+            smoke_paths='["/", "/openapi.json", "/health?deep=1"]',
+        )
+        self.assertEqual(
+            manifest["smoke_paths"], ["/", "/openapi.json", "/health?deep=1"]
+        )
+
+
+class TestSourcePathMapping(unittest.TestCase):
+    def test_reads_declared_source_path_not_hf_target_path(self):
+        with tempfile.TemporaryDirectory() as repo_root:
+            nested = os.path.join(repo_root, "space", "Dockerfile")
+            os.makedirs(os.path.dirname(nested), exist_ok=True)
+            with open(nested, "wb") as fh:
+                fh.write(b"FROM scratch\n")
+
+            data = dep.read_source_bytes(
+                repo_root, "Dockerfile", {"source_path": "space/Dockerfile"}
+            )
+            self.assertEqual(data, b"FROM scratch\n")
+
+    def test_add_operation_uses_mapped_source_bytes_for_hf_target(self):
+        captured = []
+
+        def operation(**kwargs):
+            captured.append(kwargs)
+            return kwargs
+
+        with tempfile.TemporaryDirectory() as repo_root:
+            nested = os.path.join(repo_root, "space", "Dockerfile")
+            os.makedirs(os.path.dirname(nested), exist_ok=True)
+            data = b"FROM python:3.12\n"
+            with open(nested, "wb") as fh:
+                fh.write(data)
+            files = {
+                "Dockerfile": {
+                    "source_path": "space/Dockerfile",
+                    "sha256": dep.sha256(data),
+                }
+            }
+            operations = dep.build_add_operations(repo_root, files, operation)
+
+        self.assertEqual(operations, captured)
+        self.assertEqual(captured[0]["path_in_repo"], "Dockerfile")
+        self.assertEqual(captured[0]["path_or_fileobj"], data)
+
+    def test_rejects_source_path_escape(self):
+        with tempfile.TemporaryDirectory() as repo_root:
+            with self.assertRaises(dep.DeployContractError):
+                dep.read_source_bytes(
+                    repo_root, "Dockerfile", {"source_path": "../Dockerfile"}
+                )
+
+
+class TestSmokePathPolicy(unittest.TestCase):
+    def test_default_and_deduplication(self):
+        self.assertEqual(dep.normalize_smoke_paths(), ["/"])
+        self.assertEqual(
+            dep.normalize_smoke_paths('["/", "/health", "/health"]'),
+            ["/", "/health"],
+        )
+
+    def test_rejects_external_absolute_and_scheme_relative_urls(self):
+        bad = [
+            '["https://example.com/"]',
+            '["http://example.com/"]',
+            '["//example.com/"]',
+            '["relative"]',
+            '["/ok#fragment"]',
+        ]
+        for value in bad:
+            with self.subTest(value=value):
+                with self.assertRaises(dep.DeployContractError):
+                    dep.normalize_smoke_paths(value)
+
+    def test_live_origin_is_derived_only_from_repo_id(self):
+        self.assertEqual(
+            dep.hf_live_origin("SZLHOLDINGS/a11oy"),
+            "https://szlholdings-a11oy.hf.space",
+        )
+        with self.assertRaises(dep.DeployContractError):
+            dep.hf_live_origin("https://evil.example/space")
+
+
+class TestRuntimeIdentity(unittest.TestCase):
+    def test_space_api_state_returns_stage_and_exact_sha(self):
+        oid = "a" * 40
+        payload = json.dumps({"sha": oid, "runtime": {"stage": "RUNNING"}}).encode()
+        with mock.patch.object(dep, "_http", return_value=(200, payload)):
+            self.assertEqual(
+                dep.hf_space_state("SZLHOLDINGS/a11oy"), ("RUNNING", oid)
+            )
+
+    def test_space_api_non_200_is_not_an_unknown_success(self):
+        with mock.patch.object(dep, "_http", return_value=(503, b"")):
+            with self.assertRaises(RuntimeError):
+                dep.hf_space_state("SZLHOLDINGS/a11oy")
+
+    def test_exact_running_commit_passes(self):
+        oid = "a" * 40
+        with mock.patch.object(dep, "hf_space_state", return_value=("RUNNING", oid)):
+            self.assertTrue(dep.wait_for_expected_runtime("SZLHOLDINGS/a11oy", oid, 0))
+
+    def test_running_old_commit_fails_at_timeout(self):
+        oid = "a" * 40
+        with mock.patch.object(dep, "hf_space_state", return_value=("RUNNING", "b" * 40)):
+            self.assertFalse(dep.wait_for_expected_runtime("SZLHOLDINGS/a11oy", oid, 0))
+
+    def test_app_starting_is_not_accepted_as_running(self):
+        oid = "a" * 40
+        with mock.patch.object(
+            dep, "hf_space_state", return_value=("RUNNING_APP_STARTING", oid)
+        ):
+            self.assertFalse(dep.wait_for_expected_runtime("SZLHOLDINGS/a11oy", oid, 0))
+
+    def test_positive_timeout_expires_fail_closed(self):
+        oid = "a" * 40
+        with (
+            mock.patch.object(dep, "hf_space_state", return_value=("BUILDING", oid)),
+            mock.patch.object(dep.time, "monotonic", side_effect=[0.0, 2.0]),
+            mock.patch.object(dep.time, "sleep") as sleep,
+        ):
+            self.assertFalse(
+                dep.wait_for_expected_runtime(
+                    "SZLHOLDINGS/a11oy", oid, timeout=1, poll_interval=0.1
+                )
+            )
+        sleep.assert_not_called()
+
+    def test_terminal_state_for_expected_commit_fails_immediately(self):
+        oid = "a" * 40
+        with mock.patch.object(
+            dep, "hf_space_state", return_value=("BUILD_ERROR", oid)
+        ):
+            self.assertFalse(dep.wait_for_expected_runtime("SZLHOLDINGS/a11oy", oid, 600))
+
+
+class TestLiveRouteProbe(unittest.TestCase):
+    def test_retries_then_requires_exact_200_with_nonempty_body(self):
+        with (
+            mock.patch.object(
+                dep, "_http", side_effect=[(503, b"not ready"), (200, b"ready")]
+            ) as http,
+            mock.patch.object(dep.time, "sleep") as sleep,
+        ):
+            failures = dep.probe_smoke_routes(
+                "SZLHOLDINGS/a11oy", ["/health"], retries=2, delay=0
+            )
+        self.assertEqual(failures, [])
+        self.assertEqual(http.call_count, 2)
+        self.assertFalse(http.call_args.kwargs["follow_redirects"])
+        sleep.assert_called_once_with(0.0)
+
+    def test_redirect_is_not_accepted(self):
+        with mock.patch.object(dep, "_http", return_value=(302, b"redirect")):
+            failures = dep.probe_smoke_routes(
+                "SZLHOLDINGS/a11oy", ["/"], retries=1
+            )
+        self.assertEqual(failures[0][1], 302)
+
+    def test_empty_200_body_is_not_accepted(self):
+        with mock.patch.object(dep, "_http", return_value=(200, b"")):
+            failures = dep.probe_smoke_routes(
+                "SZLHOLDINGS/a11oy", ["/"], retries=1
+            )
+        self.assertEqual(failures[0][1], 200)
+
+
+class TestImmutableAttestation(unittest.TestCase):
+    def _args(self, manifest_path):
+        return types.SimpleNamespace(
+            manifest=manifest_path,
+            hf_repo="",
+            ref="main",
+            wait_running=0,
+            smoke_retries=2,
+        )
+
+    def test_fetches_files_at_hf_commit_oid_and_probes_manifest_routes(self):
+        oid = "a" * 40
+        body = b"deployed"
+        manifest = {
+            "hf_repo": "SZLHOLDINGS/a11oy",
+            "hf_commit_oid": oid,
+            "smoke_paths": ["/", "/openapi.json"],
+            "files": {"app.py": {"sha256": dep.sha256(body)}},
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+            json.dump(manifest, fh)
+            manifest_path = fh.name
+        self.addCleanup(lambda: os.unlink(manifest_path))
+
+        with (
+            mock.patch.object(dep, "wait_for_expected_runtime", return_value=True) as runtime,
+            mock.patch.object(dep, "hf_resolve", return_value=(200, body)) as resolve,
+            mock.patch.object(dep, "probe_smoke_routes", return_value=[]) as probe,
+        ):
+            self.assertEqual(dep.attest(self._args(manifest_path)), 0)
+        runtime.assert_called_once_with("SZLHOLDINGS/a11oy", oid, 0)
+        resolve.assert_called_once_with("SZLHOLDINGS/a11oy", "app.py", oid)
+        probe.assert_called_once_with(
+            "SZLHOLDINGS/a11oy", ["/", "/openapi.json"], retries=2
+        )
+
+    def test_missing_commit_oid_fails_before_network(self):
+        manifest = {
+            "hf_repo": "SZLHOLDINGS/a11oy",
+            "files": {"app.py": {"sha256": dep.sha256(b"x")}},
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+            json.dump(manifest, fh)
+            manifest_path = fh.name
+        self.addCleanup(lambda: os.unlink(manifest_path))
+
+        with mock.patch.object(dep, "wait_for_expected_runtime") as runtime:
+            self.assertEqual(dep.attest(self._args(manifest_path)), 2)
+        runtime.assert_not_called()
+
+
+class TestReusableWorkflowContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(_HERE, "..", "workflows", "reusable-hf-deploy.yml")
+        with open(path, encoding="utf-8") as fh:
+            cls.workflow = fh.read()
+
+    def test_shared_deployer_checkout_is_exact_reusable_revision(self):
+        self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
+        self.assertIn("ref: ${{ job.workflow_sha }}", self.workflow)
+        self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
+
+    def test_shell_consumes_inputs_through_environment(self):
+        for unsafe in (
+            '--github-repo "${{ github.repository }}"',
+            '--hf-repo "${{ steps.hf.outputs.hf_repo }}"',
+            '--ref "${{ inputs.ref }}"',
+            '--dockerfile-path "${{ inputs.dockerfile-path }}"',
+            '--include-readme "${{ inputs.include-readme }}"',
+            "${{ inputs.prune && '--prune' || '' }}",
+            '--wait-running "${{ inputs.wait-running }}"',
+        ):
+            self.assertNotIn(unsafe, self.workflow)
+        for safe in (
+            'DEPLOY_REF: ${{ inputs.ref }}',
+            'DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}',
+            'SMOKE_PATHS: ${{ inputs.smoke-paths }}',
+            '--smoke-paths "${SMOKE_PATHS}"',
+            '--wait-running "${WAIT_RUNNING}"',
+        ):
+            self.assertIn(safe, self.workflow)
+
+    def test_attestation_does_not_override_immutable_manifest_ref(self):
+        attest_block = self.workflow.split("--attest", 1)[1]
+        self.assertNotIn("--ref", attest_block)
 
 
 class TestContentIdentity(unittest.TestCase):

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: boolean
         default: true
+      smoke-paths:
+        description: "JSON array of same-host live app paths that must return exact HTTP 200 with content."
+        required: false
+        type: string
+        default: '["/"]'
       prune:
         description: "Delete Space files under DIRECTORY COPY sources that are gone from git (never touches file/glob sources)."
         required: false
@@ -78,15 +83,19 @@ jobs:
           path: caller
           ref: ${{ inputs.ref }}
 
-      - name: Checkout szl-holdings/.github (shared deployer script)
+      - name: Checkout exact reusable-workflow revision (shared deployer)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # The deployed code must be the code reviewed at the immutable
+          # reusable-workflow revision, never mutable default-branch tooling.
+          # github.job_workflow_sha = the reviewed revision of THIS reusable
+          # workflow (documented context; job.workflow_* does not exist).
           repository: szl-holdings/.github
-          ref: main
+          ref: ${{ github.job_workflow_sha }}
           path: tools
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -98,6 +107,7 @@ jobs:
         env:
           HF_REPO_IN: ${{ inputs.hf-repo }}
           GH_REPO: ${{ github.repository }}
+          DEPLOY_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           if [ -n "${HF_REPO_IN}" ]; then
@@ -106,11 +116,18 @@ jobs:
             HF_REPO="SZLHOLDINGS/${GH_REPO##*/}"
           fi
           echo "hf_repo=${HF_REPO}" >> "$GITHUB_OUTPUT"
-          echo "Deploying ${GH_REPO} -> ${HF_REPO} @ ${{ inputs.ref }}"
+          echo "Deploying ${GH_REPO} -> ${HF_REPO} @ ${DEPLOY_REF}"
 
       - name: Deploy derived COPY set to the Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HF_REPO: ${{ steps.hf.outputs.hf_repo }}
+          DEPLOY_REF: ${{ inputs.ref }}
+          DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+          INCLUDE_README: ${{ inputs.include-readme }}
+          PRUNE: ${{ inputs.prune }}
+          SMOKE_PATHS: ${{ inputs.smoke-paths }}
         run: |
           set -euo pipefail
           if [ -z "${HF_TOKEN:-}" ]; then
@@ -118,14 +135,19 @@ jobs:
             echo "::error::Founder action: add repo/org secret HF_TOKEN (HF write token with org write to SZLHOLDINGS)."
             exit 1
           fi
+          PRUNE_ARGS=()
+          if [ "${PRUNE}" = "true" ]; then
+            PRUNE_ARGS+=(--prune)
+          fi
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root caller \
-            --github-repo "${{ github.repository }}" \
-            --hf-repo "${{ steps.hf.outputs.hf_repo }}" \
-            --ref "${{ inputs.ref }}" \
-            --dockerfile-path "${{ inputs.dockerfile-path }}" \
-            --include-readme "${{ inputs.include-readme }}" \
-            ${{ inputs.prune && '--prune' || '' }} \
+            --github-repo "${GH_REPO}" \
+            --hf-repo "${HF_REPO}" \
+            --ref "${DEPLOY_REF}" \
+            --dockerfile-path "${DOCKERFILE_PATH}" \
+            --include-readme "${INCLUDE_README}" \
+            --smoke-paths "${SMOKE_PATHS}" \
+            "${PRUNE_ARGS[@]}" \
             --manifest-out hf-deploy-manifest.json
 
       - name: Upload deploy manifest
@@ -139,11 +161,12 @@ jobs:
       - name: Attest — live Space matches pushed git blobs (sha256)
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ steps.hf.outputs.hf_repo }}
+          WAIT_RUNNING: ${{ inputs.wait-running }}
         run: |
           set -euo pipefail
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --attest \
             --manifest hf-deploy-manifest.json \
-            --hf-repo "${{ steps.hf.outputs.hf_repo }}" \
-            --ref "${{ inputs.ref }}" \
-            --wait-running "${{ inputs.wait-running }}"
+            --hf-repo "${HF_REPO}" \
+            --wait-running "${WAIT_RUNNING}"


### PR DESCRIPTION
Adopts `agent/hf-deployer-route-closure-20260716` (route closure + live-revision attestation, +328/-100 with tests) rebased onto current main, with one review fix: the branch used `${{ job.workflow_repository }}` / `${{ job.workflow_sha }}` — no such contexts exist, so every caller's deploy would checkout an empty ref. Replaced with hardcoded `szl-holdings/.github` + documented `${{ github.job_workflow_sha }}`. Supersedes that branch.