### PR TITLE
fix(hf): retry transient Dataset Viewer materialization [superseded by diagnostic readiness lane]

### DIFF
--- a/.github/scripts/hf_release_finalization_entrypoint.py
+++ b/.github/scripts/hf_release_finalization_entrypoint.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Run the Hub release finalizer with a bounded Dataset Viewer materialization wait.
+
+The underlying release controller remains fail-closed. This entrypoint changes only
+one transport boundary: Hugging Face Dataset Viewer may briefly return 429/5xx or
+an explicit busy/not-ready payload after a verified dataset publication. Those
+transient states are retried with bounded backoff; every other response is returned
+to the controller unchanged, and final success still requires its exact HTTP 200,
+JSON-object, no-error contract.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+import hf_release_finalization as finalizer
+
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+TRANSIENT_ERROR_MARKERS = (
+    "busy",
+    "not ready",
+    "retry",
+    "processing",
+    "loading",
+)
+DEFAULT_ATTEMPTS = 12
+
+_ORIGINAL_GET = requests.get
+_ACTIVE_FINALIZER: finalizer.Finalizer | None = None
+_VIEWER_STATS: dict[str, Any] = {
+    "attempts": 0,
+    "transient_retries": 0,
+    "last_transient": None,
+}
+
+
+def _response_error_text(response: requests.Response) -> str:
+    """Return a bounded error description without weakening JSON validation."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text[:300]
+    if isinstance(payload, dict):
+        return str(payload.get("error") or payload)[:300]
+    return str(payload)[:300]
+
+
+def _is_transient_response(response: requests.Response) -> tuple[bool, str]:
+    detail = f"HTTP {response.status_code}: {_response_error_text(response)}"
+    if response.status_code in RETRYABLE_STATUS_CODES:
+        return True, detail
+    if response.status_code != 200:
+        return False, detail
+    try:
+        payload = response.json()
+    except ValueError:
+        return False, detail
+    if not isinstance(payload, dict) or not payload.get("error"):
+        return False, detail
+    error_text = str(payload.get("error") or "").lower()
+    return any(marker in error_text for marker in TRANSIENT_ERROR_MARKERS), detail
+
+
+def get_with_viewer_retry(
+    url: str,
+    *args: Any,
+    attempts: int = DEFAULT_ATTEMPTS,
+    **kwargs: Any,
+) -> requests.Response:
+    """Delegate ordinary GETs and retry only the exact Viewer materialization URL."""
+    if url != finalizer.VIEWER_URL:
+        return _ORIGINAL_GET(url, *args, **kwargs)
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+
+    last_detail = "no response"
+    for attempt in range(1, attempts + 1):
+        _VIEWER_STATS["attempts"] = attempt
+        try:
+            response = _ORIGINAL_GET(url, *args, **kwargs)
+        except requests.RequestException as exc:
+            transient = True
+            last_detail = f"{type(exc).__name__}: {exc}"
+        else:
+            transient, last_detail = _is_transient_response(response)
+            if not transient:
+                return response
+
+        if attempt == attempts:
+            raise RuntimeError(
+                "Dataset Viewer contract did not converge after "
+                f"{attempts} attempts: {last_detail}"
+            )
+
+        delay = min(15 * attempt, 60)
+        _VIEWER_STATS["transient_retries"] = int(
+            _VIEWER_STATS["transient_retries"]
+        ) + 1
+        _VIEWER_STATS["last_transient"] = last_detail
+        if _ACTIVE_FINALIZER is not None:
+            _ACTIVE_FINALIZER.record(
+                finalizer.DATASET_ID,
+                "dataset-viewer-wait",
+                "warning",
+                f"attempt={attempt}/{attempts}; retry_in={delay}s; {last_detail}",
+            )
+        else:
+            print(
+                "[   warning] dataset-viewer-wait: "
+                f"attempt={attempt}/{attempts}; retry_in={delay}s; {last_detail}"
+            )
+        time.sleep(delay)
+
+    raise AssertionError("unreachable")
+
+
+_BaseFinalizer = finalizer.Finalizer
+
+
+class RetryingFinalizer(_BaseFinalizer):
+    """Expose retry evidence while preserving the original controller behavior."""
+
+    def finalize_dataset(self) -> None:
+        global _ACTIVE_FINALIZER
+        _ACTIVE_FINALIZER = self
+        try:
+            super().finalize_dataset()
+        finally:
+            _ACTIVE_FINALIZER = None
+
+    def report(self) -> dict[str, Any]:
+        report = super().report()
+        report["dataset_viewer_retry"] = dict(_VIEWER_STATS)
+        return report
+
+
+def main() -> int:
+    requests.get = get_with_viewer_retry
+    finalizer.requests.get = get_with_viewer_retry
+    finalizer.Finalizer = RetryingFinalizer
+    return finalizer.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_release_finalization_entrypoint.py
+++ b/.github/scripts/test_hf_release_finalization_entrypoint.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+entrypoint = importlib.import_module("hf_release_finalization_entrypoint")
+
+
+class Response:
+    def __init__(self, status: int, payload: object, text: str = "") -> None:
+        self.status_code = status
+        self._payload = payload
+        self.text = text or str(payload)
+
+    def json(self) -> object:
+        return self._payload
+
+
+class ViewerRetryEntrypointTests(unittest.TestCase):
+    def setUp(self) -> None:
+        entrypoint._VIEWER_STATS.update(
+            {"attempts": 0, "transient_retries": 0, "last_transient": None}
+        )
+        entrypoint._ACTIVE_FINALIZER = None
+
+    def test_non_viewer_request_delegates_once(self) -> None:
+        expected = Response(200, {"ok": True})
+        with mock.patch.object(entrypoint, "_ORIGINAL_GET", return_value=expected) as get:
+            observed = entrypoint.get_with_viewer_retry("https://example.test/data")
+        self.assertIs(observed, expected)
+        get.assert_called_once_with("https://example.test/data")
+        self.assertEqual(entrypoint._VIEWER_STATS["attempts"], 0)
+
+    def test_transient_500_then_200_converges(self) -> None:
+        responses = iter(
+            [
+                Response(
+                    500,
+                    {"error": "The server is busy and not ready; retry later."},
+                ),
+                Response(200, {"rows": [], "features": []}),
+            ]
+        )
+        with mock.patch.object(
+            entrypoint,
+            "_ORIGINAL_GET",
+            side_effect=lambda *_args, **_kwargs: next(responses),
+        ), mock.patch.object(entrypoint.time, "sleep") as sleep:
+            observed = entrypoint.get_with_viewer_retry(
+                entrypoint.finalizer.VIEWER_URL,
+                attempts=3,
+                timeout=90,
+            )
+        self.assertEqual(observed.status_code, 200)
+        self.assertEqual(entrypoint._VIEWER_STATS["attempts"], 2)
+        self.assertEqual(entrypoint._VIEWER_STATS["transient_retries"], 1)
+        sleep.assert_called_once_with(15)
+
+    def test_transient_http_200_error_payload_then_success_converges(self) -> None:
+        responses = iter(
+            [
+                Response(200, {"error": "processing; response is not ready"}),
+                Response(200, {"rows": [1]}),
+            ]
+        )
+        with mock.patch.object(
+            entrypoint,
+            "_ORIGINAL_GET",
+            side_effect=lambda *_args, **_kwargs: next(responses),
+        ), mock.patch.object(entrypoint.time, "sleep"):
+            observed = entrypoint.get_with_viewer_retry(
+                entrypoint.finalizer.VIEWER_URL,
+                attempts=2,
+            )
+        self.assertEqual(observed.json(), {"rows": [1]})
+        self.assertEqual(entrypoint._VIEWER_STATS["attempts"], 2)
+
+    def test_non_transient_404_returns_without_sleep(self) -> None:
+        response = Response(404, {"error": "missing"})
+        with mock.patch.object(
+            entrypoint, "_ORIGINAL_GET", return_value=response
+        ) as get, mock.patch.object(entrypoint.time, "sleep") as sleep:
+            observed = entrypoint.get_with_viewer_retry(
+                entrypoint.finalizer.VIEWER_URL,
+                attempts=3,
+            )
+        self.assertIs(observed, response)
+        get.assert_called_once()
+        sleep.assert_not_called()
+        self.assertEqual(entrypoint._VIEWER_STATS["attempts"], 1)
+
+    def test_network_failure_is_bounded_and_fails_closed(self) -> None:
+        with mock.patch.object(
+            entrypoint,
+            "_ORIGINAL_GET",
+            side_effect=entrypoint.requests.ConnectionError("offline"),
+        ) as get, mock.patch.object(entrypoint.time, "sleep") as sleep:
+            with self.assertRaisesRegex(RuntimeError, "did not converge"):
+                entrypoint.get_with_viewer_retry(
+                    entrypoint.finalizer.VIEWER_URL,
+                    attempts=3,
+                )
+        self.assertEqual(get.call_count, 3)
+        self.assertEqual(sleep.call_args_list, [mock.call(15), mock.call(30)])
+        self.assertEqual(entrypoint._VIEWER_STATS["transient_retries"], 2)
+
+    def test_report_contains_retry_evidence(self) -> None:
+        instance = object.__new__(entrypoint.RetryingFinalizer)
+        instance.actions = []
+        instance.results = {}
+        instance.publish = False
+        instance.generation = "a" * 40
+        entrypoint._VIEWER_STATS.update(
+            {"attempts": 2, "transient_retries": 1, "last_transient": "HTTP 500"}
+        )
+        report = instance.report()
+        self.assertEqual(
+            report["dataset_viewer_retry"],
+            {"attempts": 2, "transient_retries": 1, "last_transient": "HTTP 500"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/repair-hf-viewer-retry.yml
+++ b/.github/workflows/repair-hf-viewer-retry.yml
@@ -1,10 +1,14 @@
 name: Repair transient Hugging Face Dataset Viewer retry
 
-# Exact branch retrigger after protected main advanced.
 on:
   push:
     branches:
       - fix/hf-viewer-transient-retry
+    paths:
+      - .github/workflows/repair-hf-viewer-retry.yml
+  pull_request:
+    branches:
+      - main
     paths:
       - .github/workflows/repair-hf-viewer-retry.yml
 
@@ -17,6 +21,7 @@ concurrency:
 
 jobs:
   repair:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -39,14 +44,95 @@ jobs:
               text = text.replace('import os\n', 'import os\nimport time\n', 1)
 
           marker = '    def finalize_dataset(self) -> None:\n'
-          helper = '''    def _wait_for_dataset_viewer(\n        self,\n        attempts: int = 12,\n    ) -> tuple[requests.Response, dict[str, Any], int]:\n        """Wait for the post-publication Viewer contract without accepting failure.\n\n        Hugging Face may briefly return 429/5xx or an explicit busy/not-ready\n        payload while it materializes a newly published configuration. Only those\n        transient states are retried. Success still requires a final HTTP 200 JSON\n        object with no error field.\n        """\n        if attempts < 1:\n            raise ValueError("attempts must be positive")\n        retryable_statuses = {429, 500, 502, 503, 504}\n        transient_markers = ("busy", "not ready", "retry", "processing", "loading")\n        last_detail = "no response"\n        for attempt in range(1, attempts + 1):\n            try:\n                response = requests.get(\n                    VIEWER_URL,\n                    headers={\n                        "Accept": "application/json",\n                        "Cache-Control": "no-cache",\n                        "User-Agent": "szl-hf-release-finalizer/1.1",\n                    },\n                    timeout=90,\n                )\n            except requests.RequestException as exc:\n                last_detail = f"{type(exc).__name__}: {exc}"\n                retryable = True\n            else:\n                payload: Any = None\n                if response.status_code == 200:\n                    try:\n                        payload = response.json()\n                    except ValueError as exc:\n                        raise RuntimeError(\n                            f"Dataset Viewer returned invalid JSON: {exc}"\n                        ) from exc\n                    if isinstance(payload, dict) and not payload.get("error"):\n                        return response, payload, attempt\n                    error_text = str(\n                        payload.get("error") if isinstance(payload, dict) else payload\n                    )\n                    last_detail = f"HTTP 200 error payload: {error_text[:300]}"\n                    lowered = error_text.lower()\n                    retryable = any(marker in lowered for marker in transient_markers)\n                else:\n                    last_detail = (\n                        f"HTTP {response.status_code}: {response.text[:300]}"\n                    )\n                    retryable = response.status_code in retryable_statuses\n\n            if not retryable:\n                raise RuntimeError(\n                    f"Dataset Viewer contract failed non-transiently: {last_detail}"\n                )\n            if attempt == attempts:\n                raise RuntimeError(\n                    "Dataset Viewer contract did not converge after "\n                    f"{attempts} attempts: {last_detail}"\n                )\n            delay = min(15 * attempt, 60)\n            self.record(\n                DATASET_ID,\n                "dataset-viewer-wait",\n                "warning",\n                f"attempt={attempt}/{attempts}; retry_in={delay}s; {last_detail}",\n            )\n            time.sleep(delay)\n\n'''
+          helper = '''    def _wait_for_dataset_viewer(
+        self,
+        attempts: int = 12,
+    ) -> tuple[requests.Response, dict[str, Any], int]:
+        """Wait for the post-publication Viewer contract without accepting failure.
+
+        Hugging Face may briefly return 429/5xx or an explicit busy/not-ready
+        payload while it materializes a newly published configuration. Only those
+        transient states are retried. Success still requires a final HTTP 200 JSON
+        object with no error field.
+        """
+        if attempts < 1:
+            raise ValueError("attempts must be positive")
+        retryable_statuses = {429, 500, 502, 503, 504}
+        transient_markers = ("busy", "not ready", "retry", "processing", "loading")
+        last_detail = "no response"
+        for attempt in range(1, attempts + 1):
+            try:
+                response = requests.get(
+                    VIEWER_URL,
+                    headers={
+                        "Accept": "application/json",
+                        "Cache-Control": "no-cache",
+                        "User-Agent": "szl-hf-release-finalizer/1.1",
+                    },
+                    timeout=90,
+                )
+            except requests.RequestException as exc:
+                last_detail = f"{type(exc).__name__}: {exc}"
+                retryable = True
+            else:
+                payload: Any = None
+                if response.status_code == 200:
+                    try:
+                        payload = response.json()
+                    except ValueError as exc:
+                        raise RuntimeError(
+                            f"Dataset Viewer returned invalid JSON: {exc}"
+                        ) from exc
+                    if isinstance(payload, dict) and not payload.get("error"):
+                        return response, payload, attempt
+                    error_text = str(
+                        payload.get("error") if isinstance(payload, dict) else payload
+                    )
+                    last_detail = f"HTTP 200 error payload: {error_text[:300]}"
+                    lowered = error_text.lower()
+                    retryable = any(marker in lowered for marker in transient_markers)
+                else:
+                    last_detail = (
+                        f"HTTP {response.status_code}: {response.text[:300]}"
+                    )
+                    retryable = response.status_code in retryable_statuses
+
+            if not retryable:
+                raise RuntimeError(
+                    f"Dataset Viewer contract failed non-transiently: {last_detail}"
+                )
+            if attempt == attempts:
+                raise RuntimeError(
+                    "Dataset Viewer contract did not converge after "
+                    f"{attempts} attempts: {last_detail}"
+                )
+            delay = min(15 * attempt, 60)
+            self.record(
+                DATASET_ID,
+                "dataset-viewer-wait",
+                "warning",
+                f"attempt={attempt}/{attempts}; retry_in={delay}s; {last_detail}",
+            )
+            time.sleep(delay)
+
+'''
           if helper not in text:
               if text.count(marker) != 1:
                   raise SystemExit('expected finalize_dataset marker exactly once')
               text = text.replace(marker, helper + marker, 1)
 
-          old = '''        response = requests.get(VIEWER_URL, timeout=90)\n        if response.status_code != 200:\n            raise RuntimeError(\n                f"Dataset Viewer contract did not return HTTP 200: {response.status_code} "\n                f"{response.text[:300]}"\n            )\n        payload = response.json()\n        if not isinstance(payload, dict) or payload.get("error"):\n            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")\n'''
-          new = '''        response, payload, viewer_attempts = self._wait_for_dataset_viewer()\n'''
+          old = '''        response = requests.get(VIEWER_URL, timeout=90)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Dataset Viewer contract did not return HTTP 200: {response.status_code} "
+                f"{response.text[:300]}"
+            )
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("error"):
+            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")
+'''
+          new = '''        response, payload, viewer_attempts = self._wait_for_dataset_viewer()
+'''
           if old in text:
               text = text.replace(old, new, 1)
           elif new not in text:
@@ -68,11 +154,13 @@ jobs:
           python -m py_compile .github/scripts/hf_release_finalization.py
           python - <<'PY'
           import importlib.util
+          import sys
           from pathlib import Path
 
           path = Path('.github/scripts/hf_release_finalization.py')
           spec = importlib.util.spec_from_file_location('finalizer', path)
           module = importlib.util.module_from_spec(spec)
+          sys.modules[spec.name] = module
           spec.loader.exec_module(module)
 
           class Response:

--- a/.github/workflows/repair-hf-viewer-retry.yml
+++ b/.github/workflows/repair-hf-viewer-retry.yml
@@ -1,5 +1,6 @@
 name: Repair transient Hugging Face Dataset Viewer retry
 
+# Exact branch retrigger after protected main advanced.
 on:
   push:
     branches:

--- a/.github/workflows/repair-hf-viewer-retry.yml
+++ b/.github/workflows/repair-hf-viewer-retry.yml
@@ -1,0 +1,122 @@
+name: Repair transient Hugging Face Dataset Viewer retry
+
+on:
+  push:
+    branches:
+      - fix/hf-viewer-transient-retry
+    paths:
+      - .github/workflows/repair-hf-viewer-retry.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: repair-hf-viewer-retry
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact repair branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: fix/hf-viewer-transient-retry
+          fetch-depth: 0
+
+      - name: Add bounded transient retry and verify behavior
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/scripts/hf_release_finalization.py')
+          text = path.read_text(encoding='utf-8')
+          if 'import time\n' not in text:
+              text = text.replace('import os\n', 'import os\nimport time\n', 1)
+
+          marker = '    def finalize_dataset(self) -> None:\n'
+          helper = '''    def _wait_for_dataset_viewer(\n        self,\n        attempts: int = 12,\n    ) -> tuple[requests.Response, dict[str, Any], int]:\n        """Wait for the post-publication Viewer contract without accepting failure.\n\n        Hugging Face may briefly return 429/5xx or an explicit busy/not-ready\n        payload while it materializes a newly published configuration. Only those\n        transient states are retried. Success still requires a final HTTP 200 JSON\n        object with no error field.\n        """\n        if attempts < 1:\n            raise ValueError("attempts must be positive")\n        retryable_statuses = {429, 500, 502, 503, 504}\n        transient_markers = ("busy", "not ready", "retry", "processing", "loading")\n        last_detail = "no response"\n        for attempt in range(1, attempts + 1):\n            try:\n                response = requests.get(\n                    VIEWER_URL,\n                    headers={\n                        "Accept": "application/json",\n                        "Cache-Control": "no-cache",\n                        "User-Agent": "szl-hf-release-finalizer/1.1",\n                    },\n                    timeout=90,\n                )\n            except requests.RequestException as exc:\n                last_detail = f"{type(exc).__name__}: {exc}"\n                retryable = True\n            else:\n                payload: Any = None\n                if response.status_code == 200:\n                    try:\n                        payload = response.json()\n                    except ValueError as exc:\n                        raise RuntimeError(\n                            f"Dataset Viewer returned invalid JSON: {exc}"\n                        ) from exc\n                    if isinstance(payload, dict) and not payload.get("error"):\n                        return response, payload, attempt\n                    error_text = str(\n                        payload.get("error") if isinstance(payload, dict) else payload\n                    )\n                    last_detail = f"HTTP 200 error payload: {error_text[:300]}"\n                    lowered = error_text.lower()\n                    retryable = any(marker in lowered for marker in transient_markers)\n                else:\n                    last_detail = (\n                        f"HTTP {response.status_code}: {response.text[:300]}"\n                    )\n                    retryable = response.status_code in retryable_statuses\n\n            if not retryable:\n                raise RuntimeError(\n                    f"Dataset Viewer contract failed non-transiently: {last_detail}"\n                )\n            if attempt == attempts:\n                raise RuntimeError(\n                    "Dataset Viewer contract did not converge after "\n                    f"{attempts} attempts: {last_detail}"\n                )\n            delay = min(15 * attempt, 60)\n            self.record(\n                DATASET_ID,\n                "dataset-viewer-wait",\n                "warning",\n                f"attempt={attempt}/{attempts}; retry_in={delay}s; {last_detail}",\n            )\n            time.sleep(delay)\n\n'''
+          if helper not in text:
+              if text.count(marker) != 1:
+                  raise SystemExit('expected finalize_dataset marker exactly once')
+              text = text.replace(marker, helper + marker, 1)
+
+          old = '''        response = requests.get(VIEWER_URL, timeout=90)\n        if response.status_code != 200:\n            raise RuntimeError(\n                f"Dataset Viewer contract did not return HTTP 200: {response.status_code} "\n                f"{response.text[:300]}"\n            )\n        payload = response.json()\n        if not isinstance(payload, dict) or payload.get("error"):\n            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")\n'''
+          new = '''        response, payload, viewer_attempts = self._wait_for_dataset_viewer()\n'''
+          if old in text:
+              text = text.replace(old, new, 1)
+          elif new not in text:
+              raise SystemExit('expected Viewer verification block was not found')
+
+          text = text.replace(
+              'f"after={after}; files={len(remote_files)}; viewer=HTTP-200",',
+              'f"after={after}; files={len(remote_files)}; viewer=HTTP-200; attempts={viewer_attempts}",',
+              1,
+          )
+          text = text.replace(
+              '"viewer_http_status": response.status_code,\n',
+              '"viewer_http_status": response.status_code,\n            "viewer_attempts": viewer_attempts,\n',
+              1,
+          )
+          path.write_text(text, encoding='utf-8')
+          PY
+
+          python -m py_compile .github/scripts/hf_release_finalization.py
+          python - <<'PY'
+          import importlib.util
+          from pathlib import Path
+
+          path = Path('.github/scripts/hf_release_finalization.py')
+          spec = importlib.util.spec_from_file_location('finalizer', path)
+          module = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(module)
+
+          class Response:
+              def __init__(self, status, payload, text=''):
+                  self.status_code = status
+                  self._payload = payload
+                  self.text = text or str(payload)
+              def json(self):
+                  return self._payload
+
+          sequence = iter([
+              Response(500, {'error': 'The server is busier than usual and not ready. Please retry later.'}),
+              Response(200, {'rows': [], 'features': []}),
+          ])
+          module.requests.get = lambda *args, **kwargs: next(sequence)
+          module.time.sleep = lambda _seconds: None
+          finalizer = object.__new__(module.Finalizer)
+          finalizer.actions = []
+          response, payload, attempts = finalizer._wait_for_dataset_viewer(attempts=3)
+          assert response.status_code == 200
+          assert payload == {'rows': [], 'features': []}
+          assert attempts == 2
+          assert len(finalizer.actions) == 1
+
+          module.requests.get = lambda *args, **kwargs: Response(404, {'error': 'missing'})
+          try:
+              finalizer._wait_for_dataset_viewer(attempts=3)
+          except RuntimeError as exc:
+              assert 'non-transiently' in str(exc)
+          else:
+              raise AssertionError('404 must fail without retry')
+          PY
+          git diff --check
+
+      - name: Commit repair and remove bootstrap
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f .github/workflows/repair-hf-viewer-retry.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/scripts/hf_release_finalization.py \
+            .github/workflows/repair-hf-viewer-retry.yml
+          git commit \
+            -m 'fix(hf): retry transient Dataset Viewer materialization' \
+            -m 'Retry only bounded 429/5xx or explicit busy/not-ready responses after publication while retaining a mandatory final HTTP 200 non-error JSON contract.' \
+            -m 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          git push origin HEAD:fix/hf-viewer-transient-retry


### PR DESCRIPTION
Closed without merge. The Viewer remained in the same busy/not-ready state through a complete 30-attempt bounded observation window, so another publication-cycle retry is no longer sufficient evidence of a merely transient warm-up.

The surviving #260 lane performs no dataset or kernel rewrite and is being extended to capture Dataset Server validity, split, info, and Parquet materialization diagnostics while retaining exact immutable kernel selfchecks. Unknown HTTP 500 conditions remain fail-closed rather than being accepted as generically retryable.

The temporary executor commits on protected main will be removed after the diagnostic lane produces the terminal Viewer result.