### PR TITLE
fix(hf): always persist estate credential failures

### DIFF
--- a/.github/workflows/hf-estate-upgrade.yml
+++ b/.github/workflows/hf-estate-upgrade.yml
@@ -38,26 +38,68 @@ jobs:
           ref: ${{ github.ref_name }}
           fetch-depth: 1
 
+      - name: Record credential preflight
+        id: credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            mkdir -p reports
+            cat > reports/hf-estate-upgrade-latest.json <<JSON
+          {
+            "schema": "szl.hf-estate-upgrade-report/v1",
+            "organization": "SZLHOLDINGS",
+            "generation": "${GITHUB_SHA}",
+            "publish": true,
+            "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "counts": {},
+            "clone_ids": [
+              "SZLHOLDINGS/a11oy-clone-1",
+              "SZLHOLDINGS/a11oy-clone-2",
+              "SZLHOLDINGS/a11oy-clone-3",
+              "SZLHOLDINGS/a11oy-clone-4"
+            ],
+            "collections": {},
+            "actions": [
+              {
+                "target": "SZLHOLDINGS",
+                "action": "credential-preflight",
+                "status": "error",
+                "detail": "Neither GitHub Actions secret HF_ORG_TOKEN nor HF_TOKEN is configured for this repository."
+              }
+            ],
+            "summary": {
+              "ok": 0,
+              "warning": 0,
+              "error": 1,
+              "dry_run": 0
+            },
+            "boundaries": [
+              "No Hugging Face mutation was attempted without an authenticated org-scoped write token."
+            ]
+          }
+          JSON
+            echo "::error::Neither HF_ORG_TOKEN nor HF_TOKEN is configured."
+          else
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Python
+        if: steps.credentials.outputs.has_token == 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install pinned Hub client range
+        if: steps.credentials.outputs.has_token == 'true'
         run: |
           python -m pip install --disable-pip-version-check \
             "huggingface_hub>=1.3,<2" \
             "requests>=2.32,<3"
 
-      - name: Verify org write credential is available
-        run: |
-          set -euo pipefail
-          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
-            echo "::error::Neither HF_ORG_TOKEN nor HF_TOKEN is configured."
-            exit 2
-          fi
-
       - name: Execute estate upgrade
+        if: steps.credentials.outputs.has_token == 'true'
         id: estate
         shell: bash
         run: |
@@ -119,7 +161,11 @@ jobs:
 
       - name: Enforce fail-closed completion
         if: always()
+        shell: bash
         run: |
+          if [ "${{ steps.credentials.outputs.has_token }}" != "true" ]; then
+            exit 2
+          fi
           code="${{ steps.estate.outputs.exit_code }}"
           if [ -z "$code" ]; then code=2; fi
           if [ "$code" -ne 0 ]; then


### PR DESCRIPTION
Ensures the organization-wide Hugging Face rollout always commits a machine-readable report. When neither `HF_ORG_TOKEN` nor `HF_TOKEN` is configured, the workflow records that exact blocker without attempting any Hub mutation. With a valid token, the full estate upgrade continues unchanged.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2-hash@users.noreply.github.com>