### PR TITLE
feat(hf): finalize Lake viewer and first-class kernel cards

### DIFF
--- a/.github/scripts/hf_release_finalization.py
+++ b/.github/scripts/hf_release_finalization.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Finalize merged SZLHOLDINGS Hugging Face releases with fail-closed evidence.
+
+This release lane performs only three bounded publications:
+
+* ``szl-holdings/szl-lake`` -> ``SZLHOLDINGS/szl-lake`` dataset card and data;
+* ``szl-holdings/szl-energy-attest`` -> the existing first-class
+  ``SZLHOLDINGS/governed-inference-meter`` kernel card/contract;
+* ``szl-holdings/szl-lambda-gate`` -> the existing first-class
+  ``SZLHOLDINGS/szl-governed-norm`` kernel card/contract.
+
+It never rebuilds or replaces kernel binaries, model weights, dataset receipt
+contents, visibility, or hardware. Existing kernel builds remain intact; only
+reviewed README/contract files are updated after the corresponding Hub repo is
+proved to be an existing first-class kernel repository.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+from huggingface_hub import HfApi, hf_hub_download
+
+ORG = "SZLHOLDINGS"
+DATASET_ID = f"{ORG}/szl-lake"
+EVIDENCE_DATASET = f"{ORG}/szl-evidence"
+VIEWER_URL = (
+    "https://datasets-server.huggingface.co/first-rows"
+    "?dataset=SZLHOLDINGS%2Fszl-lake&config=receipts&split=train"
+)
+KERNEL_SPECS = {
+    f"{ORG}/governed-inference-meter": {
+        "source_root": "energy",
+        "source_dir": "hf-kernels/governed-inference-meter",
+    },
+    f"{ORG}/szl-governed-norm": {
+        "source_root": "lambda-gate",
+        "source_dir": "hf-kernels/szl-governed-norm",
+    },
+}
+
+
+@dataclass
+class Action:
+    target: str
+    action: str
+    status: str
+    detail: str = ""
+
+
+class Finalizer:
+    def __init__(
+        self,
+        *,
+        token: str,
+        publish: bool,
+        generation: str,
+        lake_root: Path,
+        energy_root: Path,
+        lambda_root: Path,
+    ) -> None:
+        self.token = token
+        self.publish = publish
+        self.generation = generation
+        self.roots = {
+            "lake": lake_root,
+            "energy": energy_root,
+            "lambda-gate": lambda_root,
+        }
+        self.api = HfApi(token=token)
+        self.actions: list[Action] = []
+        self.results: dict[str, Any] = {}
+
+    def record(self, target: str, action: str, status: str, detail: str = "") -> None:
+        self.actions.append(Action(target, action, status, detail))
+        print(f"[{status:>10}] {action}: {target}" + (f" — {detail}" if detail else ""))
+
+    @staticmethod
+    def digest(path: Path) -> str:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def authenticate(self) -> None:
+        who = self.api.whoami()
+        orgs = who.get("orgs") or []
+        match = next(
+            (
+                item
+                for item in orgs
+                if str(item.get("name") or item.get("fullname") or "").upper()
+                == ORG
+            ),
+            None,
+        )
+        if match is None:
+            raise RuntimeError(f"authenticated identity is not a member of {ORG}")
+        role = str(match.get("roleInOrg") or match.get("role") or "").lower()
+        if role and role not in {"admin", "write", "contributor"}:
+            raise RuntimeError(f"authenticated role is not write-capable: {role}")
+        self.record(
+            ORG,
+            "authenticate",
+            "validated",
+            f"identity={who.get('name')}; role={role or 'unknown'}",
+        )
+
+    def _download_verified(
+        self,
+        repo_id: str,
+        filename: str,
+        repo_type: str,
+        revision: str | None = None,
+    ) -> bytes:
+        local = hf_hub_download(
+            repo_id=repo_id,
+            filename=filename,
+            repo_type=repo_type,
+            revision=revision,
+            token=self.token,
+            force_download=True,
+        )
+        return Path(local).read_bytes()
+
+    def finalize_dataset(self) -> None:
+        root = self.roots["lake"]
+        card = root / "huggingface" / "README.md"
+        data = root / "data"
+        if not card.is_file() or not data.is_dir():
+            raise RuntimeError("szl-lake checkout is missing card or data directory")
+
+        required = [
+            data / "khipu" / "amaru_receipts.parquet",
+            data / "khipu" / "sentra_receipts.parquet",
+            data / "khipu" / "a11oy_receipts.parquet",
+            data / "khipu" / "rosie_receipts.parquet",
+            data / "khipu" / "killinchu_receipts.parquet",
+            data / "khipu" / "EMPTY_CHAIN_MANIFEST.json",
+        ]
+        missing = [str(path.relative_to(root)) for path in required if not path.is_file()]
+        if missing:
+            raise RuntimeError(f"szl-lake viewer payload is incomplete: {missing}")
+
+        before = self.api.dataset_info(DATASET_ID).sha
+        self.record(
+            DATASET_ID,
+            "dataset-preflight",
+            "validated",
+            f"before={before}; card_sha256={self.digest(card)}",
+        )
+
+        if self.publish:
+            self.api.upload_file(
+                repo_id=DATASET_ID,
+                repo_type="dataset",
+                path_or_fileobj=str(card),
+                path_in_repo="README.md",
+                commit_message=(
+                    "release(viewer): publish reviewed homogeneous receipts card "
+                    f"{self.generation[:12]}"
+                ),
+                commit_description=(
+                    "Source-controlled viewer contract from szl-holdings/szl-lake. "
+                    "Only the five schema-compatible Khipu Parquet files are exposed "
+                    "through the default receipts configuration."
+                ),
+            )
+            self.api.upload_folder(
+                repo_id=DATASET_ID,
+                repo_type="dataset",
+                folder_path=str(data),
+                path_in_repo=".",
+                commit_message=(
+                    "release(data): mirror verified Lake payload "
+                    f"{self.generation[:12]}"
+                ),
+                commit_description=(
+                    "Verbatim additive mirror of data/**. Receipt bodies, signatures, "
+                    "Parquet rows, and Khipu chains are not rewritten."
+                ),
+                ignore_patterns=["**/__pycache__/**", "*.pyc", "**/.pytest_cache/**"],
+            )
+            self.record(DATASET_ID, "dataset-publish", "updated")
+        else:
+            self.record(DATASET_ID, "dataset-publish", "dry-run")
+
+        after = self.api.dataset_info(DATASET_ID).sha
+        remote_card = self._download_verified(DATASET_ID, "README.md", "dataset", after)
+        if remote_card != card.read_bytes():
+            raise RuntimeError("published dataset card does not match reviewed source bytes")
+        remote_files = set(self.api.list_repo_files(DATASET_ID, repo_type="dataset"))
+        for expected in (
+            "khipu/amaru_receipts.parquet",
+            "khipu/sentra_receipts.parquet",
+            "khipu/a11oy_receipts.parquet",
+            "khipu/rosie_receipts.parquet",
+            "khipu/killinchu_receipts.parquet",
+            "khipu/EMPTY_CHAIN_MANIFEST.json",
+        ):
+            if expected not in remote_files:
+                raise RuntimeError(f"published dataset is missing {expected}")
+
+        response = requests.get(VIEWER_URL, timeout=90)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Dataset Viewer contract did not return HTTP 200: {response.status_code} "
+                f"{response.text[:300]}"
+            )
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("error"):
+            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")
+        self.record(
+            DATASET_ID,
+            "dataset-verify",
+            "validated",
+            f"after={after}; files={len(remote_files)}; viewer=HTTP-200",
+        )
+        self.results["dataset"] = {
+            "repo_id": DATASET_ID,
+            "before_sha": before,
+            "after_sha": after,
+            "card_sha256": self.digest(card),
+            "viewer_http_status": response.status_code,
+            "remote_file_count": len(remote_files),
+        }
+
+    def _kernel_selfcheck(self, repo_id: str, revision: str) -> Any:
+        from kernels import get_kernel
+
+        module = get_kernel(
+            repo_id,
+            revision=revision,
+            trust_remote_code=True,
+        )
+        check = getattr(module, "selfcheck", None)
+        if not callable(check):
+            raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+        result = check()
+        if result is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck returned false")
+        if isinstance(result, dict) and result.get("ok") is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck failed: {result}")
+        return result
+
+    def finalize_kernel(self, repo_id: str, spec: dict[str, str]) -> None:
+        source_root = self.roots[spec["source_root"]]
+        source_dir = source_root / spec["source_dir"]
+        card = source_dir / "README.md"
+        contract = source_dir / "contract.json"
+        if not card.is_file() or not contract.is_file():
+            raise RuntimeError(f"kernel source contract is incomplete: {source_dir}")
+        contract_payload = json.loads(contract.read_text(encoding="utf-8"))
+        if not isinstance(contract_payload, dict):
+            raise RuntimeError(f"kernel contract is not an object: {contract}")
+
+        before_info = self.api.kernel_info(repo_id)
+        before = str(getattr(before_info, "sha", "") or "")
+        if len(before) != 40:
+            raise RuntimeError(f"kernel repository lacks immutable revision: {repo_id}")
+        remote_files_before = set(self.api.list_repo_files(repo_id, repo_type="kernel"))
+        if not any(path.startswith("build/") for path in remote_files_before):
+            raise RuntimeError(f"first-class kernel repository lacks build variants: {repo_id}")
+        self.record(
+            repo_id,
+            "kernel-preflight",
+            "validated",
+            f"before={before}; builds_present=true",
+        )
+
+        if self.publish:
+            for source, destination in ((card, "README.md"), (contract, "contract.json")):
+                self.api.upload_file(
+                    repo_id=repo_id,
+                    repo_type="kernel",
+                    path_or_fileobj=str(source),
+                    path_in_repo=destination,
+                    commit_message=(
+                        "release(card): publish reviewed kernel contract "
+                        f"{self.generation[:12]}"
+                    ),
+                    commit_description=(
+                        "Card/contract-only publication from the canonical GitHub owner. "
+                        "Existing first-class kernel build variants are preserved."
+                    ),
+                )
+            self.record(repo_id, "kernel-card-publish", "updated")
+        else:
+            self.record(repo_id, "kernel-card-publish", "dry-run")
+
+        after_info = self.api.kernel_info(repo_id)
+        after = str(getattr(after_info, "sha", "") or "")
+        if len(after) != 40:
+            raise RuntimeError(f"published kernel lacks immutable revision: {repo_id}")
+        for source, filename in ((card, "README.md"), (contract, "contract.json")):
+            observed = self._download_verified(repo_id, filename, "kernel", after)
+            if observed != source.read_bytes():
+                raise RuntimeError(
+                    f"published kernel file differs from reviewed source: {repo_id}/{filename}"
+                )
+        remote_files_after = set(self.api.list_repo_files(repo_id, repo_type="kernel"))
+        if not any(path.startswith("build/") for path in remote_files_after):
+            raise RuntimeError(f"kernel publication removed build variants: {repo_id}")
+        selfcheck = self._kernel_selfcheck(repo_id, after)
+        self.record(
+            repo_id,
+            "kernel-verify",
+            "validated",
+            f"after={after}; selfcheck=passed; files={len(remote_files_after)}",
+        )
+        self.results.setdefault("kernels", {})[repo_id] = {
+            "before_sha": before,
+            "after_sha": after,
+            "card_sha256": self.digest(card),
+            "contract_sha256": self.digest(contract),
+            "remote_file_count": len(remote_files_after),
+            "selfcheck": selfcheck,
+        }
+
+    def report(self) -> dict[str, Any]:
+        statuses = [action.status for action in self.actions]
+        return {
+            "schema": "szl.hf-release-finalization/v1",
+            "organization": ORG,
+            "generation": self.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": self.publish,
+            "sources": {
+                "szl_lake": os.environ.get("SZL_LAKE_SHA"),
+                "szl_energy_attest": os.environ.get("SZL_ENERGY_ATTEST_SHA"),
+                "szl_lambda_gate": os.environ.get("SZL_LAMBDA_GATE_SHA"),
+            },
+            "results": self.results,
+            "actions": [asdict(action) for action in self.actions],
+            "summary": {
+                "ok": sum(
+                    status in {"validated", "updated", "ok"} for status in statuses
+                ),
+                "warning": sum(status == "warning" for status in statuses),
+                "error": sum(status == "error" for status in statuses),
+                "dry_run": sum(status == "dry-run" for status in statuses),
+            },
+            "boundaries": [
+                "Dataset receipt/data bytes are mirrored verbatim; no row or signature is synthesized.",
+                "Only reviewed README.md and contract.json files are updated in existing first-class kernel repositories.",
+                "Kernel build variants, visibility, and hardware are preserved.",
+                "Kernel selfcheck is executed at the exact post-publication immutable revision.",
+                "No model weights are trained, merged, relabeled, or promoted.",
+            ],
+        }
+
+    def publish_evidence(self, report: dict[str, Any]) -> None:
+        rendered = (json.dumps(report, indent=2, sort_keys=True, default=str) + "\n").encode()
+        output = Path("reports/hf-release-finalization-latest.json")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(rendered)
+        self.record(str(output), "local-report", "updated")
+        if not self.publish:
+            return
+        self.api.create_repo(
+            repo_id=EVIDENCE_DATASET,
+            repo_type="dataset",
+            private=True,
+            exist_ok=True,
+        )
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for destination in (
+            "release-finalization/latest.json",
+            f"release-finalization/history/{timestamp}.json",
+        ):
+            self.api.upload_file(
+                repo_id=EVIDENCE_DATASET,
+                repo_type="dataset",
+                path_or_fileobj=io.BytesIO(rendered),
+                path_in_repo=destination,
+                commit_message=f"release(evidence): record Hub finalization {timestamp}",
+            )
+        self.record(EVIDENCE_DATASET, "evidence-publish", "updated")
+
+    def run(self) -> dict[str, Any]:
+        self.authenticate()
+        self.finalize_dataset()
+        for repo_id, spec in KERNEL_SPECS.items():
+            self.finalize_kernel(repo_id, spec)
+        report = self.report()
+        self.publish_evidence(report)
+        report = self.report()
+        Path("reports/hf-release-finalization-latest.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--generation", required=True)
+    parser.add_argument("--lake-root", default="lake")
+    parser.add_argument("--energy-root", default="energy")
+    parser.add_argument("--lambda-root", default="lambda-gate")
+    args = parser.parse_args()
+
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print("FATAL: no supported Hugging Face token is configured", file=os.sys.stderr)
+        return 2
+
+    try:
+        report = Finalizer(
+            token=token,
+            publish=args.publish,
+            generation=args.generation,
+            lake_root=Path(args.lake_root),
+            energy_root=Path(args.energy_root),
+            lambda_root=Path(args.lambda_root),
+        ).run()
+    except Exception as exc:  # fail closed with an explicit local report when possible
+        Path("reports").mkdir(exist_ok=True)
+        failure = {
+            "schema": "szl.hf-release-finalization/v1",
+            "generation": args.generation,
+            "publish": args.publish,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+        }
+        Path("reports/hf-release-finalization-latest.json").write_text(
+            json.dumps(failure, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"FATAL: {exc!r}", file=os.sys.stderr)
+        return 2
+
+    summary = report["summary"]
+    print(json.dumps(summary, indent=2))
+    return 1 if summary["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_release_finalization.py
+++ b/.github/scripts/test_hf_release_finalization.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import inspect
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+finalizer = importlib.import_module("hf_release_finalization")
+
+
+class ReleaseFinalizationContractTests(unittest.TestCase):
+    def test_exact_release_targets(self) -> None:
+        self.assertEqual(finalizer.DATASET_ID, "SZLHOLDINGS/szl-lake")
+        self.assertEqual(
+            set(finalizer.KERNEL_SPECS),
+            {
+                "SZLHOLDINGS/governed-inference-meter",
+                "SZLHOLDINGS/szl-governed-norm",
+            },
+        )
+
+    def test_kernel_publication_is_card_and_contract_only(self) -> None:
+        source = inspect.getsource(finalizer.Finalizer.finalize_kernel)
+        self.assertIn('repo_type="kernel"', source)
+        self.assertIn('((card, "README.md"), (contract, "contract.json"))', source)
+        self.assertNotIn("upload_folder", source)
+        self.assertNotIn("delete_repo", source)
+        self.assertNotIn("update_repo_settings", source)
+        self.assertNotIn("build-and-upload", source)
+
+    def test_dataset_publication_uses_reviewed_card_and_data_directory(self) -> None:
+        source = inspect.getsource(finalizer.Finalizer.finalize_dataset)
+        self.assertIn('root / "huggingface" / "README.md"', source)
+        self.assertIn('root / "data"', source)
+        self.assertIn("Dataset Viewer contract", source)
+        self.assertNotIn("delete_patterns", source)
+
+    def test_no_model_or_training_target(self) -> None:
+        source = (HERE / "hf_release_finalization.py").read_text(encoding="utf-8")
+        self.assertNotIn('repo_type="model"', source)
+        self.assertNotIn("train(", source)
+        self.assertNotIn("merge_weights", source)
+        self.assertNotIn("set_space_hardware", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-release-finalization.yml
+++ b/.github/workflows/hf-release-finalization.yml
@@ -1,0 +1,249 @@
+name: HF Release Finalization
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_finalization.py
+      - .github/scripts/test_hf_release_finalization.py
+      - .github/workflows/hf-release-finalization.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_finalization.py
+      - .github/scripts/test_hf_release_finalization.py
+      - .github/workflows/hf-release-finalization.yml
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish merged Lake and kernel contracts
+        required: false
+        default: "true"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: hf-release-finalization-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    name: Publish and independently read back merged Hub contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+      TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+    steps:
+      - name: Checkout release controller
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          path: controller
+          fetch-depth: 1
+
+      - name: Checkout merged Lake source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: szl-holdings/szl-lake
+          ref: main
+          path: lake
+          fetch-depth: 0
+
+      - name: Checkout merged energy-kernel source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: szl-holdings/szl-energy-attest
+          ref: main
+          path: energy
+          fetch-depth: 0
+
+      - name: Checkout merged governed-norm source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: szl-holdings/szl-lambda-gate
+          ref: main
+          path: lambda-gate
+          fetch-depth: 0
+
+      - name: Bind exact merged source lineage
+        id: sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C lake merge-base --is-ancestor 9c3819e3eb65af862aa0234db7e595c4e423932a HEAD
+          git -C energy merge-base --is-ancestor 14c1d8fdbb19dbd69f4dfc365d7f74d515bc4bdb HEAD
+          git -C lambda-gate merge-base --is-ancestor 8b95ca47571fda65a52b0b6189677ec089a6e503 HEAD
+          lake_sha="$(git -C lake rev-parse HEAD)"
+          energy_sha="$(git -C energy rev-parse HEAD)"
+          lambda_sha="$(git -C lambda-gate rev-parse HEAD)"
+          echo "lake_sha=${lake_sha}" >> "$GITHUB_OUTPUT"
+          echo "energy_sha=${energy_sha}" >> "$GITHUB_OUTPUT"
+          echo "lambda_sha=${lambda_sha}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Bound release sources"
+            echo
+            echo "- szl-lake: \`${lake_sha}\`"
+            echo "- szl-energy-attest: \`${energy_sha}\`"
+            echo "- szl-lambda-gate: \`${lambda_sha}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned release clients and source-test dependencies
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "huggingface_hub>=1.3,<2" \
+            "kernels==0.16.0" \
+            "requests>=2.32,<3" \
+            "pytest>=8,<9" \
+            "pyarrow>=18,<24" \
+            "PyYAML>=6,<7"
+
+      - name: Verify controller safety contract
+        working-directory: controller
+        run: |
+          python -m py_compile \
+            .github/scripts/hf_release_finalization.py \
+            .github/scripts/test_hf_release_finalization.py
+          python .github/scripts/test_hf_release_finalization.py
+
+      - name: Verify merged source contracts before any Hub write
+        run: |
+          set -euo pipefail
+          python lake/scripts/test_hf_dataset_contract.py
+          PYTHONPATH=energy python -m pytest -q energy/tests/test_hf_kernel_contract.py
+          PYTHONPATH=lambda-gate/torch-ext:lambda-gate \
+            python -m pytest -q lambda-gate/tests/test_hf_governed_norm_contract.py
+
+      - name: Require authenticated publisher for release lanes
+        id: credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          if [ "${{ github.event_name }}" = "push" ]; then publish=true; fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" = "true" ]; then publish=true; fi
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+          if [ "$publish" = "true" ] && [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo "::error::No supported Hugging Face organization write token is configured."
+            exit 2
+          fi
+
+      - name: Publish and read back exact Hub revisions
+        if: steps.credentials.outputs.publish == 'true'
+        id: release
+        working-directory: controller
+        env:
+          SZL_LAKE_SHA: ${{ steps.sources.outputs.lake_sha }}
+          SZL_ENERGY_ATTEST_SHA: ${{ steps.sources.outputs.energy_sha }}
+          SZL_LAMBDA_GATE_SHA: ${{ steps.sources.outputs.lambda_sha }}
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_release_finalization.py \
+            --publish \
+            --generation "${GITHUB_SHA}" \
+            --lake-root ../lake \
+            --energy-root ../energy \
+            --lambda-root ../lambda-gate
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Record pull-request source verification
+        if: github.event_name == 'pull_request'
+        working-directory: controller
+        run: |
+          mkdir -p reports
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          report = {
+              "schema": "szl.hf-release-finalization-prerelease/v1",
+              "generation": os.environ.get("GITHUB_SHA"),
+              "generated_at": datetime.now(timezone.utc).isoformat(),
+              "publish": False,
+              "source_verification": "PASSED",
+              "summary": {"ok": 4, "warning": 0, "error": 0, "dry_run": 1},
+              "boundary": "No Hugging Face mutation occurs on pull_request events.",
+          }
+          Path("reports/hf-release-finalization-latest.json").write_text(
+              json.dumps(report, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload release evidence artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-release-finalization-${{ github.run_id }}
+          path: controller/reports/hf-release-finalization-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Commit protected-main evidence report
+        if: always() && steps.credentials.outputs.publish == 'true'
+        working-directory: controller
+        shell: bash
+        run: |
+          set -euo pipefail
+          report=reports/hf-release-finalization-latest.json
+          test -f "$report"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$report"
+          if git diff --cached --quiet; then
+            echo "Release report unchanged."
+            exit 0
+          fi
+          git commit -s -m "chore(hf): record release finalization [skip ci]"
+          git push origin "HEAD:${TARGET_BRANCH}"
+
+      - name: Publish release summary
+        if: always()
+        working-directory: controller
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          path = Path("reports/hf-release-finalization-latest.json")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as out:
+              out.write("\n## Hugging Face release finalization\n\n")
+              if not path.exists():
+                  out.write("No report was produced.\n")
+              else:
+                  report = json.loads(path.read_text(encoding="utf-8"))
+                  out.write(f"Publish: `{report.get('publish')}`\n\n")
+                  for key, value in report.get("summary", {}).items():
+                      out.write(f"- {key}: `{value}`\n")
+                  for repo_id, item in report.get("results", {}).get("kernels", {}).items():
+                      out.write(f"- kernel `{repo_id}`: `{item.get('after_sha')}` selfcheck passed\n")
+                  dataset = report.get("results", {}).get("dataset")
+                  if dataset:
+                      out.write(f"- dataset `{dataset.get('repo_id')}`: `{dataset.get('after_sha')}` viewer HTTP {dataset.get('viewer_http_status')}\n")
+          PY
+
+      - name: Enforce fail-closed release result
+        if: always()
+        shell: bash
+        run: |
+          if [ "${{ steps.credentials.outputs.publish }}" != "true" ]; then
+            exit 0
+          fi
+          code="${{ steps.release.outputs.exit_code }}"
+          if [ -z "$code" ]; then code=2; fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Hub release finalization failed; inspect the uploaded and committed report."
+            exit "$code"
+          fi


### PR DESCRIPTION
## Outcome

Adds one clean, DCO-signed protected-main release lane for the three merged Hugging Face publications still outside the estate metadata sweep:

- `szl-holdings/szl-lake@main` → `SZLHOLDINGS/szl-lake` Dataset Viewer card plus verbatim `data/**`;
- `szl-holdings/szl-energy-attest@main` → `SZLHOLDINGS/governed-inference-meter` reviewed first-class kernel card/contract;
- `szl-holdings/szl-lambda-gate@main` → `SZLHOLDINGS/szl-governed-norm` reviewed first-class kernel card/contract.

The lane verifies source lineage and local contracts before any write; reads every published file back at its exact immutable Hub revision; requires kernel build variants and `selfcheck()` with explicit trust; verifies the live Dataset Viewer contract; and publishes one machine-readable evidence report.

No kernel binary, model weight, dataset row, signature, visibility, paid hardware, or repository identity is changed.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>