### PR TITLE
ops(hf): install exact recurring publisher runtime repair

### DIFF
--- a/.github/workflows/execute-hf-publisher-numpy-patch.yml
+++ b/.github/workflows/execute-hf-publisher-numpy-patch.yml
@@ -1,0 +1,124 @@
+name: Execute HF publisher NumPy runtime repair
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/execute-hf-publisher-numpy-patch.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: execute-hf-publisher-numpy-runtime-repair
+  cancel-in-progress: false
+
+env:
+  TARGET_BRANCH: fix/hf-kernel-publisher-numpy-runtime-v2-20260722
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout protected main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Create exact repair branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git switch -c "$TARGET_BRANCH"
+
+      - name: Pin NumPy next to the existing CPU torch27 publisher runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/workflows/hf-kernel-card-publish-v2.yml')
+          text = path.read_text(encoding='utf-8')
+
+          old_packages = '''          python -m pip install --disable-pip-version-check \\
+            "huggingface_hub>=1.3,<2" \\
+            "kernels==0.16.0" \\
+            "pytest>=8,<9"
+'''
+          new_packages = '''          python -m pip install --disable-pip-version-check \\
+            "huggingface_hub>=1.3,<2" \\
+            "kernels==0.16.0" \\
+            "numpy==2.2.6" \\
+            "pytest>=8,<9"
+'''
+          if text.count(old_packages) != 1:
+              raise SystemExit('expected the current client install block exactly once')
+          text = text.replace(old_packages, new_packages, 1)
+
+          old_runtime = '''          import torch
+          assert torch.__version__.split('+', 1)[0] == '2.7.1', torch.__version__
+          assert not torch.cuda.is_available()
+          print('verified CPU PyTorch runtime:', torch.__version__)
+'''
+          new_runtime = '''          import numpy as np
+          import torch
+          assert np.__version__ == '2.2.6', np.__version__
+          assert torch.__version__.split('+', 1)[0] == '2.7.1', torch.__version__
+          assert not torch.cuda.is_available()
+          print('verified CPU PyTorch and NumPy runtime:', torch.__version__, np.__version__)
+'''
+          if text.count(old_runtime) != 1:
+              raise SystemExit('expected the current torch runtime assertion block exactly once')
+          text = text.replace(old_runtime, new_runtime, 1)
+
+          if text.count('"numpy==2.2.6"') != 1:
+              raise SystemExit('NumPy pin must appear exactly once')
+          path.write_text(text, encoding='utf-8')
+          PY
+
+          python - <<'PY'
+          from pathlib import Path
+          text = Path('.github/workflows/hf-kernel-card-publish-v2.yml').read_text(encoding='utf-8')
+          assert '"numpy==2.2.6"' in text
+          assert "assert np.__version__ == '2.2.6'" in text
+          assert 'delete_repo(' not in text
+          assert 'update_repo_settings(' not in text
+          print('publisher runtime repair is exact and mutation scope remains narrow')
+          PY
+          git diff --check
+
+      - name: Remove one-shot executor and commit clean product diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rm .github/workflows/execute-hf-publisher-numpy-patch.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/workflows/hf-kernel-card-publish-v2.yml
+          git commit \
+            -m 'fix(hf): install NumPy for governed-norm publisher selfcheck' \
+            -m 'Pin NumPy 2.2.6 next to the existing CPU torch27 runtime while preserving card/contract-only publication and exact immutable selfchecks.' \
+            -m 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          git push origin "HEAD:${TARGET_BRANCH}"
+
+      - name: Open the clean protected-main pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$TARGET_BRANCH" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "PR #${existing} already exists."
+            exit 0
+          fi
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$TARGET_BRANCH" \
+            --title 'fix(hf): install NumPy in recurring kernel publisher' \
+            --body 'Add the exact NumPy 2.2.6 runtime required by the immutable governed-norm receipt selfcheck, alongside the existing CPU torch 2.7.1 runtime. The final diff changes only the recurring card/contract publisher; it changes no model, dataset, Space, visibility, hardware, training, or promotion state.\n\nSigned-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'


### PR DESCRIPTION
## Outcome

Install one one-shot protected-main executor that will:

- patch the current recurring first-class kernel publisher from protected `main`;
- add the exact `numpy==2.2.6` runtime next to CPU PyTorch 2.7.1;
- preserve card/contract-only publication, immutable readback, build variants, and exact-revision selfchecks;
- create a separate clean product PR;
- remove this executor from that final product diff.

This installer does not itself mutate Hugging Face, models, datasets, Spaces, visibility, hardware, training, or promotion state.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>