### PR TITLE
fix(hf): use official collection and bucket inventory APIs [superseded—clone topology prohibited]

### DIFF
--- a/.github/scripts/hf_estate_command_centers_v2.py
+++ b/.github/scripts/hf_estate_command_centers_v2.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Hugging Face estate command-center reconciler using supported Hub APIs.
+
+This second-generation entrypoint retains the canonical A11oy production Space
+and four public CPU-basic recovery/showcase command centers while removing the
+two known inventory blind spots in the legacy publisher:
+
+* Collections are listed with ``HfApi.list_collections`` rather than an invalid
+  raw ``/api/collections?namespace=...`` request.
+* Buckets are listed and validated with ``HfApi.list_buckets`` and
+  ``HfApi.bucket_info`` rather than the obsolete raw ``/api/buckets`` path.
+
+Free CPU Basic Spaces use Hugging Face's platform-managed sleep policy; this
+entrypoint never submits a custom sleep time for CPU Basic. All existing safety
+boundaries from ``hf_estate_canonicalize.CommandCenterEstateUpgrade`` remain in
+force.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import hf_estate_canonicalize as command_centers
+
+legacy = command_centers.legacy
+
+
+def _record_from_object(value: Any) -> dict[str, Any]:
+    """Convert Hub dataclasses into a small stable inventory record."""
+    if isinstance(value, dict):
+        return dict(value)
+    record: dict[str, Any] = {}
+    for field in (
+        "id",
+        "slug",
+        "title",
+        "name",
+        "private",
+        "sha",
+        "size",
+        "total_files",
+        "created_at",
+        "last_modified",
+    ):
+        item = getattr(value, field, None)
+        if item is not None:
+            record[field] = item.isoformat() if hasattr(item, "isoformat") else item
+    identifier = record.get("id") or record.get("slug") or record.get("name")
+    if identifier is not None:
+        record["id"] = str(identifier)
+    return record
+
+
+def _records(values: Iterable[Any]) -> list[dict[str, Any]]:
+    return [_record_from_object(value) for value in values]
+
+
+class CommandCenterEstateUpgradeV2(command_centers.CommandCenterEstateUpgrade):
+    """Full estate maintenance with official Collections and Buckets APIs."""
+
+    def collect_inventory(self) -> dict[str, list[dict[str, Any]]]:
+        endpoints = {
+            "models": f"{legacy.HF_BASE}/api/models?author={legacy.ORG}&limit=1000&full=true",
+            "datasets": f"{legacy.HF_BASE}/api/datasets?author={legacy.ORG}&limit=1000&full=true",
+            "spaces": f"{legacy.HF_BASE}/api/spaces?author={legacy.ORG}&limit=1000&full=true",
+            "kernels": f"{legacy.HF_BASE}/api/kernels?author={legacy.ORG}&limit=1000",
+        }
+        for kind, endpoint in endpoints.items():
+            try:
+                self.inventory[kind] = self._paginate(endpoint)
+                self.record(
+                    legacy.ORG,
+                    f"inventory:{kind}",
+                    "ok",
+                    f"count={len(self.inventory[kind])}",
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.inventory[kind] = []
+                self.record(legacy.ORG, f"inventory:{kind}", "error", repr(exc)[:300])
+
+        try:
+            self.inventory["collections"] = _records(
+                self.api.list_collections(owner=legacy.ORG, limit=1000)
+            )
+            self.record(
+                legacy.ORG,
+                "inventory:collections",
+                "ok",
+                f"count={len(self.inventory['collections'])}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.inventory["collections"] = []
+            self.record(legacy.ORG, "inventory:collections", "error", repr(exc)[:300])
+
+        try:
+            self.inventory["buckets"] = _records(
+                self.api.list_buckets(namespace=legacy.ORG)
+            )
+            self.record(
+                legacy.ORG,
+                "inventory:buckets",
+                "ok",
+                f"count={len(self.inventory['buckets'])}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.inventory["buckets"] = []
+            self.record(legacy.ORG, "inventory:buckets", "error", repr(exc)[:300])
+        return self.inventory
+
+    def _create_missing_clone(self, clone_id: str) -> None:
+        if not self.publish:
+            self.record(
+                clone_id,
+                "flagship-clone",
+                "dry-run",
+                "would create public CPU Basic Space with platform-managed sleep",
+            )
+            return
+        self.api.create_repo(
+            repo_id=clone_id,
+            repo_type="space",
+            private=False,
+            exist_ok=True,
+            space_sdk="docker",
+            space_hardware="cpu-basic",
+        )
+        if not self.api.repo_exists(clone_id, repo_type="space"):
+            raise RuntimeError(f"Clone creation did not produce repository: {clone_id}")
+        self.record(
+            clone_id,
+            "flagship-clone",
+            "created",
+            "public CPU Basic; platform-managed free-hardware sleep policy",
+        )
+
+    def validate_collections(self) -> None:
+        """Read back every managed collection and verify all repository items resolve."""
+        for title, slug in self.collections.items():
+            try:
+                collection = self.api.get_collection(slug)
+                unresolved: list[str] = []
+                checked = 0
+                for item in collection.items:
+                    item_type = str(item.item_type)
+                    item_id = str(item.item_id)
+                    if item_type not in {"model", "dataset", "space"}:
+                        continue
+                    checked += 1
+                    try:
+                        exists = self.api.repo_exists(item_id, repo_type=item_type)
+                    except Exception:  # noqa: BLE001
+                        exists = False
+                    if not exists:
+                        unresolved.append(f"{item_type}:{item_id}")
+                if unresolved:
+                    self.record(
+                        slug,
+                        "collection-resolution",
+                        "error",
+                        f"title={title}; unresolved={unresolved[:20]}",
+                    )
+                else:
+                    self.record(
+                        slug,
+                        "collection-resolution",
+                        "validated",
+                        f"title={title}; resolving_items={checked}",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                self.record(slug, "collection-resolution", "error", repr(exc)[:300])
+
+    def validate_buckets(self) -> None:
+        """Read back visibility, size, and file count for every organization bucket."""
+        for item in self.inventory.get("buckets", []):
+            bucket_id = str(item.get("id") or item.get("name") or "")
+            if not bucket_id:
+                self.record(legacy.ORG, "bucket-contract", "error", "bucket without id")
+                continue
+            try:
+                info = self.api.bucket_info(bucket_id)
+                size = getattr(info, "size", None)
+                total_files = getattr(info, "total_files", None)
+                private = getattr(info, "private", None)
+                self.record(
+                    bucket_id,
+                    "bucket-contract",
+                    "validated",
+                    f"private={private}; size={size}; total_files={total_files}",
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.record(bucket_id, "bucket-contract", "error", repr(exc)[:300])
+
+    def run(self) -> dict[str, Any]:
+        self.authenticate()
+        self.collect_inventory()
+        self.upgrade_models_and_datasets()
+        self.upgrade_spaces()
+        self.create_or_refresh_clones()
+        self.upgrade_collections()
+        self.validate_collections()
+        self.validate_kernels()
+        self.validate_buckets()
+        report = self.report()
+        self.publish_report(report)
+        report = self.report()
+        with open("reports/hf-estate-upgrade-latest.json", "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--generation",
+        default=os.environ.get("GITHUB_SHA") or f"manual-{int(time.time())}",
+    )
+    args = parser.parse_args()
+
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print(
+            "FATAL: HF_ORG_TOKEN/HF_ORG_TOKEN1/HF_TOKEN is not set.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = CommandCenterEstateUpgradeV2(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        print(f"FATAL: {exc!r}", file=sys.stderr)
+        return 2
+
+    summary = report["summary"]
+    print(json.dumps(summary, indent=2))
+    return 1 if summary["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/hf_estate_official_inventory.py
+++ b/.github/scripts/hf_estate_official_inventory.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Run the SZLHOLDINGS Hub estate publisher with supported inventory APIs.
+
+The active estate reconciler remains authoritative for publication, clone
+synchronization, collection curation, kernel validation, and evidence writing.
+This wrapper replaces only inventory discovery so collection and bucket counts
+are obtained through the supported ``huggingface_hub`` client instead of
+unstable raw endpoints.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import json
+import os
+import sys
+import time
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Iterable
+
+import hf_estate_canonicalize as active
+
+ORG = active.legacy.ORG
+
+
+def _base_class():
+    for name in ("CommandCenterEstateUpgrade", "CanonicalEstateUpgrade"):
+        candidate = getattr(active, name, None)
+        if isinstance(candidate, type):
+            return candidate
+    raise RuntimeError("active Hugging Face estate reconciler class was not found")
+
+
+BaseEstateUpgrade = _base_class()
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if dataclasses.is_dataclass(value):
+        return {key: _json_safe(item) for key, item in dataclasses.asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        result = dict(value)
+    elif dataclasses.is_dataclass(value):
+        result = dataclasses.asdict(value)
+    else:
+        result = {}
+        raw = getattr(value, "__dict__", None)
+        if isinstance(raw, dict):
+            result.update({key: item for key, item in raw.items() if not key.startswith("_")})
+        for name in (
+            "id",
+            "modelId",
+            "repo_id",
+            "repoId",
+            "slug",
+            "name",
+            "owner",
+            "author",
+            "sha",
+            "sdk",
+            "private",
+            "lastModified",
+            "last_modified",
+            "size",
+            "num_files",
+            "file_count",
+            "bucket_id",
+        ):
+            if name not in result and hasattr(value, name):
+                result[name] = getattr(value, name)
+    result = _json_safe(result)
+    if not isinstance(result, dict):
+        raise TypeError(f"cannot normalize Hub object: {type(value).__name__}")
+    if not result.get("id"):
+        result["id"] = (
+            result.get("repo_id")
+            or result.get("repoId")
+            or result.get("slug")
+            or result.get("bucket_id")
+            or result.get("name")
+        )
+    if not result.get("lastModified") and result.get("last_modified"):
+        result["lastModified"] = result["last_modified"]
+    return result
+
+
+def _identifier(item: dict[str, Any]) -> str:
+    return str(
+        item.get("id")
+        or item.get("modelId")
+        or item.get("repo_id")
+        or item.get("slug")
+        or item.get("bucket_id")
+        or item.get("name")
+        or ""
+    )
+
+
+def _belongs_to_org(item: dict[str, Any]) -> bool:
+    identifier = _identifier(item)
+    owner = str(item.get("owner") or item.get("author") or "")
+    return (
+        identifier.upper() == ORG
+        or identifier.upper().startswith(ORG + "/")
+        or owner.upper() == ORG
+    )
+
+
+def _invoke_supported(api: Any, name: str, **preferred: Any) -> list[Any]:
+    method = getattr(api, name, None)
+    if not callable(method):
+        raise RuntimeError(f"installed huggingface_hub lacks HfApi.{name}()")
+    signature = inspect.signature(method)
+    kwargs = {
+        key: value
+        for key, value in preferred.items()
+        if key in signature.parameters and value is not None
+    }
+    return list(method(**kwargs))
+
+
+class OfficialInventoryEstateUpgrade(BaseEstateUpgrade):
+    """Active estate publisher with supported-client inventory discovery."""
+
+    def _inventory_kind(self, kind: str, method: str, **kwargs: Any) -> list[dict[str, Any]]:
+        items = [_mapping(item) for item in _invoke_supported(self.api, method, **kwargs)]
+        scoped = [item for item in items if _belongs_to_org(item)]
+        self.inventory[kind] = scoped
+        self.record(ORG, f"inventory:{kind}", "ok", f"count={len(scoped)}; api=HfApi.{method}")
+        return scoped
+
+    def _bucket_details(self, buckets: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+        info_method = getattr(self.api, "bucket_info", None)
+        if not callable(info_method):
+            return list(buckets)
+        signature = inspect.signature(info_method)
+        output: list[dict[str, Any]] = []
+        for summary in buckets:
+            identity = _identifier(summary)
+            if not identity:
+                output.append(summary)
+                continue
+            try:
+                if "bucket_id" in signature.parameters:
+                    detail = info_method(bucket_id=identity)
+                elif "bucket" in signature.parameters:
+                    detail = info_method(bucket=identity)
+                else:
+                    detail = info_method(identity)
+                merged = dict(summary)
+                merged.update(_mapping(detail))
+                output.append(merged)
+            except Exception as exc:  # retain the supported list result, fail honestly in detail
+                item = dict(summary)
+                item["detail_error"] = f"{type(exc).__name__}: {exc}"[:300]
+                output.append(item)
+        return output
+
+    def collect_inventory(self) -> dict[str, list[dict[str, Any]]]:
+        self.inventory = {}
+        self._inventory_kind("models", "list_models", author=ORG, full=True, limit=None)
+        self._inventory_kind("datasets", "list_datasets", author=ORG, full=True, limit=None)
+        self._inventory_kind("spaces", "list_spaces", author=ORG, full=True, limit=None)
+        self._inventory_kind("kernels", "list_kernels", author=ORG, owner=ORG, limit=None)
+        self._inventory_kind("collections", "list_collections", owner=ORG, namespace=ORG, limit=1000)
+
+        buckets = [_mapping(item) for item in _invoke_supported(
+            self.api,
+            "list_buckets",
+            owner=ORG,
+            namespace=ORG,
+            limit=1000,
+        )]
+        buckets = [item for item in buckets if _belongs_to_org(item)]
+        buckets = self._bucket_details(buckets)
+        self.inventory["buckets"] = buckets
+        self.record(
+            ORG,
+            "inventory:buckets",
+            "ok",
+            f"count={len(buckets)}; api=HfApi.list_buckets",
+        )
+        return self.inventory
+
+    def report(self) -> dict[str, Any]:
+        report = super().report()
+        report["inventory_api"] = {
+            "models": "HfApi.list_models",
+            "datasets": "HfApi.list_datasets",
+            "spaces": "HfApi.list_spaces",
+            "kernels": "HfApi.list_kernels",
+            "collections": "HfApi.list_collections",
+            "buckets": "HfApi.list_buckets + HfApi.bucket_info",
+        }
+        report["collection_reference_count"] = sum(
+            len(item.get("items") or [])
+            for item in self.inventory.get("collections", [])
+            if isinstance(item, dict)
+        )
+        report["bucket_observations"] = [
+            {
+                "id": _identifier(item),
+                "private": item.get("private"),
+                "size": item.get("size"),
+                "num_files": item.get("num_files") or item.get("file_count"),
+                "detail_error": item.get("detail_error"),
+            }
+            for item in self.inventory.get("buckets", [])
+        ]
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--generation",
+        default=os.environ.get("GITHUB_SHA") or f"manual-{int(time.time())}",
+    )
+    args = parser.parse_args()
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print("FATAL: HF_ORG_TOKEN/HF_ORG_TOKEN1/HF_TOKEN is not set.", file=sys.stderr)
+        return 2
+    try:
+        report = OfficialInventoryEstateUpgrade(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        print(f"FATAL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+    summary = report.get("summary") or {}
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 1 if int(summary.get("error") or 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_estate_official_inventory.py
+++ b/.github/scripts/test_hf_estate_official_inventory.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import inspect
+import pathlib
+import sys
+import unittest
+from dataclasses import dataclass
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+inventory = importlib.import_module("hf_estate_official_inventory")
+
+
+@dataclass
+class Example:
+    id: str
+    sha: str
+    private: bool = False
+
+
+class Api:
+    def list_models(self, author=None, full=None, limit=None):
+        return [Example("SZLHOLDINGS/model-a", "a" * 40), Example("other/model", "b" * 40)]
+
+    def list_buckets(self, namespace=None, limit=None):
+        return [Example("SZLHOLDINGS/bucket-a", "c" * 40)]
+
+
+class OfficialInventoryContractTests(unittest.TestCase):
+    def test_active_reconciler_is_reused(self) -> None:
+        self.assertTrue(issubclass(inventory.OfficialInventoryEstateUpgrade, inventory.BaseEstateUpgrade))
+
+    def test_mapping_normalizes_dataclass(self) -> None:
+        observed = inventory._mapping(Example("SZLHOLDINGS/example", "d" * 40))
+        self.assertEqual(observed["id"], "SZLHOLDINGS/example")
+        self.assertEqual(observed["sha"], "d" * 40)
+        self.assertFalse(observed["private"])
+
+    def test_supported_invocation_filters_signature(self) -> None:
+        values = inventory._invoke_supported(
+            Api(),
+            "list_models",
+            author="SZLHOLDINGS",
+            full=True,
+            limit=None,
+            unsupported="must-not-pass",
+        )
+        self.assertEqual(len(values), 2)
+
+    def test_org_filter_is_fail_closed(self) -> None:
+        self.assertTrue(inventory._belongs_to_org({"id": "SZLHOLDINGS/a11oy"}))
+        self.assertTrue(inventory._belongs_to_org({"name": "asset", "owner": "SZLHOLDINGS"}))
+        self.assertFalse(inventory._belongs_to_org({"id": "other/a11oy"}))
+
+    def test_source_contains_no_invalid_raw_inventory_endpoint(self) -> None:
+        source = inspect.getsource(inventory)
+        self.assertNotIn("/api/collections", source)
+        self.assertNotIn("/api/buckets", source)
+        self.assertIn('"list_collections"', source)
+        self.assertIn('"list_buckets"', source)
+        self.assertIn('os.environ.get("HF_ORG_TOKEN1")', source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-estate-official-inventory.yml
+++ b/.github/workflows/hf-estate-official-inventory.yml
@@ -1,0 +1,179 @@
+name: HF Estate Official Inventory
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_estate_official_inventory.py
+      - .github/scripts/test_hf_estate_official_inventory.py
+      - .github/workflows/hf-estate-official-inventory.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_estate_official_inventory.py
+      - .github/scripts/test_hf_estate_official_inventory.py
+      - .github/workflows/hf-estate-official-inventory.yml
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Apply the estate reconciliation and publish evidence
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-estate-official-inventory
+  cancel-in-progress: false
+
+jobs:
+  verify-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install supported Hub client
+        run: |
+          python -m pip install --disable-pip-version-check \
+            'huggingface_hub>=1.3,<2' \
+            'requests>=2.32,<3'
+
+      - name: Compile and test official inventory contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/hf_estate_upgrade.py \
+            .github/scripts/hf_estate_canonicalize.py \
+            .github/scripts/hf_estate_official_inventory.py \
+            .github/scripts/test_hf_estate_official_inventory.py
+          python .github/scripts/test_hf_estate_official_inventory.py
+          git diff --check
+
+      - name: Determine execution mode
+        id: mode
+        shell: bash
+        run: |
+          publish=false
+          if [ "$GITHUB_EVENT_NAME" = push ]; then
+            publish=true
+          elif [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] && [ '${{ inputs.publish }}' = true ]; then
+            publish=true
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+
+      - name: Require authenticated organization credential
+        if: steps.mode.outputs.publish == 'true'
+        run: |
+          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo '::error::No Hugging Face organization write credential is configured.'
+            exit 2
+          fi
+
+      - name: Execute supported-client estate publisher
+        if: steps.mode.outputs.publish == 'true'
+        id: estate
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_estate_official_inventory.py \
+            --publish \
+            --generation "$GITHUB_SHA"
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Enforce zero-error, zero-warning public command-center state
+        if: steps.mode.outputs.publish == 'true'
+        shell: python
+        run: |
+          import json
+          from pathlib import Path
+
+          path = Path('reports/hf-estate-upgrade-latest.json')
+          report = json.loads(path.read_text(encoding='utf-8'))
+          summary = report.get('summary') or {}
+          if int(summary.get('error') or 0) != 0:
+              raise SystemExit(f"estate report has errors: {summary}")
+          if int(summary.get('warning') or 0) != 0:
+              raise SystemExit(f"estate report has warnings: {summary}")
+
+          snapshots = report.get('managed_clone_snapshots') or {}
+          expected = {f'SZLHOLDINGS/a11oy-clone-{index}' for index in range(1, 5)}
+          if set(snapshots) != expected:
+              raise SystemExit(f"managed clone set mismatch: {sorted(snapshots)}")
+          for repo_id, snapshot in snapshots.items():
+              if snapshot.get('private') is not False:
+                  raise SystemExit(f"{repo_id} is not public: {snapshot}")
+              if str(snapshot.get('stage') or '').upper() != 'RUNNING':
+                  raise SystemExit(f"{repo_id} is not RUNNING: {snapshot}")
+              sha = str(snapshot.get('sha') or '')
+              if len(sha) != 40:
+                  raise SystemExit(f"{repo_id} lacks immutable revision: {snapshot}")
+
+          canonical = report.get('canonical_flagship_space') or {}
+          if canonical.get('repo_id') != 'SZLHOLDINGS/a11oy':
+              raise SystemExit(f"canonical Space mismatch: {canonical}")
+          if canonical.get('private') is not False or canonical.get('stage') != 'RUNNING':
+              raise SystemExit(f"canonical Space is not public/RUNNING: {canonical}")
+          print('official inventory and five-Space A11oy topology: PASS')
+
+      - name: Upload immutable report
+        if: always() && steps.mode.outputs.publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-estate-official-inventory-${{ github.run_id }}
+          path: reports/hf-estate-upgrade-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist report in deterministic issue
+        if: always() && steps.mode.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          title='[hf-official-inventory-report] canonical A11oy + four public command centers'
+          test -f reports/hf-estate-upgrade-latest.json
+          {
+            echo '<!-- szl-hf-official-inventory-report -->'
+            echo "# $title"
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Source revision: \`${GITHUB_SHA}\`"
+            echo
+            echo '```json'
+            cat reports/hf-estate-upgrade-latest.json
+            echo '```'
+          } > /tmp/report.md
+          number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all --search "$title in:title" --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -n1)"
+          if [ -n "$number" ]; then
+            gh issue edit "$number" --repo "$GITHUB_REPOSITORY" --body-file /tmp/report.md
+          else
+            gh issue create "$GITHUB_REPOSITORY" --title "$title" --body-file /tmp/report.md
+          fi
+
+      - name: Enforce publisher result
+        if: always() && steps.mode.outputs.publish == 'true'
+        run: |
+          code='${{ steps.estate.outputs.exit_code }}'
+          if [ -z "$code" ]; then code=2; fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Official estate publisher exited $code"
+            exit "$code"
+          fi


### PR DESCRIPTION
Closed without merge because this branch imports the retired clone publisher and explicitly recreates `a11oy-clone-1` through `a11oy-clone-4`, conflicting with merged #256 and the owner-confirmed single-canonical architecture.

The valid part of this proposal—supported `huggingface_hub` collection and bucket inventory—must be rebuilt against the permanent GitHub-authoritative singleton verifier. No clone creation, adoption, refresh, visibility mutation, or collection re-addition may return.

No Hugging Face mutation was executed from this branch.