### PR TITLE
ops(merge): authorize exact A11oy deployment relock

### DIFF
--- a/.github/data/owner_authorized_merge_wave.json
+++ b/.github/data/owner_authorized_merge_wave.json
@@ -3,11 +3,11 @@
   "base_branch": "main",
   "targets": [
     {
-      "repository": "szl-holdings/platform",
-      "pull_request": 458,
-      "expected_head_sha": "9798feff9af3d6b0d8737abd70f71a1db1755a65",
+      "repository": "szl-holdings/a11oy",
+      "pull_request": 1031,
+      "expected_head_sha": "50dfd0fe8682e3063035f35c8f22eb38fbc0c358",
       "merge_method": "squash",
-      "purpose": "Canonical SDA receipt-verifier widget repair"
+      "purpose": "Relock the current verified Hugging Face deployment authority"
     }
   ]
 }


### PR DESCRIPTION
## Outcome

Moves the owner-authorized exact merge manifest to the current A11oy deployment relock PR:

- repository: `szl-holdings/a11oy`
- pull request: `#1031`
- immutable head: `50dfd0fe8682e3063035f35c8f22eb38fbc0c358`

The existing zero-review migration will reduce only the exact branch approval count while preserving all other protections. The exact merge verifier will still reject unresolved review threads, active change requests, conflicts, stale heads, and unapproved check failures.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>