### PR TITLE
fix(hf): inventory Kernel Hub through current official APIs [superseded by #266]

### DIFF
--- a/.github/scripts/hf_official_estate_inventory_compat.py
+++ b/.github/scripts/hf_official_estate_inventory_compat.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Run the official estate inventory with current Kernel Hub compatibility.
+
+`huggingface_hub` officially supports `kernel_info()` and repository readback for
+kernel repositories, but it does not currently expose `HfApi.list_kernels()`.
+Kernel discovery therefore uses the public authenticated Hub `/api/kernels`
+endpoint and immediately reads every discovered repository back through the
+supported `HfApi.kernel_info()` method. All other resource classes continue to
+use the supported HfApi inventory methods in `hf_official_estate_inventory`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+import hf_official_estate_inventory as base
+
+KERNEL_LIST_URL = f"https://huggingface.co/api/kernels?author={base.ORG}&limit=1000"
+
+
+def _next_link(header: str) -> str:
+    for part in str(header or "").split(","):
+        if 'rel="next"' not in part:
+            continue
+        if "<" not in part or ">" not in part:
+            continue
+        return part.split("<", 1)[1].split(">", 1)[0]
+    return ""
+
+
+class CurrentHubEstateInventory(base.OfficialEstateInventory):
+    """Official inventory with REST discovery and HfApi kernel readback."""
+
+    def __init__(self, *, token: str, generation: str, publish: bool) -> None:
+        super().__init__(token=token, generation=generation, publish=publish)
+        self.http = requests.Session()
+        self.http.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+                "Cache-Control": "no-cache, no-store, max-age=0",
+                "Pragma": "no-cache",
+                "User-Agent": "szl-hf-official-estate-inventory/2",
+            }
+        )
+
+    def _list_kernel_summaries(self) -> list[dict[str, Any]]:
+        output: list[dict[str, Any]] = []
+        url = KERNEL_LIST_URL
+        pages = 0
+        while url:
+            pages += 1
+            if pages > 100:
+                raise RuntimeError("kernel inventory exceeded 100 pagination pages")
+            response = self.http.get(url, timeout=45)
+            response.raise_for_status()
+            payload = response.json()
+            if isinstance(payload, dict) and isinstance(payload.get("items"), list):
+                payload = payload["items"]
+            if not isinstance(payload, list):
+                raise TypeError(
+                    f"official Kernel Hub endpoint returned {type(payload).__name__}, expected list"
+                )
+            output.extend(
+                base._mapping(item)
+                for item in payload
+                if isinstance(item, dict)
+            )
+            url = _next_link(response.headers.get("Link") or response.headers.get("link") or "")
+        return output
+
+    def inventory_kernels(self) -> None:
+        summaries = [
+            item
+            for item in self._list_kernel_summaries()
+            if base._belongs_to_org(item)
+        ]
+        output: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for summary in sorted(summaries, key=base._identifier):
+            repo_id = base._identifier(summary)
+            if not repo_id or repo_id in seen:
+                continue
+            seen.add(repo_id)
+            info = self.api.kernel_info(repo_id)
+            detail = base._mapping(info)
+            merged = dict(summary)
+            merged.update({key: value for key, value in detail.items() if value is not None})
+            merged["id"] = repo_id
+            revision = str(merged.get("sha") or "")
+            if not base.SHA40.fullmatch(revision):
+                raise RuntimeError(f"kernel lacks immutable revision: {repo_id}@{revision!r}")
+            files = set(
+                self.api.list_repo_files(
+                    repo_id,
+                    repo_type="kernel",
+                    revision=revision,
+                )
+            )
+            if "README.md" not in files:
+                raise RuntimeError(f"kernel repository lacks README.md: {repo_id}")
+            if not any(path.startswith("build/") for path in files):
+                raise RuntimeError(f"kernel repository lacks build variants: {repo_id}")
+            merged["file_count"] = len(files)
+            merged["build_variants_present"] = True
+            output.append(merged)
+        self.inventory["kernels"] = output
+        self.record(
+            base.ORG,
+            "inventory:kernels",
+            "validated",
+            (
+                f"count={len(output)}; discovery=Hub REST /api/kernels; "
+                "readback=HfApi.kernel_info+list_repo_files"
+            ),
+        )
+
+    def inventory_repositories(self) -> None:
+        self._inventory_kind("models", "list_models", author=base.ORG, full=True, limit=None)
+        self._inventory_kind("datasets", "list_datasets", author=base.ORG, full=True, limit=None)
+        self._inventory_kind("spaces", "list_spaces", author=base.ORG, full=True, limit=None)
+        self.inventory_kernels()
+
+    def report(self) -> dict[str, Any]:
+        report = super().report()
+        report["schema"] = "szl.hf-official-estate-inventory/v2"
+        report["inventory_api"]["kernels"] = (
+            "Official Hub REST /api/kernels discovery + "
+            "HfApi.kernel_info + HfApi.list_repo_files readback"
+        )
+        report["boundaries"].append(
+            "Kernel listing uses the official public Hub endpoint because the current "
+            "huggingface_hub client supports kernel_info/readback but does not expose list_kernels."
+        )
+        return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--generation",
+        default=os.environ.get("GITHUB_SHA") or "manual",
+    )
+    args = parser.parse_args()
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+    )
+    if not token:
+        print("FATAL: no supported Hugging Face credential is configured", file=sys.stderr)
+        return 2
+
+    try:
+        report = CurrentHubEstateInventory(
+            token=token,
+            generation=args.generation,
+            publish=args.publish,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        Path("reports").mkdir(exist_ok=True)
+        failure = {
+            "schema": "szl.hf-official-estate-inventory/v2",
+            "organization": base.ORG,
+            "generation": args.generation,
+            "publish": args.publish,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+        }
+        Path("reports/hf-official-estate-inventory-latest.json").write_text(
+            json.dumps(failure, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"FATAL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 1 if report["summary"]["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_official_estate_inventory_compat.py
+++ b/.github/scripts/test_hf_official_estate_inventory_compat.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import inspect
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+compat = importlib.import_module("hf_official_estate_inventory_compat")
+
+
+class Response:
+    def __init__(self, payload, link=""):
+        self._payload = payload
+        self.headers = {"Link": link} if link else {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class Session:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.headers = {}
+
+    def get(self, url, timeout=None):
+        self.calls.append((url, timeout))
+        return self.responses.pop(0)
+
+
+class KernelInfo:
+    def __init__(self, repo_id, sha):
+        self.id = repo_id
+        self.sha = sha
+        self.downloads = 12
+        self.likes = 3
+        self.private = False
+
+
+class Api:
+    def __init__(self):
+        self.info_calls = []
+        self.file_calls = []
+
+    def kernel_info(self, repo_id):
+        self.info_calls.append(repo_id)
+        return KernelInfo(repo_id, "a" * 40)
+
+    def list_repo_files(self, repo_id, repo_type=None, revision=None):
+        self.file_calls.append((repo_id, repo_type, revision))
+        return ["README.md", "contract.json", "build/torch27-cxx11-cpu-x86_64-linux/__init__.py"]
+
+
+class KernelInventoryCompatibilityTests(unittest.TestCase):
+    def test_next_link_parser(self) -> None:
+        header = '<https://huggingface.co/api/kernels?cursor=next>; rel="next"'
+        self.assertEqual(
+            compat._next_link(header),
+            "https://huggingface.co/api/kernels?cursor=next",
+        )
+        self.assertEqual(compat._next_link(""), "")
+
+    def test_official_endpoint_pagination(self) -> None:
+        verifier = object.__new__(compat.CurrentHubEstateInventory)
+        verifier.http = Session(
+            [
+                Response(
+                    [{"id": "SZLHOLDINGS/kernel-a", "sha": "1" * 40}],
+                    '<https://huggingface.co/api/kernels?cursor=next>; rel="next"',
+                ),
+                Response([{"id": "SZLHOLDINGS/kernel-b", "sha": "2" * 40}]),
+            ]
+        )
+        values = verifier._list_kernel_summaries()
+        self.assertEqual([item["id"] for item in values], [
+            "SZLHOLDINGS/kernel-a",
+            "SZLHOLDINGS/kernel-b",
+        ])
+        self.assertEqual(len(verifier.http.calls), 2)
+        self.assertTrue(all(timeout == 45 for _, timeout in verifier.http.calls))
+
+    def test_kernel_discovery_requires_hfapi_readback(self) -> None:
+        verifier = object.__new__(compat.CurrentHubEstateInventory)
+        verifier.api = Api()
+        verifier.inventory = {}
+        verifier.actions = []
+        verifier.http = Session(
+            [Response([
+                {"id": "SZLHOLDINGS/kernel-a", "sha": "stale"},
+                {"id": "other/kernel", "sha": "b" * 40},
+            ])]
+        )
+        verifier.inventory_kernels()
+        self.assertEqual(len(verifier.inventory["kernels"]), 1)
+        item = verifier.inventory["kernels"][0]
+        self.assertEqual(item["id"], "SZLHOLDINGS/kernel-a")
+        self.assertEqual(item["sha"], "a" * 40)
+        self.assertTrue(item["build_variants_present"])
+        self.assertEqual(verifier.api.info_calls, ["SZLHOLDINGS/kernel-a"])
+        self.assertEqual(
+            verifier.api.file_calls,
+            [("SZLHOLDINGS/kernel-a", "kernel", "a" * 40)],
+        )
+
+    def test_active_compatibility_source_uses_no_nonexistent_list_method(self) -> None:
+        source = inspect.getsource(compat)
+        self.assertNotIn("list_kernels(", source)
+        self.assertIn("/api/kernels?author=", source)
+        self.assertIn("kernel_info(", source)
+        self.assertIn("list_repo_files(", source)
+
+    def test_source_is_read_only_except_inherited_evidence_report(self) -> None:
+        source = (HERE / "hf_official_estate_inventory_compat.py").read_text(encoding="utf-8")
+        for forbidden in (
+            "duplicate_repo(",
+            "create_repo(",
+            "delete_repo(",
+            "update_repo_settings(",
+            "restart_space(",
+            "CommitOperationCopy",
+        ):
+            self.assertNotIn(forbidden, source)
+
+    def test_report_names_mixed_official_api_contract_honestly(self) -> None:
+        source = inspect.getsource(compat.CurrentHubEstateInventory.report)
+        self.assertIn("Official Hub REST /api/kernels", source)
+        self.assertIn("HfApi.kernel_info", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-official-estate-inventory.yml
+++ b/.github/workflows/hf-official-estate-inventory.yml
@@ -5,13 +5,17 @@ on:
     branches: [main]
     paths:
       - .github/scripts/hf_official_estate_inventory.py
+      - .github/scripts/hf_official_estate_inventory_compat.py
       - .github/scripts/test_hf_official_estate_inventory.py
+      - .github/scripts/test_hf_official_estate_inventory_compat.py
       - .github/workflows/hf-official-estate-inventory.yml
   pull_request:
     branches: [main]
     paths:
       - .github/scripts/hf_official_estate_inventory.py
+      - .github/scripts/hf_official_estate_inventory_compat.py
       - .github/scripts/test_hf_official_estate_inventory.py
+      - .github/scripts/test_hf_official_estate_inventory_compat.py
       - .github/workflows/hf-official-estate-inventory.yml
   schedule:
     - cron: '41 */12 * * *'
@@ -63,18 +67,22 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install supported Hub client
+      - name: Install supported Hub clients
         run: |
           python -m pip install --disable-pip-version-check \
-            "huggingface_hub>=1.3,<2"
+            "huggingface_hub>=1.3,<2" \
+            "requests>=2.32,<3"
 
       - name: Compile and test no-clone official inventory contract
         run: |
           set -euo pipefail
           python -m py_compile \
             .github/scripts/hf_official_estate_inventory.py \
-            .github/scripts/test_hf_official_estate_inventory.py
+            .github/scripts/hf_official_estate_inventory_compat.py \
+            .github/scripts/test_hf_official_estate_inventory.py \
+            .github/scripts/test_hf_official_estate_inventory_compat.py
           python .github/scripts/test_hf_official_estate_inventory.py
+          python .github/scripts/test_hf_official_estate_inventory_compat.py
           git diff --check
 
       - name: Require organization credential for publish-mode inventory
@@ -92,7 +100,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          python .github/scripts/hf_official_estate_inventory.py \
+          python .github/scripts/hf_official_estate_inventory_compat.py \
             --publish \
             --generation "${GITHUB_SHA}"
           code=$?
@@ -165,6 +173,7 @@ jobs:
               and canonical.get('sdk') == 'docker'
               and all(clones.values())
               and len(clones) == 4
+              and counts.get('kernels') is not None
               and counts.get('collections') is not None
               and counts.get('collection_references') is not None
               and counts.get('buckets') is not None
@@ -175,7 +184,7 @@ jobs:
             gh issue close "$issue_number" \
               --repo "$GITHUB_REPOSITORY" \
               --reason completed \
-              --comment 'Official HfApi inventory, collection reference resolution, bucket readback, canonical runtime, and permanent clone absence all passed.' || true
+              --comment 'Supported HfApi inventory, official Kernel Hub discovery with HfApi readback, collection reference resolution, bucket readback, canonical runtime, and permanent clone absence all passed.' || true
           else
             gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY" || true
           fi


### PR DESCRIPTION
Closed without merge because protected `.github/main` advanced with the Viewer readiness and Dataset Server diagnostic implementation.

The exact three-file compatibility fix was rebuilt directly on the new protected head as #266. #266 retains the same current Kernel Hub discovery and HfApi readback contract with zero commits behind main.