### PR TITLE
fix(hf): verify release readiness without unsupported kernel repo_type

### DIFF
--- a/.github/scripts/hf_release_readiness_terminal.py
+++ b/.github/scripts/hf_release_readiness_terminal.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Close the HF release-readiness gate without unsupported kernel repo_type calls.
+
+This verifier is intentionally read-only for Hugging Face assets. It validates the
+published Lake Dataset Viewer and exact first-class kernel selfchecks, writes one
+local JSON report, and may update the deterministic GitHub evidence issue.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import requests
+from huggingface_hub import HfApi
+
+ORG = "SZLHOLDINGS"
+DATASET_ID = f"{ORG}/szl-lake"
+ISSUE_REPO = "szl-holdings/.github"
+ISSUE_NUMBER = 257
+ISSUE_MARKER = "szl-hf-release-finalization-report"
+KERNEL_IDS = (
+    f"{ORG}/governed-inference-meter",
+    f"{ORG}/szl-governed-norm",
+)
+VIEWER_URL = (
+    "https://datasets-server.huggingface.co/first-rows"
+    "?dataset=SZLHOLDINGS%2Fszl-lake&config=receipts&split=train"
+)
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class Action:
+    target: str
+    action: str
+    status: str
+    detail: str = ""
+
+
+def _token() -> str | None:
+    return os.environ.get("HF_ORG_TOKEN") or os.environ.get("HF_ORG_TOKEN1") or os.environ.get("HF_TOKEN")
+
+
+def _headers(token: str | None) -> dict[str, str]:
+    headers = {"Accept": "application/json", "User-Agent": "szl-hf-release-readiness-terminal/1"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _selfcheck_passed(value: Any) -> bool:
+    if value is True:
+        return True
+    if not isinstance(value, Mapping):
+        return False
+    if value.get("ok") is False or value.get("passed") is False:
+        return False
+    if value.get("ok") is True or value.get("passed") is True:
+        return True
+    checks = value.get("checks")
+    return isinstance(checks, Mapping) and bool(checks) and all(item is True for item in checks.values())
+
+
+class TerminalReadiness:
+    def __init__(self, *, token: str, generation: str) -> None:
+        self.token = token
+        self.generation = generation
+        self.api = HfApi(token=token)
+        self.actions: list[Action] = []
+        self.results: dict[str, Any] = {}
+
+    def record(self, target: str, action: str, status: str, detail: str = "") -> None:
+        self.actions.append(Action(target, action, status, detail))
+        print(f"[{status:>10}] {action}: {target}" + (f" — {detail}" if detail else ""))
+
+    def verify_dataset(self) -> None:
+        info = self.api.dataset_info(DATASET_ID)
+        revision = str(getattr(info, "sha", "") or "")
+        if not SHA40.fullmatch(revision):
+            raise RuntimeError(f"dataset lacks immutable revision: {revision!r}")
+        files = set(self.api.list_repo_files(DATASET_ID, repo_type="dataset"))
+        required = {
+            "README.md",
+            "khipu/amaru_receipts.parquet",
+            "khipu/sentra_receipts.parquet",
+            "khipu/a11oy_receipts.parquet",
+            "khipu/rosie_receipts.parquet",
+            "khipu/killinchu_receipts.parquet",
+            "khipu/EMPTY_CHAIN_MANIFEST.json",
+        }
+        missing = sorted(required - files)
+        if missing:
+            raise RuntimeError(f"dataset is missing viewer files: {missing}")
+        response = requests.get(VIEWER_URL, headers=_headers(self.token), timeout=90)
+        if response.status_code != 200:
+            raise RuntimeError(f"Dataset Viewer did not return HTTP 200: {response.status_code} {response.text[:300]}")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RuntimeError("Dataset Viewer did not return JSON") from exc
+        if not isinstance(payload, dict) or payload.get("error"):
+            raise RuntimeError(f"Dataset Viewer returned an error payload: {payload}")
+        self.results["dataset"] = {
+            "repo_id": DATASET_ID,
+            "revision": revision,
+            "remote_file_count": len(files),
+            "viewer_http_status": response.status_code,
+            "viewer_json_keys": sorted(payload)[:50],
+        }
+        self.record(DATASET_ID, "dataset-viewer-readback", "validated", f"revision={revision}; files={len(files)}")
+
+    def _kernel_tree_count(self, repo_id: str, revision: str) -> int:
+        owner, name = repo_id.split("/", 1)
+        url = f"https://huggingface.co/api/kernels/{owner}/{name}/tree/{revision}?recursive=true"
+        response = requests.get(url, headers=_headers(self.token), timeout=90)
+        if response.status_code != 200:
+            raise RuntimeError(f"kernel tree readback failed for {repo_id}@{revision}: HTTP {response.status_code} {response.text[:300]}")
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise RuntimeError(f"kernel tree payload is not a list for {repo_id}")
+        file_count = sum(1 for item in payload if isinstance(item, dict) and item.get("type") in {"file", "blob"})
+        if file_count <= 0:
+            raise RuntimeError(f"kernel tree contains no files for {repo_id}@{revision}")
+        return file_count
+
+    def verify_kernel(self, repo_id: str) -> None:
+        info = self.api.kernel_info(repo_id)
+        revision = str(getattr(info, "sha", "") or "")
+        if not SHA40.fullmatch(revision):
+            raise RuntimeError(f"kernel lacks immutable revision: {repo_id} {revision!r}")
+        file_count = self._kernel_tree_count(repo_id, revision)
+        from kernels import get_kernel
+
+        module = get_kernel(repo_id, revision=revision, trust_remote_code=True)
+        check = getattr(module, "selfcheck", None)
+        if not callable(check):
+            raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+        result = check()
+        if not _selfcheck_passed(result):
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck did not pass: {result}")
+        self.results.setdefault("kernels", {})[repo_id] = {
+            "revision": revision,
+            "remote_file_count": file_count,
+            "selfcheck": result,
+        }
+        self.record(repo_id, "kernel-tree-and-selfcheck", "validated", f"revision={revision}; files={file_count}")
+
+    def report(self) -> dict[str, Any]:
+        statuses = [action.status for action in self.actions]
+        return {
+            "schema": "szl.hf-release-finalization/v1",
+            "organization": ORG,
+            "generation": self.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": True,
+            "results": self.results,
+            "actions": [asdict(action) for action in self.actions],
+            "summary": {
+                "ok": sum(status in {"validated", "updated", "ok"} for status in statuses),
+                "warning": sum(status == "warning" for status in statuses),
+                "error": sum(status == "error" for status in statuses),
+                "dry_run": 0,
+            },
+            "boundaries": [
+                "This terminal verifier performs no Hugging Face mutation.",
+                "It uses dataset repo_type only for the Lake dataset and Kernel Hub REST tree readback for first-class kernels.",
+                "Kernel selfcheck is executed at the exact immutable revision observed by HfApi.kernel_info().",
+                "No model weights are trained, merged, relabeled, uploaded, deployed, or promoted.",
+            ],
+        }
+
+    def run(self) -> dict[str, Any]:
+        self.verify_dataset()
+        for repo_id in KERNEL_IDS:
+            self.verify_kernel(repo_id)
+        return self.report()
+
+
+def issue_body(report: Mapping[str, Any], run_url: str | None) -> str:
+    lines = [
+        f"<!-- {ISSUE_MARKER} -->",
+        "# Hugging Face release finalization",
+        "",
+    ]
+    if run_url:
+        lines.append(f"- Run: {run_url}")
+    lines.extend([
+        f"- Source revision: `{report.get('generation')}`",
+        "",
+        "```json",
+        json.dumps(report, indent=2, sort_keys=True, default=str),
+        "```",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def publish_issue(report: Mapping[str, Any]) -> None:
+    token = os.environ.get("SZL_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise RuntimeError("no GitHub token is configured for issue publication")
+    run_url = None
+    if os.environ.get("GITHUB_SERVER_URL") and os.environ.get("GITHUB_REPOSITORY") and os.environ.get("GITHUB_RUN_ID"):
+        run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    body = issue_body(report, run_url)
+    state = "closed" if int((report.get("summary") or {}).get("error", 1)) == 0 else "open"
+    response = requests.patch(
+        f"https://api.github.com/repos/{ISSUE_REPO}/issues/{ISSUE_NUMBER}",
+        headers={**_headers(token), "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
+        json={"body": body, "state": state},
+        timeout=60,
+    )
+    if response.status_code not in {200, 201}:
+        raise RuntimeError(f"issue update failed: HTTP {response.status_code} {response.text[:500]}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", default="reports/hf-release-finalization-latest.json")
+    parser.add_argument("--generation", default=os.environ.get("GITHUB_SHA") or "manual")
+    parser.add_argument("--publish-issue", action="store_true")
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    token = _token()
+    try:
+        if not token:
+            raise RuntimeError("no supported Hugging Face token is configured")
+        report = TerminalReadiness(token=token, generation=args.generation).run()
+    except Exception as exc:  # noqa: BLE001
+        report = {
+            "schema": "szl.hf-release-finalization/v1",
+            "organization": ORG,
+            "generation": args.generation,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "publish": True,
+            "fatal": f"{type(exc).__name__}: {exc}",
+            "summary": {"ok": 0, "warning": 0, "error": 1, "dry_run": 0},
+        }
+        report_path.write_text(json.dumps(report, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+        if args.publish_issue:
+            publish_issue(report)
+        print(f"FATAL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1 if args.enforce else 0
+
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+    if args.publish_issue:
+        publish_issue(report)
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_release_readiness_terminal.py
+++ b/.github/scripts/test_hf_release_readiness_terminal.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+terminal = importlib.import_module("hf_release_readiness_terminal")
+
+
+class TerminalReleaseReadinessTests(unittest.TestCase):
+    def test_selfcheck_parser_requires_positive_evidence(self) -> None:
+        self.assertTrue(terminal._selfcheck_passed(True))
+        self.assertTrue(terminal._selfcheck_passed({"ok": True}))
+        self.assertTrue(terminal._selfcheck_passed({"checks": {"a": True, "b": True}}))
+        self.assertFalse(terminal._selfcheck_passed(False))
+        self.assertFalse(terminal._selfcheck_passed({"ok": False}))
+        self.assertFalse(terminal._selfcheck_passed({"checks": {"a": True, "b": False}}))
+        self.assertFalse(terminal._selfcheck_passed({"checks": {}}))
+
+    def test_issue_body_contains_machine_readable_report(self) -> None:
+        report = {
+            "schema": "szl.hf-release-finalization/v1",
+            "generation": "a" * 40,
+            "generated_at": "2026-07-22T00:00:00+00:00",
+            "publish": True,
+            "results": {"dataset": {"revision": "b" * 40}},
+            "summary": {"ok": 1, "warning": 0, "error": 0, "dry_run": 0},
+        }
+        body = terminal.issue_body(report, "https://github.com/szl-holdings/.github/actions/runs/1")
+        self.assertIn(terminal.ISSUE_MARKER, body)
+        start = body.index("```json") + len("```json")
+        end = body.index("```", start)
+        parsed = json.loads(body[start:end].strip())
+        self.assertEqual(parsed["schema"], "szl.hf-release-finalization/v1")
+        self.assertEqual(parsed["generation"], "a" * 40)
+
+    def test_source_does_not_use_unsupported_kernel_repo_type_or_hf_mutation(self) -> None:
+        source = (HERE / "hf_release_readiness_terminal.py").read_text(encoding="utf-8")
+        forbidden = (
+            'repo_type="kernel"',
+            "repo_type='kernel'",
+            "upload_file(",
+            "upload_folder(",
+            "create_repo(",
+            "delete_repo(",
+            "duplicate_repo(",
+            "restart_space(",
+        )
+        for token in forbidden:
+            self.assertNotIn(token, source)
+
+    def test_report_shape_matches_final_estate_reconciler_expectations(self) -> None:
+        report = {
+            "schema": "szl.hf-release-finalization/v1",
+            "publish": True,
+            "summary": {"ok": 3, "warning": 0, "error": 0, "dry_run": 0},
+            "results": {
+                "dataset": {
+                    "revision": "b" * 40,
+                    "remote_file_count": 7,
+                    "viewer_http_status": 200,
+                },
+                "kernels": {
+                    repo_id: {
+                        "revision": "c" * 40,
+                        "remote_file_count": 10,
+                        "selfcheck": {"ok": True},
+                    }
+                    for repo_id in terminal.KERNEL_IDS
+                },
+            },
+        }
+        dataset = report["results"]["dataset"]
+        kernels = report["results"]["kernels"]
+        self.assertEqual(dataset["viewer_http_status"], 200)
+        self.assertGreater(dataset["remote_file_count"], 0)
+        self.assertEqual(set(kernels), set(terminal.KERNEL_IDS))
+        self.assertTrue(all(terminal.SHA40.fullmatch(v["revision"]) for v in kernels.values()))
+        self.assertTrue(all(terminal._selfcheck_passed(v["selfcheck"]) for v in kernels.values()))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-release-readiness-terminal.yml
+++ b/.github/workflows/hf-release-readiness-terminal.yml
@@ -1,0 +1,136 @@
+name: HF Release Readiness Terminal
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_terminal.py
+      - .github/scripts/test_hf_release_readiness_terminal.py
+      - .github/workflows/hf-release-readiness-terminal.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_release_readiness_terminal.py
+      - .github/scripts/test_hf_release_readiness_terminal.py
+      - .github/workflows/hf-release-readiness-terminal.yml
+  schedule:
+    - cron: '11,41 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: hf-release-readiness-terminal-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lake Viewer plus first-class kernel selfchecks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ github.token }}
+      HF_HUB_DISABLE_PROGRESS_BARS: '1'
+      REPORT_PATH: reports/hf-release-finalization-latest.json
+    steps:
+      - name: Checkout verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned CPU runtime and supported clients
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check \
+            --index-url https://download.pytorch.org/whl/cpu \
+            'torch==2.7.1'
+          python -m pip install --disable-pip-version-check \
+            'numpy==2.2.6' \
+            'huggingface_hub>=1.3,<2' \
+            'kernels==0.16.0' \
+            'requests>=2.32,<3'
+
+      - name: Compile and test terminal contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/hf_release_readiness_terminal.py \
+            .github/scripts/test_hf_release_readiness_terminal.py
+          python .github/scripts/test_hf_release_readiness_terminal.py
+          python - <<'PY'
+          import numpy
+          import torch
+          assert numpy.__version__ == '2.2.6', numpy.__version__
+          assert torch.__version__.startswith('2.7.1'), torch.__version__
+          assert not torch.cuda.is_available(), 'terminal readiness must use the CPU runtime'
+          print('numpy runtime:', numpy.__version__)
+          print('torch runtime:', torch.__version__)
+          PY
+          git diff --check
+
+      - name: Verify current Lake and kernel evidence
+        id: terminal
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_release_readiness_terminal.py \
+            --report "$REPORT_PATH" \
+            --generation "$GITHUB_SHA" \
+            --publish-issue \
+            --enforce
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write pull request no-mutation report
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p reports
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          Path(os.environ['REPORT_PATH']).write_text(json.dumps({
+              'schema': 'szl.hf-release-finalization/v1-prerelease',
+              'generation': os.environ.get('GITHUB_SHA'),
+              'generated_at': datetime.now(timezone.utc).isoformat(),
+              'publish': False,
+              'source_tests': 'PASSED',
+              'summary': {'ok': 1, 'warning': 0, 'error': 0, 'dry_run': 1},
+              'boundary': 'pull_request verifies source only; no Hugging Face or issue mutation occurs',
+          }, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+      - name: Upload immutable terminal readiness evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-release-readiness-terminal-${{ github.run_id }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Enforce terminal result outside pull requests
+        if: always() && github.event_name != 'pull_request'
+        env:
+          EXIT_CODE: ${{ steps.terminal.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          if [ "$code" -ne 0 ]; then
+            echo '::error::HF release readiness terminal verifier failed. The deterministic evidence issue remains open.'
+            exit "$code"
+          fi
+          echo 'Lake Viewer and both exact first-class kernel selfchecks are operational.'


### PR DESCRIPTION
## Root cause

The current release finalization evidence issue is still open because Hugging Face's installed client rejects `repo_type="kernel"` for file APIs. That blocks the Lake/kernel readiness gate even though first-class kernel selfchecks are available through the Kernel Hub runtime path.

## Repair

- add a terminal, read-only readiness verifier for issue #257;
- keep supported `repo_type="dataset"` usage for the Lake dataset only;
- replace kernel file readback with Kernel Hub REST tree readback;
- execute both exact first-class kernel `selfcheck()` calls through `kernels.get_kernel()` at immutable revisions;
- publish only the deterministic GitHub evidence issue and immutable workflow artifact;
- add unit tests proving the final-estate report shape and that no HF mutation or unsupported kernel repo-type call is present.

No model, dataset, Space, kernel implementation, visibility, hardware, training, signing, upload, deployment, or promotion state is mutated by this PR.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>