### PR TITLE
fix(hf): make Lake and kernel readiness verification asynchronous-safe

### DIFF
--- a/.github/scripts/hf_dataset_server_diagnose.py
+++ b/.github/scripts/hf_dataset_server_diagnose.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Collect read-only diagnostics for the published SZL Lake Dataset Viewer.
+
+No Hub asset is mutated. The report binds the current immutable dataset revision,
+required file set, remote Parquet readability, and the public Dataset Server
+validity/splits/info/parquet/size/first-rows responses so a persistent Viewer
+failure can be repaired at the correct layer.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import pyarrow.parquet as pq
+import requests
+from huggingface_hub import HfApi, hf_hub_download
+
+DATASET_ID = "SZLHOLDINGS/szl-lake"
+CONFIG = "receipts"
+SPLIT = "train"
+BASE = "https://datasets-server.huggingface.co"
+REQUIRED_FILES = (
+    "README.md",
+    "khipu/amaru_receipts.parquet",
+    "khipu/sentra_receipts.parquet",
+    "khipu/a11oy_receipts.parquet",
+    "khipu/rosie_receipts.parquet",
+    "khipu/killinchu_receipts.parquet",
+    "khipu/EMPTY_CHAIN_MANIFEST.json",
+)
+PARQUET_FILES = tuple(path for path in REQUIRED_FILES if path.endswith(".parquet"))
+
+
+def endpoint_urls() -> dict[str, str]:
+    dataset = quote(DATASET_ID, safe="")
+    config = quote(CONFIG, safe="")
+    split = quote(SPLIT, safe="")
+    return {
+        "is_valid": f"{BASE}/is-valid?dataset={dataset}",
+        "splits": f"{BASE}/splits?dataset={dataset}",
+        "info": f"{BASE}/info?dataset={dataset}&config={config}",
+        "parquet": f"{BASE}/parquet?dataset={dataset}",
+        "size": f"{BASE}/size?dataset={dataset}&config={config}&split={split}",
+        "first_rows": (
+            f"{BASE}/first-rows?dataset={dataset}&config={config}&split={split}"
+        ),
+    }
+
+
+def _bounded_payload(response: requests.Response) -> dict[str, Any]:
+    text = response.text[:4000]
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    return {
+        "http_status": response.status_code,
+        "headers": {
+            key: value
+            for key, value in response.headers.items()
+            if key.lower() in {
+                "age",
+                "cache-control",
+                "cf-cache-status",
+                "content-type",
+                "date",
+                "etag",
+                "retry-after",
+                "x-cache",
+                "x-request-id",
+            }
+        },
+        "json": payload if isinstance(payload, (dict, list)) else None,
+        "text": text if payload is None else None,
+    }
+
+
+def query_dataset_server(session: requests.Session) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for name, url in endpoint_urls().items():
+        try:
+            response = session.get(
+                url,
+                headers={
+                    "Accept": "application/json",
+                    "Cache-Control": "no-cache, no-store, max-age=0",
+                    "Pragma": "no-cache",
+                    "User-Agent": "szl-hf-dataset-server-diagnostic/1",
+                },
+                timeout=90,
+            )
+        except Exception as exc:  # noqa: BLE001
+            output[name] = {
+                "url": url,
+                "transport_error": f"{type(exc).__name__}: {exc}",
+            }
+        else:
+            output[name] = {"url": url, **_bounded_payload(response)}
+    return output
+
+
+def inspect_remote_parquets(api: HfApi, token: str, revision: str) -> dict[str, Any]:
+    observations: dict[str, Any] = {}
+    schemas: list[Any] = []
+    for path in PARQUET_FILES:
+        try:
+            local = hf_hub_download(
+                repo_id=DATASET_ID,
+                repo_type="dataset",
+                filename=path,
+                revision=revision,
+                token=token,
+                force_download=True,
+            )
+            parquet = pq.ParquetFile(local)
+            schema = parquet.schema_arrow
+            schemas.append(schema)
+            observations[path] = {
+                "rows": parquet.metadata.num_rows,
+                "row_groups": parquet.metadata.num_row_groups,
+                "columns": schema.names,
+                "schema": str(schema),
+                "readable": True,
+            }
+        except Exception as exc:  # noqa: BLE001
+            observations[path] = {
+                "readable": False,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+    readable = [item for item in observations.values() if item.get("readable")]
+    schema_equal = bool(schemas) and all(schema.equals(schemas[0]) for schema in schemas[1:])
+    return {
+        "files": observations,
+        "all_readable": len(readable) == len(PARQUET_FILES),
+        "schema_equal": schema_equal,
+        "total_rows": sum(int(item.get("rows") or 0) for item in readable),
+    }
+
+
+def diagnose(*, token: str, generation: str) -> dict[str, Any]:
+    api = HfApi(token=token)
+    info = api.dataset_info(DATASET_ID)
+    revision = str(getattr(info, "sha", "") or "")
+    files = set(api.list_repo_files(DATASET_ID, repo_type="dataset", revision=revision))
+    missing = sorted(set(REQUIRED_FILES) - files)
+    parquets = inspect_remote_parquets(api, token, revision)
+    endpoints = query_dataset_server(requests.Session())
+
+    first_rows = endpoints.get("first_rows") or {}
+    report = {
+        "schema": "szl.hf-dataset-server-diagnostic/v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generation": generation,
+        "dataset": DATASET_ID,
+        "revision": revision,
+        "private": getattr(info, "private", None),
+        "downloads": getattr(info, "downloads", None),
+        "likes": getattr(info, "likes", None),
+        "remote_file_count": len(files),
+        "required_files_missing": missing,
+        "remote_parquets": parquets,
+        "dataset_server": endpoints,
+        "viewer_ready": (
+            first_rows.get("http_status") == 200
+            and isinstance(first_rows.get("json"), dict)
+            and not first_rows["json"].get("error")
+        ),
+        "status": "PASS" if not missing and parquets["all_readable"] else "SOURCE_INVALID",
+        "boundaries": [
+            "This diagnostic performs no Hub mutation.",
+            "Remote Parquet readability and schema equality do not substitute for Dataset Server materialization.",
+            "The Viewer is PASS only when first-rows returns HTTP 200 with no error payload.",
+        ],
+    }
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--generation", required=True)
+    parser.add_argument(
+        "--output",
+        default="reports/hf-dataset-server-diagnostic-latest.json",
+    )
+    args = parser.parse_args()
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        raise SystemExit("no supported Hugging Face credential is configured")
+    report = diagnose(token=token, generation=args.generation)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True, default=str) + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/hf_release_readiness_verify.py
+++ b/.github/scripts/hf_release_readiness_verify.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Verify the published Lake viewer and first-class kernels without rewriting them.
+
+The release publisher has already written and read back the reviewed dataset and
+kernel card bytes. Hugging Face's Dataset Viewer is asynchronous and can return a
+bounded "busier than usual / not ready yet" response while it prepares a fresh
+revision. This verifier retries only that transient readiness class. Unknown
+viewer errors, malformed payloads, missing immutable revisions, and failed kernel
+selfchecks remain terminal.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import requests
+from huggingface_hub import HfApi
+
+ORG = "SZLHOLDINGS"
+DATASET_ID = f"{ORG}/szl-lake"
+EVIDENCE_DATASET = f"{ORG}/szl-evidence"
+KERNEL_IDS = (
+    f"{ORG}/governed-inference-meter",
+    f"{ORG}/szl-governed-norm",
+)
+VIEWER_URL = (
+    "https://datasets-server.huggingface.co/first-rows"
+    "?dataset=SZLHOLDINGS%2Fszl-lake&config=receipts&split=train"
+)
+VIEWER_ATTEMPTS = 30
+VIEWER_RETRY_SECONDS = 20
+TRANSIENT_STATUSES = {425, 429, 502, 503, 504}
+TRANSIENT_MARKERS = (
+    "busier than usual",
+    "not ready yet",
+    "still processing",
+    "temporarily unavailable",
+)
+
+
+@dataclass(frozen=True)
+class Action:
+    target: str
+    action: str
+    status: str
+    detail: str = ""
+
+
+def _response_text(response: Any) -> str:
+    return str(getattr(response, "text", "") or "")
+
+
+def _transient_viewer_response(response: Any) -> bool:
+    status = int(getattr(response, "status_code", 0) or 0)
+    if status in TRANSIENT_STATUSES:
+        return True
+    if status != 500:
+        return False
+    body = _response_text(response).lower()
+    return any(marker in body for marker in TRANSIENT_MARKERS)
+
+
+def wait_for_viewer(
+    session: Any,
+    *,
+    attempts: int = VIEWER_ATTEMPTS,
+    retry_seconds: float = VIEWER_RETRY_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[Any, dict[str, Any], int]:
+    """Return the first valid HTTP-200 viewer payload or fail closed."""
+    if attempts < 1:
+        raise ValueError("viewer attempts must be positive")
+
+    last_error = "viewer was not queried"
+    for attempt in range(1, attempts + 1):
+        try:
+            response = session.get(
+                VIEWER_URL,
+                timeout=90,
+                headers={
+                    "Accept": "application/json",
+                    "Cache-Control": "no-cache, no-store, max-age=0",
+                    "Pragma": "no-cache",
+                    "User-Agent": "szl-hf-release-readiness/1",
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"transport {type(exc).__name__}: {exc}"
+            if attempt == attempts:
+                break
+            sleep(retry_seconds)
+            continue
+
+        status = int(getattr(response, "status_code", 0) or 0)
+        if status == 200:
+            try:
+                payload = response.json()
+            except Exception as exc:  # noqa: BLE001
+                raise RuntimeError(f"Dataset Viewer returned non-JSON HTTP 200: {exc}") from exc
+            if not isinstance(payload, dict):
+                raise RuntimeError("Dataset Viewer HTTP 200 payload is not an object")
+            error = payload.get("error")
+            if not error:
+                return response, payload, attempt
+            text = str(error).lower()
+            if any(marker in text for marker in TRANSIENT_MARKERS):
+                last_error = f"HTTP 200 transient payload: {error}"
+                if attempt < attempts:
+                    sleep(retry_seconds)
+                    continue
+            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")
+
+        if _transient_viewer_response(response):
+            last_error = f"HTTP {status}: {_response_text(response)[:300]}"
+            if attempt < attempts:
+                retry_after = str(getattr(response, "headers", {}).get("Retry-After", "") or "")
+                try:
+                    delay = min(60.0, max(retry_seconds, float(retry_after)))
+                except ValueError:
+                    delay = retry_seconds
+                sleep(delay)
+                continue
+            break
+
+        raise RuntimeError(
+            f"Dataset Viewer contract returned terminal HTTP {status}: "
+            f"{_response_text(response)[:300]}"
+        )
+
+    raise RuntimeError(
+        f"Dataset Viewer did not become ready after {attempts} attempts: {last_error}"
+    )
+
+
+class ReadinessVerifier:
+    def __init__(self, *, token: str, generation: str, publish: bool) -> None:
+        self.token = token
+        self.generation = generation
+        self.publish = publish
+        self.api = HfApi(token=token)
+        self.actions: list[Action] = []
+        self.results: dict[str, Any] = {}
+
+    def record(self, target: str, action: str, status: str, detail: str = "") -> None:
+        self.actions.append(Action(target, action, status, detail))
+        print(f"[{status:>10}] {action}: {target}" + (f" — {detail}" if detail else ""))
+
+    def authenticate(self) -> None:
+        who = self.api.whoami()
+        match = next(
+            (
+                item
+                for item in (who.get("orgs") or [])
+                if str(item.get("name") or item.get("fullname") or "").upper() == ORG
+            ),
+            None,
+        )
+        if match is None:
+            raise RuntimeError(f"authenticated identity is not a member of {ORG}")
+        role = str(match.get("roleInOrg") or match.get("role") or "").lower()
+        if role and role not in {"admin", "write", "contributor"}:
+            raise RuntimeError(f"authenticated role is not write-capable: {role}")
+        self.record(ORG, "authenticate", "validated", f"role={role or 'unknown'}")
+
+    def verify_dataset(self) -> None:
+        info = self.api.dataset_info(DATASET_ID)
+        revision = str(getattr(info, "sha", "") or "")
+        if len(revision) != 40:
+            raise RuntimeError(f"dataset lacks an immutable revision: {revision!r}")
+        files = set(self.api.list_repo_files(DATASET_ID, repo_type="dataset", revision=revision))
+        required = {
+            "README.md",
+            "khipu/amaru_receipts.parquet",
+            "khipu/sentra_receipts.parquet",
+            "khipu/a11oy_receipts.parquet",
+            "khipu/rosie_receipts.parquet",
+            "khipu/killinchu_receipts.parquet",
+            "khipu/EMPTY_CHAIN_MANIFEST.json",
+        }
+        missing = sorted(required - files)
+        if missing:
+            raise RuntimeError(f"published Lake revision is incomplete: {missing}")
+
+        session = requests.Session()
+        response, payload, attempts = wait_for_viewer(session)
+        self.results["dataset"] = {
+            "repo_id": DATASET_ID,
+            "revision": revision,
+            "viewer_http_status": int(response.status_code),
+            "viewer_attempts": attempts,
+            "remote_file_count": len(files),
+            "viewer_payload_keys": sorted(payload.keys()),
+        }
+        self.record(
+            DATASET_ID,
+            "dataset-viewer-readiness",
+            "validated",
+            f"revision={revision}; HTTP=200; attempts={attempts}; files={len(files)}",
+        )
+
+    @staticmethod
+    def _run_selfcheck(repo_id: str, revision: str) -> Any:
+        from kernels import get_kernel
+
+        module = get_kernel(repo_id, revision=revision, trust_remote_code=True)
+        check = getattr(module, "selfcheck", None)
+        if not callable(check):
+            raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+        result = check()
+        if result is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck returned false")
+        if isinstance(result, dict) and result.get("ok") is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck failed: {result}")
+        return result
+
+    def verify_kernels(self) -> None:
+        output: dict[str, Any] = {}
+        for repo_id in KERNEL_IDS:
+            info = self.api.kernel_info(repo_id)
+            revision = str(getattr(info, "sha", "") or "")
+            if len(revision) != 40:
+                raise RuntimeError(f"kernel lacks an immutable revision: {repo_id}")
+            files = set(self.api.list_repo_files(repo_id, repo_type="kernel", revision=revision))
+            if "README.md" not in files or "contract.json" not in files:
+                raise RuntimeError(f"kernel card contract is incomplete: {repo_id}")
+            if not any(path.startswith("build/") for path in files):
+                raise RuntimeError(f"kernel build variants are missing: {repo_id}")
+            result = self._run_selfcheck(repo_id, revision)
+            output[repo_id] = {
+                "revision": revision,
+                "remote_file_count": len(files),
+                "selfcheck": result,
+            }
+            self.record(
+                repo_id,
+                "kernel-selfcheck",
+                "validated",
+                f"revision={revision}; files={len(files)}",
+            )
+        self.results["kernels"] = output
+
+    def report(self) -> dict[str, Any]:
+        statuses = [item.status for item in self.actions]
+        return {
+            "schema": "szl.hf-release-readiness/v1",
+            "organization": ORG,
+            "generation": self.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": self.publish,
+            "results": self.results,
+            "actions": [asdict(item) for item in self.actions],
+            "summary": {
+                "ok": sum(status in {"validated", "updated", "ok"} for status in statuses),
+                "warning": sum(status == "warning" for status in statuses),
+                "error": sum(status == "error" for status in statuses),
+                "dry_run": sum(status == "dry-run" for status in statuses),
+            },
+            "boundaries": [
+                "This verifier performs no dataset, kernel, model, Space, visibility, or hardware mutation.",
+                "Only the known asynchronous Dataset Viewer readiness response is retried.",
+                "Unknown viewer responses and every kernel selfcheck failure remain terminal.",
+                "Kernel selfchecks run at the exact immutable revisions recorded in this report.",
+            ],
+        }
+
+    def persist(self, report: dict[str, Any]) -> None:
+        rendered = (json.dumps(report, indent=2, sort_keys=True, default=str) + "\n").encode()
+        os.makedirs("reports", exist_ok=True)
+        with open("reports/hf-release-readiness-latest.json", "wb") as handle:
+            handle.write(rendered)
+        self.record("reports/hf-release-readiness-latest.json", "local-report", "updated")
+        if not self.publish:
+            return
+        if not self.api.repo_exists(EVIDENCE_DATASET, repo_type="dataset"):
+            raise RuntimeError(f"evidence dataset is missing: {EVIDENCE_DATASET}")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for destination in (
+            "release-readiness/latest.json",
+            f"release-readiness/history/{timestamp}.json",
+        ):
+            self.api.upload_file(
+                repo_id=EVIDENCE_DATASET,
+                repo_type="dataset",
+                path_or_fileobj=io.BytesIO(rendered),
+                path_in_repo=destination,
+                commit_message=f"release(evidence): record viewer and kernel readiness {timestamp}",
+            )
+        self.record(EVIDENCE_DATASET, "evidence-publish", "updated")
+
+    def run(self) -> dict[str, Any]:
+        self.authenticate()
+        self.verify_dataset()
+        self.verify_kernels()
+        report = self.report()
+        self.persist(report)
+        report = self.report()
+        with open("reports/hf-release-readiness-latest.json", "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True, default=str)
+            handle.write("\n")
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument("--generation", required=True)
+    args = parser.parse_args()
+
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print("FATAL: no supported Hugging Face token is configured", file=sys.stderr)
+        return 2
+
+    try:
+        report = ReadinessVerifier(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        os.makedirs("reports", exist_ok=True)
+        failure = {
+            "schema": "szl.hf-release-readiness/v1",
+            "generation": args.generation,
+            "publish": args.publish,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+        }
+        with open("reports/hf-release-readiness-latest.json", "w", encoding="utf-8") as handle:
+            json.dump(failure, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        print(f"FATAL: {exc!r}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report["summary"], indent=2))
+    return 1 if report["summary"]["error"] else 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_dataset_server_diagnose.py
+++ b/.github/scripts/test_hf_dataset_server_diagnose.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+diagnostic = importlib.import_module("hf_dataset_server_diagnose")
+
+
+class Response:
+    status_code = 500
+    text = '{"error":"busy"}'
+    headers = {"Content-Type": "application/json", "Retry-After": "5", "Secret": "no"}
+
+    @staticmethod
+    def json():
+        return {"error": "busy"}
+
+
+class Session:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return Response()
+
+
+class DatasetServerDiagnosticTests(unittest.TestCase):
+    def test_exact_endpoint_set(self) -> None:
+        urls = diagnostic.endpoint_urls()
+        self.assertEqual(
+            set(urls),
+            {"is_valid", "splits", "info", "parquet", "size", "first_rows"},
+        )
+        self.assertIn("dataset=SZLHOLDINGS%2Fszl-lake", urls["is_valid"])
+        self.assertIn("config=receipts", urls["info"])
+        self.assertIn("split=train", urls["first_rows"])
+
+    def test_endpoint_query_is_read_only_and_bounded(self) -> None:
+        session = Session()
+        output = diagnostic.query_dataset_server(session)
+        self.assertEqual(set(output), set(diagnostic.endpoint_urls()))
+        self.assertEqual(len(session.calls), 6)
+        self.assertTrue(all(call[1]["timeout"] == 90 for call in session.calls))
+        self.assertTrue(all(item["http_status"] == 500 for item in output.values()))
+        self.assertTrue(all("Secret" not in item["headers"] for item in output.values()))
+
+    def test_exact_required_lake_file_set(self) -> None:
+        self.assertEqual(len(diagnostic.PARQUET_FILES), 5)
+        self.assertIn("README.md", diagnostic.REQUIRED_FILES)
+        self.assertIn("khipu/EMPTY_CHAIN_MANIFEST.json", diagnostic.REQUIRED_FILES)
+
+    def test_source_contains_no_hub_mutation(self) -> None:
+        source = (HERE / "hf_dataset_server_diagnose.py").read_text(encoding="utf-8")
+        for forbidden in (
+            "upload_file(",
+            "upload_folder(",
+            "create_repo(",
+            "delete_repo(",
+            "update_repo_settings(",
+            "restart_space(",
+        ):
+            self.assertNotIn(forbidden, source)
+        self.assertIn("hf_hub_download(", source)
+        self.assertIn("pq.ParquetFile", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_hf_release_readiness_verify.py
+++ b/.github/scripts/test_hf_release_readiness_verify.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import inspect
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+readiness = importlib.import_module("hf_release_readiness_verify")
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload=None, text: str = "", headers=None):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    def get(self, *_args, **_kwargs):
+        self.calls += 1
+        if not self.responses:
+            raise AssertionError("unexpected viewer request")
+        return self.responses.pop(0)
+
+
+class ReleaseReadinessContractTests(unittest.TestCase):
+    def test_exact_targets(self) -> None:
+        self.assertEqual(readiness.DATASET_ID, "SZLHOLDINGS/szl-lake")
+        self.assertEqual(
+            readiness.KERNEL_IDS,
+            (
+                "SZLHOLDINGS/governed-inference-meter",
+                "SZLHOLDINGS/szl-governed-norm",
+            ),
+        )
+
+    def test_known_busy_response_retries_then_passes(self) -> None:
+        session = FakeSession(
+            [
+                FakeResponse(
+                    500,
+                    {"error": "The server is busier than usual and the response is not ready yet."},
+                    '{"error":"The server is busier than usual and the response is not ready yet."}',
+                ),
+                FakeResponse(200, {"rows": [], "features": []}, "{}"),
+            ]
+        )
+        sleeps = []
+        response, payload, attempts = readiness.wait_for_viewer(
+            session,
+            attempts=3,
+            retry_seconds=0.25,
+            sleep=sleeps.append,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload["rows"], [])
+        self.assertEqual(attempts, 2)
+        self.assertEqual(session.calls, 2)
+        self.assertEqual(sleeps, [0.25])
+
+    def test_unknown_http_500_fails_without_retry(self) -> None:
+        session = FakeSession([FakeResponse(500, {"error": "schema exploded"}, "schema exploded")])
+        with self.assertRaisesRegex(RuntimeError, "terminal HTTP 500"):
+            readiness.wait_for_viewer(
+                session,
+                attempts=5,
+                retry_seconds=0,
+                sleep=lambda _delay: None,
+            )
+        self.assertEqual(session.calls, 1)
+
+    def test_retry_budget_is_bounded(self) -> None:
+        session = FakeSession(
+            [FakeResponse(503, {"error": "temporarily unavailable"}, "temporarily unavailable")]
+            * 3
+        )
+        with self.assertRaisesRegex(RuntimeError, "after 3 attempts"):
+            readiness.wait_for_viewer(
+                session,
+                attempts=3,
+                retry_seconds=0,
+                sleep=lambda _delay: None,
+            )
+        self.assertEqual(session.calls, 3)
+
+    def test_verifier_is_evidence_only(self) -> None:
+        source = (HERE / "hf_release_readiness_verify.py").read_text(encoding="utf-8")
+        self.assertNotIn("upload_folder(", source)
+        self.assertNotIn("delete_repo(", source)
+        self.assertNotIn("update_repo_settings(", source)
+        self.assertNotIn('repo_type="model"', source)
+        self.assertNotIn("set_space_hardware", source)
+        self.assertIn("release-readiness/latest.json", source)
+
+    def test_kernel_selfcheck_is_immutable_and_explicit(self) -> None:
+        source = inspect.getsource(readiness.ReadinessVerifier._run_selfcheck)
+        self.assertIn("revision=revision", source)
+        self.assertIn("trust_remote_code=True", source)
+        self.assertIn("selfcheck", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-dataset-server-diagnostics.yml
+++ b/.github/workflows/hf-dataset-server-diagnostics.yml
@@ -1,0 +1,100 @@
+name: HF Dataset Server Diagnostics
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_dataset_server_diagnose.py
+      - .github/scripts/test_hf_dataset_server_diagnose.py
+      - .github/workflows/hf-dataset-server-diagnostics.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-dataset-server-diagnostics-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diagnose:
+    name: Lake source and Dataset Server stages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+    steps:
+      - name: Checkout diagnostic
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Require read credential
+        run: |
+          set -euo pipefail
+          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo "::error::No supported Hugging Face credential is configured."
+            exit 2
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install diagnostic clients
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "huggingface_hub>=1.3,<2" \
+            "requests>=2.32,<3" \
+            "pyarrow>=18,<24"
+
+      - name: Verify read-only diagnostic contract
+        run: |
+          python -m py_compile \
+            .github/scripts/hf_dataset_server_diagnose.py \
+            .github/scripts/test_hf_dataset_server_diagnose.py
+          python .github/scripts/test_hf_dataset_server_diagnose.py
+          git diff --check
+
+      - name: Capture current Dataset Server state
+        run: |
+          python .github/scripts/hf_dataset_server_diagnose.py \
+            --generation "${GITHUB_SHA}"
+
+      - name: Upload immutable diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-dataset-server-diagnostic-${{ github.run_id }}
+          path: reports/hf-dataset-server-diagnostic-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Publish diagnostic summary
+        if: always()
+        shell: python
+        run: |
+          import json
+          import os
+          from pathlib import Path
+          path = Path('reports/hf-dataset-server-diagnostic-latest.json')
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as out:
+              out.write('## SZL Lake Dataset Server diagnostic\n\n')
+              if not path.exists():
+                  out.write('No diagnostic report was produced.\n')
+              else:
+                  report = json.loads(path.read_text())
+                  out.write(f"- revision: `{report.get('revision', 'UNKNOWN')}`\n")
+                  out.write(f"- source status: `{report.get('status', 'UNKNOWN')}`\n")
+                  out.write(f"- viewer ready: `{report.get('viewer_ready')}`\n")
+                  out.write(f"- remote Parquets readable: `{report.get('remote_parquets', {}).get('all_readable')}`\n")
+                  out.write(f"- schemas equal: `{report.get('remote_parquets', {}).get('schema_equal')}`\n")
+                  out.write('\n| Endpoint | HTTP | Error |\n|---|---:|---|\n')
+                  for name, item in report.get('dataset_server', {}).items():
+                      payload = item.get('json') or {}
+                      error = payload.get('error') if isinstance(payload, dict) else item.get('transport_error')
+                      out.write(f"| `{name}` | `{item.get('http_status', 'N/A')}` | `{str(error or '')[:160]}` |\n")

--- a/.github/workflows/hf-release-readiness.yml
+++ b/.github/workflows/hf-release-readiness.yml
@@ -1,0 +1,183 @@
+name: HF Release Readiness
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_verify.py
+      - .github/scripts/test_hf_release_readiness_verify.py
+      - .github/workflows/hf-release-readiness.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_verify.py
+      - .github/scripts/test_hf_release_readiness_verify.py
+      - .github/workflows/hf-release-readiness.yml
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the immutable readiness report
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-release-readiness-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lake viewer HTTP 200 and exact kernel selfchecks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+      GH_TOKEN: ${{ github.token }}
+      REPORT_ISSUE_TITLE: '[hf-release-finalization-report] Lake viewer and kernel selfchecks'
+    steps:
+      - name: Checkout readiness verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Determine execution mode
+        id: mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=true
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then publish=false; fi
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then publish=false; fi
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Require governed Hugging Face credential
+        run: |
+          set -euo pipefail
+          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo "::error::No supported Hugging Face organization credential is configured."
+            exit 2
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned verification clients
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "huggingface_hub>=1.3,<2" \
+            "kernels==0.16.0" \
+            "requests>=2.32,<3"
+
+      - name: Verify bounded readiness contract
+        run: |
+          python -m py_compile \
+            .github/scripts/hf_release_readiness_verify.py \
+            .github/scripts/test_hf_release_readiness_verify.py
+          python .github/scripts/test_hf_release_readiness_verify.py
+          git diff --check
+
+      - name: Verify published revisions without rewriting them
+        id: readiness
+        shell: bash
+        run: |
+          set +e
+          args=(--generation "${GITHUB_SHA}")
+          if [ "${{ steps.mode.outputs.publish }}" = "true" ]; then args+=(--publish); fi
+          python .github/scripts/hf_release_readiness_verify.py "${args[@]}"
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload immutable readiness evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-release-readiness-${{ github.run_id }}
+          path: reports/hf-release-readiness-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist deterministic release report
+        if: always() && steps.mode.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f reports/hf-release-readiness-latest.json
+          {
+            echo '<!-- szl-hf-release-finalization-report -->'
+            echo '# Hugging Face release finalization'
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Source revision: \`${GITHUB_SHA}\`"
+            echo
+            echo '```json'
+            cat reports/hf-release-readiness-latest.json
+            echo '```'
+          } > /tmp/hf-release-readiness.md
+
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --search "${REPORT_ISSUE_TITLE} in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
+            | head -n1)"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/hf-release-readiness.md
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$REPORT_ISSUE_TITLE" \
+              --body-file /tmp/hf-release-readiness.md >/dev/null
+            issue_number="$(gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state all \
+              --search "${REPORT_ISSUE_TITLE} in:title" \
+              --json number,title \
+              --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
+              | head -n1)"
+          fi
+
+          if python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('reports/hf-release-readiness-latest.json').read_text())
+          dataset = report.get('results', {}).get('dataset', {})
+          kernels = report.get('results', {}).get('kernels', {})
+          ok = (
+              report.get('summary', {}).get('error') == 0
+              and dataset.get('viewer_http_status') == 200
+              and len(kernels) == 2
+              and all(item.get('revision') for item in kernels.values())
+          )
+          raise SystemExit(0 if ok else 1)
+          PY
+          then
+            gh issue close "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed \
+              --comment 'The live Lake viewer returned HTTP 200 and both exact kernel revisions passed selfcheck().' || true
+          else
+            gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY" || true
+          fi
+
+      - name: Enforce fail-closed readiness result
+        if: always()
+        run: |
+          code="${{ steps.readiness.outputs.exit_code }}"
+          if [ -z "$code" ]; then code=2; fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Release readiness failed with exit ${code}."
+            exit "$code"
+          fi
+          echo 'Lake viewer and both kernel selfchecks passed at immutable revisions.'


### PR DESCRIPTION
## Outcome

Close the last Hugging Face release-finalization gap without republishing already verified bytes.

- retries only the known asynchronous Dataset Viewer readiness class (`busier than usual`, `not ready yet`, 425/429/502/503/504) with a bounded budget;
- treats unknown HTTP 500 responses, malformed HTTP-200 payloads, missing files, and all other contract errors as terminal;
- verifies the current immutable `SZLHOLDINGS/szl-lake` revision contains the reviewed card and six required Lake files;
- runs `selfcheck()` on the exact current revisions of `SZLHOLDINGS/governed-inference-meter` and `SZLHOLDINGS/szl-governed-norm`;
- performs no dataset, kernel, model, Space, visibility, or hardware mutation;
- publishes one immutable report to Actions, the private evidence dataset, and deterministic issue #257.

The prior publisher successfully completed its write and readback steps. This PR isolates the genuinely asynchronous readiness proof so transient Hugging Face processing does not trigger another publication cycle.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>