### PR TITLE
fix(ci): execute final publisher repair from protected main

### DIFF
--- a/.github/workflows/execute-hf-publisher-numpy-patch.yml
+++ b/.github/workflows/execute-hf-publisher-numpy-patch.yml
@@ -1,6 +1,10 @@
 name: Execute final HF publisher NumPy repair
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/execute-hf-publisher-numpy-patch.yml
   issue_comment:
     types: [created]
   workflow_dispatch: {}
@@ -15,13 +19,14 @@ concurrency:
 jobs:
   repair:
     if: >-
+      github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       (github.actor == 'stephenlutar2-hash' &&
        github.event.comment.body == '/execute-hf-publisher-numpy-repair')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      TARGET_BRANCH: fix/hf-kernel-publisher-numpy-runtime-v3-20260722
+      TARGET_BRANCH: fix/hf-kernel-publisher-numpy-runtime-v4-20260722
     steps:
       - name: Checkout protected main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Outcome

Add the missing protected-main push trigger to the already-reviewed publisher repair workflow and move its generated product branch to a fresh v4 ref.

When this PR merges, the default-branch workflow will:

- start from exact protected main;
- add NumPy 2.2.6 beside CPU PyTorch 2.7.1 in the recurring kernel publisher;
- verify exact runtime assertions and the narrow mutation boundary;
- delete itself and the superseded one-shot installer;
- create a clean signed product commit on `fix/hf-kernel-publisher-numpy-runtime-v4-20260722`.

This trigger PR itself performs no Hugging Face mutation and changes no model, dataset, Space, visibility, hardware, training, weight, or promotion state.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>