### PR TITLE
ops(hf): execute registered NumPy publisher installer

### DIFF
--- a/.github/workflows/patch-hf-kernel-publisher-numpy-final.yml
+++ b/.github/workflows/patch-hf-kernel-publisher-numpy-final.yml
@@ -1,5 +1,6 @@
 name: Install final NumPy kernel publisher repair
 
+# Registered on protected main; this second reviewed touch executes the installer.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Outcome

Perform the required second protected-main touch after the installer workflow was registered.

The resulting protected-main push executes the already-reviewed installer, which creates a clean product branch that:

- adds `numpy==2.2.6` to the recurring kernel publisher;
- asserts exact NumPy 2.2.6 and CPU PyTorch 2.7.1 runtimes;
- modifies only the recurring publisher workflow;
- removes the temporary installer from the final product branch.

This trigger performs no Hugging Face mutation and changes no model, dataset, Space, visibility, hardware, training, or promotion state.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>