### PR TITLE
fix(hf): finalize governed-norm publisher runtime

### DIFF
--- a/.github/workflows/finalize-kernel-publisher-branch.yml
+++ b/.github/workflows/finalize-kernel-publisher-branch.yml
@@ -1,0 +1,112 @@
+name: Finalize kernel publisher product branch
+
+on:
+  push:
+    branches:
+      - fix/hf-kernel-publisher-numpy-runtime-v3-20260722
+    paths:
+      - .github/workflows/finalize-kernel-publisher-branch.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-kernel-publisher-product-branch
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout exact product branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: fix/hf-kernel-publisher-numpy-runtime-v3-20260722
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Apply exact runtime repair and remove all installers
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/workflows/hf-kernel-card-publish-v2.yml')
+          text = path.read_text(encoding='utf-8')
+
+          old_packages = '''          python -m pip install --disable-pip-version-check \\
+            "huggingface_hub>=1.3,<2" \\
+            "kernels==0.16.0" \\
+            "pytest>=8,<9"
+'''
+          new_packages = '''          python -m pip install --disable-pip-version-check \\
+            "huggingface_hub>=1.3,<2" \\
+            "kernels==0.16.0" \\
+            "numpy==2.2.6" \\
+            "pytest>=8,<9"
+'''
+          if text.count(old_packages) != 1:
+              raise SystemExit('expected the current publisher package block exactly once')
+          text = text.replace(old_packages, new_packages, 1)
+
+          old_runtime = '''          import torch
+          assert torch.__version__.split('+', 1)[0] == '2.7.1', torch.__version__
+          assert not torch.cuda.is_available()
+          print('verified CPU PyTorch runtime:', torch.__version__)
+'''
+          new_runtime = '''          import numpy as np
+          import torch
+          assert np.__version__ == '2.2.6', np.__version__
+          assert torch.__version__.split('+', 1)[0] == '2.7.1', torch.__version__
+          assert not torch.cuda.is_available()
+          print('verified CPU PyTorch and NumPy runtime:', torch.__version__, np.__version__)
+'''
+          if text.count(old_runtime) != 1:
+              raise SystemExit('expected the current torch runtime assertion block exactly once')
+          text = text.replace(old_runtime, new_runtime, 1)
+
+          if text.count('"numpy==2.2.6"') != 1:
+              raise SystemExit('NumPy pin must appear exactly once')
+          if text.count("assert np.__version__ == '2.2.6'") != 1:
+              raise SystemExit('NumPy runtime assertion must appear exactly once')
+          path.write_text(text, encoding='utf-8')
+          PY
+
+          git rm -f --ignore-unmatch \
+            .github/workflows/execute-hf-publisher-numpy-patch.yml \
+            .github/workflows/patch-hf-kernel-publisher-numpy-final.yml \
+            .github/workflows/finalize-kernel-publisher-branch.yml
+
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path('.github/workflows/hf-kernel-card-publish-v2.yml')
+          text = path.read_text(encoding='utf-8')
+          assert text.count('"numpy==2.2.6"') == 1
+          assert text.count("assert np.__version__ == '2.2.6'") == 1
+          assert 'delete_repo(' not in text
+          assert 'update_repo_settings(' not in text
+          assert 'set_space_hardware(' not in text
+          assert 'request_space_hardware(' not in text
+          for removed in (
+              '.github/workflows/execute-hf-publisher-numpy-patch.yml',
+              '.github/workflows/patch-hf-kernel-publisher-numpy-final.yml',
+              '.github/workflows/finalize-kernel-publisher-branch.yml',
+          ):
+              assert not Path(removed).exists(), removed
+          print('clean publisher product diff verified')
+          PY
+
+          git diff --check
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/workflows/hf-kernel-card-publish-v2.yml
+          git diff --cached --check
+          git commit \
+            -m 'fix(hf): finalize governed-norm publisher runtime' \
+            -m 'Pin NumPy 2.2.6 next to CPU torch 2.7.1 and remove every completed one-shot installer workflow from the final product diff.' \
+            -m 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          git push origin HEAD:fix/hf-kernel-publisher-numpy-runtime-v3-20260722

--- a/.github/workflows/finalize-kernel-publisher-branch.yml
+++ b/.github/workflows/finalize-kernel-publisher-branch.yml
@@ -6,6 +6,10 @@ on:
       - fix/hf-kernel-publisher-numpy-runtime-v3-20260722
     paths:
       - .github/workflows/finalize-kernel-publisher-branch.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/finalize-kernel-publisher-branch.yml
   workflow_dispatch: {}
 
 permissions:
@@ -17,6 +21,7 @@ concurrency:
 
 jobs:
   finalize:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Superseded without merge by the protected-main two-stage execution path in #291.

The branch-only assembler could not run because repository automation executes trusted workflow definitions from protected main. No product change from this PR was merged. The replacement path creates a fresh v4 product branch and removes every installer from the final diff.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>