### PR TITLE
fix(hf): prove Lake and torch27 kernel readiness end to end

### DIFF
--- a/.github/scripts/hf_release_readiness_v2.py
+++ b/.github/scripts/hf_release_readiness_v2.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Verify the current SZL Lake Viewer and first-class kernels without mutation.
+
+This verifier is read-only for Hugging Face assets. It requires the current Lake
+revision to expose the reviewed homogeneous receipts configuration, waits only
+through bounded transient Dataset Server states, and runs ``selfcheck()`` on the
+exact immutable revisions of both first-class kernels. The workflow that calls
+this module supplies the CPU PyTorch 2.7.1 runtime required by the published
+``torch27`` governed-norm build.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+ORG = "SZLHOLDINGS"
+DATASET_ID = f"{ORG}/szl-lake"
+KERNEL_IDS = (
+    f"{ORG}/governed-inference-meter",
+    f"{ORG}/szl-governed-norm",
+)
+VIEWER_URL = (
+    "https://datasets-server.huggingface.co/first-rows"
+    "?dataset=SZLHOLDINGS%2Fszl-lake&config=receipts&split=train"
+)
+REQUIRED_DATASET_FILES = {
+    "README.md",
+    "khipu/amaru_receipts.parquet",
+    "khipu/sentra_receipts.parquet",
+    "khipu/a11oy_receipts.parquet",
+    "khipu/rosie_receipts.parquet",
+    "khipu/killinchu_receipts.parquet",
+    "khipu/EMPTY_CHAIN_MANIFEST.json",
+}
+TRANSIENT_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+TRANSIENT_MARKERS = (
+    "busy",
+    "busier than usual",
+    "not ready",
+    "processing",
+    "loading",
+    "temporarily unavailable",
+    "retry",
+)
+
+
+@dataclass(frozen=True)
+class Action:
+    target: str
+    action: str
+    status: str
+    detail: str = ""
+
+
+def json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if dataclasses.is_dataclass(value):
+        return {key: json_safe(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [json_safe(item) for item in value]
+    return str(value)
+
+
+def response_detail(response: Any) -> str:
+    status = int(getattr(response, "status_code", 0) or 0)
+    text = str(getattr(response, "text", "") or "")[:300]
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001
+        payload = None
+    if isinstance(payload, dict) and payload.get("error"):
+        text = str(payload.get("error"))[:300]
+    return f"HTTP {status}: {text}"
+
+
+def is_transient_response(response: Any) -> bool:
+    status = int(getattr(response, "status_code", 0) or 0)
+    if status in TRANSIENT_STATUSES:
+        return True
+    try:
+        payload = response.json()
+    except Exception:  # noqa: BLE001
+        payload = None
+    if status != 200 or not isinstance(payload, dict) or not payload.get("error"):
+        return False
+    lowered = str(payload.get("error") or "").lower()
+    return any(marker in lowered for marker in TRANSIENT_MARKERS)
+
+
+def wait_for_viewer(
+    session: Any,
+    *,
+    attempts: int = 30,
+    retry_seconds: float = 20.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[Any, dict[str, Any], int]:
+    """Return the first valid Viewer response or fail closed after a bound."""
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+    if retry_seconds < 0:
+        raise ValueError("retry_seconds must be non-negative")
+
+    last_detail = "viewer was not queried"
+    for attempt in range(1, attempts + 1):
+        try:
+            response = session.get(
+                VIEWER_URL,
+                timeout=90,
+                headers={
+                    "Accept": "application/json",
+                    "Cache-Control": "no-cache, no-store, max-age=0",
+                    "Pragma": "no-cache",
+                    "User-Agent": "szl-hf-release-readiness-v2/1",
+                },
+            )
+        except requests.RequestException as exc:
+            last_detail = f"{type(exc).__name__}: {exc}"
+            transient = True
+        else:
+            status = int(getattr(response, "status_code", 0) or 0)
+            if status == 200:
+                try:
+                    payload = response.json()
+                except Exception as exc:  # noqa: BLE001
+                    raise RuntimeError(
+                        f"Dataset Viewer returned non-JSON HTTP 200: {exc}"
+                    ) from exc
+                if not isinstance(payload, dict):
+                    raise RuntimeError("Dataset Viewer HTTP 200 payload is not an object")
+                if not payload.get("error"):
+                    return response, payload, attempt
+            transient = is_transient_response(response)
+            last_detail = response_detail(response)
+
+        if not transient:
+            raise RuntimeError(
+                f"Dataset Viewer contract failed non-transiently: {last_detail}"
+            )
+        if attempt == attempts:
+            break
+        sleep(min(60.0, retry_seconds * attempt))
+
+    raise RuntimeError(
+        f"Dataset Viewer did not become ready after {attempts} attempts: {last_detail}"
+    )
+
+
+def default_kernel_loader(repo_id: str, revision: str) -> Any:
+    from kernels import get_kernel
+
+    return get_kernel(repo_id, revision=revision, trust_remote_code=True)
+
+
+def verify_kernel(
+    api: Any,
+    repo_id: str,
+    *,
+    loader: Callable[[str, str], Any] = default_kernel_loader,
+) -> dict[str, Any]:
+    info = api.kernel_info(repo_id)
+    revision = str(getattr(info, "sha", "") or "")
+    if len(revision) != 40:
+        raise RuntimeError(f"kernel lacks immutable revision: {repo_id}@{revision!r}")
+    files = set(api.list_repo_files(repo_id, repo_type="kernel", revision=revision))
+    missing = {"README.md", "contract.json"} - files
+    if missing:
+        raise RuntimeError(f"kernel contract is incomplete: {repo_id}: {sorted(missing)}")
+    if not any(path.startswith("build/") for path in files):
+        raise RuntimeError(f"kernel build variants are missing: {repo_id}")
+
+    module = loader(repo_id, revision)
+    check = getattr(module, "selfcheck", None)
+    if not callable(check):
+        raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+    outcome = check()
+    if outcome is False or (isinstance(outcome, dict) and outcome.get("ok") is False):
+        raise RuntimeError(f"{repo_id}@{revision} selfcheck failed: {outcome}")
+    return {
+        "repo_id": repo_id,
+        "revision": revision,
+        "remote_file_count": len(files),
+        "build_variants_present": True,
+        "selfcheck": json_safe(outcome),
+    }
+
+
+class ReleaseReadinessVerifier:
+    def __init__(
+        self,
+        *,
+        token: str,
+        generation: str,
+        attempts: int,
+        retry_seconds: float,
+    ) -> None:
+        from huggingface_hub import HfApi
+
+        self.token = token
+        self.generation = generation
+        self.attempts = attempts
+        self.retry_seconds = retry_seconds
+        self.api = HfApi(token=token or None)
+        self.actions: list[Action] = []
+        self.results: dict[str, Any] = {}
+
+    def record(self, target: str, action: str, status: str, detail: str = "") -> None:
+        self.actions.append(Action(target, action, status, detail))
+        print(f"[{status:>10}] {action}: {target}" + (f" — {detail}" if detail else ""))
+
+    def authenticate(self) -> None:
+        if not self.token:
+            self.record(ORG, "authenticate", "warning", "public read-only mode")
+            return
+        who = self.api.whoami()
+        match = next(
+            (
+                item
+                for item in (who.get("orgs") or [])
+                if str(item.get("name") or item.get("fullname") or "").upper() == ORG
+            ),
+            None,
+        )
+        if match is None:
+            raise RuntimeError(f"authenticated identity is not a member of {ORG}")
+        role = str(match.get("roleInOrg") or match.get("role") or "").lower()
+        self.record(ORG, "authenticate", "validated", f"role={role or 'unknown'}")
+
+    def verify_dataset(self) -> None:
+        info = self.api.dataset_info(DATASET_ID)
+        revision = str(getattr(info, "sha", "") or "")
+        if len(revision) != 40:
+            raise RuntimeError(f"dataset lacks immutable revision: {revision!r}")
+        files = set(
+            self.api.list_repo_files(DATASET_ID, repo_type="dataset", revision=revision)
+        )
+        missing = sorted(REQUIRED_DATASET_FILES - files)
+        if missing:
+            raise RuntimeError(f"published Lake revision is incomplete: {missing}")
+        response, payload, attempts = wait_for_viewer(
+            requests.Session(),
+            attempts=self.attempts,
+            retry_seconds=self.retry_seconds,
+        )
+        self.results["dataset"] = {
+            "repo_id": DATASET_ID,
+            "revision": revision,
+            "viewer_http_status": int(response.status_code),
+            "viewer_attempts": attempts,
+            "remote_file_count": len(files),
+            "viewer_payload_keys": sorted(payload.keys()),
+        }
+        self.record(
+            DATASET_ID,
+            "dataset-viewer-readiness",
+            "validated",
+            f"revision={revision}; HTTP=200; attempts={attempts}; files={len(files)}",
+        )
+
+    def verify_kernels(self) -> None:
+        output: dict[str, Any] = {}
+        for repo_id in KERNEL_IDS:
+            result = verify_kernel(self.api, repo_id)
+            output[repo_id] = result
+            self.record(
+                repo_id,
+                "kernel-selfcheck",
+                "validated",
+                f"revision={result['revision']}; files={result['remote_file_count']}",
+            )
+        self.results["kernels"] = output
+
+    def report(self) -> dict[str, Any]:
+        statuses = [item.status for item in self.actions]
+        return {
+            "schema": "szl.hf-release-readiness/v2",
+            "organization": ORG,
+            "generation": self.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": False,
+            "results": json_safe(self.results),
+            "actions": [asdict(item) for item in self.actions],
+            "summary": {
+                "ok": sum(status == "validated" for status in statuses),
+                "warning": sum(status == "warning" for status in statuses),
+                "error": 0,
+            },
+            "boundaries": [
+                "This verifier performs no Hugging Face asset mutation.",
+                "Dataset success requires a final HTTP 200 JSON object without an error field.",
+                "Kernel success requires exact immutable revisions, retained build variants, and selfcheck().",
+                "PyTorch is supplied by the workflow runtime and is not published into a kernel repository.",
+            ],
+        }
+
+    def run(self) -> dict[str, Any]:
+        self.authenticate()
+        self.verify_dataset()
+        self.verify_kernels()
+        return self.report()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        default="reports/hf-release-readiness-v2-latest.json",
+    )
+    parser.add_argument("--generation", default=os.environ.get("GITHUB_SHA") or "manual")
+    parser.add_argument("--attempts", type=int, default=30)
+    parser.add_argument("--retry-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+
+    token = (
+        os.environ.get("HF_ORG_TOKEN")
+        or os.environ.get("HF_ORG_TOKEN1")
+        or os.environ.get("HF_TOKEN")
+        or ""
+    )
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        report = ReleaseReadinessVerifier(
+            token=token,
+            generation=args.generation,
+            attempts=args.attempts,
+            retry_seconds=args.retry_seconds,
+        ).run()
+    except Exception as exc:  # noqa: BLE001
+        report = {
+            "schema": "szl.hf-release-readiness/v2",
+            "organization": ORG,
+            "generation": args.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": False,
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1},
+        }
+        report_path.write_text(
+            json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+            encoding="utf-8",
+        )
+        print(json.dumps(report, indent=2, sort_keys=True, default=str))
+        return 1
+
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_release_readiness_v2.py
+++ b/.github/scripts/test_hf_release_readiness_v2.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+readiness = importlib.import_module("hf_release_readiness_v2")
+
+
+class Response:
+    def __init__(self, status: int, payload: object, text: str = "") -> None:
+        self.status_code = status
+        self._payload = payload
+        self.text = text or str(payload)
+
+    def json(self) -> object:
+        return self._payload
+
+
+class Session:
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def get(self, *_args, **_kwargs):
+        self.calls += 1
+        value = next(self.responses)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class KernelInfo:
+    def __init__(self, sha: str = "a" * 40) -> None:
+        self.sha = sha
+
+
+class Api:
+    def __init__(self, files: list[str] | None = None) -> None:
+        self.files = files or [
+            "README.md",
+            "contract.json",
+            "build/torch27-cxx11-cpu-x86_64-linux/__init__.py",
+        ]
+        self.info_calls: list[str] = []
+        self.file_calls: list[tuple[str, str | None, str | None]] = []
+
+    def kernel_info(self, repo_id: str) -> KernelInfo:
+        self.info_calls.append(repo_id)
+        return KernelInfo()
+
+    def list_repo_files(
+        self,
+        repo_id: str,
+        repo_type: str | None = None,
+        revision: str | None = None,
+    ) -> list[str]:
+        self.file_calls.append((repo_id, repo_type, revision))
+        return list(self.files)
+
+
+class Module:
+    def __init__(self, result: object) -> None:
+        self.result = result
+
+    def selfcheck(self) -> object:
+        return self.result
+
+
+class ReleaseReadinessV2Tests(unittest.TestCase):
+    def test_viewer_retries_transient_then_requires_real_success(self) -> None:
+        session = Session(
+            [
+                Response(500, {"error": "The server is busier than usual and not ready"}),
+                Response(200, {"rows": [], "features": []}),
+            ]
+        )
+        sleeps: list[float] = []
+        response, payload, attempts = readiness.wait_for_viewer(
+            session,
+            attempts=3,
+            retry_seconds=2,
+            sleep=sleeps.append,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(payload, {"rows": [], "features": []})
+        self.assertEqual(attempts, 2)
+        self.assertEqual(sleeps, [2])
+
+    def test_viewer_fails_immediately_on_non_transient_response(self) -> None:
+        session = Session([Response(404, {"error": "missing"})])
+        with self.assertRaisesRegex(RuntimeError, "non-transiently"):
+            readiness.wait_for_viewer(session, attempts=3, retry_seconds=0)
+        self.assertEqual(session.calls, 1)
+
+    def test_kernel_requires_exact_revision_builds_and_selfcheck(self) -> None:
+        api = Api()
+        observed = readiness.verify_kernel(
+            api,
+            "SZLHOLDINGS/example",
+            loader=lambda repo_id, revision: Module(
+                {"ok": True, "repo_id": repo_id, "revision": revision}
+            ),
+        )
+        self.assertEqual(observed["revision"], "a" * 40)
+        self.assertTrue(observed["build_variants_present"])
+        self.assertTrue(observed["selfcheck"]["ok"])
+        self.assertEqual(api.info_calls, ["SZLHOLDINGS/example"])
+        self.assertEqual(
+            api.file_calls,
+            [("SZLHOLDINGS/example", "kernel", "a" * 40)],
+        )
+
+    def test_kernel_rejects_false_selfcheck(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "selfcheck failed"):
+            readiness.verify_kernel(
+                Api(),
+                "SZLHOLDINGS/example",
+                loader=lambda _repo_id, _revision: Module(False),
+            )
+
+    def test_kernel_rejects_missing_build_variant(self) -> None:
+        api = Api(files=["README.md", "contract.json"])
+        with self.assertRaisesRegex(RuntimeError, "build variants are missing"):
+            readiness.verify_kernel(
+                api,
+                "SZLHOLDINGS/example",
+                loader=lambda _repo_id, _revision: Module(True),
+            )
+
+    def test_source_has_no_asset_mutation_path(self) -> None:
+        source = (HERE / "hf_release_readiness_v2.py").read_text(encoding="utf-8")
+        for forbidden in (
+            "upload_file(",
+            "upload_folder(",
+            "create_repo(",
+            "delete_repo(",
+            "update_repo_settings(",
+            "set_space_hardware(",
+            "restart_space(",
+        ):
+            self.assertNotIn(forbidden, source)
+        self.assertIn("torch27", source)
+        self.assertIn("selfcheck()", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-release-readiness-v2.yml
+++ b/.github/workflows/hf-release-readiness-v2.yml
@@ -1,0 +1,183 @@
+name: HF Release Readiness v2
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_v2.py
+      - .github/scripts/test_hf_release_readiness_v2.py
+      - .github/workflows/hf-release-readiness-v2.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_v2.py
+      - .github/scripts/test_hf_release_readiness_v2.py
+      - .github/workflows/hf-release-readiness-v2.yml
+  schedule:
+    - cron: '7,37 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-release-readiness-v2-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lake Viewer and exact torch27 kernel selfchecks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: '1'
+      GH_TOKEN: ${{ github.token }}
+      REPORT_PATH: reports/hf-release-readiness-v2-latest.json
+    steps:
+      - name: Checkout verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install exact CPU runtime and supported Hub clients
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            --index-url https://download.pytorch.org/whl/cpu \
+            'torch==2.7.1'
+          python -m pip install --disable-pip-version-check \
+            'huggingface_hub>=1.3,<2' \
+            'kernels==0.16.0' \
+            'requests>=2.32,<3'
+
+      - name: Verify fail-closed source contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/hf_release_readiness_v2.py \
+            .github/scripts/test_hf_release_readiness_v2.py
+          python .github/scripts/test_hf_release_readiness_v2.py
+          python - <<'PY'
+          import torch
+          assert torch.__version__.startswith('2.7.1'), torch.__version__
+          assert not torch.cuda.is_available(), 'readiness runner must use the CPU runtime'
+          print('torch runtime:', torch.__version__)
+          PY
+          git diff --check
+
+      - name: Verify current immutable Hub state
+        if: github.event_name != 'pull_request'
+        id: readiness
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_release_readiness_v2.py \
+            --report "$REPORT_PATH" \
+            --generation "$GITHUB_SHA" \
+            --attempts 30 \
+            --retry-seconds 20
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write pull-request evidence without external mutation
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          mkdir -p reports
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          Path(os.environ['REPORT_PATH']).write_text(
+              json.dumps({
+                  'schema': 'szl.hf-release-readiness/v2-prerelease',
+                  'generation': os.environ.get('GITHUB_SHA'),
+                  'generated_at': datetime.now(timezone.utc).isoformat(),
+                  'publish': False,
+                  'source_tests': 'PASSED',
+                  'summary': {'ok': 1, 'warning': 0, 'error': 0},
+                  'boundary': 'No Hugging Face or issue mutation occurs on pull_request.',
+              }, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+      - name: Upload immutable readiness report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-release-readiness-v2-${{ github.run_id }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist and close deterministic evidence issues
+        if: always() && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          EXIT_CODE: ${{ steps.readiness.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          test -f "$REPORT_PATH"
+          write_issue() {
+            title="$1"
+            marker="$2"
+            body="$(mktemp)"
+            {
+              echo "<!-- ${marker} -->"
+              echo "# ${title}"
+              echo
+              echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+              echo "- Source revision: \`${GITHUB_SHA}\`"
+              echo
+              echo '```json'
+              cat "$REPORT_PATH"
+              echo '```'
+            } > "$body"
+            number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+              --search "${title} in:title" --json number,title \
+              --jq ".[] | select(.title == \"${title}\") | .number" | head -n1)"
+            if [ -n "$number" ]; then
+              gh issue edit "$number" --repo "$GITHUB_REPOSITORY" --body-file "$body"
+            else
+              gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+                --body-file "$body" >/dev/null
+              number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+                --search "${title} in:title" --json number,title \
+                --jq ".[] | select(.title == \"${title}\") | .number" | head -n1)"
+            fi
+            if [ "${EXIT_CODE:-2}" = '0' ]; then
+              gh issue close "$number" --repo "$GITHUB_REPOSITORY" --reason completed \
+                --comment 'The live Lake Viewer returned HTTP 200 and both exact immutable kernel revisions passed selfcheck() under the pinned CPU torch27 runtime.' || true
+            else
+              gh issue reopen "$number" --repo "$GITHUB_REPOSITORY" || true
+            fi
+            rm -f "$body"
+          }
+          write_issue '[hf-release-finalization-report] Lake viewer and kernel selfchecks' \
+            'szl-hf-release-finalization-report'
+          write_issue '[hf-kernel-card-publish] first-class card contracts' \
+            'szl-hf-kernel-card-publish'
+
+      - name: Enforce real readiness result
+        if: always() && github.event_name != 'pull_request'
+        env:
+          EXIT_CODE: ${{ steps.readiness.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::HF release readiness v2 failed with exit ${code}."
+            exit "$code"
+          fi
+          echo 'Lake Viewer and both exact kernel selfchecks are operational.'


### PR DESCRIPTION
## Outcome

Replace the remaining environment-only verification gap with one read-only, recurring proof of the published estate.

- pin CPU PyTorch 2.7.1 from the official CPU wheel index;
- verify the current immutable `SZLHOLDINGS/szl-lake` revision contains the reviewed homogeneous receipt files;
- wait only through bounded transient Dataset Server states and still require a final HTTP 200 JSON object with no error;
- read both first-class kernels at exact immutable revisions;
- require `README.md`, `contract.json`, and retained `build/` variants;
- execute `selfcheck()` for `governed-inference-meter` and `szl-governed-norm` under the correct torch27 runtime;
- update and close issues #257 and #275 only after every gate passes;
- perform no dataset, kernel, model, Space, visibility, hardware, training, or promotion mutation.

This supersedes the broken deletion-only repair in #276 and provides the durable half-hourly readiness lane required for external Dataset Server convergence.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>