### PR TITLE
fix(hf): make release evidence execution deterministic

### DIFF
--- a/.github/workflows/finalize-hf-release-evidence-now.yml
+++ b/.github/workflows/finalize-hf-release-evidence-now.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/finalize-hf-release-evidence-now.yml
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 concurrency:
@@ -37,6 +37,7 @@ jobs:
             echo '::error::No supported Hugging Face organization write token is configured.'
             exit 2
           fi
+
       - name: Checkout current release controller
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -45,6 +46,7 @@ jobs:
           token: ${{ env.SZL_GITHUB_TOKEN }}
           path: controller
           fetch-depth: 0
+
       - name: Checkout merged Lake source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -53,6 +55,7 @@ jobs:
           token: ${{ env.SZL_GITHUB_TOKEN }}
           path: lake
           fetch-depth: 0
+
       - name: Checkout merged energy-kernel source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -61,6 +64,7 @@ jobs:
           token: ${{ env.SZL_GITHUB_TOKEN }}
           path: energy
           fetch-depth: 0
+
       - name: Checkout merged governed-norm source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -69,10 +73,12 @@ jobs:
           token: ${{ env.SZL_GITHUB_TOKEN }}
           path: lambda-gate
           fetch-depth: 0
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
       - name: Install pinned release clients and test dependencies
         run: |
           python -m pip install --disable-pip-version-check \
@@ -82,6 +88,7 @@ jobs:
             "pytest>=8,<9" \
             "pyarrow>=18,<24" \
             "PyYAML>=6,<7"
+
       - name: Verify source lineage and contracts
         shell: bash
         run: |
@@ -97,6 +104,7 @@ jobs:
           PYTHONPATH=energy python -m pytest -q energy/tests/test_hf_kernel_contract.py
           PYTHONPATH=lambda-gate/torch-ext:lambda-gate \
             python -m pytest -q lambda-gate/tests/test_hf_governed_norm_contract.py
+
       - name: Publish and independently read back exact Hub revisions
         id: release
         shell: bash
@@ -120,7 +128,49 @@ jobs:
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
-      - name: Persist machine-readable report and remove one-shot executors
+
+      - name: Guarantee a machine-readable outcome
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          report=controller/reports/hf-release-finalization-latest.json
+          if [ -f "$report" ]; then
+            exit 0
+          fi
+          mkdir -p controller/reports
+          EXIT_CODE="${{ steps.release.outputs.exit_code }}" python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          raw = os.environ.get("EXIT_CODE", "")
+          code = int(raw) if raw.isdigit() else 2
+          report = {
+              "schema": "szl.hf-release-finalization/v1",
+              "generation": os.environ.get("GITHUB_SHA"),
+              "generated_at": datetime.now(timezone.utc).isoformat(),
+              "publish": True,
+              "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+              "errors": ["Release controller exited before producing its normal report."],
+              "exit_code": code,
+          }
+          Path("controller/reports/hf-release-finalization-latest.json").write_text(
+              json.dumps(report, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload immutable release evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-release-finalization-${{ github.run_id }}
+          path: controller/reports/hf-release-finalization-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist deterministic release report
         if: always()
         env:
           GH_TOKEN: ${{ env.SZL_GITHUB_TOKEN }}
@@ -147,8 +197,9 @@ jobs:
           if [ -n "$issue" ]; then
             gh issue edit "$issue" --repo "$GITHUB_REPOSITORY" --body-file /tmp/report.md
           else
-            issue="$(gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "$REPORT_TITLE" --body-file /tmp/report.md --json number --jq .number)"
+            issue_url="$(gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$REPORT_TITLE" --body-file /tmp/report.md)"
+            issue="${issue_url##*/}"
           fi
           if [ "${{ steps.release.outputs.exit_code }}" = "0" ]; then
             gh issue close "$issue" --repo "$GITHUB_REPOSITORY" --reason completed \
@@ -156,21 +207,7 @@ jobs:
           else
             gh issue reopen "$issue" --repo "$GITHUB_REPOSITORY" || true
           fi
-          cd controller
-          rm -f .github/workflows/finalize-hf-release-evidence-now.yml
-          rm -f .github/workflows/execute-hf-finalizer-243.yml
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add reports/hf-release-finalization-latest.json \
-            .github/workflows/finalize-hf-release-evidence-now.yml \
-            .github/workflows/execute-hf-finalizer-243.yml
-          if ! git diff --cached --quiet; then
-            git commit \
-              -m 'chore(hf): persist release evidence and remove one-shot executors' \
-              -m "Run ${GITHUB_RUN_ID}; exit ${{ steps.release.outputs.exit_code }}." \
-              -m 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
-            git push origin HEAD:main
-          fi
+
       - name: Enforce fail-closed publication result
         if: always()
         run: |


### PR DESCRIPTION
## Outcome

Execute the merged Lake Viewer and first-class kernel publication controller from protected main with a deterministic, machine-readable result in every case.

- verifies exact source lineage and source contracts before any Hub write;
- publishes and reads back the Lake dataset and both kernel cards;
- requires live Dataset Viewer HTTP 200 and both kernel `selfcheck()` passes;
- guarantees an Actions artifact and deterministic report issue even on early failure;
- fixes issue creation without relying on unsupported CLI output flags;
- leaves one-shot workflow cleanup for a separate reviewed change after completion.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>