### PR TITLE
ops(notifications): clear personal GitHub inbox to zero

### DIFF
--- a/.github/scripts/clear_personal_notifications.py
+++ b/.github/scripts/clear_personal_notifications.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Clear the authenticated GitHub user's unread notification inbox.
+
+The script records counts only. It never logs notification subjects, repository
+names, URLs, or token material. Bulk clearing is followed by an exact unread
+inventory and an individual-thread fallback so the final count must be zero.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+API = "https://api.github.com"
+API_VERSION = "2022-11-28"
+PER_PAGE = 100
+MAX_PAGES = 100
+MAX_ATTEMPTS = 5
+
+
+class NotificationError(RuntimeError):
+    """Fail-closed notification API error."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def request(
+    token: str,
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        API + path,
+        data=body,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": API_VERSION,
+            "User-Agent": "szl-clear-personal-notifications/1.0",
+            **({"Content-Type": "application/json"} if body is not None else {}),
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as response:
+            raw = response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:2000]
+        raise NotificationError(
+            f"GitHub API {method} {path} failed HTTP {exc.code}: {detail}"
+        ) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise NotificationError(
+            f"GitHub API {method} {path} failed: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    if not raw:
+        return status, None
+    try:
+        return status, json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise NotificationError(
+            f"GitHub API {method} {path} returned non-JSON content"
+        ) from exc
+
+
+def unread_thread_ids(token: str) -> list[str]:
+    ids: list[str] = []
+    for page in range(1, MAX_PAGES + 1):
+        query = urllib.parse.urlencode(
+            {
+                "all": "false",
+                "participating": "false",
+                "per_page": PER_PAGE,
+                "page": page,
+            }
+        )
+        _, payload = request(token, "GET", f"/notifications?{query}")
+        if not isinstance(payload, list):
+            raise NotificationError("GitHub notifications endpoint returned a non-list")
+        for item in payload:
+            thread_id = str((item or {}).get("id") or "")
+            if not thread_id:
+                raise NotificationError("GitHub returned a notification without a thread id")
+            ids.append(thread_id)
+        if len(payload) < PER_PAGE:
+            return ids
+    raise NotificationError(
+        f"Unread inventory exceeded the fail-closed limit of {MAX_PAGES * PER_PAGE}"
+    )
+
+
+def mark_all_read(token: str) -> int:
+    status, _ = request(
+        token,
+        "PUT",
+        "/notifications",
+        {"last_read_at": utc_now()},
+    )
+    if status not in {202, 205}:
+        raise NotificationError(f"Unexpected bulk-clear response status: {status}")
+    return status
+
+
+def mark_thread_read(token: str, thread_id: str) -> None:
+    status, _ = request(
+        token,
+        "PATCH",
+        f"/notifications/threads/{urllib.parse.quote(thread_id, safe='')}",
+        {"read": True},
+    )
+    if status not in {200, 205}:
+        raise NotificationError(
+            f"Unexpected thread-clear response status for {thread_id}: {status}"
+        )
+
+
+def clear_inbox(token: str) -> dict[str, Any]:
+    _, user = request(token, "GET", "/user")
+    identity = str((user or {}).get("login") or "")
+    if not identity:
+        raise NotificationError("Authenticated GitHub identity did not expose a login")
+
+    before_ids = unread_thread_ids(token)
+    bulk_attempts = 0
+    fallback_threads = 0
+    remaining = before_ids
+
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        bulk_attempts = attempt
+        mark_all_read(token)
+        time.sleep(2)
+        remaining = unread_thread_ids(token)
+        if not remaining:
+            break
+
+        for thread_id in remaining:
+            mark_thread_read(token, thread_id)
+            fallback_threads += 1
+        time.sleep(2)
+        remaining = unread_thread_ids(token)
+        if not remaining:
+            break
+
+    if remaining:
+        mark_all_read(token)
+        time.sleep(3)
+        remaining = unread_thread_ids(token)
+
+    if remaining:
+        raise NotificationError(
+            f"Unread inbox did not converge to zero; remaining_count={len(remaining)}"
+        )
+
+    return {
+        "schema": "szl.github-notification-clearance/v1",
+        "generated_at": utc_now(),
+        "identity": identity,
+        "before_unread_count": len(before_ids),
+        "after_unread_count": 0,
+        "cleared_count": len(before_ids),
+        "bulk_attempts": bulk_attempts,
+        "individual_thread_fallbacks": fallback_threads,
+        "notification_content_recorded": False,
+        "status": "CLEARED",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+
+    report: dict[str, Any]
+    code = 1
+    token = (
+        os.environ.get("GH_NOTIFICATIONS_TOKEN", "").strip()
+        or os.environ.get("SZL_GITHUB_TOKEN", "").strip()
+    )
+    try:
+        if not token:
+            raise NotificationError(
+                "GH_NOTIFICATIONS_TOKEN/SZL_GITHUB_TOKEN is not configured"
+            )
+        report = clear_inbox(token)
+        code = 0
+    except Exception as exc:  # noqa: BLE001
+        report = {
+            "schema": "szl.github-notification-clearance/v1",
+            "generated_at": utc_now(),
+            "after_unread_count": None,
+            "notification_content_recorded": False,
+            "status": "FAILED",
+            "errors": [f"{type(exc).__name__}: {exc}"],
+        }
+    finally:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/clear-personal-notifications.yml
+++ b/.github/workflows/clear-personal-notifications.yml
@@ -1,0 +1,102 @@
+name: GitHub Notification Inbox Zero
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/clear_personal_notifications.py
+      - .github/workflows/clear-personal-notifications.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-personal-notification-clearance
+  cancel-in-progress: false
+
+jobs:
+  clear:
+    name: Count, clear, and verify zero unread notifications
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_NOTIFICATIONS_TOKEN: ${{ secrets.GH_NOTIFICATIONS_TOKEN || secrets.SZL_GITHUB_TOKEN }}
+    steps:
+      - name: Checkout control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Validate notification clearer
+        run: |
+          set -euo pipefail
+          python -m py_compile .github/scripts/clear_personal_notifications.py
+          test -n "${GH_NOTIFICATIONS_TOKEN:-}" || {
+            echo '::error::No user token is configured. Add GH_NOTIFICATIONS_TOKEN with Notifications: read/write, or grant that permission to SZL_GITHUB_TOKEN.'
+            exit 2
+          }
+
+      - name: Clear authenticated user notification inbox
+        id: clearance
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/clear_personal_notifications.py \
+            --report github-notification-clearance.json
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload count-only clearance receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-notification-clearance-${{ github.run_id }}
+          path: github-notification-clearance.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish count-only summary
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path('github-notification-clearance.json')
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as out:
+              out.write('## GitHub notification inbox clearance\n\n')
+              if not path.exists():
+                  out.write('No clearance report was produced.\n')
+              else:
+                  report = json.loads(path.read_text(encoding='utf-8'))
+                  out.write(f"Status: **{report.get('status', 'UNKNOWN')}**\n\n")
+                  out.write(f"Authenticated identity: `{report.get('identity', 'UNAVAILABLE')}`\n\n")
+                  out.write(f"Unread before: **{report.get('before_unread_count', 'UNAVAILABLE')}**\n\n")
+                  out.write(f"Unread after: **{report.get('after_unread_count', 'UNAVAILABLE')}**\n\n")
+                  out.write('Notification subjects, repository names, URLs, and token material were not recorded.\n')
+          PY
+
+      - name: Enforce zero unread result
+        if: always()
+        run: |
+          code="${{ steps.clearance.outputs.exit_code }}"
+          if [ -z "$code" ]; then code=2; fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Notification clearance failed closed with exit ${code}; inspect the count-only artifact."
+            exit "$code"
+          fi
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('github-notification-clearance.json').read_text())
+          assert report['status'] == 'CLEARED'
+          assert report['after_unread_count'] == 0
+          print(f"Cleared {report['cleared_count']} unread notifications; verified final count 0.")
+          PY


### PR DESCRIPTION
## Outcome

Adds a count-only, fail-closed clearance lane for the authenticated GitHub user's notification inbox.

- inventories every unread notification thread through the personal Notifications API;
- records counts only—never subjects, repository names, URLs, or token material;
- marks all notifications read;
- individually clears any API-lagged or concurrently-created unread threads;
- performs a final bulk pass and refuses success unless the exact unread count is `0`;
- publishes only a retained count receipt as a GitHub Actions artifact.

## Credential boundary

The protected-main run uses `GH_NOTIFICATIONS_TOKEN` when configured, otherwise the existing `SZL_GITHUB_TOKEN`. The token must have Notifications read/write permission. Pull-request checks do not touch the inbox because this workflow triggers only on protected-main push or explicit manual dispatch.

## Safety

- does not unsubscribe from repositories;
- does not delete issues, pull requests, releases, discussions, or notification threads;
- does not expose notification content;
- does not weaken branch protections or required checks;
- fails closed on missing permission, API errors, pagination overflow, or a non-zero final unread count.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>