### PR TITLE
fix(hf): retain four public A11oy command centers

### DIFF
--- a/.github/scripts/hf_estate_canonicalize.py
+++ b/.github/scripts/hf_estate_canonicalize.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-"""Reconcile the SZLHOLDINGS Hub estate around one canonical A11oy Space.
+"""Reconcile the SZLHOLDINGS Hub around one canonical A11oy and four public clones.
 
-This wrapper deliberately disables the legacy clone path in
-``hf_estate_upgrade.py``. It preserves the estate-wide inventory, markers,
-Space health checks, collection curation, kernel validation, and evidence
-report while retiring only these exact historical private duplicates:
+The canonical production Space remains ``SZLHOLDINGS/a11oy``. The four exact
+managed clones ``a11oy-clone-1`` through ``a11oy-clone-4`` are retained as
+public CPU-basic recovery/showcase runtimes and refreshed from the canonical
+Space without using Hugging Face's daily-limited duplication endpoint.
 
-- SZLHOLDINGS/a11oy-clone-1
-- SZLHOLDINGS/a11oy-clone-2
-- SZLHOLDINGS/a11oy-clone-3
-- SZLHOLDINGS/a11oy-clone-4
+Only surplus repositories that are positively identified as A11oy duplicates
+are eligible for deletion. A repository is a surplus duplicate only when it is
+outside the five-Space keep set and either:
 
