### PR TITLE
fix(ci): preserve anatomy required-check context

### DIFF
--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -52,7 +52,10 @@ concurrency:
 
 jobs:
   anatomy-map-drift:
-    name: Anatomy map honest & in sync (locked-five + experimental-three + Λ=Conjecture-1)
+    # Compatibility note: protected branches across the estate still require
+    # this historical context string. The implementation below enforces the
+    # newer locked-five + experimental-three taxonomy; only the label is legacy.
+    name: Anatomy map honest & in sync (locked-8 + Λ=Conjecture-1)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -127,4 +130,3 @@ jobs:
               exit 1
               ;;
           esac
-


### PR DESCRIPTION
## Purpose

Restore the exact historical status-context label required by existing protected branches while keeping the new locked-five plus experimental-three implementation unchanged.

## Scope

- one reusable-workflow file
- job display name only, plus an explicit compatibility comment
- the checker still enforces locked `{F1,F11,F12,F18,F19}`, experimental/not-locked `{F4,F7,F22}`, and Λ = Conjecture 1
- no threshold, test, branch rule, permission, fetch target, or failure behavior is weakened

## Why

After the taxonomy upgrade, GitHub continued waiting for the required context `anatomy-map-drift / Anatomy map honest & in sync (locked-8 + Λ=Conjecture-1)`. The stricter workflow emitted a new name, so protected PRs could never satisfy the existing context even when the new checker passed.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>