### PR TITLE
feat(hf): verify official singleton estate inventory and buckets

### DIFF
--- a/.github/scripts/hf_official_estate_inventory.py
+++ b/.github/scripts/hf_official_estate_inventory.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Inventory the SZLHOLDINGS Hugging Face estate through supported HfApi calls.
+
+This verifier is deliberately separate from the retired clone publisher. It is
+read-only for models, datasets, Spaces, kernels, collections, and buckets. Its
+only write is an immutable JSON evidence report in the private szl-evidence
+dataset when publish mode is enabled.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import io
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+from huggingface_hub import HfApi
+
+ORG = "SZLHOLDINGS"
+CANONICAL_SPACE = f"{ORG}/a11oy"
+EVIDENCE_DATASET = f"{ORG}/szl-evidence"
+HISTORICAL_CLONE_IDS = tuple(f"{ORG}/a11oy-clone-{index}" for index in range(1, 5))
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SUPPORTED_COLLECTION_REPO_TYPES = {
+    "model": None,
+    "dataset": "dataset",
+    "space": "space",
+}
+
+
+@dataclass(frozen=True)
+class Action:
+    target: str
+    action: str
+    status: str
+    detail: str = ""
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if dataclasses.is_dataclass(value):
+        return {key: _json_safe(item) for key, item in dataclasses.asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        result = dict(value)
+    elif dataclasses.is_dataclass(value):
+        result = dataclasses.asdict(value)
+    else:
+        result = {}
+        raw = getattr(value, "__dict__", None)
+        if isinstance(raw, dict):
+            result.update({key: item for key, item in raw.items() if not key.startswith("_")})
+        for name in (
+            "id",
+            "modelId",
+            "repo_id",
+            "repoId",
+            "slug",
+            "title",
+            "name",
+            "owner",
+            "author",
+            "sha",
+            "sdk",
+            "private",
+            "lastModified",
+            "last_modified",
+            "downloads",
+            "likes",
+            "size",
+            "num_files",
+            "file_count",
+            "bucket_id",
+            "item_id",
+            "item_type",
+            "item_object_id",
+            "position",
+            "note",
+        ):
+            if name not in result and hasattr(value, name):
+                result[name] = getattr(value, name)
+    normalized = _json_safe(result)
+    if not isinstance(normalized, dict):
+        raise TypeError(f"cannot normalize Hub object: {type(value).__name__}")
+    if not normalized.get("id"):
+        normalized["id"] = (
+            normalized.get("repo_id")
+            or normalized.get("repoId")
+            or normalized.get("slug")
+            or normalized.get("bucket_id")
+            or normalized.get("item_id")
+            or normalized.get("name")
+        )
+    if not normalized.get("lastModified") and normalized.get("last_modified"):
+        normalized["lastModified"] = normalized["last_modified"]
+    return normalized
+
+
+def _identifier(item: dict[str, Any]) -> str:
+    return str(
+        item.get("id")
+        or item.get("modelId")
+        or item.get("repo_id")
+        or item.get("repoId")
+        or item.get("slug")
+        or item.get("bucket_id")
+        or item.get("item_id")
+        or item.get("name")
+        or ""
+    )
+
+
+def _belongs_to_org(item: dict[str, Any]) -> bool:
+    identifier = _identifier(item)
+    owner = str(item.get("owner") or item.get("author") or "")
+    return (
+        identifier.upper() == ORG
+        or identifier.upper().startswith(ORG + "/")
+        or owner.upper() == ORG
+    )
+
+
+def _invoke_supported(api: Any, name: str, **preferred: Any) -> list[Any]:
+    method = getattr(api, name, None)
+    if not callable(method):
+        raise RuntimeError(f"installed huggingface_hub lacks HfApi.{name}()")
+    signature = inspect.signature(method)
+    kwargs = {
+        key: value
+        for key, value in preferred.items()
+        if key in signature.parameters and value is not None
+    }
+    return list(method(**kwargs))
+
+
+def _stage(info: Any) -> str:
+    runtime = getattr(info, "runtime", None)
+    raw = getattr(runtime, "stage", None)
+    raw = getattr(raw, "value", raw)
+    return str(raw or "UNKNOWN").split(".")[-1].upper()
+
+
+class OfficialEstateInventory:
+    def __init__(self, *, token: str, generation: str, publish: bool) -> None:
+        self.token = token
+        self.generation = generation
+        self.publish = publish
+        self.api = HfApi(token=token)
+        self.actions: list[Action] = []
+        self.inventory: dict[str, Any] = {}
+        self.collection_reference_count = 0
+        self.collection_resolution_errors: list[str] = []
+        self.clone_collection_references: list[str] = []
+
+    def record(self, target: str, action: str, status: str, detail: str = "") -> None:
+        self.actions.append(Action(target, action, status, detail))
+        print(f"[{status:>10}] {action}: {target}" + (f" — {detail}" if detail else ""))
+
+    def authenticate(self) -> None:
+        who = self.api.whoami()
+        match = next(
+            (
+                item
+                for item in (who.get("orgs") or [])
+                if str(item.get("name") or item.get("fullname") or "").upper() == ORG
+            ),
+            None,
+        )
+        if match is None:
+            raise RuntimeError(f"authenticated identity is not a member of {ORG}")
+        role = str(match.get("roleInOrg") or match.get("role") or "").lower()
+        if role and role not in {"admin", "write", "contributor"}:
+            raise RuntimeError(f"authenticated role is not write-capable: {role}")
+        self.record(ORG, "authenticate", "validated", f"role={role or 'unknown'}")
+
+    def _inventory_kind(self, kind: str, method: str, **kwargs: Any) -> None:
+        values = [_mapping(item) for item in _invoke_supported(self.api, method, **kwargs)]
+        scoped = [item for item in values if _belongs_to_org(item)]
+        scoped.sort(key=_identifier)
+        self.inventory[kind] = scoped
+        self.record(
+            ORG,
+            f"inventory:{kind}",
+            "validated",
+            f"count={len(scoped)}; api=HfApi.{method}",
+        )
+
+    def inventory_repositories(self) -> None:
+        self._inventory_kind("models", "list_models", author=ORG, full=True, limit=None)
+        self._inventory_kind("datasets", "list_datasets", author=ORG, full=True, limit=None)
+        self._inventory_kind("spaces", "list_spaces", author=ORG, full=True, limit=None)
+        self._inventory_kind("kernels", "list_kernels", author=ORG, owner=ORG, limit=None)
+
+    def verify_canonical_and_clones(self) -> None:
+        info = self.api.space_info(CANONICAL_SPACE)
+        revision = str(getattr(info, "sha", "") or "")
+        sdk = str(getattr(info, "sdk", "") or "").lower()
+        private = getattr(info, "private", None)
+        stage = _stage(info)
+        files = set(self.api.list_repo_files(CANONICAL_SPACE, repo_type="space"))
+        if not SHA40.fullmatch(revision):
+            raise RuntimeError(f"canonical A11oy lacks an immutable revision: {revision!r}")
+        if sdk != "docker" or private is not False or stage != "RUNNING":
+            raise RuntimeError(
+                f"canonical A11oy is not public Docker RUNNING: sdk={sdk}; "
+                f"private={private}; stage={stage}"
+            )
+        if "Dockerfile" not in files:
+            raise RuntimeError("canonical A11oy is missing Dockerfile")
+        self.inventory["canonical_a11oy"] = {
+            "repo_id": CANONICAL_SPACE,
+            "sha": revision,
+            "sdk": sdk,
+            "private": private,
+            "stage": stage,
+            "file_count": len(files),
+        }
+        self.record(
+            CANONICAL_SPACE,
+            "canonical-a11oy",
+            "validated",
+            f"sha={revision}; stage={stage}; files={len(files)}",
+        )
+
+        clone_absence = {}
+        for clone_id in HISTORICAL_CLONE_IDS:
+            exists = bool(self.api.repo_exists(clone_id, repo_type="space"))
+            clone_absence[clone_id] = not exists
+            if exists:
+                raise RuntimeError(f"historical A11oy clone reappeared: {clone_id}")
+            self.record(clone_id, "clone-absence", "validated", "absent")
+        self.inventory["clone_absence"] = clone_absence
+
+    def _resolve_collection_item(self, collection_slug: str, item: dict[str, Any]) -> dict[str, Any]:
+        item_id = str(item.get("item_id") or item.get("id") or "")
+        item_type = str(item.get("item_type") or "").lower()
+        result = {
+            "item_id": item_id,
+            "item_type": item_type,
+            "item_object_id": item.get("item_object_id"),
+            "position": item.get("position"),
+            "note": item.get("note"),
+            "resolution": "NOT_APPLICABLE",
+        }
+        if not item_id or not item_type:
+            result["resolution"] = "MALFORMED"
+            self.collection_resolution_errors.append(
+                f"{collection_slug}: malformed collection item {item!r}"
+            )
+            return result
+
+        if item_id in HISTORICAL_CLONE_IDS:
+            self.clone_collection_references.append(f"{collection_slug}:{item_id}")
+
+        if item_type in SUPPORTED_COLLECTION_REPO_TYPES:
+            repo_type = SUPPORTED_COLLECTION_REPO_TYPES[item_type]
+            try:
+                exists = bool(self.api.repo_exists(item_id, repo_type=repo_type))
+            except Exception as exc:  # noqa: BLE001
+                exists = False
+                result["resolution_error"] = f"{type(exc).__name__}: {exc}"[:300]
+            result["resolution"] = "RESOLVED" if exists else "MISSING"
+            if not exists:
+                self.collection_resolution_errors.append(
+                    f"{collection_slug}: missing {item_type} {item_id}"
+                )
+        return result
+
+    def inventory_collections(self) -> None:
+        summaries = [_mapping(item) for item in _invoke_supported(
+            self.api,
+            "list_collections",
+            owner=ORG,
+            namespace=ORG,
+            limit=99,
+        )]
+        summaries = [item for item in summaries if _belongs_to_org(item)]
+        output = []
+        for summary in sorted(summaries, key=_identifier):
+            slug = str(summary.get("slug") or summary.get("id") or "")
+            if not slug:
+                raise RuntimeError(f"collection summary lacks slug: {summary}")
+            collection = self.api.get_collection(slug)
+            raw_items: Iterable[Any] = getattr(collection, "items", None) or []
+            items = [self._resolve_collection_item(slug, _mapping(item)) for item in raw_items]
+            self.collection_reference_count += len(items)
+            output.append(
+                {
+                    "slug": slug,
+                    "title": getattr(collection, "title", None) or summary.get("title"),
+                    "private": getattr(collection, "private", None),
+                    "item_count": len(items),
+                    "items": items,
+                }
+            )
+        if self.clone_collection_references:
+            raise RuntimeError(
+                f"historical clone collection references remain: {self.clone_collection_references}"
+            )
+        if self.collection_resolution_errors:
+            raise RuntimeError(
+                "collection reference verification failed: "
+                + "; ".join(self.collection_resolution_errors[:20])
+            )
+        self.inventory["collections"] = output
+        self.record(
+            ORG,
+            "inventory:collections",
+            "validated",
+            f"count={len(output)}; references={self.collection_reference_count}; "
+            "api=HfApi.list_collections+get_collection",
+        )
+
+    def _bucket_detail(self, summary: dict[str, Any]) -> dict[str, Any]:
+        identity = _identifier(summary)
+        if not identity:
+            raise RuntimeError(f"bucket summary lacks identity: {summary}")
+        method = getattr(self.api, "bucket_info", None)
+        if not callable(method):
+            raise RuntimeError("installed huggingface_hub lacks HfApi.bucket_info()")
+        signature = inspect.signature(method)
+        if "bucket_id" in signature.parameters:
+            detail = method(bucket_id=identity)
+        elif "bucket" in signature.parameters:
+            detail = method(bucket=identity)
+        else:
+            detail = method(identity)
+        merged = dict(summary)
+        merged.update(_mapping(detail))
+        merged["id"] = _identifier(merged) or identity
+        return merged
+
+    def inventory_buckets(self) -> None:
+        summaries = [_mapping(item) for item in _invoke_supported(
+            self.api,
+            "list_buckets",
+            owner=ORG,
+            namespace=ORG,
+            limit=1000,
+        )]
+        summaries = [item for item in summaries if _belongs_to_org(item)]
+        details = [self._bucket_detail(item) for item in summaries]
+        details.sort(key=_identifier)
+        self.inventory["buckets"] = details
+        self.record(
+            ORG,
+            "inventory:buckets",
+            "validated",
+            f"count={len(details)}; api=HfApi.list_buckets+bucket_info",
+        )
+
+    @staticmethod
+    def _public_asset_view(item: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": _identifier(item),
+            "sha": item.get("sha"),
+            "private": item.get("private"),
+            "sdk": item.get("sdk"),
+            "downloads": item.get("downloads"),
+            "likes": item.get("likes"),
+            "last_modified": item.get("lastModified"),
+        }
+
+    def report(self) -> dict[str, Any]:
+        statuses = [item.status for item in self.actions]
+        repository_kinds = ("models", "datasets", "spaces", "kernels")
+        assets = {
+            kind: [self._public_asset_view(item) for item in self.inventory.get(kind, [])]
+            for kind in repository_kinds
+        }
+        return {
+            "schema": "szl.hf-official-estate-inventory/v1",
+            "organization": ORG,
+            "generation": self.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": self.publish,
+            "inventory_api": {
+                "models": "HfApi.list_models",
+                "datasets": "HfApi.list_datasets",
+                "spaces": "HfApi.list_spaces",
+                "kernels": "HfApi.list_kernels",
+                "collections": "HfApi.list_collections + HfApi.get_collection",
+                "buckets": "HfApi.list_buckets + HfApi.bucket_info",
+            },
+            "counts": {
+                "models": len(self.inventory.get("models", [])),
+                "datasets": len(self.inventory.get("datasets", [])),
+                "spaces": len(self.inventory.get("spaces", [])),
+                "kernels": len(self.inventory.get("kernels", [])),
+                "collections": len(self.inventory.get("collections", [])),
+                "collection_references": self.collection_reference_count,
+                "buckets": len(self.inventory.get("buckets", [])),
+            },
+            "canonical_a11oy": self.inventory.get("canonical_a11oy"),
+            "clone_absence": self.inventory.get("clone_absence", {}),
+            "assets": assets,
+            "collections": self.inventory.get("collections", []),
+            "buckets": self.inventory.get("buckets", []),
+            "actions": [asdict(item) for item in self.actions],
+            "summary": {
+                "ok": sum(status in {"validated", "updated", "ok"} for status in statuses),
+                "warning": sum(status == "warning" for status in statuses),
+                "error": sum(status == "error" for status in statuses),
+                "dry_run": sum(status == "dry-run" for status in statuses),
+            },
+            "boundaries": [
+                "The verifier performs no model, dataset, Space, kernel, collection, bucket, visibility, or hardware mutation.",
+                "Its only publish-mode write is an immutable JSON report in the private szl-evidence dataset.",
+                "SZLHOLDINGS/a11oy remains the sole permanent A11oy Space and protected GitHub main remains source authority.",
+                "Every supported collection repository reference must resolve and every historical clone reference must remain absent.",
+                "Bucket discovery and readback use supported huggingface_hub APIs rather than raw private endpoints.",
+            ],
+        }
+
+    def persist(self, report: dict[str, Any]) -> None:
+        rendered = (json.dumps(report, indent=2, sort_keys=True, default=str) + "\n").encode()
+        output = Path("reports/hf-official-estate-inventory-latest.json")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(rendered)
+        self.record(str(output), "local-report", "updated")
+        if not self.publish:
+            return
+        if not self.api.repo_exists(EVIDENCE_DATASET, repo_type="dataset"):
+            raise RuntimeError(f"evidence dataset is missing: {EVIDENCE_DATASET}")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        for destination in (
+            "estate/official-inventory/latest.json",
+            f"estate/official-inventory/history/{timestamp}.json",
+        ):
+            self.api.upload_file(
+                repo_id=EVIDENCE_DATASET,
+                repo_type="dataset",
+                path_or_fileobj=io.BytesIO(rendered),
+                path_in_repo=destination,
+                commit_message=f"chore(estate): record official Hub inventory {timestamp}",
+            )
+        self.record(EVIDENCE_DATASET, "evidence-publish", "updated")
+
+    def run(self) -> dict[str, Any]:
+        self.authenticate()
+        self.inventory_repositories()
+        self.verify_canonical_and_clones()
+        self.inventory_collections()
+        self.inventory_buckets()
+        report = self.report()
+        self.persist(report)
+        report = self.report()
+        Path("reports/hf-official-estate-inventory-latest.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--generation",
+        default=os.environ.get("GITHUB_SHA") or f"manual-{int(time.time())}",
+    )
+    args = parser.parse_args()
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print("FATAL: no supported Hugging Face credential is configured", file=sys.stderr)
+        return 2
+
+    try:
+        report = OfficialEstateInventory(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        Path("reports").mkdir(exist_ok=True)
+        failure = {
+            "schema": "szl.hf-official-estate-inventory/v1",
+            "organization": ORG,
+            "generation": args.generation,
+            "publish": args.publish,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+        }
+        Path("reports/hf-official-estate-inventory-latest.json").write_text(
+            json.dumps(failure, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"FATAL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 1 if report["summary"]["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_official_estate_inventory.py
+++ b/.github/scripts/test_hf_official_estate_inventory.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import inspect
+import pathlib
+import sys
+import unittest
+from dataclasses import dataclass
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+inventory = importlib.import_module("hf_official_estate_inventory")
+
+
+@dataclass
+class Example:
+    id: str
+    sha: str = "a" * 40
+    private: bool = False
+    owner: str | None = None
+
+
+class SignatureApi:
+    def list_models(self, author=None, full=None, limit=None):
+        return [Example("SZLHOLDINGS/model-a"), Example("other/model")]
+
+    def list_buckets(self, namespace=None, limit=None):
+        return [Example("SZLHOLDINGS/bucket-a")]
+
+
+class ResolveApi:
+    def repo_exists(self, repo_id, repo_type=None):
+        return repo_id == "SZLHOLDINGS/present"
+
+
+class OfficialEstateInventoryContractTests(unittest.TestCase):
+    def test_exact_singleton_policy(self) -> None:
+        self.assertEqual(inventory.CANONICAL_SPACE, "SZLHOLDINGS/a11oy")
+        self.assertEqual(
+            inventory.HISTORICAL_CLONE_IDS,
+            (
+                "SZLHOLDINGS/a11oy-clone-1",
+                "SZLHOLDINGS/a11oy-clone-2",
+                "SZLHOLDINGS/a11oy-clone-3",
+                "SZLHOLDINGS/a11oy-clone-4",
+            ),
+        )
+
+    def test_mapping_normalizes_dataclass(self) -> None:
+        observed = inventory._mapping(Example("SZLHOLDINGS/example", "d" * 40))
+        self.assertEqual(observed["id"], "SZLHOLDINGS/example")
+        self.assertEqual(observed["sha"], "d" * 40)
+        self.assertFalse(observed["private"])
+
+    def test_supported_invocation_filters_signature(self) -> None:
+        values = inventory._invoke_supported(
+            SignatureApi(),
+            "list_models",
+            author="SZLHOLDINGS",
+            full=True,
+            limit=None,
+            unsupported="must-not-pass",
+        )
+        self.assertEqual(len(values), 2)
+
+    def test_org_filter_is_fail_closed(self) -> None:
+        self.assertTrue(inventory._belongs_to_org({"id": "SZLHOLDINGS/a11oy"}))
+        self.assertTrue(inventory._belongs_to_org({"name": "asset", "owner": "SZLHOLDINGS"}))
+        self.assertFalse(inventory._belongs_to_org({"id": "other/a11oy"}))
+
+    def test_collection_resolution_detects_missing_supported_repo(self) -> None:
+        verifier = object.__new__(inventory.OfficialEstateInventory)
+        verifier.api = ResolveApi()
+        verifier.collection_resolution_errors = []
+        verifier.clone_collection_references = []
+        missing = verifier._resolve_collection_item(
+            "SZLHOLDINGS/example-collection",
+            {"item_id": "SZLHOLDINGS/missing", "item_type": "model"},
+        )
+        present = verifier._resolve_collection_item(
+            "SZLHOLDINGS/example-collection",
+            {"item_id": "SZLHOLDINGS/present", "item_type": "dataset"},
+        )
+        self.assertEqual(missing["resolution"], "MISSING")
+        self.assertEqual(present["resolution"], "RESOLVED")
+        self.assertEqual(len(verifier.collection_resolution_errors), 1)
+
+    def test_source_uses_supported_inventory_apis_only(self) -> None:
+        source = inspect.getsource(inventory)
+        self.assertNotIn("/api/collections", source)
+        self.assertNotIn("/api/buckets", source)
+        self.assertIn('"list_collections"', source)
+        self.assertIn('"get_collection"', source)
+        self.assertIn('"list_buckets"', source)
+        self.assertIn('"bucket_info"', source)
+
+    def test_source_has_no_clone_or_asset_mutation_path(self) -> None:
+        source = (HERE / "hf_official_estate_inventory.py").read_text(encoding="utf-8")
+        for forbidden in (
+            "duplicate_repo(",
+            "duplicate_space(",
+            "create_repo(",
+            "delete_repo(",
+            "update_repo_settings(",
+            "CommitOperationCopy",
+            "select-newest-a11oy-source",
+            "canonical-content-adoption",
+            "clone-refresh",
+        ):
+            self.assertNotIn(forbidden, source)
+        self.assertIn("estate/official-inventory/latest.json", source)
+
+    def test_report_exposes_downloads_and_likes_for_showcase(self) -> None:
+        view = inventory.OfficialEstateInventory._public_asset_view(
+            {"id": "SZLHOLDINGS/model", "downloads": 42, "likes": 7}
+        )
+        self.assertEqual(view["downloads"], 42)
+        self.assertEqual(view["likes"], 7)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_hf_official_estate_inventory.py
+++ b/.github/scripts/test_hf_official_estate_inventory.py
@@ -93,7 +93,7 @@ class OfficialEstateInventoryContractTests(unittest.TestCase):
         self.assertNotIn("/api/collections", source)
         self.assertNotIn("/api/buckets", source)
         self.assertIn('"list_collections"', source)
-        self.assertIn('"get_collection"', source)
+        self.assertIn("get_collection(", source)
         self.assertIn('"list_buckets"', source)
         self.assertIn('"bucket_info"', source)
 

--- a/.github/workflows/hf-official-estate-inventory.yml
+++ b/.github/workflows/hf-official-estate-inventory.yml
@@ -1,0 +1,211 @@
+name: HF Official Estate Inventory
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_official_estate_inventory.py
+      - .github/scripts/test_hf_official_estate_inventory.py
+      - .github/workflows/hf-official-estate-inventory.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_official_estate_inventory.py
+      - .github/scripts/test_hf_official_estate_inventory.py
+      - .github/workflows/hf-official-estate-inventory.yml
+  schedule:
+    - cron: '41 */12 * * *'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the official inventory evidence report
+        required: false
+        default: "true"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-official-estate-inventory-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Models, datasets, Spaces, kernels, collections, and buckets
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+      GH_TOKEN: ${{ github.token }}
+      REPORT_ISSUE_TITLE: '[hf-estate-inventory] official collections and buckets'
+    steps:
+      - name: Checkout inventory verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Determine execution mode
+        id: mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=true
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then publish=false; fi
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" != "true" ]; then publish=false; fi
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install supported Hub client
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "huggingface_hub>=1.3,<2"
+
+      - name: Compile and test no-clone official inventory contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/hf_official_estate_inventory.py \
+            .github/scripts/test_hf_official_estate_inventory.py
+          python .github/scripts/test_hf_official_estate_inventory.py
+          git diff --check
+
+      - name: Require organization credential for publish-mode inventory
+        if: steps.mode.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          if [ -z "${HF_ORG_TOKEN:-}" ] && [ -z "${HF_TOKEN:-}" ]; then
+            echo "::error::No supported Hugging Face organization credential is configured."
+            exit 2
+          fi
+
+      - name: Execute official supported-API inventory
+        if: steps.mode.outputs.publish == 'true'
+        id: estate
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_official_estate_inventory.py \
+            --publish \
+            --generation "${GITHUB_SHA}"
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload immutable inventory report
+        if: always() && steps.mode.outputs.publish == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-official-estate-inventory-${{ github.run_id }}
+          path: reports/hf-official-estate-inventory-latest.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist deterministic inventory issue
+        if: always() && steps.mode.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f reports/hf-official-estate-inventory-latest.json
+          {
+            echo '<!-- szl-hf-official-estate-inventory -->'
+            echo '# Hugging Face official estate inventory'
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Source revision: \`${GITHUB_SHA}\`"
+            echo
+            echo '```json'
+            cat reports/hf-official-estate-inventory-latest.json
+            echo '```'
+          } > /tmp/hf-official-inventory.md
+
+          issue_number="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --search "${REPORT_ISSUE_TITLE} in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
+            | head -n1)"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/hf-official-inventory.md
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$REPORT_ISSUE_TITLE" \
+              --body-file /tmp/hf-official-inventory.md >/dev/null
+            issue_number="$(gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state all \
+              --search "${REPORT_ISSUE_TITLE} in:title" \
+              --json number,title \
+              --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
+              | head -n1)"
+          fi
+
+          if python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('reports/hf-official-estate-inventory-latest.json').read_text())
+          counts = report.get('counts', {})
+          canonical = report.get('canonical_a11oy', {})
+          clones = report.get('clone_absence', {})
+          ok = (
+              report.get('summary', {}).get('error') == 0
+              and canonical.get('stage') == 'RUNNING'
+              and canonical.get('private') is False
+              and canonical.get('sdk') == 'docker'
+              and all(clones.values())
+              and len(clones) == 4
+              and counts.get('collections') is not None
+              and counts.get('collection_references') is not None
+              and counts.get('buckets') is not None
+          )
+          raise SystemExit(0 if ok else 1)
+          PY
+          then
+            gh issue close "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed \
+              --comment 'Official HfApi inventory, collection reference resolution, bucket readback, canonical runtime, and permanent clone absence all passed.' || true
+          else
+            gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY" || true
+          fi
+
+      - name: Publish inventory summary
+        if: always() && steps.mode.outputs.publish == 'true'
+        shell: python
+        run: |
+          import json
+          import os
+          from pathlib import Path
+          path = Path('reports/hf-official-estate-inventory-latest.json')
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as out:
+              out.write('## Official Hugging Face estate inventory\n\n')
+              if not path.exists():
+                  out.write('No report was produced.\n')
+              else:
+                  report = json.loads(path.read_text())
+                  for key, value in report.get('counts', {}).items():
+                      out.write(f'- {key}: `{value}`\n')
+                  canonical = report.get('canonical_a11oy', {})
+                  out.write(f"- canonical A11oy: `{canonical.get('sha', 'UNKNOWN')}` ({canonical.get('stage', 'UNKNOWN')})\n")
+
+      - name: Enforce fail-closed inventory result
+        if: always() && steps.mode.outputs.publish == 'true'
+        run: |
+          code="${{ steps.estate.outputs.exit_code }}"
+          if [ -z "$code" ]; then code=2; fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Official estate inventory failed with exit ${code}."
+            exit "$code"
+          fi
+          echo 'Official estate inventory completed successfully.'


### PR DESCRIPTION
## Outcome

Rebuild the useful inventory scope from superseded #258 without importing any retired clone publisher.

- inventories models, datasets, Spaces, kernels, collections, collection items, and buckets exclusively through supported `huggingface_hub.HfApi` methods;
- reads every collection with `get_collection()` and resolves every supported model/dataset/Space reference;
- reads every listed bucket back with `bucket_info()`;
- proves `SZLHOLDINGS/a11oy` is public, Docker-backed, immutable, and `RUNNING`;
- fails if any historical A11oy clone or clone collection reference reappears;
- records per-asset downloads and likes for evidence-backed public showcasing;
- writes only one immutable JSON report to Actions and the private `SZLHOLDINGS/szl-evidence` dataset;
- runs every 12 hours and on relevant verifier changes.

## Permanent boundary

This implementation contains no clone creation, duplication, adoption, refresh, deletion, visibility mutation, asset mutation, or hardware mutation path. Protected GitHub source remains authoritative and `SZLHOLDINGS/a11oy` remains the only permanent A11oy Space.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>