### PR TITLE
fix(hf): retire four private A11oy clones

### DIFF
--- a/.github/scripts/hf_estate_canonicalize.py
+++ b/.github/scripts/hf_estate_canonicalize.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Reconcile the SZLHOLDINGS Hub estate around one canonical A11oy Space.
+
+This wrapper deliberately disables the legacy clone path in
+``hf_estate_upgrade.py``. It preserves the estate-wide inventory, markers,
+Space health checks, collection curation, kernel validation, and evidence
+report while retiring only these exact historical private duplicates:
+
+- SZLHOLDINGS/a11oy-clone-1
+- SZLHOLDINGS/a11oy-clone-2
+- SZLHOLDINGS/a11oy-clone-3
+- SZLHOLDINGS/a11oy-clone-4
+
+Deletion is fail-closed and only occurs after the canonical
+``SZLHOLDINGS/a11oy`` Space is verified RUNNING at an immutable revision with
+its Dockerfile present. Collection references are removed before repository
+deletion, and repository absence is verified afterwards.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from typing import Any
+
+import hf_estate_upgrade as legacy
+
+RETIRED_CLONE_IDS = (
+    "SZLHOLDINGS/a11oy-clone-1",
+    "SZLHOLDINGS/a11oy-clone-2",
+    "SZLHOLDINGS/a11oy-clone-3",
+    "SZLHOLDINGS/a11oy-clone-4",
+)
+
+# Fail closed if the historical implementation ever changes its clone set.
+if tuple(legacy.CLONE_IDS) != RETIRED_CLONE_IDS:
+    raise RuntimeError(
+        "Legacy A11oy clone allowlist changed; review before estate reconciliation: "
+        f"{legacy.CLONE_IDS!r}"
+    )
+
+# The inherited collection builder consults this module global. Emptying it
+# prevents any future collection add for the retired repositories.
+legacy.CLONE_IDS = []
+
+
+def _runtime_stage(info: Any) -> str:
+    runtime = getattr(info, "runtime", None)
+    raw = getattr(runtime, "stage", None)
+    raw = getattr(raw, "value", raw)
+    return str(raw or "UNKNOWN").split(".")[-1].upper()
+
+
+class CanonicalEstateUpgrade(legacy.EstateUpgrade):
+    """Estate upgrade with exact, one-time A11oy clone retirement."""
+
+    def _verify_canonical_flagship(self) -> dict[str, Any]:
+        if not self.api.repo_exists(legacy.FLAGSHIP_SPACE, repo_type="space"):
+            raise RuntimeError(f"Canonical Space is missing: {legacy.FLAGSHIP_SPACE}")
+
+        info = self.api.space_info(legacy.FLAGSHIP_SPACE)
+        stage = _runtime_stage(info)
+        sha = str(getattr(info, "sha", "") or "")
+        private = getattr(info, "private", None)
+        files = set(self.api.list_repo_files(legacy.FLAGSHIP_SPACE, repo_type="space"))
+
+        if stage != "RUNNING":
+            raise RuntimeError(
+                f"Canonical Space is not RUNNING: {legacy.FLAGSHIP_SPACE} stage={stage}"
+            )
+        if not re.fullmatch(r"[0-9a-f]{40}", sha):
+            raise RuntimeError(
+                f"Canonical Space revision is not an immutable 40-character SHA: {sha!r}"
+            )
+        if private is True:
+            raise RuntimeError(
+                f"Canonical Space unexpectedly became private: {legacy.FLAGSHIP_SPACE}"
+            )
+        if "Dockerfile" not in files:
+            raise RuntimeError(
+                f"Canonical Docker Space is missing Dockerfile: {legacy.FLAGSHIP_SPACE}"
+            )
+
+        snapshot = {
+            "repo_id": legacy.FLAGSHIP_SPACE,
+            "stage": stage,
+            "sha": sha,
+            "private": private,
+            "dockerfile_present": True,
+        }
+        self.record(
+            legacy.FLAGSHIP_SPACE,
+            "canonical-space-preflight",
+            "validated",
+            f"stage={stage}; sha={sha}; private={private}",
+        )
+        return snapshot
+
+    def _clone_snapshots(self) -> dict[str, dict[str, Any]]:
+        snapshots: dict[str, dict[str, Any]] = {}
+        for clone_id in RETIRED_CLONE_IDS:
+            exists = self.api.repo_exists(clone_id, repo_type="space")
+            if not exists:
+                snapshots[clone_id] = {"exists": False}
+                self.record(clone_id, "clone-preflight", "ok", "already absent")
+                continue
+            info = self.api.space_info(clone_id)
+            snapshot = {
+                "exists": True,
+                "sha": str(getattr(info, "sha", "") or ""),
+                "private": getattr(info, "private", None),
+                "stage": _runtime_stage(info),
+            }
+            snapshots[clone_id] = snapshot
+            self.record(
+                clone_id,
+                "clone-preflight",
+                "ok",
+                "existing exact retired clone; "
+                f"private={snapshot['private']}; stage={snapshot['stage']}; "
+                f"sha={snapshot['sha']}",
+            )
+        return snapshots
+
+    def _remove_clone_collection_references(self) -> None:
+        summaries = list(self.api.list_collections(owner=legacy.ORG, limit=100))
+        for summary in summaries:
+            collection = self.api.get_collection(summary.slug)
+            for item in collection.items:
+                if item.item_type != "space" or item.item_id not in RETIRED_CLONE_IDS:
+                    continue
+                target = f"{collection.slug}:{item.item_id}"
+                if not self.publish:
+                    self.record(target, "collection-remove-clone", "dry-run")
+                    continue
+                self.api.delete_collection_item(
+                    collection_slug=collection.slug,
+                    item_object_id=item.item_object_id,
+                    missing_ok=True,
+                )
+                self.record(target, "collection-remove-clone", "deleted")
+
+    def create_or_refresh_clones(self) -> None:
+        """Replace the legacy clone creator with exact clone retirement."""
+        self.canonical_flagship = self._verify_canonical_flagship()
+        self.retired_clone_snapshots = self._clone_snapshots()
+
+        # Remove stale collection references before irreversible deletion.
+        self._remove_clone_collection_references()
+
+        for clone_id, snapshot in self.retired_clone_snapshots.items():
+            if not snapshot["exists"]:
+                continue
+            if not self.publish:
+                self.record(
+                    clone_id,
+                    "retire-flagship-clone",
+                    "dry-run",
+                    "would delete exact legacy private duplicate",
+                )
+                continue
+            self.api.delete_repo(
+                repo_id=clone_id,
+                repo_type="space",
+                missing_ok=True,
+            )
+            if self.api.repo_exists(clone_id, repo_type="space"):
+                raise RuntimeError(f"Retired clone still exists after deletion: {clone_id}")
+            self.record(
+                clone_id,
+                "retire-flagship-clone",
+                "deleted",
+                f"former_sha={snapshot.get('sha')}",
+            )
+
+        # The initial inventory was collected before retirement. Remove exact
+        # retired IDs so collection curation and final counts cannot reintroduce
+        # them or report them as live estate assets.
+        self.inventory["spaces"] = [
+            item
+            for item in self.inventory.get("spaces", [])
+            if self._asset_id(item) not in RETIRED_CLONE_IDS
+        ]
+
+    def report(self) -> dict[str, Any]:
+        report = super().report()
+        report.pop("clone_ids", None)
+        report["canonical_flagship_space"] = getattr(
+            self, "canonical_flagship", {"repo_id": legacy.FLAGSHIP_SPACE}
+        )
+        report["retired_clone_ids"] = list(RETIRED_CLONE_IDS)
+        report["retired_clone_snapshots"] = getattr(
+            self, "retired_clone_snapshots", {}
+        )
+        report["summary"]["ok"] = sum(
+            action.status
+            in {
+                "ok",
+                "updated",
+                "created",
+                "validated",
+                "requested",
+                "deleted",
+            }
+            for action in self.actions
+        )
+        report["boundaries"] = [
+            "SZLHOLDINGS/a11oy is the only canonical A11oy Space.",
+            "Only the four exact allowlisted a11oy-clone-1..4 repositories may be deleted.",
+            "Clone deletion requires a RUNNING public canonical Space at an immutable revision with Dockerfile present.",
+            "No model weights or dataset payloads are changed.",
+            "No paid hardware tier is changed.",
+            "Healthy dynamic Spaces are not rewritten or restarted.",
+            "Kernel repositories are validated; first-class kernel publishing remains governed by kernel-builder release workflows.",
+        ]
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--generation",
+        default=os.environ.get("GITHUB_SHA") or f"manual-{int(time.time())}",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("HF_ORG_TOKEN") or os.environ.get("HF_TOKEN")
+    if not token:
+        print("FATAL: HF_ORG_TOKEN/HF_TOKEN is not set.", file=sys.stderr)
+        return 2
+
+    try:
+        report = CanonicalEstateUpgrade(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:
+        print(f"FATAL: {exc!r}", file=sys.stderr)
+        return 2
+
+    summary = report["summary"]
+    print(json.dumps(summary, indent=2))
+    return 1 if summary["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_estate_canonicalize.py
+++ b/.github/scripts/test_hf_estate_canonicalize.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+canonical = importlib.import_module("hf_estate_canonicalize")
+
+
+class CanonicalEstateContractTests(unittest.TestCase):
+    def test_exact_retired_clone_allowlist(self) -> None:
+        self.assertEqual(
+            canonical.RETIRED_CLONE_IDS,
+            (
+                "SZLHOLDINGS/a11oy-clone-1",
+                "SZLHOLDINGS/a11oy-clone-2",
+                "SZLHOLDINGS/a11oy-clone-3",
+                "SZLHOLDINGS/a11oy-clone-4",
+            ),
+        )
+
+    def test_inherited_clone_additions_are_disabled(self) -> None:
+        self.assertEqual(canonical.legacy.CLONE_IDS, [])
+
+    def test_wrapper_contains_no_clone_creation_api(self) -> None:
+        source = (SCRIPT_DIR / "hf_estate_canonicalize.py").read_text(encoding="utf-8")
+        self.assertNotIn("duplicate_repo(", source)
+        self.assertNotIn("duplicate_space(", source)
+        self.assertIn("delete_repo(", source)
+        self.assertIn("canonical-space-preflight", source)
+
+    def test_workflow_executes_canonical_reconciler_only(self) -> None:
+        workflow = (
+            SCRIPT_DIR.parent / "workflows" / "hf-estate-upgrade.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("hf_estate_canonicalize.py", workflow)
+        self.assertNotIn("python .github/scripts/hf_estate_upgrade.py", workflow)
+
+    def test_runtime_stage_normalization(self) -> None:
+        class Runtime:
+            stage = "SpaceStage.RUNNING"
+
+        class Info:
+            runtime = Runtime()
+
+        self.assertEqual(canonical._runtime_stage(Info()), "RUNNING")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-estate-upgrade.yml
+++ b/.github/workflows/hf-estate-upgrade.yml
@@ -142,8 +142,17 @@ jobs:
           echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: Upload pull-request dry-run evidence
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-estate-canonicalization-dry-run-${{ github.run_id }}
+          path: reports/hf-estate-upgrade-latest.json
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Commit the evidence report
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/hf-estate-upgrade.yml
+++ b/.github/workflows/hf-estate-upgrade.yml
@@ -1,23 +1,27 @@
-name: HF Estate Upgrade
+name: HF Estate Canonicalization
 
-# Organization-wide, non-destructive Hub maintenance.
+# Organization-wide Hugging Face maintenance with one canonical A11oy Space.
+# Pull requests are read-only dry runs. A protected-main push or an explicitly
+# published manual dispatch performs the exact clone retirement and estate sync.
 on:
   push:
-    branches:
-      - main
-      - agent/hf-estate-upgrade-20260722
+    branches: [main]
     paths:
       - .github/scripts/hf_estate_upgrade.py
+      - .github/scripts/hf_estate_canonicalize.py
+      - .github/scripts/test_hf_estate_canonicalize.py
       - .github/workflows/hf-estate-upgrade.yml
   pull_request:
     branches: [main]
     paths:
       - .github/scripts/hf_estate_upgrade.py
+      - .github/scripts/hf_estate_canonicalize.py
+      - .github/scripts/test_hf_estate_canonicalize.py
       - .github/workflows/hf-estate-upgrade.yml
   workflow_dispatch:
     inputs:
       publish:
-        description: Apply the upgrade rather than produce a dry-run report
+        description: Apply canonicalization rather than produce a dry-run report
         required: false
         default: "true"
 
@@ -25,12 +29,12 @@ permissions:
   contents: write
 
 concurrency:
-  group: hf-estate-upgrade-${{ github.event_name }}-${{ github.ref }}
+  group: hf-estate-canonicalization-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  upgrade:
-    name: Upgrade SZLHOLDINGS Hub estate
+  canonicalize:
+    name: Canonicalize SZLHOLDINGS Hub estate
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -63,7 +67,10 @@ jobs:
             "publish": ${publish},
             "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "counts": {},
-            "clone_ids": [
+            "canonical_flagship_space": {
+              "repo_id": "SZLHOLDINGS/a11oy"
+            },
+            "retired_clone_ids": [
               "SZLHOLDINGS/a11oy-clone-1",
               "SZLHOLDINGS/a11oy-clone-2",
               "SZLHOLDINGS/a11oy-clone-3",
@@ -107,7 +114,16 @@ jobs:
             "huggingface_hub>=1.3,<2" \
             "requests>=2.32,<3"
 
-      - name: Execute estate upgrade
+      - name: Verify canonical one-Space contract
+        if: steps.credentials.outputs.has_token == 'true'
+        run: |
+          python -m py_compile \
+            .github/scripts/hf_estate_upgrade.py \
+            .github/scripts/hf_estate_canonicalize.py \
+            .github/scripts/test_hf_estate_canonicalize.py
+          python .github/scripts/test_hf_estate_canonicalize.py
+
+      - name: Execute canonical estate reconciliation
         if: steps.credentials.outputs.has_token == 'true'
         id: estate
         shell: bash
@@ -119,7 +135,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
             publish_flag=""
           fi
-          python .github/scripts/hf_estate_upgrade.py \
+          python .github/scripts/hf_estate_canonicalize.py \
             ${publish_flag} \
             --generation "${GITHUB_SHA}"
           code=$?
@@ -142,7 +158,7 @@ jobs:
             echo "Report is unchanged."
             exit 0
           fi
-          git commit -s -m "chore(hf): record estate upgrade report [skip ci]"
+          git commit -s -m "chore(hf): record canonical estate report [skip ci]"
           git push origin "HEAD:${TARGET_BRANCH}"
 
       - name: Publish job summary
@@ -156,12 +172,19 @@ jobs:
 
           path = Path("reports/hf-estate-upgrade-latest.json")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as out:
-              out.write("## Hugging Face estate upgrade\n\n")
+              out.write("## Hugging Face estate canonicalization\n\n")
               if not path.exists():
                   out.write("No report was produced.\n")
               else:
                   report = json.loads(path.read_text(encoding="utf-8"))
                   out.write(f"Generation: `{report.get('generation')}`\n\n")
+                  canonical = report.get("canonical_flagship_space", {})
+                  out.write(
+                      "Canonical A11oy: "
+                      f"`{canonical.get('repo_id', 'UNKNOWN')}` "
+                      f"at `{canonical.get('sha', 'UNVERIFIED')}` "
+                      f"({canonical.get('stage', 'UNKNOWN')})\n\n"
+                  )
                   out.write("| Inventory | Count |\n|---|---:|\n")
                   for key, value in report.get("counts", {}).items():
                       out.write(f"| {key} | {value} |\n")
@@ -180,6 +203,6 @@ jobs:
           code="${{ steps.estate.outputs.exit_code }}"
           if [ -z "$code" ]; then code=2; fi
           if [ "$code" -ne 0 ]; then
-            echo "::error::Estate upgrade completed with exit code $code; inspect the committed report."
+            echo "::error::Estate canonicalization completed with exit code $code; inspect the committed report."
             exit "$code"
           fi

--- a/reports/hf-estate-upgrade-latest.json
+++ b/reports/hf-estate-upgrade-latest.json
@@ -20,7 +20,7 @@
     },
     {
       "action": "inventory:spaces",
-      "detail": "count=26",
+      "detail": "count=30",
       "status": "ok",
       "target": "SZLHOLDINGS"
     },
@@ -565,26 +565,128 @@
       "target": "SZLHOLDINGS/szl-model-inference-lab"
     },
     {
-      "action": "flagship-clone",
-      "detail": "source=SZLHOLDINGS/a11oy",
+      "action": "space-health",
+      "detail": "sdk=docker stage=RUNNING",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-1"
+    },
+    {
+      "action": "space-health",
+      "detail": "sdk=docker stage=RUNNING",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-2"
+    },
+    {
+      "action": "space-health",
+      "detail": "sdk=docker stage=RUNNING",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-3"
+    },
+    {
+      "action": "space-health",
+      "detail": "sdk=docker stage=RUNNING_APP_STARTING",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-4"
+    },
+    {
+      "action": "canonical-space-preflight",
+      "detail": "stage=RUNNING; sha=ce45517588dcbb19076917653dd87f3c20ed0db8; private=False",
+      "status": "validated",
+      "target": "SZLHOLDINGS/a11oy"
+    },
+    {
+      "action": "clone-preflight",
+      "detail": "existing exact retired clone; private=True; stage=RUNNING; sha=9e71bb0a7a8a0fdfdc67c0ec3b4a04b2c7be78b4",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-1"
+    },
+    {
+      "action": "clone-preflight",
+      "detail": "existing exact retired clone; private=True; stage=RUNNING; sha=c7cf189da4eabde68e6413615e702a7a3b2f85a4",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-2"
+    },
+    {
+      "action": "clone-preflight",
+      "detail": "existing exact retired clone; private=True; stage=RUNNING; sha=e15ff6ce6b0db003d6102227907f30e2db7e3f1c",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-3"
+    },
+    {
+      "action": "clone-preflight",
+      "detail": "existing exact retired clone; private=True; stage=RUNNING_APP_STARTING; sha=ea643786a2565a0577fe4e6e23360b104b670ec3",
+      "status": "ok",
+      "target": "SZLHOLDINGS/a11oy-clone-4"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-canonical-estate-6a6053498f1195071c8f73c2:SZLHOLDINGS/a11oy-clone-1"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-canonical-estate-6a6053498f1195071c8f73c2:SZLHOLDINGS/a11oy-clone-2"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-canonical-estate-6a6053498f1195071c8f73c2:SZLHOLDINGS/a11oy-clone-3"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-canonical-estate-6a6053498f1195071c8f73c2:SZLHOLDINGS/a11oy-clone-4"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-spaces-6a6053493e2dbe1deddd1f2d:SZLHOLDINGS/a11oy-clone-1"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-spaces-6a6053493e2dbe1deddd1f2d:SZLHOLDINGS/a11oy-clone-2"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-spaces-6a6053493e2dbe1deddd1f2d:SZLHOLDINGS/a11oy-clone-3"
+    },
+    {
+      "action": "collection-remove-clone",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-holdings-spaces-6a6053493e2dbe1deddd1f2d:SZLHOLDINGS/a11oy-clone-4"
+    },
+    {
+      "action": "retire-flagship-clone",
+      "detail": "would delete exact legacy private duplicate",
       "status": "dry-run",
       "target": "SZLHOLDINGS/a11oy-clone-1"
     },
     {
-      "action": "flagship-clone",
-      "detail": "source=SZLHOLDINGS/a11oy",
+      "action": "retire-flagship-clone",
+      "detail": "would delete exact legacy private duplicate",
       "status": "dry-run",
       "target": "SZLHOLDINGS/a11oy-clone-2"
     },
     {
-      "action": "flagship-clone",
-      "detail": "source=SZLHOLDINGS/a11oy",
+      "action": "retire-flagship-clone",
+      "detail": "would delete exact legacy private duplicate",
       "status": "dry-run",
       "target": "SZLHOLDINGS/a11oy-clone-3"
     },
     {
-      "action": "flagship-clone",
-      "detail": "source=SZLHOLDINGS/a11oy",
+      "action": "retire-flagship-clone",
+      "detail": "would delete exact legacy private duplicate",
       "status": "dry-run",
       "target": "SZLHOLDINGS/a11oy-clone-4"
     },
@@ -602,9 +704,9 @@
     },
     {
       "action": "collection",
-      "detail": "would create",
-      "status": "dry-run",
-      "target": "SZL Holdings \u2014 Models & Kernel Contracts"
+      "detail": "existing",
+      "status": "ok",
+      "target": "SZLHOLDINGS/szl-holdings-models-and-kernel-contracts-6a605eaece7ff15ea2af6f74"
     },
     {
       "action": "collection",
@@ -623,30 +725,6 @@
       "detail": "",
       "status": "dry-run",
       "target": "SZLHOLDINGS/a11oy"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Spaces",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-1"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Spaces",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-2"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Spaces",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-3"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Spaces",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-4"
     },
     {
       "action": "collection-add:SZL Holdings \u2014 Spaces",
@@ -791,6 +869,96 @@
       "detail": "",
       "status": "dry-run",
       "target": "SZLHOLDINGS/yarqa"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/SZL-Khipu-1.5B"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/a11oy-v19-substrate"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-governed-norm"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-lambda-gate"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/governed-inference-meter"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-kernels"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-blocked"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-govsign"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-provctl"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-nemo"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-invariants"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-ouroboros"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/szl-formulas"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/SZL-Forge-1.5B-ReceiptAgent"
+    },
+    {
+      "action": "collection-add:SZL Holdings \u2014 Models & Kernel Contracts",
+      "detail": "",
+      "status": "dry-run",
+      "target": "SZLHOLDINGS/SZL-Khipu-1.5B-GGUF"
     },
     {
       "action": "collection-add:SZL Holdings \u2014 Datasets & Evidence",
@@ -1009,30 +1177,6 @@
       "target": "SZLHOLDINGS/szl-evidence"
     },
     {
-      "action": "collection-add:SZL Holdings \u2014 Canonical Estate",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-1"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Canonical Estate",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-2"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Canonical Estate",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-3"
-    },
-    {
-      "action": "collection-add:SZL Holdings \u2014 Canonical Estate",
-      "detail": "",
-      "status": "dry-run",
-      "target": "SZLHOLDINGS/a11oy-clone-4"
-    },
-    {
       "action": "kernel-contract",
       "detail": "sha=8a99694472bab97b9e00bd3ef1a1fd73cfaabc4a",
       "status": "validated",
@@ -1100,21 +1244,25 @@
     }
   ],
   "boundaries": [
-    "No repository was deleted, renamed, or made more public.",
-    "No model weights or dataset payloads were changed.",
-    "No paid hardware tier was changed.",
-    "Healthy dynamic Spaces were not rewritten or restarted.",
-    "Kernel repositories were validated; first-class kernel publishing remains governed by kernel-builder release workflows."
+    "SZLHOLDINGS/a11oy is the only canonical A11oy Space.",
+    "Only the four exact allowlisted a11oy-clone-1..4 repositories may be deleted.",
+    "Clone deletion requires a RUNNING public canonical Space at an immutable revision with Dockerfile present.",
+    "No model weights or dataset payloads are changed.",
+    "No paid hardware tier is changed.",
+    "Healthy dynamic Spaces are not rewritten or restarted.",
+    "Kernel repositories are validated; first-class kernel publishing remains governed by kernel-builder release workflows."
   ],
-  "clone_ids": [
-    "SZLHOLDINGS/a11oy-clone-1",
-    "SZLHOLDINGS/a11oy-clone-2",
-    "SZLHOLDINGS/a11oy-clone-3",
-    "SZLHOLDINGS/a11oy-clone-4"
-  ],
+  "canonical_flagship_space": {
+    "dockerfile_present": true,
+    "private": false,
+    "repo_id": "SZLHOLDINGS/a11oy",
+    "sha": "ce45517588dcbb19076917653dd87f3c20ed0db8",
+    "stage": "RUNNING"
+  },
   "collections": {
     "SZL Holdings \u2014 Canonical Estate": "SZLHOLDINGS/szl-holdings-canonical-estate-6a6053498f1195071c8f73c2",
     "SZL Holdings \u2014 Datasets & Evidence": "SZLHOLDINGS/szl-holdings-datasets-and-evidence-6a605349b7137fa34ac94728",
+    "SZL Holdings \u2014 Models & Kernel Contracts": "SZLHOLDINGS/szl-holdings-models-and-kernel-contracts-6a605eaece7ff15ea2af6f74",
     "SZL Holdings \u2014 Spaces": "SZLHOLDINGS/szl-holdings-spaces-6a6053493e2dbe1deddd1f2d"
   },
   "counts": {
@@ -1125,15 +1273,47 @@
     "models": 15,
     "spaces": 26
   },
-  "generated_at": "2026-07-22T05:38:15.227575+00:00",
-  "generation": "adfc10eaffc200f1844e1344c7a48129c00df91f",
+  "generated_at": "2026-07-22T06:34:06.003563+00:00",
+  "generation": "1578aa3cecdee90ba0a03f31080b9eaa9d58ae23",
   "organization": "SZLHOLDINGS",
   "publish": false,
+  "retired_clone_ids": [
+    "SZLHOLDINGS/a11oy-clone-1",
+    "SZLHOLDINGS/a11oy-clone-2",
+    "SZLHOLDINGS/a11oy-clone-3",
+    "SZLHOLDINGS/a11oy-clone-4"
+  ],
+  "retired_clone_snapshots": {
+    "SZLHOLDINGS/a11oy-clone-1": {
+      "exists": true,
+      "private": true,
+      "sha": "9e71bb0a7a8a0fdfdc67c0ec3b4a04b2c7be78b4",
+      "stage": "RUNNING"
+    },
+    "SZLHOLDINGS/a11oy-clone-2": {
+      "exists": true,
+      "private": true,
+      "sha": "c7cf189da4eabde68e6413615e702a7a3b2f85a4",
+      "stage": "RUNNING"
+    },
+    "SZLHOLDINGS/a11oy-clone-3": {
+      "exists": true,
+      "private": true,
+      "sha": "e15ff6ce6b0db003d6102227907f30e2db7e3f1c",
+      "stage": "RUNNING"
+    },
+    "SZLHOLDINGS/a11oy-clone-4": {
+      "exists": true,
+      "private": true,
+      "sha": "ea643786a2565a0577fe4e6e23360b104b670ec3",
+      "stage": "RUNNING_APP_STARTING"
+    }
+  },
   "schema": "szl.hf-estate-upgrade-report/v1",
   "summary": {
-    "dry_run": 136,
+    "dry_run": 150,
     "error": 0,
-    "ok": 45,
+    "ok": 55,
     "warning": 2
   }
 }


