### PR TITLE
fix(hf): enforce one governed A11oy Space permanently

### DIFF
--- a/.github/scripts/hf_estate_canonicalize.py
+++ b/.github/scripts/hf_estate_canonicalize.py
@@ -1,21 +1,15 @@
 #!/usr/bin/env python3
-"""Reconcile the SZLHOLDINGS Hub around one canonical A11oy and four public clones.
+"""Keep exactly one governed A11oy Hugging Face Space.
 
-The canonical production Space remains ``SZLHOLDINGS/a11oy``. The four exact
-managed clones ``a11oy-clone-1`` through ``a11oy-clone-4`` are retained as
-public CPU-basic recovery/showcase runtimes and refreshed from the canonical
-Space without using Hugging Face's daily-limited duplication endpoint.
+The sole survivor is ``SZLHOLDINGS/a11oy``. The reconciler inventories that
+Space plus the four historical ``a11oy-clone-*`` repositories, adopts the most
+recently modified valid Docker Space into the canonical repository, verifies the
+canonical runtime, removes all clone collection references, deletes only the
+four exact clone IDs, and proves they are absent.
 
-Only surplus repositories that are positively identified as A11oy duplicates
-are eligible for deletion. A repository is a surplus duplicate only when it is
-outside the five-Space keep set and either:
-
-* its name matches the narrow ``a11oy-(clone|copy|duplicate)-<number>`` form; or
-* its managed marker explicitly declares ``clone_of=SZLHOLDINGS/a11oy``.
-
-The wrapper preserves the estate-wide model/dataset markers, Space health
-checks, collections, kernel validation, and evidence report from
-``hf_estate_upgrade.py``.
+No code path creates, duplicates, restores, refreshes, or changes visibility of
+an A11oy clone. The inherited estate publisher's clone list is disabled before
+its normal estate-maintenance sequence runs.
 """
 from __future__ import annotations
 
@@ -25,249 +19,141 @@ import os
 import re
 import sys
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 import hf_estate_upgrade as legacy
 
-MANAGED_CLONE_IDS = tuple(
-    f"{legacy.ORG}/a11oy-clone-{index}" for index in range(1, 5)
-)
-KEEP_SPACE_IDS = frozenset((legacy.FLAGSHIP_SPACE, *MANAGED_CLONE_IDS))
-DUPLICATE_NAME = re.compile(
-    rf"^{re.escape(legacy.ORG)}/a11oy-(?:clone|copy|duplicate)-\d+$",
-    re.IGNORECASE,
-)
-MARKER_URL = (
-    "https://huggingface.co/spaces/{repo_id}/resolve/main/"
-    + legacy.MANAGED_PATH
-)
-TERMINAL_FAILURE_STAGES = {
-    "BUILD_ERROR",
-    "RUNTIME_ERROR",
-    "CONFIG_ERROR",
-    "NO_APP_FILE",
-}
+CLONES = tuple(f"{legacy.ORG}/a11oy-clone-{i}" for i in range(1, 5))
+CANDIDATES = (legacy.FLAGSHIP_SPACE, *CLONES)
+HISTORICAL_CLONE_IDS = CLONES
+CANDIDATE_IDS = CANDIDATES
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+FAILURE_STAGES = {"BUILD_ERROR", "RUNTIME_ERROR", "CONFIG_ERROR", "NO_APP_FILE"}
+EXCLUDED_PATHS = {".gitattributes", legacy.MANAGED_PATH}
+
+# Kill the inherited creation and collection-add paths before base execution.
+legacy.CLONE_IDS = []
 
 
-# The inherited collection builder consults this module global. Keep the exact
-# managed clone set enabled so the Spaces and Canonical Estate collections
-# include the four public recovery/showcase runtimes.
-legacy.CLONE_IDS = list(MANAGED_CLONE_IDS)
+def _epoch(value: Any) -> float:
+    text = str(value or "").strip()
+    if not text:
+        return 0.0
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
 
 
-def _runtime_stage(info: Any) -> str:
-    runtime = getattr(info, "runtime", None)
-    raw = getattr(runtime, "stage", None)
-    raw = getattr(raw, "value", raw)
-    return str(raw or "UNKNOWN").split(".")[-1].upper()
+_modified_epoch = _epoch
 
 
-def _snapshot(info: Any) -> dict[str, Any]:
-    return {
-        "sha": str(getattr(info, "sha", "") or ""),
-        "private": getattr(info, "private", None),
-        "stage": _runtime_stage(info),
-    }
+def _stage(detail: dict[str, Any]) -> str:
+    runtime = detail.get("runtime") or {}
+    value = runtime.get("stage") or runtime.get("status") or "UNKNOWN"
+    return str(value).split(".")[-1].upper()
 
 
-class CommandCenterEstateUpgrade(legacy.EstateUpgrade):
-    """Estate upgrade with four retained public A11oy command-center clones."""
+class SingleA11oyUpgrade(legacy.EstateUpgrade):
+    """Run normal estate maintenance while converging A11oy to one Space."""
 
-    def _verify_canonical_flagship(self) -> dict[str, Any]:
-        if not self.api.repo_exists(legacy.FLAGSHIP_SPACE, repo_type="space"):
-            raise RuntimeError(f"Canonical Space is missing: {legacy.FLAGSHIP_SPACE}")
+    def _snapshot(self, repo_id: str) -> dict[str, Any]:
+        if not self.api.repo_exists(repo_id, repo_type="space"):
+            result = {"repo_id": repo_id, "exists": False, "valid": False}
+            self.record(repo_id, "a11oy-candidate", "ok", "absent")
+            return result
 
-        info = self.api.space_info(legacy.FLAGSHIP_SPACE)
-        stage = _runtime_stage(info)
-        sha = str(getattr(info, "sha", "") or "")
-        private = getattr(info, "private", None)
-        files = set(self.api.list_repo_files(legacy.FLAGSHIP_SPACE, repo_type="space"))
-
-        if stage != "RUNNING":
-            raise RuntimeError(
-                f"Canonical Space is not RUNNING: {legacy.FLAGSHIP_SPACE} stage={stage}"
-            )
-        if not re.fullmatch(r"[0-9a-f]{40}", sha):
-            raise RuntimeError(
-                "Canonical Space revision is not an immutable 40-character SHA: "
-                f"{sha!r}"
-            )
-        if private is True:
-            raise RuntimeError(
-                f"Canonical Space unexpectedly became private: {legacy.FLAGSHIP_SPACE}"
-            )
-        if "Dockerfile" not in files:
-            raise RuntimeError(
-                f"Canonical Docker Space is missing Dockerfile: {legacy.FLAGSHIP_SPACE}"
-            )
-
-        snapshot = {
-            "repo_id": legacy.FLAGSHIP_SPACE,
-            "stage": stage,
+        detail = self._space_detail(repo_id)
+        files = set(self.api.list_repo_files(repo_id, repo_type="space"))
+        modified = detail.get("lastModified") or detail.get("last_modified")
+        sha = str(detail.get("sha") or "")
+        result = {
+            "repo_id": repo_id,
+            "exists": True,
             "sha": sha,
-            "private": private,
-            "dockerfile_present": True,
+            "private": detail.get("private"),
+            "stage": _stage(detail),
+            "last_modified": str(modified or ""),
+            "modified_epoch": _epoch(modified),
+            "dockerfile_present": "Dockerfile" in files,
+            "valid": bool(SHA_RE.fullmatch(sha) and "Dockerfile" in files),
         }
         self.record(
-            legacy.FLAGSHIP_SPACE,
-            "canonical-space-preflight",
-            "validated",
-            f"stage={stage}; sha={sha}; private={private}",
-        )
-        return snapshot
-
-    def _read_marker(self, repo_id: str) -> dict[str, Any] | None:
-        response = self.http.get(
-            MARKER_URL.format(repo_id=repo_id),
-            headers={"Cache-Control": "no-cache"},
-            timeout=45,
-        )
-        if response.status_code == 404:
-            return None
-        response.raise_for_status()
-        payload = response.json()
-        return payload if isinstance(payload, dict) else None
-
-    def _is_surplus_duplicate(self, repo_id: str) -> tuple[bool, str]:
-        if repo_id in KEEP_SPACE_IDS:
-            return False, "keep-set"
-        if DUPLICATE_NAME.fullmatch(repo_id):
-            return True, "narrow-name-match"
-        try:
-            marker = self._read_marker(repo_id)
-        except Exception as exc:
-            self.record(
-                repo_id,
-                "duplicate-marker-read",
-                "warning",
-                repr(exc)[:250],
-            )
-            return False, "marker-unavailable"
-        if marker and marker.get("clone_of") == legacy.FLAGSHIP_SPACE:
-            return True, "managed-marker-clone-of-canonical"
-        return False, "not-proven-duplicate"
-
-    def _set_public(self, repo_id: str) -> None:
-        info = self.api.space_info(repo_id)
-        if getattr(info, "private", None) is False:
-            self.record(repo_id, "clone-visibility", "ok", "already public")
-            return
-        if not self.publish:
-            self.record(repo_id, "clone-visibility", "dry-run", "would make public")
-            return
-
-        update = getattr(self.api, "update_repo_settings", None)
-        if not callable(update):
-            raise RuntimeError(
-                "Installed huggingface_hub lacks HfApi.update_repo_settings; "
-                f"cannot safely make {repo_id} public"
-            )
-        try:
-            update(repo_id=repo_id, repo_type="space", private=False)
-        except TypeError:
-            # Compatibility with clients whose signature infers repo_type.
-            update(repo_id=repo_id, private=False)
-
-        after = self.api.space_info(repo_id)
-        if getattr(after, "private", None) is not False:
-            raise RuntimeError(f"Visibility update did not make {repo_id} public")
-        self.record(repo_id, "clone-visibility", "updated", "public")
-
-    def _create_missing_clone(self, clone_id: str) -> None:
-        if not self.publish:
-            self.record(
-                clone_id,
-                "flagship-clone",
-                "dry-run",
-                "would create public cpu-basic Space without duplication API",
-            )
-            return
-        self.api.create_repo(
-            repo_id=clone_id,
-            repo_type="space",
-            private=False,
-            exist_ok=True,
-            space_sdk="docker",
-            space_hardware="cpu-basic",
-            space_sleep_time=300,
-        )
-        if not self.api.repo_exists(clone_id, repo_type="space"):
-            raise RuntimeError(f"Clone creation did not produce repository: {clone_id}")
-        self.record(
-            clone_id,
-            "flagship-clone",
-            "created",
-            "public cpu-basic; quota-safe create_repo path",
-        )
-
-    def _wait_for_running(self, repo_id: str, timeout_seconds: int = 1800) -> dict[str, Any]:
-        deadline = time.monotonic() + timeout_seconds
-        last: dict[str, Any] = {}
-        while True:
-            info = self.api.space_info(repo_id)
-            last = _snapshot(info)
-            stage = last["stage"]
-            if stage == "RUNNING":
-                self.record(
-                    repo_id,
-                    "clone-runtime",
-                    "validated",
-                    f"stage=RUNNING; sha={last['sha']}; private={last['private']}",
-                )
-                return last
-            if stage in TERMINAL_FAILURE_STAGES:
-                raise RuntimeError(
-                    f"Clone runtime entered terminal failure: {repo_id} stage={stage}"
-                )
-            if time.monotonic() >= deadline:
-                raise RuntimeError(
-                    f"Clone runtime did not reach RUNNING within {timeout_seconds}s: "
-                    f"{repo_id} last={last}"
-                )
-            time.sleep(15)
-
-    @staticmethod
-    def _tree_identity(entry: Any) -> str | None:
-        lfs = getattr(entry, "lfs", None)
-        lfs_sha = getattr(lfs, "sha256", None)
-        if lfs_sha:
-            return f"lfs:{lfs_sha}"
-        blob_id = getattr(entry, "blob_id", None)
-        return f"git:{blob_id}" if blob_id else None
-
-    def _repo_file_map(self, repo_id: str) -> dict[str, str]:
-        mapping: dict[str, str] = {}
-        for entry in self.api.list_repo_tree(
             repo_id,
-            repo_type="space",
-            recursive=True,
-            expand=False,
-        ):
-            identity = self._tree_identity(entry)
-            path = str(getattr(entry, "path", "") or "")
-            if path and identity:
-                mapping[path] = identity
-        return mapping
-
-    def _sync_clone_from_canonical(self, clone_id: str) -> tuple[int, int]:
-        source = self._repo_file_map(legacy.FLAGSHIP_SPACE)
-        destination = self._repo_file_map(clone_id)
-
-        copy_paths = sorted(
-            path
-            for path, identity in source.items()
-            if path != ".gitattributes" and destination.get(path) != identity
+            "a11oy-candidate",
+            "validated" if result["valid"] else "warning",
+            (
+                f"stage={result['stage']}; private={result['private']}; "
+                f"sha={sha or 'UNKNOWN'}; modified={result['last_modified'] or 'UNKNOWN'}; "
+                f"dockerfile={result['dockerfile_present']}"
+            ),
         )
-        delete_paths = sorted(
-            path
-            for path in destination
-            if path not in source and path not in {".gitattributes", legacy.MANAGED_PATH}
+        return result
+
+    def _select_source(
+        self,
+    ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+        snapshots = {repo_id: self._snapshot(repo_id) for repo_id in CANDIDATES}
+        valid = [item for item in snapshots.values() if item.get("valid")]
+        if not valid:
+            raise RuntimeError("No valid canonical-or-clone A11oy Docker Space exists")
+        selected = max(
+            valid,
+            key=lambda item: (
+                float(item.get("modified_epoch") or 0.0),
+                item["repo_id"] == legacy.FLAGSHIP_SPACE,
+                str(item.get("sha") or ""),
+            ),
         )
+        self.record(
+            selected["repo_id"],
+            "select-newest-a11oy-source",
+            "validated",
+            (
+                f"modified={selected.get('last_modified') or 'UNKNOWN'}; "
+                f"sha={selected.get('sha')}; stage={selected.get('stage')}"
+            ),
+        )
+        return selected, snapshots
+
+    def _adopt_source(self, source_id: str) -> str | None:
+        if source_id == legacy.FLAGSHIP_SPACE:
+            info = self.api.space_info(legacy.FLAGSHIP_SPACE)
+            self.record(
+                legacy.FLAGSHIP_SPACE,
+                "canonical-content-adoption",
+                "ok",
+                "canonical repository is already the newest valid source",
+            )
+            return str(getattr(info, "sha", "") or "")
+
+        source_files = set(self.api.list_repo_files(source_id, repo_type="space"))
+        canonical_files = set(
+            self.api.list_repo_files(legacy.FLAGSHIP_SPACE, repo_type="space")
+        )
+        copy_paths = sorted(source_files - EXCLUDED_PATHS)
+        delete_paths = sorted(canonical_files - source_files - EXCLUDED_PATHS)
+        if not self.publish:
+            self.record(
+                legacy.FLAGSHIP_SPACE,
+                "canonical-content-adoption",
+                "dry-run",
+                (
+                    f"would adopt {source_id}; copy={len(copy_paths)}; "
+                    f"delete={len(delete_paths)}"
+                ),
+            )
+            return None
+
         operations = [
             legacy.CommitOperationCopy(
                 src_path_in_repo=path,
                 path_in_repo=path,
-                src_repo_id=legacy.FLAGSHIP_SPACE,
+                src_repo_id=source_id,
                 src_repo_type="space",
             )
             for path in copy_paths
@@ -275,211 +161,215 @@ class CommandCenterEstateUpgrade(legacy.EstateUpgrade):
             legacy.CommitOperationDelete(path_in_repo=path)
             for path in delete_paths
         ]
-
-        if not operations:
-            self.record(clone_id, "clone-refresh", "ok", "already byte-current")
-            return 0, 0
-
-        for index in range(0, len(operations), 500):
-            chunk = operations[index : index + 500]
-            self.api.create_commit(
-                repo_id=clone_id,
+        expected: str | None = None
+        for offset in range(0, len(operations), 500):
+            result = self.api.create_commit(
+                repo_id=legacy.FLAGSHIP_SPACE,
                 repo_type="space",
-                operations=chunk,
+                operations=operations[offset : offset + 500],
                 commit_message=(
-                    f"chore(clone): sync canonical A11oy generation "
-                    f"{self.generation[:12]} ({index // 500 + 1})"
+                    f"fix(estate): adopt newest A11oy source {source_id} "
+                    f"({offset // 500 + 1})"
                 ),
                 commit_description=(
-                    f"Quota-safe server-side copy from "
-                    f"{legacy.FLAGSHIP_SPACE}; canonical revision is recorded "
-                    "in the managed marker."
+                    "Consolidate the newest valid A11oy source into the sole "
+                    "governed Space before retiring historical clones."
                 ),
             )
-
+            expected = str(
+                getattr(result, "oid", None)
+                or getattr(result, "commit_id", None)
+                or ""
+            ) or expected
         self.record(
-            clone_id,
-            "clone-refresh",
+            legacy.FLAGSHIP_SPACE,
+            "canonical-content-adoption",
             "updated",
-            f"copied={len(copy_paths)} deleted={len(delete_paths)}",
+            (
+                f"source={source_id}; copied={len(copy_paths)}; "
+                f"deleted={len(delete_paths)}; expected_sha={expected or 'UNKNOWN'}"
+            ),
         )
-        return len(copy_paths), len(delete_paths)
+        return expected
 
-    def _verify_clone_file_set(self, clone_id: str) -> None:
-        source_files = set(
-            self.api.list_repo_files(legacy.FLAGSHIP_SPACE, repo_type="space")
-        )
-        clone_files = set(self.api.list_repo_files(clone_id, repo_type="space"))
-        source_files.discard(".gitattributes")
-        clone_files.discard(".gitattributes")
-        clone_files.discard(legacy.MANAGED_PATH)
-        if clone_files != source_files:
-            missing = sorted(source_files - clone_files)[:20]
-            extra = sorted(clone_files - source_files)[:20]
-            raise RuntimeError(
-                f"Clone file-set mismatch for {clone_id}: missing={missing}; extra={extra}"
-            )
-        self.record(
-            clone_id,
-            "clone-file-set",
-            "validated",
-            f"files={len(source_files)}",
-        )
-
-    def _reconcile_clone(
+    def _wait_for_canonical(
         self,
-        clone_id: str,
-        canonical_sha: str,
+        expected_sha: str | None,
+        timeout_seconds: int = 1800,
     ) -> dict[str, Any]:
-        exists = self.api.repo_exists(clone_id, repo_type="space")
-        if not exists:
-            self._create_missing_clone(clone_id)
-            if not self.publish:
-                return {"exists": False, "planned": True}
-
-        before = _snapshot(self.api.space_info(clone_id))
-        self.record(
-            clone_id,
-            "clone-preflight",
-            "ok",
-            f"private={before['private']}; stage={before['stage']}; sha={before['sha']}",
+        deadline = time.monotonic() + timeout_seconds
+        restart_requested = False
+        last: dict[str, Any] = {}
+        while time.monotonic() < deadline:
+            detail = self._space_detail(legacy.FLAGSHIP_SPACE)
+            sha = str(detail.get("sha") or "")
+            stage = _stage(detail)
+            last = {
+                "repo_id": legacy.FLAGSHIP_SPACE,
+                "sha": sha,
+                "stage": stage,
+                "private": detail.get("private"),
+                "dockerfile_present": (
+                    "Dockerfile"
+                    in set(
+                        self.api.list_repo_files(
+                            legacy.FLAGSHIP_SPACE,
+                            repo_type="space",
+                        )
+                    )
+                ),
+            }
+            if (
+                (not expected_sha or sha == expected_sha)
+                and stage == "RUNNING"
+                and SHA_RE.fullmatch(sha)
+                and last["private"] is not True
+                and last["dockerfile_present"]
+            ):
+                self.record(
+                    legacy.FLAGSHIP_SPACE,
+                    "canonical-runtime",
+                    "validated",
+                    f"stage=RUNNING; sha={sha}; private={last['private']}",
+                )
+                return last
+            if stage in FAILURE_STAGES:
+                raise RuntimeError(f"Canonical A11oy entered terminal failure: {last}")
+            if (
+                self.publish
+                and not restart_requested
+                and stage in {"PAUSED", "STOPPED", "SLEEPING"}
+            ):
+                self.api.restart_space(
+                    repo_id=legacy.FLAGSHIP_SPACE,
+                    factory_reboot=False,
+                )
+                restart_requested = True
+                self.record(
+                    legacy.FLAGSHIP_SPACE,
+                    "canonical-restart",
+                    "requested",
+                    f"stage={stage}",
+                )
+            time.sleep(15)
+        raise RuntimeError(
+            f"Canonical A11oy did not converge: expected={expected_sha}; last={last}"
         )
-        self._set_public(clone_id)
 
-        if not self.publish:
-            self.record(
-                clone_id,
-                "clone-refresh",
-                "dry-run",
-                f"would sync from {legacy.FLAGSHIP_SPACE}@{canonical_sha}",
-            )
-            return before
-
-        # Copy only byte-different files in bounded server-side commits, avoiding
-        # local downloads and the daily-limited duplicate endpoint.
-        self._sync_clone_from_canonical(clone_id)
-        self._upload_marker(
-            repo_id=clone_id,
-            repo_type="space",
-            observed_sha=before.get("sha"),
-            runtime={"stage_before": before.get("stage")},
-            clone_of=legacy.FLAGSHIP_SPACE,
-        )
-        self._verify_clone_file_set(clone_id)
-
-        # A content commit normally triggers a rebuild. If the clone was already
-        # current, restart only when it is not running.
-        current = self.api.space_info(clone_id)
-        if _runtime_stage(current) != "RUNNING":
-            self.api.restart_space(repo_id=clone_id, factory_reboot=False)
-            self.record(clone_id, "clone-restart", "requested")
-
-        after = self._wait_for_running(clone_id)
-        if after["private"] is not False:
-            raise RuntimeError(f"Clone became non-public after reconciliation: {clone_id}")
-        return after
-
-    def _remove_collection_references(self, repo_ids: set[str]) -> None:
-        if not repo_ids:
-            return
-        summaries = list(self.api.list_collections(owner=legacy.ORG, limit=100))
-        for summary in summaries:
+    def _remove_collection_refs(self) -> None:
+        clone_ids = set(CLONES)
+        for summary in self.api.list_collections(owner=legacy.ORG, limit=100):
             collection = self.api.get_collection(summary.slug)
             for item in collection.items:
-                if item.item_type != "space" or item.item_id not in repo_ids:
+                if item.item_type != "space" or item.item_id not in clone_ids:
                     continue
                 target = f"{collection.slug}:{item.item_id}"
                 if not self.publish:
-                    self.record(target, "collection-remove-surplus", "dry-run")
+                    self.record(target, "collection-remove-a11oy-clone", "dry-run")
                     continue
                 self.api.delete_collection_item(
                     collection_slug=collection.slug,
                     item_object_id=item.item_object_id,
                     missing_ok=True,
                 )
-                self.record(target, "collection-remove-surplus", "deleted")
+                self.record(
+                    target,
+                    "collection-remove-a11oy-clone",
+                    "deleted",
+                )
 
-    def _delete_surplus_duplicates(self) -> list[dict[str, Any]]:
-        candidates: list[dict[str, Any]] = []
-        for item in self.inventory.get("spaces", []):
-            repo_id = self._asset_id(item)
-            if not repo_id:
+    def _delete_clones(self, snapshots: dict[str, dict[str, Any]]) -> None:
+        self._remove_collection_refs()
+        for clone_id in CLONES:
+            snapshot = snapshots[clone_id]
+            if not snapshot.get("exists"):
+                self.record(clone_id, "retire-a11oy-clone", "ok", "already absent")
                 continue
-            eligible, reason = self._is_surplus_duplicate(repo_id)
-            if not eligible:
-                continue
-            info = self.api.space_info(repo_id)
-            candidates.append(
-                {
-                    "repo_id": repo_id,
-                    "reason": reason,
-                    **_snapshot(info),
-                }
-            )
-
-        candidate_ids = {item["repo_id"] for item in candidates}
-        self._remove_collection_references(candidate_ids)
-        for candidate in candidates:
-            repo_id = candidate["repo_id"]
             if not self.publish:
                 self.record(
-                    repo_id,
-                    "delete-surplus-duplicate",
+                    clone_id,
+                    "retire-a11oy-clone",
                     "dry-run",
-                    f"reason={candidate['reason']}; sha={candidate['sha']}",
+                    f"would delete former_sha={snapshot.get('sha')}",
                 )
                 continue
-            self.api.delete_repo(repo_id=repo_id, repo_type="space", missing_ok=True)
-            if self.api.repo_exists(repo_id, repo_type="space"):
-                raise RuntimeError(f"Surplus duplicate still exists after deletion: {repo_id}")
-            self.record(
-                repo_id,
-                "delete-surplus-duplicate",
-                "deleted",
-                f"reason={candidate['reason']}; former_sha={candidate['sha']}",
+            self.api.delete_repo(
+                repo_id=clone_id,
+                repo_type="space",
+                missing_ok=True,
             )
-        return candidates
+            if self.api.repo_exists(clone_id, repo_type="space"):
+                raise RuntimeError(f"Clone remains after deletion: {clone_id}")
+            self.record(
+                clone_id,
+                "retire-a11oy-clone",
+                "deleted",
+                f"former_sha={snapshot.get('sha')}",
+            )
+
+    def upgrade_spaces(self) -> None:
+        original = self.inventory.get("spaces", [])
+        self.inventory["spaces"] = [
+            item for item in original if self._asset_id(item) not in CLONES
+        ]
+        try:
+            super().upgrade_spaces()
+        finally:
+            self.inventory["spaces"] = original
 
     def create_or_refresh_clones(self) -> None:
-        """Retain, publish, synchronize, and verify four exact managed clones."""
-        self.canonical_flagship = self._verify_canonical_flagship()
-        canonical_sha = self.canonical_flagship["sha"]
-        self.managed_clone_snapshots: dict[str, dict[str, Any]] = {}
+        """Adopt newest A11oy content and retire every historical clone."""
+        selected, snapshots = self._select_source()
+        expected_sha = self._adopt_source(selected["repo_id"])
+        self.selected_source = selected
+        self.candidate_snapshots = snapshots
 
-        for clone_id in MANAGED_CLONE_IDS:
-            self.managed_clone_snapshots[clone_id] = self._reconcile_clone(
-                clone_id, canonical_sha
-            )
+        canonical_snapshot = snapshots.get(legacy.FLAGSHIP_SPACE, {})
+        self.canonical_flagship = (
+            self._wait_for_canonical(expected_sha)
+            if self.publish
+            else {
+                "repo_id": legacy.FLAGSHIP_SPACE,
+                "sha": canonical_snapshot.get("sha"),
+                "stage": canonical_snapshot.get("stage"),
+                "private": canonical_snapshot.get("private"),
+                "dockerfile_present": canonical_snapshot.get(
+                    "dockerfile_present"
+                ),
+            }
+        )
+        self._delete_clones(snapshots)
 
-        self.surplus_duplicate_snapshots = self._delete_surplus_duplicates()
-
-        # Refresh Space inventory after clone creation/visibility changes/deletions
-        # so collection curation and report counts describe the final estate.
-        try:
+        if self.publish:
+            for clone_id in CLONES:
+                if self.api.repo_exists(clone_id, repo_type="space"):
+                    raise RuntimeError(f"Clone still exists: {clone_id}")
             self.inventory["spaces"] = self._paginate(
-                f"{legacy.HF_BASE}/api/spaces?author={legacy.ORG}&limit=1000&full=true"
+                f"{legacy.HF_BASE}/api/spaces?"
+                f"author={legacy.ORG}&limit=1000&full=true"
             )
-        except Exception as exc:
-            self.record(
-                legacy.ORG,
-                "inventory:spaces:refresh",
-                "error",
-                repr(exc)[:300],
-            )
+        else:
+            self.inventory["spaces"] = [
+                item
+                for item in self.inventory.get("spaces", [])
+                if self._asset_id(item) not in CLONES
+            ]
 
     def report(self) -> dict[str, Any]:
         report = super().report()
         report["canonical_flagship_space"] = getattr(
-            self, "canonical_flagship", {"repo_id": legacy.FLAGSHIP_SPACE}
+            self,
+            "canonical_flagship",
+            {"repo_id": legacy.FLAGSHIP_SPACE},
         )
-        report["managed_clone_ids"] = list(MANAGED_CLONE_IDS)
-        report["managed_clone_snapshots"] = getattr(
-            self, "managed_clone_snapshots", {}
+        report["selected_newest_source"] = getattr(self, "selected_source", None)
+        report["candidate_snapshots"] = getattr(
+            self,
+            "candidate_snapshots",
+            {},
         )
-        report["surplus_duplicate_snapshots"] = getattr(
-            self, "surplus_duplicate_snapshots", []
-        )
-        report["command_center_keep_set"] = sorted(KEEP_SPACE_IDS)
+        report["clone_ids"] = []
+        report["retired_clone_ids"] = list(CLONES)
         report["summary"]["ok"] = sum(
             action.status
             in {
@@ -493,14 +383,12 @@ class CommandCenterEstateUpgrade(legacy.EstateUpgrade):
             for action in self.actions
         )
         report["boundaries"] = [
-            "SZLHOLDINGS/a11oy remains the canonical production A11oy Space.",
-            "The four exact a11oy-clone-1..4 Spaces are retained, public, and synchronized from the canonical Space.",
-            "The daily-limited Hugging Face duplication endpoint is never used.",
-            "Only positively identified surplus A11oy duplicates outside the five-Space keep set may be deleted.",
+            "SZLHOLDINGS/a11oy is the sole governed A11oy Space.",
+            "The newest valid A11oy content is adopted before clone deletion.",
+            "Only the four exact a11oy-clone-1..4 repositories may be deleted.",
+            "No active path creates, restores, refreshes, or publicizes an A11oy clone.",
             "No model weights or dataset payloads are changed.",
             "No paid hardware tier is changed.",
-            "Healthy non-A11oy dynamic Spaces are not rewritten or restarted.",
-            "Kernel repositories are validated; first-class kernel publishing remains governed by kernel-builder release workflows.",
         ]
         return report
 
@@ -520,25 +408,19 @@ def main() -> int:
         or os.environ.get("HF_TOKEN")
     )
     if not token:
-        print(
-            "FATAL: HF_ORG_TOKEN/HF_ORG_TOKEN1/HF_TOKEN is not set.",
-            file=sys.stderr,
-        )
+        print("FATAL: HF_ORG_TOKEN/HF_ORG_TOKEN1/HF_TOKEN is not set.", file=sys.stderr)
         return 2
-
     try:
-        report = CommandCenterEstateUpgrade(
+        report = SingleA11oyUpgrade(
             token=token,
             generation=args.generation,
             publish=args.publish,
         ).run()
-    except Exception as exc:
-        print(f"FATAL: {exc!r}", file=sys.stderr)
+    except Exception as exc:  # noqa: BLE001
+        print(f"FATAL: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 2
-
-    summary = report["summary"]
-    print(json.dumps(summary, indent=2))
-    return 1 if summary["error"] else 0
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 1 if report["summary"]["error"] else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/hf_estate_canonicalize.py
+++ b/.github/scripts/hf_estate_canonicalize.py
@@ -49,9 +49,6 @@ def _epoch(value: Any) -> float:
     return parsed.timestamp()
 
 
-_modified_epoch = _epoch
-
-
 def _stage(detail: dict[str, Any]) -> str:
     runtime = detail.get("runtime") or {}
     value = runtime.get("stage") or runtime.get("status") or "UNKNOWN"

--- a/.github/scripts/hf_estate_canonicalize.py
+++ b/.github/scripts/hf_estate_canonicalize.py
@@ -98,11 +98,17 @@ class SingleA11oyUpgrade(legacy.EstateUpgrade):
         self,
     ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
         snapshots = {repo_id: self._snapshot(repo_id) for repo_id in CANDIDATES}
-        valid = [item for item in snapshots.values() if item.get("valid")]
-        if not valid:
-            raise RuntimeError("No valid canonical-or-clone A11oy Docker Space exists")
+        eligible = [
+            item
+            for item in snapshots.values()
+            if item.get("valid") and item.get("stage") == "RUNNING"
+        ]
+        if not eligible:
+            raise RuntimeError(
+                "No RUNNING valid canonical-or-clone A11oy Docker Space exists"
+            )
         selected = max(
-            valid,
+            eligible,
             key=lambda item: (
                 float(item.get("modified_epoch") or 0.0),
                 item["repo_id"] == legacy.FLAGSHIP_SPACE,

--- a/.github/scripts/test_hf_estate_canonicalize.py
+++ b/.github/scripts/test_hf_estate_canonicalize.py
@@ -10,13 +10,13 @@ SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-command_centers = importlib.import_module("hf_estate_canonicalize")
+single = importlib.import_module("hf_estate_canonicalize")
 
 
-class CommandCenterEstateContractTests(unittest.TestCase):
-    def test_exact_public_clone_keep_set(self) -> None:
+class SingleA11oyEstateContractTests(unittest.TestCase):
+    def test_exact_historical_clone_set(self) -> None:
         self.assertEqual(
-            command_centers.MANAGED_CLONE_IDS,
+            single.HISTORICAL_CLONE_IDS,
             (
                 "SZLHOLDINGS/a11oy-clone-1",
                 "SZLHOLDINGS/a11oy-clone-2",
@@ -25,71 +25,81 @@ class CommandCenterEstateContractTests(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            command_centers.KEEP_SPACE_IDS,
-            frozenset(
-                {
-                    "SZLHOLDINGS/a11oy",
-                    "SZLHOLDINGS/a11oy-clone-1",
-                    "SZLHOLDINGS/a11oy-clone-2",
-                    "SZLHOLDINGS/a11oy-clone-3",
-                    "SZLHOLDINGS/a11oy-clone-4",
-                }
-            ),
+            single.CANDIDATE_IDS,
+            ("SZLHOLDINGS/a11oy", *single.HISTORICAL_CLONE_IDS),
         )
 
-    def test_inherited_collection_builder_keeps_clones(self) -> None:
-        self.assertEqual(
-            command_centers.legacy.CLONE_IDS,
-            list(command_centers.MANAGED_CLONE_IDS),
-        )
+    def test_inherited_clone_creator_is_disabled(self) -> None:
+        self.assertEqual(single.legacy.CLONE_IDS, [])
 
-    def test_quota_safe_clone_path(self) -> None:
+    def test_active_source_has_no_clone_creation_or_restoration_path(self) -> None:
         source = (SCRIPT_DIR / "hf_estate_canonicalize.py").read_text(
             encoding="utf-8"
         )
-        self.assertNotIn("duplicate_repo(", source)
-        self.assertNotIn("duplicate_space(", source)
-        self.assertIn("create_repo(", source)
-        self.assertIn("update_repo_settings", source)
-        self.assertIn("delete-surplus-duplicate", source)
+        for forbidden in (
+            "duplicate_repo(",
+            "duplicate_space(",
+            "_create_missing_clone",
+            "update_repo_settings",
+            "clone-visibility",
+            "clone-refresh",
+            "MANAGED_CLONE_IDS",
+            "KEEP_SPACE_IDS",
+            "Retain four public",
+            "restore-four-public-a11oy",
+        ):
+            self.assertNotIn(forbidden, source)
+        self.assertIn("select-newest-a11oy-source", source)
+        self.assertIn("retire-a11oy-clone", source)
+        self.assertIn("delete_repo(", source)
 
-    def test_narrow_name_match_does_not_select_unrelated_spaces(self) -> None:
-        self.assertIsNotNone(
-            command_centers.DUPLICATE_NAME.fullmatch(
-                "SZLHOLDINGS/a11oy-copy-99"
-            )
-        )
-        self.assertIsNotNone(
-            command_centers.DUPLICATE_NAME.fullmatch(
-                "SZLHOLDINGS/a11oy-duplicate-2"
-            )
-        )
-        self.assertIsNone(
-            command_centers.DUPLICATE_NAME.fullmatch(
-                "SZLHOLDINGS/a11oy-research-lab"
-            )
-        )
-        self.assertIn(
-            "SZLHOLDINGS/a11oy-clone-1",
-            command_centers.KEEP_SPACE_IDS,
-        )
+    def test_timestamp_ordering(self) -> None:
+        older = single._modified_epoch("2026-07-22T01:00:00Z")
+        newer = single._modified_epoch("2026-07-22T02:00:00+00:00")
+        self.assertGreater(newer, older)
+        self.assertEqual(single._modified_epoch("not-a-time"), 0.0)
 
-    def test_workflow_executes_command_center_reconciler(self) -> None:
-        workflow = (
-            SCRIPT_DIR.parent / "workflows" / "hf-estate-upgrade.yml"
-        ).read_text(encoding="utf-8")
+    def test_workflow_has_one_single_space_publisher(self) -> None:
+        workflow_dir = SCRIPT_DIR.parent / "workflows"
+        workflow = (workflow_dir / "hf-estate-upgrade.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("sole governed A11oy Space", workflow)
         self.assertIn("hf_estate_canonicalize.py", workflow)
-        self.assertIn("Retain four public A11oy command centers", workflow)
-        self.assertNotIn("retired_clone_ids", workflow)
+        self.assertNotIn("Retain four public A11oy command centers", workflow)
+        self.assertNotIn("managed_clone_ids", workflow)
+        self.assertNotIn("restore-public-a11oy-clones", workflow)
 
-    def test_runtime_stage_normalization(self) -> None:
-        class Runtime:
-            stage = "SpaceStage.RUNNING"
+        publisher_hits = []
+        for path in workflow_dir.glob("*.yml"):
+            text = path.read_text(encoding="utf-8")
+            if "hf_estate_canonicalize.py" in text:
+                publisher_hits.append(path.name)
+            self.assertNotIn(
+                "python .github/scripts/hf_estate_upgrade.py",
+                text,
+                msg=f"base clone-capable publisher invoked directly in {path.name}",
+            )
+            self.assertNotIn(
+                "restore-four-public-a11oy-command-centers",
+                text,
+                msg=f"stale restoration branch in {path.name}",
+            )
+            self.assertNotIn(
+                "c2549d77d900ad3df86794b3e8b2098ad908cf97",
+                text,
+                msg=f"stale four-clone restore revision in {path.name}",
+            )
+        self.assertEqual(publisher_hits, ["hf-estate-upgrade.yml"])
 
-        class Info:
-            runtime = Runtime()
-
-        self.assertEqual(command_centers._runtime_stage(Info()), "RUNNING")
+    def test_no_clone_restore_workflow_exists(self) -> None:
+        workflow_dir = SCRIPT_DIR.parent / "workflows"
+        forbidden = (
+            "restore-public-a11oy-clones.yml",
+            "estate-finalization.yml",
+        )
+        for name in forbidden:
+            self.assertFalse((workflow_dir / name).exists(), name)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_hf_estate_canonicalize.py
+++ b/.github/scripts/test_hf_estate_canonicalize.py
@@ -50,6 +50,7 @@ class SingleA11oyEstateContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, source)
         self.assertIn("select-newest-a11oy-source", source)
+        self.assertIn('item.get("stage") == "RUNNING"', source)
         self.assertIn("retire-a11oy-clone", source)
         self.assertIn("delete_repo(", source)
 

--- a/.github/scripts/test_hf_estate_canonicalize.py
+++ b/.github/scripts/test_hf_estate_canonicalize.py
@@ -55,10 +55,10 @@ class SingleA11oyEstateContractTests(unittest.TestCase):
         self.assertIn("delete_repo(", source)
 
     def test_timestamp_ordering(self) -> None:
-        older = single._modified_epoch("2026-07-22T01:00:00Z")
-        newer = single._modified_epoch("2026-07-22T02:00:00+00:00")
+        older = single._epoch("2026-07-22T01:00:00Z")
+        newer = single._epoch("2026-07-22T02:00:00+00:00")
         self.assertGreater(newer, older)
-        self.assertEqual(single._modified_epoch("not-a-time"), 0.0)
+        self.assertEqual(single._epoch("not-a-time"), 0.0)
 
     def test_workflow_has_one_single_space_publisher(self) -> None:
         workflow_dir = SCRIPT_DIR.parent / "workflows"

--- a/.github/workflows/hf-estate-upgrade.yml
+++ b/.github/workflows/hf-estate-upgrade.yml
@@ -1,7 +1,9 @@
-name: HF Estate Command Centers
+name: HF Estate — Single A11oy Canonicalization
 
-# Organization-wide Hugging Face maintenance with one canonical A11oy production
-# Space and four public, synchronized recovery/showcase command centers.
+# One governed A11oy Space only. Pull requests are authenticated dry runs.
+# Protected-main pushes adopt the newest valid A11oy content into the canonical
+# repository, remove clone collection references, and delete the four exact
+# historical clone repositories.
 on:
   push:
     branches: [main]
@@ -20,42 +22,54 @@ on:
   workflow_dispatch:
     inputs:
       publish:
-        description: Apply the estate reconciliation rather than run a dry run
+        description: Apply single-Space reconciliation instead of a dry run
         required: false
         default: "true"
 
 permissions:
-  contents: write
+  contents: read
+  issues: write
 
 concurrency:
-  group: hf-estate-command-centers-${{ github.event_name }}-${{ github.ref }}
+  group: hf-estate-single-a11oy-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   reconcile:
-    name: Retain four public A11oy command centers
+    name: Enforce the sole governed A11oy Space
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       HF_HUB_DISABLE_PROGRESS_BARS: "1"
-      TARGET_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+      REPORT_ISSUE_TITLE: "[hf-canonicalization-report] single governed A11oy Space"
     steps:
       - name: Checkout triggering revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           fetch-depth: 1
+          persist-credentials: false
 
-      - name: Record credential preflight
+      - name: Determine execution mode
+        id: mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          if [ "${{ github.event_name }}" = "push" ]; then
+            publish=true
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" = "true" ]; then
+            publish=true
+          fi
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Hugging Face credential without exposing it
         id: credentials
         shell: bash
         run: |
           set -euo pipefail
-          publish=true
-          if [ "${{ github.event_name }}" = "pull_request" ]; then publish=false; fi
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then publish=false; fi
           if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
             echo "has_token=false" >> "$GITHUB_OUTPUT"
             mkdir -p reports
@@ -64,35 +78,26 @@ jobs:
             "schema": "szl.hf-estate-upgrade-report/v1",
             "organization": "SZLHOLDINGS",
             "generation": "${GITHUB_SHA}",
-            "publish": ${publish},
+            "publish": ${{ steps.mode.outputs.publish }},
             "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "counts": {},
-            "canonical_flagship_space": {
-              "repo_id": "SZLHOLDINGS/a11oy"
-            },
-            "managed_clone_ids": [
+            "canonical_flagship_space": {"repo_id": "SZLHOLDINGS/a11oy"},
+            "retired_clone_ids": [
               "SZLHOLDINGS/a11oy-clone-1",
               "SZLHOLDINGS/a11oy-clone-2",
               "SZLHOLDINGS/a11oy-clone-3",
               "SZLHOLDINGS/a11oy-clone-4"
             ],
-            "collections": {},
-            "actions": [
-              {
-                "target": "SZLHOLDINGS",
-                "action": "credential-preflight",
-                "status": "error",
-                "detail": "No supported Hugging Face Actions secret is configured for this repository."
-              }
-            ],
-            "summary": {
-              "ok": 0,
-              "warning": 0,
-              "error": 1,
-              "dry_run": 0
-            },
+            "clone_ids": [],
+            "actions": [{
+              "target": "SZLHOLDINGS",
+              "action": "credential-preflight",
+              "status": "error",
+              "detail": "No supported Hugging Face Actions secret is configured."
+            }],
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
             "boundaries": [
-              "No Hugging Face mutation was attempted without an authenticated org-scoped write token."
+              "No Hub mutation was attempted without an authenticated org-scoped write token.",
+              "SZLHOLDINGS/a11oy is the sole governed A11oy Space."
             ]
           }
           JSON
@@ -114,7 +119,7 @@ jobs:
             "huggingface_hub>=1.3,<2" \
             "requests>=2.32,<3"
 
-      - name: Verify command-center estate contract
+      - name: Verify permanent no-clone contract
         if: steps.credentials.outputs.has_token == 'true'
         run: |
           python -m py_compile \
@@ -123,17 +128,15 @@ jobs:
             .github/scripts/test_hf_estate_canonicalize.py
           python .github/scripts/test_hf_estate_canonicalize.py
 
-      - name: Execute command-center estate reconciliation
+      - name: Reconcile single A11oy Space
         if: steps.credentials.outputs.has_token == 'true'
         id: estate
         shell: bash
         run: |
           set +e
-          publish_flag="--publish"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            publish_flag=""
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then
-            publish_flag=""
+          publish_flag=""
+          if [ "${{ steps.mode.outputs.publish }}" = "true" ]; then
+            publish_flag="--publish"
           fi
           python .github/scripts/hf_estate_canonicalize.py \
             ${publish_flag} \
@@ -142,33 +145,51 @@ jobs:
           echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
           exit 0
 
-      - name: Upload pull-request dry-run evidence
-        if: always() && github.event_name == 'pull_request'
+      - name: Upload immutable reconciliation report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: hf-estate-command-centers-dry-run-${{ github.run_id }}
+          name: hf-single-a11oy-${{ github.run_id }}
           path: reports/hf-estate-upgrade-latest.json
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
 
-      - name: Commit the evidence report
-        if: always() && github.event_name != 'pull_request'
+      - name: Persist published result in deterministic issue
+        if: always() && steps.mode.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ ! -f reports/hf-estate-upgrade-latest.json ]; then
-            echo "::warning::No estate report was produced."
-            exit 0
+          test -f reports/hf-estate-upgrade-latest.json
+          {
+            echo '<!-- szl-single-a11oy-report -->'
+            echo '# Single governed A11oy reconciliation'
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Source revision: \`${GITHUB_SHA}\`"
+            echo
+            echo '```json'
+            cat reports/hf-estate-upgrade-latest.json
+            echo '```'
+          } > /tmp/hf-single-a11oy.md
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --search "${REPORT_ISSUE_TITLE} in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
+            | head -n1)"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/hf-single-a11oy.md
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$REPORT_ISSUE_TITLE" \
+              --body-file /tmp/hf-single-a11oy.md
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add reports/hf-estate-upgrade-latest.json
-          if git diff --cached --quiet; then
-            echo "Report is unchanged."
-            exit 0
-          fi
-          git commit -s -m "chore(hf): record command-center estate report [skip ci]"
-          git push origin "HEAD:${TARGET_BRANCH}"
 
       - name: Publish job summary
         if: always()
@@ -181,34 +202,18 @@ jobs:
 
           path = Path("reports/hf-estate-upgrade-latest.json")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as out:
-              out.write("## Hugging Face command-center estate\n\n")
+              out.write("## Single governed A11oy Space\n\n")
               if not path.exists():
                   out.write("No report was produced.\n")
               else:
                   report = json.loads(path.read_text(encoding="utf-8"))
-                  out.write(f"Generation: `{report.get('generation')}`\n\n")
-                  canonical = report.get("canonical_flagship_space", {})
+                  canonical = report.get("canonical_flagship_space") or {}
                   out.write(
-                      "Canonical A11oy: "
-                      f"`{canonical.get('repo_id', 'UNKNOWN')}` "
+                      f"Canonical: `{canonical.get('repo_id', 'UNKNOWN')}` "
                       f"at `{canonical.get('sha', 'UNVERIFIED')}` "
                       f"({canonical.get('stage', 'UNKNOWN')})\n\n"
                   )
-                  clones = report.get("managed_clone_snapshots", {})
-                  out.write("| Retained clone | Visibility | Runtime | Revision |\n")
-                  out.write("|---|---|---|---|\n")
-                  for repo_id in report.get("managed_clone_ids", []):
-                      item = clones.get(repo_id, {})
-                      visibility = "public" if item.get("private") is False else "unknown"
-                      out.write(
-                          f"| `{repo_id}` | {visibility} | "
-                          f"{item.get('stage', 'UNKNOWN')} | "
-                          f"`{item.get('sha', 'UNVERIFIED')}` |\n"
-                      )
-                  out.write("\n| Inventory | Count |\n|---|---:|\n")
-                  for key, value in report.get("counts", {}).items():
-                      out.write(f"| {key} | {value} |\n")
-                  out.write("\n| Result | Count |\n|---|---:|\n")
+                  out.write("| Result | Count |\n|---|---:|\n")
                   for key, value in report.get("summary", {}).items():
                       out.write(f"| {key} | {value} |\n")
           PY
@@ -223,6 +228,7 @@ jobs:
           code="${{ steps.estate.outputs.exit_code }}"
           if [ -z "$code" ]; then code=2; fi
           if [ "$code" -ne 0 ]; then
-            echo "::error::Estate reconciliation completed with exit code $code; inspect the committed report."
+            echo "::error::Single-A11oy reconciliation failed with exit ${code}; inspect the uploaded report."
             exit "$code"
           fi
+          echo "Single-A11oy reconciliation completed successfully."


### PR DESCRIPTION
Superseded by merged PR #247 (`fix(hf): enforce one canonical A11oy Space`) and protected-main execution report #239.

The authenticated main run published with `publish: true`, retained only `SZLHOLDINGS/a11oy`, removed clone collection references, deleted `a11oy-clone-1` through `a11oy-clone-4`, verified their absence, and reduced the final Space inventory from 30 to 26. The active publisher now forces the inherited clone list to empty and contains no clone creation, refresh, visibility-change, or restoration path.

This branch is closed without merge to avoid reapplying an older conflicting implementation.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>