### PR TITLE
fix(ci): restrict publisher repair command to repository owner

### DIFF
--- a/.github/workflows/execute-hf-publisher-numpy-patch.yml
+++ b/.github/workflows/execute-hf-publisher-numpy-patch.yml
@@ -16,7 +16,7 @@ jobs:
   repair:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.issue.number == 275 &&
+      (github.actor == 'stephenlutar2-hash' &&
        github.event.comment.body == '/execute-hf-publisher-numpy-repair')
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Outcome

Make the explicit one-shot publisher repair command both usable and fail-closed.

- accept the exact `/execute-hf-publisher-numpy-repair` command only from `stephenlutar2-hash`;
- allow the command on an open issue so GitHub emits the workflow event reliably;
- preserve the clean product-branch behavior introduced in #284;
- keep Hugging Face mutations out of this command PR;
- retain normal protected checks for the generated product PR.

The command creates a branch that adds NumPy 2.2.6 beside CPU PyTorch 2.7.1 and removes both completed installer workflows.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>