### PR TITLE
ops(merge): adapt exact merge wave to current CheckRun schema

### DIFF
--- a/.github/scripts/owner_authorized_merge_wave_v2.py
+++ b/.github/scripts/owner_authorized_merge_wave_v2.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for the current GitHub CheckRun GraphQL schema.
+
+GitHub no longer exposes ``CheckRun.app`` on the schema used by this workflow.
+The underlying verifier does not depend on that field for any decision; it was
+report-only metadata.  Remove only that selection and run the original exact-SHA,
+check-rollup, review-thread, review-decision, mergeability, and admin-authority
+logic unchanged.
+"""
+from __future__ import annotations
+
+import owner_authorized_merge_wave as wave
+
+_OBSOLETE_SELECTION = "                    app { slug }\n"
+if _OBSOLETE_SELECTION not in wave.PR_QUERY:
+    raise SystemExit("expected obsolete CheckRun.app selection was not found")
+wave.PR_QUERY = wave.PR_QUERY.replace(_OBSOLETE_SELECTION, "")
+
+raise SystemExit(wave.main())

--- a/.github/workflows/owner-authorized-merge-wave.yml
+++ b/.github/workflows/owner-authorized-merge-wave.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - .github/data/owner_authorized_merge_wave.json
       - .github/scripts/owner_authorized_merge_wave.py
+      - .github/scripts/owner_authorized_merge_wave_v2.py
       - .github/workflows/owner-authorized-merge-wave.yml
   push:
     branches: [main]
     paths:
       - .github/data/owner_authorized_merge_wave.json
       - .github/scripts/owner_authorized_merge_wave.py
+      - .github/scripts/owner_authorized_merge_wave_v2.py
       - .github/workflows/owner-authorized-merge-wave.yml
   workflow_dispatch:
     inputs:
@@ -42,7 +44,9 @@ jobs:
       - name: Compile and validate manifest
         run: |
           set -euo pipefail
-          python -m py_compile .github/scripts/owner_authorized_merge_wave.py
+          python -m py_compile \
+            .github/scripts/owner_authorized_merge_wave.py \
+            .github/scripts/owner_authorized_merge_wave_v2.py
           python - <<'PY'
           import json
           from pathlib import Path
@@ -100,7 +104,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          python .github/scripts/owner_authorized_merge_wave.py \
+          python .github/scripts/owner_authorized_merge_wave_v2.py \
             --manifest .github/data/owner_authorized_merge_wave.json \
             --report owner-authorized-merge-report.json \
             --execute


### PR DESCRIPTION
## Root cause

The durable report from issue #218 showed that GitHub's current GraphQL schema no longer exposes `CheckRun.app`. That field was report-only metadata; no merge decision depended on it.

## Change

- add a tiny compatibility entrypoint that removes only the obsolete `app { slug }` selection;
- execute and statically compile that entrypoint;
- retain the original verifier's exact-head, admin-permission, mergeability, complete green check-rollup, review-thread, change-request, and review-only bypass gates unchanged.

No target SHA or merge policy is changed. The existing durable report issue will record the next exact result.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>