### PR TITLE
fix(replit): install fail-closed Unified Control Hub deployment verifier [duplicate of merged #287]

### DIFF
--- a/.github/scripts/discover_replit_receipt.py
+++ b/.github/scripts/discover_replit_receipt.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Discover and validate the public Unified Control Hub deployment receipt.
+
+The verifier is read-only.  It accepts only a complete, public HTTPS contract:
+GET and HEAD must agree on immutable source/deployment revisions, the receipt
+must bind itself to the expected Replit application, and test/mobile/readiness
+evidence must be explicit rather than inferred from an HTTP 200.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+REPL_ID = "34870515-2d52-4ad8-9636-40cc3ced1771"
+RECEIPT_PATH = "/api/szl/deployment-receipt"
+RECEIPT_SCHEMA = "szl.unified-control-hub.deployment-receipt/v1"
+REPORT_SCHEMA = "szl.replit-public-status/v1"
+DEFAULT_ORIGINS = (
+    "https://unified-control-hub--stephenlutar2.repl.co",
+    "https://unified-control-hub-stephenlutar2.repl.co",
+    "https://unified-control-hub-stephenlutar2.replit.app",
+    "https://unified-control-hub.stephenlutar2.repl.co",
+)
+SOURCE_REVISION_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+DEPLOYMENT_REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{6,127}$")
+MAX_BODY_BYTES = 1_048_576
+
+
+@dataclass(frozen=True)
+class Attempt:
+    origin: str
+    receipt_url: str
+    ok: bool
+    missing: list[str]
+    detail: str
+    get_status: int | None = None
+    head_status: int | None = None
+    final_origin: str | None = None
+
+
+class ContractError(RuntimeError):
+    """Raised when a reachable endpoint violates the deployment contract."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalized_origin(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value.strip())
+    if parsed.scheme.lower() != "https":
+        raise ValueError("origin must use HTTPS")
+    if not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError("origin must contain a public hostname and no credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("origin must not contain a query or fragment")
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"https://{parsed.hostname.lower()}{port}"
+
+
+def origin_from_url(value: str) -> str:
+    return normalized_origin(value)
+
+
+def candidate_origins(
+    explicit: Iterable[str] = (),
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> list[str]:
+    environment = environment or os.environ
+    values: list[str] = []
+    values.extend(explicit)
+    configured = environment.get("REPLIT_PRODUCTION_URL", "").strip()
+    if configured:
+        values.append(configured)
+    configured_many = environment.get("REPLIT_ORIGINS", "").strip()
+    if configured_many:
+        values.extend(item.strip() for item in configured_many.split(","))
+    values.extend(DEFAULT_ORIGINS)
+
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not value:
+            continue
+        try:
+            origin = normalized_origin(value)
+        except (TypeError, ValueError):
+            continue
+        if origin not in seen:
+            seen.add(origin)
+            output.append(origin)
+    if not output:
+        raise ValueError("no valid HTTPS Replit origins were supplied")
+    return output
+
+
+def _read_response(response: Any, *, read_body: bool) -> tuple[int, str, dict[str, str], bytes]:
+    status = int(getattr(response, "status", 0) or getattr(response, "code", 0) or 0)
+    final_url = str(response.geturl())
+    headers = {str(key).lower(): str(value) for key, value in response.headers.items()}
+    body = response.read(MAX_BODY_BYTES + 1) if read_body else b""
+    if len(body) > MAX_BODY_BYTES:
+        raise ContractError("response body exceeds 1 MiB")
+    return status, final_url, headers, body
+
+
+def http_request(
+    opener: Any,
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+) -> tuple[int, str, dict[str, str], bytes]:
+    request = urllib.request.Request(
+        url,
+        method=method,
+        headers={
+            "Accept": "application/json",
+            "Cache-Control": "no-cache, no-store, max-age=0",
+            "Pragma": "no-cache",
+            "User-Agent": "szl-replit-receipt-verifier/1",
+        },
+    )
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            return _read_response(response, read_body=method != "HEAD")
+    except urllib.error.HTTPError as exc:
+        status, final_url, headers, body = _read_response(
+            exc,
+            read_body=method != "HEAD",
+        )
+        detail = body[:300].decode("utf-8", errors="replace")
+        raise ContractError(f"{method} returned HTTP {status}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise ContractError(f"{method} failed: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise ContractError(f"{method} timed out") from exc
+
+
+def _expect_object(receipt: dict[str, Any], key: str, missing: list[str]) -> dict[str, Any]:
+    value = receipt.get(key)
+    if not isinstance(value, dict):
+        missing.append(key)
+        return {}
+    return value
+
+
+def _validate_timestamp(value: Any, key: str, missing: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        missing.append(key)
+        return
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        missing.append(key)
+        return
+    if parsed.tzinfo is None:
+        missing.append(key)
+
+
+def validate_receipt(
+    receipt: Any,
+    *,
+    requested_origin: str,
+    final_url: str,
+    head_headers: Mapping[str, str],
+) -> tuple[list[str], str]:
+    missing: list[str] = []
+    if not isinstance(receipt, dict):
+        return ["JSON object"], requested_origin
+
+    final_origin = origin_from_url(final_url)
+    if receipt.get("schema") != RECEIPT_SCHEMA:
+        missing.append("schema")
+    if receipt.get("repl_id") != REPL_ID:
+        missing.append("repl_id")
+
+    source_revision = receipt.get("source_revision")
+    if not isinstance(source_revision, str) or not SOURCE_REVISION_RE.fullmatch(
+        source_revision.strip().lower()
+    ):
+        missing.append("source_revision")
+
+    deployment_revision = receipt.get("deployment_revision")
+    if not isinstance(deployment_revision, str) or not DEPLOYMENT_REVISION_RE.fullmatch(
+        deployment_revision.strip()
+    ):
+        missing.append("deployment_revision")
+
+    production_url = receipt.get("production_url")
+    try:
+        receipt_origin = normalized_origin(str(production_url))
+    except (TypeError, ValueError):
+        missing.append("production_url")
+        receipt_origin = ""
+    else:
+        if receipt_origin != final_origin:
+            missing.append("production_url binding")
+
+    _validate_timestamp(receipt.get("generated_at"), "generated_at", missing)
+
+    tests = _expect_object(receipt, "tests", missing)
+    if str(tests.get("status", "")).lower() not in {"passed", "pass", "green"}:
+        missing.append("tests.status")
+    commands = tests.get("commands")
+    if not isinstance(commands, list) or not commands or not all(
+        isinstance(item, str) and item.strip() for item in commands
+    ):
+        missing.append("tests.commands")
+
+    mobile = _expect_object(receipt, "mobile", missing)
+    if str(mobile.get("status", "")).lower() not in {"passed", "pass", "green"}:
+        missing.append("mobile.status")
+    viewports = mobile.get("viewport_widths")
+    if not isinstance(viewports, list) or not any(
+        isinstance(item, int) and 280 <= item <= 480 for item in viewports
+    ):
+        missing.append("mobile.viewport_widths")
+
+    readiness = _expect_object(receipt, "readiness", missing)
+    if readiness.get("ok") is not True:
+        missing.append("readiness.ok")
+    if str(readiness.get("status", "")).lower() not in {"ready", "operational", "green"}:
+        missing.append("readiness.status")
+    checks = readiness.get("checks")
+    if not isinstance(checks, dict) or not checks or any(value is not True for value in checks.values()):
+        missing.append("readiness.checks")
+
+    expected_source = str(source_revision or "")
+    expected_deployment = str(deployment_revision or "")
+    if head_headers.get("x-szl-source-revision", "") != expected_source:
+        missing.append("HEAD X-SZL-Source-Revision")
+    if head_headers.get("x-szl-deployment-revision", "") != expected_deployment:
+        missing.append("HEAD X-SZL-Deployment-Revision")
+
+    return sorted(set(missing)), final_origin
+
+
+def probe_origin(
+    origin: str,
+    *,
+    opener: Any | None = None,
+    timeout: float = 20.0,
+) -> tuple[Attempt, dict[str, Any] | None]:
+    opener = opener or urllib.request.build_opener()
+    origin = normalized_origin(origin)
+    url = origin + RECEIPT_PATH
+    get_status: int | None = None
+    head_status: int | None = None
+    try:
+        get_status, final_url, get_headers, body = http_request(
+            opener,
+            "GET",
+            url,
+            timeout=timeout,
+        )
+        if get_status != 200:
+            raise ContractError(f"GET returned HTTP {get_status}")
+        if "application/json" not in get_headers.get("content-type", "").lower():
+            raise ContractError("GET did not return application/json")
+        try:
+            receipt = json.loads(body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ContractError(f"GET returned invalid JSON: {exc}") from exc
+
+        head_status, head_final_url, head_headers, _ = http_request(
+            opener,
+            "HEAD",
+            url,
+            timeout=timeout,
+        )
+        if head_status not in {200, 204}:
+            raise ContractError(f"HEAD returned HTTP {head_status}")
+        if origin_from_url(head_final_url) != origin_from_url(final_url):
+            raise ContractError("GET and HEAD resolved to different public origins")
+
+        missing, final_origin = validate_receipt(
+            receipt,
+            requested_origin=origin,
+            final_url=final_url,
+            head_headers=head_headers,
+        )
+        if missing:
+            return (
+                Attempt(
+                    origin=origin,
+                    receipt_url=url,
+                    ok=False,
+                    missing=missing,
+                    detail="deployment receipt is incomplete or inconsistent",
+                    get_status=get_status,
+                    head_status=head_status,
+                    final_origin=final_origin,
+                ),
+                None,
+            )
+        return (
+            Attempt(
+                origin=origin,
+                receipt_url=url,
+                ok=True,
+                missing=[],
+                detail="GET/HEAD and deployment evidence contract passed",
+                get_status=get_status,
+                head_status=head_status,
+                final_origin=final_origin,
+            ),
+            receipt,
+        )
+    except (ContractError, ValueError) as exc:
+        return (
+            Attempt(
+                origin=origin,
+                receipt_url=url,
+                ok=False,
+                missing=["receipt GET/HEAD or contract"],
+                detail=str(exc),
+                get_status=get_status,
+                head_status=head_status,
+            ),
+            None,
+        )
+
+
+def discover(
+    origins: Iterable[str],
+    *,
+    attempts: int = 3,
+    interval_seconds: float = 20.0,
+    timeout: float = 20.0,
+    opener_factory: Callable[[], Any] = urllib.request.build_opener,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+    if interval_seconds < 0:
+        raise ValueError("interval_seconds must be non-negative")
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    candidates = list(origins)
+    all_attempts: list[Attempt] = []
+    for cycle in range(1, attempts + 1):
+        for origin in candidates:
+            attempt, receipt = probe_origin(
+                origin,
+                opener=opener_factory(),
+                timeout=timeout,
+            )
+            all_attempts.append(attempt)
+            if attempt.ok and receipt is not None:
+                return {
+                    "schema": REPORT_SCHEMA,
+                    "repl_id": REPL_ID,
+                    "generated_at": utc_now(),
+                    "ok": True,
+                    "status": "OPERATIONAL",
+                    "production_url": attempt.final_origin,
+                    "receipt": receipt,
+                    "attempts": [asdict(item) for item in all_attempts],
+                    "current_blocker": None,
+                }
+        if cycle < attempts:
+            sleep(interval_seconds)
+
+    details = "; ".join(
+        f"{item.origin}: {item.detail}" for item in all_attempts[-len(candidates) :]
+    )
+    return {
+        "schema": REPORT_SCHEMA,
+        "repl_id": REPL_ID,
+        "generated_at": utc_now(),
+        "ok": False,
+        "status": "BLOCKED",
+        "production_url": None,
+        "receipt": None,
+        "attempts": [asdict(item) for item in all_attempts],
+        "current_blocker": (
+            "No complete public Unified Control Hub deployment receipt passed "
+            f"GET, HEAD, provenance, tests, mobile, and readiness validation: {details}"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        default="reports/replit-receipt-discovery-latest.json",
+    )
+    parser.add_argument("--origin", action="append", default=[])
+    parser.add_argument("--attempts", type=int, default=3)
+    parser.add_argument("--interval-seconds", type=float, default=20.0)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        report = discover(
+            candidate_origins(args.origin),
+            attempts=args.attempts,
+            interval_seconds=args.interval_seconds,
+            timeout=args.timeout,
+        )
+    except Exception as exc:  # noqa: BLE001
+        report = {
+            "schema": REPORT_SCHEMA,
+            "repl_id": REPL_ID,
+            "generated_at": utc_now(),
+            "ok": False,
+            "status": "BLOCKED",
+            "production_url": None,
+            "receipt": None,
+            "attempts": [],
+            "current_blocker": f"{type(exc).__name__}: {exc}",
+        }
+
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report.get("ok") is True else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_discover_replit_receipt.py
+++ b/.github/scripts/test_discover_replit_receipt.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Contract tests for discover_replit_receipt.py."""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timezone
+from email.message import Message
+
+import discover_replit_receipt as target
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        url: str,
+        body: bytes = b"",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status = status
+        self.code = status
+        self._url = url
+        self._body = body
+        self._headers = Message()
+        for key, value in (headers or {}).items():
+            self._headers[key] = value
+
+    @property
+    def headers(self) -> Message:
+        return self._headers
+
+    def read(self, amount: int = -1) -> bytes:
+        return self._body if amount < 0 else self._body[:amount]
+
+    def geturl(self) -> str:
+        return self._url
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class FakeOpener:
+    def __init__(self, responses: dict[tuple[str, str], FakeResponse]) -> None:
+        self.responses = responses
+
+    def open(self, request: object, timeout: float) -> FakeResponse:
+        method = request.get_method()
+        url = request.full_url
+        response = self.responses.get((method, url))
+        if response is None:
+            raise AssertionError(f"unexpected request: {method} {url}")
+        return response
+
+
+def valid_receipt(origin: str) -> dict[str, object]:
+    return {
+        "schema": target.RECEIPT_SCHEMA,
+        "repl_id": target.REPL_ID,
+        "source_revision": "a" * 64,
+        "deployment_revision": "deployment-20260722-0001",
+        "production_url": origin,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "tests": {
+            "status": "passed",
+            "commands": ["npm run lint", "npm test", "npm run build"],
+        },
+        "mobile": {
+            "status": "passed",
+            "viewport_widths": [320, 390, 768, 1440],
+        },
+        "readiness": {
+            "ok": True,
+            "status": "ready",
+            "checks": {
+                "http": True,
+                "frontend": True,
+                "backend": True,
+                "receipt": True,
+            },
+        },
+    }
+
+
+def opener_for(origin: str, receipt: dict[str, object]) -> FakeOpener:
+    url = origin + target.RECEIPT_PATH
+    return FakeOpener(
+        {
+            ("GET", url): FakeResponse(
+                status=200,
+                url=url,
+                body=json.dumps(receipt).encode(),
+                headers={"Content-Type": "application/json; charset=utf-8"},
+            ),
+            ("HEAD", url): FakeResponse(
+                status=200,
+                url=url,
+                headers={
+                    "X-SZL-Source-Revision": str(receipt["source_revision"]),
+                    "X-SZL-Deployment-Revision": str(receipt["deployment_revision"]),
+                },
+            ),
+        }
+    )
+
+
+class ReceiptContractTests(unittest.TestCase):
+    def test_valid_receipt_passes_get_head_and_evidence(self) -> None:
+        origin = "https://example.replit.app"
+        receipt = valid_receipt(origin)
+        attempt, observed = target.probe_origin(
+            origin,
+            opener=opener_for(origin, receipt),
+            timeout=1,
+        )
+        self.assertTrue(attempt.ok)
+        self.assertEqual(observed, receipt)
+        self.assertEqual(attempt.get_status, 200)
+        self.assertEqual(attempt.head_status, 200)
+
+    def test_missing_mobile_evidence_fails_closed(self) -> None:
+        origin = "https://example.replit.app"
+        receipt = valid_receipt(origin)
+        receipt.pop("mobile")
+        attempt, observed = target.probe_origin(
+            origin,
+            opener=opener_for(origin, receipt),
+            timeout=1,
+        )
+        self.assertFalse(attempt.ok)
+        self.assertIsNone(observed)
+        self.assertIn("mobile", attempt.missing)
+
+    def test_head_revision_mismatch_fails_closed(self) -> None:
+        origin = "https://example.replit.app"
+        receipt = valid_receipt(origin)
+        opener = opener_for(origin, receipt)
+        url = origin + target.RECEIPT_PATH
+        opener.responses[("HEAD", url)] = FakeResponse(
+            status=200,
+            url=url,
+            headers={
+                "X-SZL-Source-Revision": "b" * 64,
+                "X-SZL-Deployment-Revision": str(receipt["deployment_revision"]),
+            },
+        )
+        attempt, observed = target.probe_origin(origin, opener=opener, timeout=1)
+        self.assertFalse(attempt.ok)
+        self.assertIsNone(observed)
+        self.assertIn("HEAD X-SZL-Source-Revision", attempt.missing)
+
+    def test_candidate_origins_deduplicate_and_reject_http(self) -> None:
+        origins = target.candidate_origins(
+            [
+                "https://Example.Replit.App/",
+                "https://example.replit.app",
+                "http://unsafe.example",
+            ],
+            environment={"REPLIT_PRODUCTION_URL": ""},
+        )
+        self.assertEqual(origins[0], "https://example.replit.app")
+        self.assertEqual(origins.count("https://example.replit.app"), 1)
+        self.assertNotIn("http://unsafe.example", origins)
+
+    def test_discover_returns_first_complete_origin(self) -> None:
+        broken = "https://broken.replit.app"
+        working = "https://working.replit.app"
+        broken_receipt = valid_receipt(broken)
+        broken_receipt["tests"] = {"status": "failed", "commands": ["npm test"]}
+        working_receipt = valid_receipt(working)
+        openers = iter(
+            [
+                opener_for(broken, broken_receipt),
+                opener_for(working, working_receipt),
+            ]
+        )
+        report = target.discover(
+            [broken, working],
+            attempts=1,
+            interval_seconds=0,
+            timeout=1,
+            opener_factory=lambda: next(openers),
+            sleep=lambda _: None,
+        )
+        self.assertTrue(report["ok"])
+        self.assertEqual(report["status"], "OPERATIONAL")
+        self.assertEqual(report["production_url"], working)
+        self.assertEqual(len(report["attempts"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/discover-replit-receipt-main.yml
+++ b/.github/workflows/discover-replit-receipt-main.yml
@@ -1,0 +1,160 @@
+name: Discover Unified Control Hub Receipt
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/discover_replit_receipt.py
+      - .github/scripts/test_discover_replit_receipt.py
+      - .github/workflows/discover-replit-receipt-main.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/discover_replit_receipt.py
+      - .github/scripts/test_discover_replit_receipt.py
+      - .github/workflows/discover-replit-receipt-main.yml
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: discover-unified-control-hub-receipt-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Public GET/HEAD, provenance, tests, mobile and readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPORT_PATH: reports/replit-receipt-discovery-latest.json
+      REPLIT_PRODUCTION_URL: ${{ vars.REPLIT_PRODUCTION_URL }}
+    steps:
+      - name: Checkout verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Verify fail-closed source contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/discover_replit_receipt.py \
+            .github/scripts/test_discover_replit_receipt.py
+          python .github/scripts/test_discover_replit_receipt.py
+          git diff --check
+
+      - name: Discover and validate public deployment receipt
+        if: github.event_name != 'pull_request'
+        id: discovery
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/discover_replit_receipt.py \
+            --report "$REPORT_PATH" \
+            --attempts 3 \
+            --interval-seconds 20 \
+            --timeout 20
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write pull-request evidence without external calls
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          mkdir -p reports
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          Path(os.environ['REPORT_PATH']).write_text(
+              json.dumps({
+                  'schema': 'szl.replit-public-status/v1-prerelease',
+                  'generated_at': datetime.now(timezone.utc).isoformat(),
+                  'source_revision': os.environ.get('GITHUB_SHA'),
+                  'publish': False,
+                  'source_tests': 'PASSED',
+                  'summary': {'ok': 1, 'warning': 0, 'error': 0},
+                  'boundary': 'No Replit endpoint or GitHub issue mutation occurs on pull_request.',
+              }, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+      - name: Upload immutable discovery report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: replit-receipt-discovery-${{ github.run_id }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist deterministic deployment issue
+        if: always() && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          EXIT_CODE: ${{ steps.discovery.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          test -f "$REPORT_PATH"
+          title='[replit-deployment-receipt] Unified Control Hub'
+          marker='szl-replit-public-status'
+          body="$(mktemp)"
+          {
+            echo "<!-- ${marker} -->"
+            echo '# Unified Control Hub deployment receipt'
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Verifier source revision: \`${GITHUB_SHA}\`"
+            echo
+            echo '```json'
+            cat "$REPORT_PATH"
+            echo '```'
+          } > "$body"
+
+          number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+            --search "${title} in:title" --json number,title \
+            --jq ".[] | select(.title == \"${title}\") | .number" | head -n1)"
+          if [ -n "$number" ]; then
+            gh issue edit "$number" --repo "$GITHUB_REPOSITORY" --body-file "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --body-file "$body" >/dev/null
+            number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+              --search "${title} in:title" --json number,title \
+              --jq ".[] | select(.title == \"${title}\") | .number" | head -n1)"
+          fi
+
+          if [ "${EXIT_CODE:-2}" = '0' ]; then
+            gh issue close "$number" --repo "$GITHUB_REPOSITORY" --reason completed \
+              --comment 'The public Unified Control Hub passed GET and HEAD receipt validation with bound source/deployment revisions, explicit test and mobile evidence, and ready backend/frontend checks.' || true
+          else
+            gh issue reopen "$number" --repo "$GITHUB_REPOSITORY" || true
+          fi
+          rm -f "$body"
+
+      - name: Enforce real deployment result
+        if: always() && github.event_name != 'pull_request'
+        env:
+          EXIT_CODE: ${{ steps.discovery.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::Unified Control Hub has no complete public deployment receipt."
+            exit "$code"
+          fi
+          echo 'Unified Control Hub is public, revision-bound, tested, mobile-verified and operational.'


### PR DESCRIPTION
Closed without merge because #287 landed the same three-file read-only Replit receipt verifier on protected main.

This branch was independently rebuilt as one signed commit, but merging it would duplicate the already-landed verifier. No Replit or Hugging Face mutation occurred from this branch.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>