-Deletion is fail-closed and only occurs after the canonical
-``SZLHOLDINGS/a11oy`` Space is verified RUNNING at an immutable revision with
-its Dockerfile present. Collection references are removed before repository
-deletion, and repository absence is verified afterwards.
+* its name matches the narrow ``a11oy-(clone|copy|duplicate)-<number>`` form; or
+* its managed marker explicitly declares ``clone_of=SZLHOLDINGS/a11oy``.
+
+The wrapper preserves the estate-wide model/dataset markers, Space health
+checks, collections, kernel validation, and evidence report from
+``hf_estate_upgrade.py``.
 """
 from __future__ import annotations
 
@@ -28,23 +29,30 @@ from typing import Any
 
 import hf_estate_upgrade as legacy
 
-RETIRED_CLONE_IDS = (
-    "SZLHOLDINGS/a11oy-clone-1",
-    "SZLHOLDINGS/a11oy-clone-2",
-    "SZLHOLDINGS/a11oy-clone-3",
-    "SZLHOLDINGS/a11oy-clone-4",
+MANAGED_CLONE_IDS = tuple(
+    f"{legacy.ORG}/a11oy-clone-{index}" for index in range(1, 5)
 )
+KEEP_SPACE_IDS = frozenset((legacy.FLAGSHIP_SPACE, *MANAGED_CLONE_IDS))
+DUPLICATE_NAME = re.compile(
+    rf"^{re.escape(legacy.ORG)}/a11oy-(?:clone|copy|duplicate)-\d+$",
+    re.IGNORECASE,
+)
+MARKER_URL = (
+    "https://huggingface.co/spaces/{repo_id}/resolve/main/"
+    + legacy.MANAGED_PATH
+)
+TERMINAL_FAILURE_STAGES = {
+    "BUILD_ERROR",
+    "RUNTIME_ERROR",
+    "CONFIG_ERROR",
+    "NO_APP_FILE",
+}
 
-# Fail closed if the historical implementation ever changes its clone set.
-if tuple(legacy.CLONE_IDS) != RETIRED_CLONE_IDS:
-    raise RuntimeError(
-        "Legacy A11oy clone allowlist changed; review before estate reconciliation: "
-        f"{legacy.CLONE_IDS!r}"
-    )
 
-# The inherited collection builder consults this module global. Emptying it
-# prevents any future collection add for the retired repositories.
-legacy.CLONE_IDS = []
+# The inherited collection builder consults this module global. Keep the exact
+# managed clone set enabled so the Spaces and Canonical Estate collections
+# include the four public recovery/showcase runtimes.
+legacy.CLONE_IDS = list(MANAGED_CLONE_IDS)
 
 
 def _runtime_stage(info: Any) -> str:
@@ -54,8 +62,16 @@ def _runtime_stage(info: Any) -> str:
     return str(raw or "UNKNOWN").split(".")[-1].upper()
 
 
-class CanonicalEstateUpgrade(legacy.EstateUpgrade):
-    """Estate upgrade with exact, one-time A11oy clone retirement."""
+def _snapshot(info: Any) -> dict[str, Any]:
+    return {
+        "sha": str(getattr(info, "sha", "") or ""),
+        "private": getattr(info, "private", None),
+        "stage": _runtime_stage(info),
+    }
+
+
+class CommandCenterEstateUpgrade(legacy.EstateUpgrade):
+    """Estate upgrade with four retained public A11oy command-center clones."""
 
     def _verify_canonical_flagship(self) -> dict[str, Any]:
         if not self.api.repo_exists(legacy.FLAGSHIP_SPACE, repo_type="space"):
@@ -73,7 +89,8 @@ class CanonicalEstateUpgrade(legacy.EstateUpgrade):
             )
         if not re.fullmatch(r"[0-9a-f]{40}", sha):
             raise RuntimeError(
-                f"Canonical Space revision is not an immutable 40-character SHA: {sha!r}"
+                "Canonical Space revision is not an immutable 40-character SHA: "
+                f"{sha!r}"
             )
         if private is True:
             raise RuntimeError(
@@ -99,102 +116,370 @@ class CanonicalEstateUpgrade(legacy.EstateUpgrade):
         )
         return snapshot
 
-    def _clone_snapshots(self) -> dict[str, dict[str, Any]]:
-        snapshots: dict[str, dict[str, Any]] = {}
-        for clone_id in RETIRED_CLONE_IDS:
-            exists = self.api.repo_exists(clone_id, repo_type="space")
-            if not exists:
-                snapshots[clone_id] = {"exists": False}
-                self.record(clone_id, "clone-preflight", "ok", "already absent")
-                continue
-            info = self.api.space_info(clone_id)
-            snapshot = {
-                "exists": True,
-                "sha": str(getattr(info, "sha", "") or ""),
-                "private": getattr(info, "private", None),
-                "stage": _runtime_stage(info),
-            }
-            snapshots[clone_id] = snapshot
+    def _read_marker(self, repo_id: str) -> dict[str, Any] | None:
+        response = self.http.get(
+            MARKER_URL.format(repo_id=repo_id),
+            headers={"Cache-Control": "no-cache"},
+            timeout=45,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+
+    def _is_surplus_duplicate(self, repo_id: str) -> tuple[bool, str]:
+        if repo_id in KEEP_SPACE_IDS:
+            return False, "keep-set"
+        if DUPLICATE_NAME.fullmatch(repo_id):
+            return True, "narrow-name-match"
+        try:
+            marker = self._read_marker(repo_id)
+        except Exception as exc:
+            self.record(
+                repo_id,
+                "duplicate-marker-read",
+                "warning",
+                repr(exc)[:250],
+            )
+            return False, "marker-unavailable"
+        if marker and marker.get("clone_of") == legacy.FLAGSHIP_SPACE:
+            return True, "managed-marker-clone-of-canonical"
+        return False, "not-proven-duplicate"
+
+    def _set_public(self, repo_id: str) -> None:
+        info = self.api.space_info(repo_id)
+        if getattr(info, "private", None) is False:
+            self.record(repo_id, "clone-visibility", "ok", "already public")
+            return
+        if not self.publish:
+            self.record(repo_id, "clone-visibility", "dry-run", "would make public")
+            return
+
+        update = getattr(self.api, "update_repo_settings", None)
+        if not callable(update):
+            raise RuntimeError(
+                "Installed huggingface_hub lacks HfApi.update_repo_settings; "
+                f"cannot safely make {repo_id} public"
+            )
+        try:
+            update(repo_id=repo_id, repo_type="space", private=False)
+        except TypeError:
+            # Compatibility with clients whose signature infers repo_type.
+            update(repo_id=repo_id, private=False)
+
+        after = self.api.space_info(repo_id)
+        if getattr(after, "private", None) is not False:
+            raise RuntimeError(f"Visibility update did not make {repo_id} public")
+        self.record(repo_id, "clone-visibility", "updated", "public")
+
+    def _create_missing_clone(self, clone_id: str) -> None:
+        if not self.publish:
             self.record(
                 clone_id,
-                "clone-preflight",
-                "ok",
-                "existing exact retired clone; "
-                f"private={snapshot['private']}; stage={snapshot['stage']}; "
-                f"sha={snapshot['sha']}",
+                "flagship-clone",
+                "dry-run",
+                "would create public cpu-basic Space without duplication API",
             )
-        return snapshots
+            return
+        self.api.create_repo(
+            repo_id=clone_id,
+            repo_type="space",
+            private=False,
+            exist_ok=True,
+            space_sdk="docker",
+            space_hardware="cpu-basic",
+            space_sleep_time=300,
+        )
+        if not self.api.repo_exists(clone_id, repo_type="space"):
+            raise RuntimeError(f"Clone creation did not produce repository: {clone_id}")
+        self.record(
+            clone_id,
+            "flagship-clone",
+            "created",
+            "public cpu-basic; quota-safe create_repo path",
+        )
 
-    def _remove_clone_collection_references(self) -> None:
+    def _wait_for_running(self, repo_id: str, timeout_seconds: int = 1800) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout_seconds
+        last: dict[str, Any] = {}
+        while True:
+            info = self.api.space_info(repo_id)
+            last = _snapshot(info)
+            stage = last["stage"]
+            if stage == "RUNNING":
+                self.record(
+                    repo_id,
+                    "clone-runtime",
+                    "validated",
+                    f"stage=RUNNING; sha={last['sha']}; private={last['private']}",
+                )
+                return last
+            if stage in TERMINAL_FAILURE_STAGES:
+                raise RuntimeError(
+                    f"Clone runtime entered terminal failure: {repo_id} stage={stage}"
+                )
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"Clone runtime did not reach RUNNING within {timeout_seconds}s: "
+                    f"{repo_id} last={last}"
+                )
+            time.sleep(15)
+
+    @staticmethod
+    def _tree_identity(entry: Any) -> str | None:
+        lfs = getattr(entry, "lfs", None)
+        lfs_sha = getattr(lfs, "sha256", None)
+        if lfs_sha:
+            return f"lfs:{lfs_sha}"
+        blob_id = getattr(entry, "blob_id", None)
+        return f"git:{blob_id}" if blob_id else None
+
+    def _repo_file_map(self, repo_id: str) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        for entry in self.api.list_repo_tree(
+            repo_id,
+            repo_type="space",
+            recursive=True,
+            expand=False,
+        ):
+            identity = self._tree_identity(entry)
+            path = str(getattr(entry, "path", "") or "")
+            if path and identity:
+                mapping[path] = identity
+        return mapping
+
+    def _sync_clone_from_canonical(self, clone_id: str) -> tuple[int, int]:
+        source = self._repo_file_map(legacy.FLAGSHIP_SPACE)
+        destination = self._repo_file_map(clone_id)
+
+        copy_paths = sorted(
+            path
+            for path, identity in source.items()
+            if path != ".gitattributes" and destination.get(path) != identity
+        )
+        delete_paths = sorted(
+            path
+            for path in destination
+            if path not in source and path not in {".gitattributes", legacy.MANAGED_PATH}
+        )
+        operations = [
+            legacy.CommitOperationCopy(
+                src_path_in_repo=path,
+                path_in_repo=path,
+                src_repo_id=legacy.FLAGSHIP_SPACE,
+                src_repo_type="space",
+            )
+            for path in copy_paths
+        ] + [
+            legacy.CommitOperationDelete(path_in_repo=path)
+            for path in delete_paths
+        ]
+
+        if not operations:
+            self.record(clone_id, "clone-refresh", "ok", "already byte-current")
+            return 0, 0
+
+        for index in range(0, len(operations), 500):
+            chunk = operations[index : index + 500]
+            self.api.create_commit(
+                repo_id=clone_id,
+                repo_type="space",
+                operations=chunk,
+                commit_message=(
+                    f"chore(clone): sync canonical A11oy generation "
+                    f"{self.generation[:12]} ({index // 500 + 1})"
+                ),
+                commit_description=(
+                    f"Quota-safe server-side copy from "
+                    f"{legacy.FLAGSHIP_SPACE}; canonical revision is recorded "
+                    "in the managed marker."
+                ),
+            )
+
+        self.record(
+            clone_id,
+            "clone-refresh",
+            "updated",
+            f"copied={len(copy_paths)} deleted={len(delete_paths)}",
+        )
+        return len(copy_paths), len(delete_paths)
+
+    def _verify_clone_file_set(self, clone_id: str) -> None:
+        source_files = set(
+            self.api.list_repo_files(legacy.FLAGSHIP_SPACE, repo_type="space")
+        )
+        clone_files = set(self.api.list_repo_files(clone_id, repo_type="space"))
+        source_files.discard(".gitattributes")
+        clone_files.discard(".gitattributes")
+        clone_files.discard(legacy.MANAGED_PATH)
+        if clone_files != source_files:
+            missing = sorted(source_files - clone_files)[:20]
+            extra = sorted(clone_files - source_files)[:20]
+            raise RuntimeError(
+                f"Clone file-set mismatch for {clone_id}: missing={missing}; extra={extra}"
+            )
+        self.record(
+            clone_id,
+            "clone-file-set",
+            "validated",
+            f"files={len(source_files)}",
+        )
+
+    def _reconcile_clone(
+        self,
+        clone_id: str,
+        canonical_sha: str,
+    ) -> dict[str, Any]:
+        exists = self.api.repo_exists(clone_id, repo_type="space")
+        if not exists:
+            self._create_missing_clone(clone_id)
+            if not self.publish:
+                return {"exists": False, "planned": True}
+
+        before = _snapshot(self.api.space_info(clone_id))
+        self.record(
+            clone_id,
+            "clone-preflight",
+            "ok",
+            f"private={before['private']}; stage={before['stage']}; sha={before['sha']}",
+        )
+        self._set_public(clone_id)
+
+        if not self.publish:
+            self.record(
+                clone_id,
+                "clone-refresh",
+                "dry-run",
+                f"would sync from {legacy.FLAGSHIP_SPACE}@{canonical_sha}",
+            )
+            return before
+
+        # Copy only byte-different files in bounded server-side commits, avoiding
+        # local downloads and the daily-limited duplicate endpoint.
+        self._sync_clone_from_canonical(clone_id)
+        self._upload_marker(
+            repo_id=clone_id,
+            repo_type="space",
+            observed_sha=before.get("sha"),
+            runtime={"stage_before": before.get("stage")},
+            clone_of=legacy.FLAGSHIP_SPACE,
+        )
+        self._verify_clone_file_set(clone_id)
+
+        # A content commit normally triggers a rebuild. If the clone was already
+        # current, restart only when it is not running.
+        current = self.api.space_info(clone_id)
+        if _runtime_stage(current) != "RUNNING":
+            self.api.restart_space(repo_id=clone_id, factory_reboot=False)
+            self.record(clone_id, "clone-restart", "requested")
+
+        after = self._wait_for_running(clone_id)
+        if after["private"] is not False:
+            raise RuntimeError(f"Clone became non-public after reconciliation: {clone_id}")
+        return after
+
+    def _remove_collection_references(self, repo_ids: set[str]) -> None:
+        if not repo_ids:
+            return
         summaries = list(self.api.list_collections(owner=legacy.ORG, limit=100))
         for summary in summaries:
             collection = self.api.get_collection(summary.slug)
             for item in collection.items:
-                if item.item_type != "space" or item.item_id not in RETIRED_CLONE_IDS:
+                if item.item_type != "space" or item.item_id not in repo_ids:
                     continue
                 target = f"{collection.slug}:{item.item_id}"
                 if not self.publish:
-                    self.record(target, "collection-remove-clone", "dry-run")
+                    self.record(target, "collection-remove-surplus", "dry-run")
                     continue
                 self.api.delete_collection_item(
                     collection_slug=collection.slug,
                     item_object_id=item.item_object_id,
                     missing_ok=True,
                 )
-                self.record(target, "collection-remove-clone", "deleted")
+                self.record(target, "collection-remove-surplus", "deleted")
 
-    def create_or_refresh_clones(self) -> None:
-        """Replace the legacy clone creator with exact clone retirement."""
-        self.canonical_flagship = self._verify_canonical_flagship()
-        self.retired_clone_snapshots = self._clone_snapshots()
-
-        # Remove stale collection references before irreversible deletion.
-        self._remove_clone_collection_references()
-
-        for clone_id, snapshot in self.retired_clone_snapshots.items():
-            if not snapshot["exists"]:
+    def _delete_surplus_duplicates(self) -> list[dict[str, Any]]:
+        candidates: list[dict[str, Any]] = []
+        for item in self.inventory.get("spaces", []):
+            repo_id = self._asset_id(item)
+            if not repo_id:
                 continue
+            eligible, reason = self._is_surplus_duplicate(repo_id)
+            if not eligible:
+                continue
+            info = self.api.space_info(repo_id)
+            candidates.append(
+                {
+                    "repo_id": repo_id,
+                    "reason": reason,
+                    **_snapshot(info),
+                }
+            )
+
+        candidate_ids = {item["repo_id"] for item in candidates}
+        self._remove_collection_references(candidate_ids)
+        for candidate in candidates:
+            repo_id = candidate["repo_id"]
             if not self.publish:
                 self.record(
-                    clone_id,
-                    "retire-flagship-clone",
+                    repo_id,
+                    "delete-surplus-duplicate",
                     "dry-run",
-                    "would delete exact legacy private duplicate",
+                    f"reason={candidate['reason']}; sha={candidate['sha']}",
                 )
                 continue
-            self.api.delete_repo(
-                repo_id=clone_id,
-                repo_type="space",
-                missing_ok=True,
-            )
-            if self.api.repo_exists(clone_id, repo_type="space"):
-                raise RuntimeError(f"Retired clone still exists after deletion: {clone_id}")
+            self.api.delete_repo(repo_id=repo_id, repo_type="space", missing_ok=True)
+            if self.api.repo_exists(repo_id, repo_type="space"):
+                raise RuntimeError(f"Surplus duplicate still exists after deletion: {repo_id}")
             self.record(
-                clone_id,
-                "retire-flagship-clone",
+                repo_id,
+                "delete-surplus-duplicate",
                 "deleted",
-                f"former_sha={snapshot.get('sha')}",
+                f"reason={candidate['reason']}; former_sha={candidate['sha']}",
+            )
+        return candidates
+
+    def create_or_refresh_clones(self) -> None:
+        """Retain, publish, synchronize, and verify four exact managed clones."""
+        self.canonical_flagship = self._verify_canonical_flagship()
+        canonical_sha = self.canonical_flagship["sha"]
+        self.managed_clone_snapshots: dict[str, dict[str, Any]] = {}
+
+        for clone_id in MANAGED_CLONE_IDS:
+            self.managed_clone_snapshots[clone_id] = self._reconcile_clone(
+                clone_id, canonical_sha
             )
 
-        # The initial inventory was collected before retirement. Remove exact
-        # retired IDs so collection curation and final counts cannot reintroduce
-        # them or report them as live estate assets.
-        self.inventory["spaces"] = [
-            item
-            for item in self.inventory.get("spaces", [])
-            if self._asset_id(item) not in RETIRED_CLONE_IDS
-        ]
+        self.surplus_duplicate_snapshots = self._delete_surplus_duplicates()
+
+        # Refresh Space inventory after clone creation/visibility changes/deletions
+        # so collection curation and report counts describe the final estate.
+        try:
+            self.inventory["spaces"] = self._paginate(
+                f"{legacy.HF_BASE}/api/spaces?author={legacy.ORG}&limit=1000&full=true"
+            )
+        except Exception as exc:
+            self.record(
+                legacy.ORG,
+                "inventory:spaces:refresh",
+                "error",
+                repr(exc)[:300],
+            )
 
     def report(self) -> dict[str, Any]:
         report = super().report()
-        report.pop("clone_ids", None)
         report["canonical_flagship_space"] = getattr(
             self, "canonical_flagship", {"repo_id": legacy.FLAGSHIP_SPACE}
         )
-        report["retired_clone_ids"] = list(RETIRED_CLONE_IDS)
-        report["retired_clone_snapshots"] = getattr(
-            self, "retired_clone_snapshots", {}
+        report["managed_clone_ids"] = list(MANAGED_CLONE_IDS)
+        report["managed_clone_snapshots"] = getattr(
+            self, "managed_clone_snapshots", {}
         )
+        report["surplus_duplicate_snapshots"] = getattr(
+            self, "surplus_duplicate_snapshots", []
+        )
+        report["command_center_keep_set"] = sorted(KEEP_SPACE_IDS)
         report["summary"]["ok"] = sum(
             action.status
             in {
@@ -208,12 +493,13 @@ class CanonicalEstateUpgrade(legacy.EstateUpgrade):
             for action in self.actions
         )
         report["boundaries"] = [
-            "SZLHOLDINGS/a11oy is the only canonical A11oy Space.",
-            "Only the four exact allowlisted a11oy-clone-1..4 repositories may be deleted.",
-            "Clone deletion requires a RUNNING public canonical Space at an immutable revision with Dockerfile present.",
+            "SZLHOLDINGS/a11oy remains the canonical production A11oy Space.",
+            "The four exact a11oy-clone-1..4 Spaces are retained, public, and synchronized from the canonical Space.",
+            "The daily-limited Hugging Face duplication endpoint is never used.",
+            "Only positively identified surplus A11oy duplicates outside the five-Space keep set may be deleted.",
             "No model weights or dataset payloads are changed.",
             "No paid hardware tier is changed.",
-            "Healthy dynamic Spaces are not rewritten or restarted.",
+            "Healthy non-A11oy dynamic Spaces are not rewritten or restarted.",
             "Kernel repositories are validated; first-class kernel publishing remains governed by kernel-builder release workflows.",
         ]
         return report
@@ -228,13 +514,20 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    token = os.environ.get("HF_ORG_TOKEN") or os.environ.get("HF_TOKEN")
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
     if not token:
-        print("FATAL: HF_ORG_TOKEN/HF_TOKEN is not set.", file=sys.stderr)
+        print(
+            "FATAL: HF_ORG_TOKEN/HF_ORG_TOKEN1/HF_TOKEN is not set.",
+            file=sys.stderr,
+        )
         return 2
 
     try:
-        report = CanonicalEstateUpgrade(
+        report = CommandCenterEstateUpgrade(
             token=token,
             generation=args.generation,
             publish=args.publish,

--- a/.github/scripts/test_hf_estate_canonicalize.py
+++ b/.github/scripts/test_hf_estate_canonicalize.py
@@ -10,13 +10,13 @@ SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-canonical = importlib.import_module("hf_estate_canonicalize")
+command_centers = importlib.import_module("hf_estate_canonicalize")
 
 
-class CanonicalEstateContractTests(unittest.TestCase):
-    def test_exact_retired_clone_allowlist(self) -> None:
+class CommandCenterEstateContractTests(unittest.TestCase):
+    def test_exact_public_clone_keep_set(self) -> None:
         self.assertEqual(
-            canonical.RETIRED_CLONE_IDS,
+            command_centers.MANAGED_CLONE_IDS,
             (
                 "SZLHOLDINGS/a11oy-clone-1",
                 "SZLHOLDINGS/a11oy-clone-2",
@@ -24,23 +24,63 @@ class CanonicalEstateContractTests(unittest.TestCase):
                 "SZLHOLDINGS/a11oy-clone-4",
             ),
         )
+        self.assertEqual(
+            command_centers.KEEP_SPACE_IDS,
+            frozenset(
+                {
+                    "SZLHOLDINGS/a11oy",
+                    "SZLHOLDINGS/a11oy-clone-1",
+                    "SZLHOLDINGS/a11oy-clone-2",
+                    "SZLHOLDINGS/a11oy-clone-3",
+                    "SZLHOLDINGS/a11oy-clone-4",
+                }
+            ),
+        )
 
-    def test_inherited_clone_additions_are_disabled(self) -> None:
-        self.assertEqual(canonical.legacy.CLONE_IDS, [])
+    def test_inherited_collection_builder_keeps_clones(self) -> None:
+        self.assertEqual(
+            command_centers.legacy.CLONE_IDS,
+            list(command_centers.MANAGED_CLONE_IDS),
+        )
 
-    def test_wrapper_contains_no_clone_creation_api(self) -> None:
-        source = (SCRIPT_DIR / "hf_estate_canonicalize.py").read_text(encoding="utf-8")
+    def test_quota_safe_clone_path(self) -> None:
+        source = (SCRIPT_DIR / "hf_estate_canonicalize.py").read_text(
+            encoding="utf-8"
+        )
         self.assertNotIn("duplicate_repo(", source)
         self.assertNotIn("duplicate_space(", source)
-        self.assertIn("delete_repo(", source)
-        self.assertIn("canonical-space-preflight", source)
+        self.assertIn("create_repo(", source)
+        self.assertIn("update_repo_settings", source)
+        self.assertIn("delete-surplus-duplicate", source)
 
-    def test_workflow_executes_canonical_reconciler_only(self) -> None:
+    def test_narrow_name_match_does_not_select_unrelated_spaces(self) -> None:
+        self.assertIsNotNone(
+            command_centers.DUPLICATE_NAME.fullmatch(
+                "SZLHOLDINGS/a11oy-copy-99"
+            )
+        )
+        self.assertIsNotNone(
+            command_centers.DUPLICATE_NAME.fullmatch(
+                "SZLHOLDINGS/a11oy-duplicate-2"
+            )
+        )
+        self.assertIsNone(
+            command_centers.DUPLICATE_NAME.fullmatch(
+                "SZLHOLDINGS/a11oy-research-lab"
+            )
+        )
+        self.assertIn(
+            "SZLHOLDINGS/a11oy-clone-1",
+            command_centers.KEEP_SPACE_IDS,
+        )
+
+    def test_workflow_executes_command_center_reconciler(self) -> None:
         workflow = (
             SCRIPT_DIR.parent / "workflows" / "hf-estate-upgrade.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("hf_estate_canonicalize.py", workflow)
-        self.assertNotIn("python .github/scripts/hf_estate_upgrade.py", workflow)
+        self.assertIn("Retain four public A11oy command centers", workflow)
+        self.assertNotIn("retired_clone_ids", workflow)
 
     def test_runtime_stage_normalization(self) -> None:
         class Runtime:
@@ -49,7 +89,7 @@ class CanonicalEstateContractTests(unittest.TestCase):
         class Info:
             runtime = Runtime()
 
-        self.assertEqual(canonical._runtime_stage(Info()), "RUNNING")
+        self.assertEqual(command_centers._runtime_stage(Info()), "RUNNING")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/hf-estate-upgrade.yml
+++ b/.github/workflows/hf-estate-upgrade.yml
@@ -1,8 +1,7 @@
-name: HF Estate Canonicalization
+name: HF Estate Command Centers
 
-# Organization-wide Hugging Face maintenance with one canonical A11oy Space.
-# Pull requests are read-only dry runs. A protected-main push or an explicitly
-# published manual dispatch performs the exact clone retirement and estate sync.
+# Organization-wide Hugging Face maintenance with one canonical A11oy production
+# Space and four public, synchronized recovery/showcase command centers.
 on:
   push:
     branches: [main]
@@ -21,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: Apply canonicalization rather than produce a dry-run report
+        description: Apply the estate reconciliation rather than run a dry run
         required: false
         default: "true"
 
@@ -29,21 +28,22 @@ permissions:
   contents: write
 
 concurrency:
-  group: hf-estate-canonicalization-${{ github.event_name }}-${{ github.ref }}
+  group: hf-estate-command-centers-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  canonicalize:
-    name: Canonicalize SZLHOLDINGS Hub estate
+  reconcile:
+    name: Retain four public A11oy command centers
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
       TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
     steps:
       - name: Checkout triggering revision
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           fetch-depth: 1
@@ -70,7 +70,7 @@ jobs:
             "canonical_flagship_space": {
               "repo_id": "SZLHOLDINGS/a11oy"
             },
-            "retired_clone_ids": [
+            "managed_clone_ids": [
               "SZLHOLDINGS/a11oy-clone-1",
               "SZLHOLDINGS/a11oy-clone-2",
               "SZLHOLDINGS/a11oy-clone-3",
@@ -114,7 +114,7 @@ jobs:
             "huggingface_hub>=1.3,<2" \
             "requests>=2.32,<3"
 
-      - name: Verify canonical one-Space contract
+      - name: Verify command-center estate contract
         if: steps.credentials.outputs.has_token == 'true'
         run: |
           python -m py_compile \
@@ -123,7 +123,7 @@ jobs:
             .github/scripts/test_hf_estate_canonicalize.py
           python .github/scripts/test_hf_estate_canonicalize.py
 
-      - name: Execute canonical estate reconciliation
+      - name: Execute command-center estate reconciliation
         if: steps.credentials.outputs.has_token == 'true'
         id: estate
         shell: bash
@@ -146,7 +146,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: hf-estate-canonicalization-dry-run-${{ github.run_id }}
+          name: hf-estate-command-centers-dry-run-${{ github.run_id }}
           path: reports/hf-estate-upgrade-latest.json
           if-no-files-found: error
           retention-days: 30
@@ -167,7 +167,7 @@ jobs:
             echo "Report is unchanged."
             exit 0
           fi
-          git commit -s -m "chore(hf): record canonical estate report [skip ci]"
+          git commit -s -m "chore(hf): record command-center estate report [skip ci]"
           git push origin "HEAD:${TARGET_BRANCH}"
 
       - name: Publish job summary
@@ -181,7 +181,7 @@ jobs:
 
           path = Path("reports/hf-estate-upgrade-latest.json")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as out:
-              out.write("## Hugging Face estate canonicalization\n\n")
+              out.write("## Hugging Face command-center estate\n\n")
               if not path.exists():
                   out.write("No report was produced.\n")
               else:
@@ -194,7 +194,18 @@ jobs:
                       f"at `{canonical.get('sha', 'UNVERIFIED')}` "
                       f"({canonical.get('stage', 'UNKNOWN')})\n\n"
                   )
-                  out.write("| Inventory | Count |\n|---|---:|\n")
+                  clones = report.get("managed_clone_snapshots", {})
+                  out.write("| Retained clone | Visibility | Runtime | Revision |\n")
+                  out.write("|---|---|---|---|\n")
+                  for repo_id in report.get("managed_clone_ids", []):
+                      item = clones.get(repo_id, {})
+                      visibility = "public" if item.get("private") is False else "unknown"
+                      out.write(
+                          f"| `{repo_id}` | {visibility} | "
+                          f"{item.get('stage', 'UNKNOWN')} | "
+                          f"`{item.get('sha', 'UNVERIFIED')}` |\n"
+                      )
+                  out.write("\n| Inventory | Count |\n|---|---:|\n")
                   for key, value in report.get("counts", {}).items():
                       out.write(f"| {key} | {value} |\n")
                   out.write("\n| Result | Count |\n|---|---:|\n")
@@ -212,6 +223,6 @@ jobs:
           code="${{ steps.estate.outputs.exit_code }}"
           if [ -z "$code" ]; then code=2; fi
           if [ "$code" -ne 0 ]; then
-            echo "::error::Estate canonicalization completed with exit code $code; inspect the committed report."
+            echo "::error::Estate reconciliation completed with exit code $code; inspect the committed report."
             exit "$code"
           fi


### PR DESCRIPTION
## Outcome

Preserve the requested A11oy command-center estate:

- keep `SZLHOLDINGS/a11oy` as the canonical production Space
- retain `a11oy-clone-1` through `a11oy-clone-4`
- make all four managed clones public
- synchronize only byte-different files from the canonical Space using quota-safe server-side copy commits
- verify file-set parity and wait for each clone to reach `RUNNING`
- delete only surplus A11oy duplicates outside the five-Space keep set when a narrow duplicate name or managed `clone_of` marker proves the relationship
- preserve the full model, dataset, Space, collection, and kernel estate reconciliation

## Safety

- no use of Hugging Face's daily-limited repository duplication endpoint
- no model-weight or dataset-payload changes
- no paid hardware-tier changes
- no deletion of the canonical Space or the four exact managed clones
- unrelated A11oy-named research/product Spaces are not selected by the deletion rule
- pull requests remain read-only dry runs; mutation starts only after protected merge

## Verification

- Python syntax compiled locally
- six contract tests passed locally
- all commits carry DCO sign-off

Supersedes the automatically closed empty handle #227.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>