### PR DESCRIPTION
## Root cause

The merged estate-upgrade implementation explicitly created `SZLHOLDINGS/a11oy-clone-1` through `a11oy-clone-4` as private CPU-basic duplicates and added them to estate collections. They are not required deployment replicas.

## Change

- retain `SZLHOLDINGS/a11oy` as the sole canonical A11oy Space;
- replace the active workflow entrypoint with a canonical reconciler;
- verify the canonical Space is public, `RUNNING`, pinned to an immutable 40-character revision, and contains its Dockerfile before any destructive operation;
- inventory the four exact legacy clone IDs and retain their former revision/runtime evidence;
- remove their references from every SZLHOLDINGS collection;
- delete only those four exact repositories and verify each is absent;
- filter them from final Space inventory and prevent the inherited collection builder from re-adding them;
- preserve the existing model/dataset markers, Space health audit, unhealthy-Space restarts, collection curation, kernel validation, and evidence publication;
- add static contract tests proving the live workflow cannot call the legacy clone creator.

## Execution boundary

Pull-request runs are authenticated read-only dry runs. The protected-main push performs the authorized deletion and estate reconciliation using the existing org-scoped Hugging Face credential. No model weights, dataset payloads, paid hardware, healthy dynamic Space runtime, or non-allowlisted repository is changed.

## Irreversibility

Hugging Face repository deletion is irreversible. The deletion allowlist is fixed to the four exact `a11oy-clone-{1..4}` IDs and fails closed if the historical clone set changes.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>