### PR TITLE
feat(hf): bind exact source identity in reusable Space deploys

### DIFF
--- a/.github/scripts/hf_space_source_binding.py
+++ b/.github/scripts/hf_space_source_binding.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Bind and verify an exact protected source revision in a Hugging Face Space.
+
+This module is deliberately separate from file publication. The reusable deployer
+already derives, pushes, and byte-attests the Dockerfile COPY set. This contract
+adds the missing runtime identity plane:
+
+1. add/update one non-secret Space variable with the exact checked-out Git SHA;
+2. independently read the variable back through the supported HfApi client;
+3. after deployment, GET a same-host standard build-info endpoint and require
+   ``build.state=OBSERVED`` plus ``build.revision=<exact Git SHA>``.
+
+It never changes Space hardware, visibility, sleep policy, secrets, models, or data.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+import requests
+from huggingface_hub import HfApi
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+VARIABLE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+REPORT_SCHEMA = "szl.hf-space-source-binding/v1"
+
+
+class SourceBindingError(RuntimeError):
+    """The source-binding contract cannot be established or verified."""
+
+
+def normalize_binding(repo_id: str, variable: str, revision: str, probe_path: str) -> dict[str, str]:
+    repo = str(repo_id or "").strip()
+    key = str(variable or "").strip()
+    sha = str(revision or "").strip().lower()
+    raw_path = str(probe_path or "").strip()
+    if REPO_ID.fullmatch(repo) is None:
+        raise SourceBindingError(f"invalid Hugging Face Space id: {repo!r}")
+    if VARIABLE.fullmatch(key) is None:
+        raise SourceBindingError(f"invalid source revision variable: {key!r}")
+    if SHA40.fullmatch(sha) is None:
+        raise SourceBindingError(f"source revision must be an exact 40-character SHA: {sha!r}")
+    parsed = urlsplit(raw_path)
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or not parsed.path.startswith("/")
+        or parsed.path.startswith("//")
+        or parsed.fragment
+    ):
+        raise SourceBindingError(
+            "source revision probe must be a same-host absolute path without a fragment"
+        )
+    path = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+    return {"repo_id": repo, "variable": key, "revision": sha, "probe_path": path}
+
+
+def live_origin(repo_id: str) -> str:
+    binding = normalize_binding(repo_id, "SOURCE_SHA", "0" * 40, "/api/build-info")
+    owner, name = binding["repo_id"].split("/", 1)
+    host = re.sub(r"[^a-z0-9-]+", "-", f"{owner}-{name}".lower()).strip("-")
+    if not host:
+        raise SourceBindingError(f"Space id has no usable app hostname: {repo_id!r}")
+    return f"https://{host}.hf.space"
+
+
+def _variable_value(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        observed = value.get("value")
+    else:
+        observed = getattr(value, "value", None)
+    return str(observed) if observed is not None else None
+
+
+def verify_variable(api: HfApi, binding: Mapping[str, str]) -> dict[str, Any]:
+    values = api.get_space_variables(binding["repo_id"])
+    if not isinstance(values, Mapping):
+        raise SourceBindingError("HfApi.get_space_variables() did not return a mapping")
+    item = values.get(binding["variable"])
+    observed = _variable_value(item)
+    if observed != binding["revision"]:
+        raise SourceBindingError(
+            f"Space variable readback mismatch for {binding['variable']}: "
+            f"expected {binding['revision']!r}, observed {observed!r}"
+        )
+    return {
+        "key": binding["variable"],
+        "expected": binding["revision"],
+        "observed": observed,
+        "matched": True,
+    }
+
+
+def bind_variable(api: HfApi, binding: Mapping[str, str]) -> dict[str, Any]:
+    api.add_space_variable(
+        repo_id=binding["repo_id"],
+        key=binding["variable"],
+        value=binding["revision"],
+        description=(
+            "Exact protected GitHub source revision serving this Space. "
+            "The reusable deployment contract fails closed on readback or runtime drift."
+        ),
+    )
+    return verify_variable(api, binding)
+
+
+def verify_runtime_probe(
+    binding: Mapping[str, str], *, session: requests.Session | None = None
+) -> dict[str, Any]:
+    session = session or requests.Session()
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Cache-Control": "no-cache, no-store, max-age=0",
+            "Pragma": "no-cache",
+            "User-Agent": "szl-hf-space-source-binding/1",
+        }
+    )
+    url = live_origin(binding["repo_id"]) + binding["probe_path"]
+    response = session.get(url, allow_redirects=False, timeout=60)
+    if response.status_code != 200:
+        raise SourceBindingError(
+            f"source revision probe returned HTTP {response.status_code}: {url}"
+        )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise SourceBindingError("source revision probe did not return JSON") from exc
+    if not isinstance(payload, Mapping):
+        raise SourceBindingError("source revision probe JSON is not an object")
+    build = payload.get("build")
+    if not isinstance(build, Mapping):
+        raise SourceBindingError("source revision probe lacks a build object")
+    observed = str(build.get("revision") or "").lower()
+    state = str(build.get("state") or "").upper()
+    receipt_minted = payload.get("receipt_minted")
+    if observed != binding["revision"] or state != "OBSERVED" or receipt_minted is not False:
+        raise SourceBindingError(
+            "runtime source binding mismatch: "
+            f"state={state!r}; expected={binding['revision']!r}; observed={observed!r}; "
+            f"receipt_minted={receipt_minted!r}"
+        )
+    return {
+        "url": url,
+        "http_status": response.status_code,
+        "content_type": response.headers.get("content-type"),
+        "bytes": len(response.content),
+        "build_state": state,
+        "expected_revision": binding["revision"],
+        "observed_revision": observed,
+        "receipt_minted": False,
+        "matched": True,
+    }
+
+
+def write_report(path: str, report: Mapping[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    binding = normalize_binding(args.repo_id, args.variable, args.revision, args.probe_path)
+    token = os.environ.get("HF_TOKEN")
+    if not token:
+        raise SourceBindingError("HF_TOKEN is required for Space variable bind/readback")
+    api = HfApi(token=token)
+    variable = bind_variable(api, binding) if args.mode == "bind" else verify_variable(api, binding)
+    runtime = verify_runtime_probe(binding) if args.mode == "verify" else {"status": "NOT_RUN"}
+    return {
+        "schema": REPORT_SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "mode": args.mode,
+        "repo_id": binding["repo_id"],
+        "source_revision": binding["revision"],
+        "source_revision_variable": binding["variable"],
+        "probe_path": binding["probe_path"],
+        "variable_readback": variable,
+        "runtime_probe": runtime,
+        "ok": True,
+        "boundaries": [
+            "Only one non-secret Space variable may be added or updated.",
+            "Verification uses supported HfApi variable readback and one same-host GET.",
+            "No Space hardware, visibility, sleep policy, secret, model, dataset, or branch state is changed.",
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("bind", "verify"), required=True)
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--variable", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--probe-path", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    try:
+        report = run(args)
+    except Exception as exc:  # noqa: BLE001
+        report = {
+            "schema": REPORT_SCHEMA,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "mode": args.mode,
+            "repo_id": args.repo_id,
+            "source_revision": args.revision,
+            "source_revision_variable": args.variable,
+            "probe_path": args.probe_path,
+            "ok": False,
+            "fatal": f"{type(exc).__name__}: {exc}",
+        }
+        write_report(args.output, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 1
+    write_report(args.output, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+import unittest.mock as mock
+from types import SimpleNamespace
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MODULE_PATH = os.path.join(HERE, "hf_space_source_binding.py")
+
+# The contract tests are network-free and must run in the repository's stdlib-only
+# test job. Stub import-time client modules only when they are not installed; every
+# API interaction is injected below.
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    requests_stub.Session = object
+    sys.modules["requests"] = requests_stub
+if "huggingface_hub" not in sys.modules:
+    hub_stub = types.ModuleType("huggingface_hub")
+    hub_stub.HfApi = object
+    sys.modules["huggingface_hub"] = hub_stub
+
+SPEC = importlib.util.spec_from_file_location("hf_space_source_binding", MODULE_PATH)
+assert SPEC and SPEC.loader
+binding = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(binding)
+
+
+class FakeApi:
+    def __init__(self, values=None):
+        self.values = values or {}
+        self.add_calls = []
+
+    def add_space_variable(self, **kwargs):
+        self.add_calls.append(kwargs)
+        self.values[kwargs["key"]] = SimpleNamespace(value=kwargs["value"])
+
+    def get_space_variables(self, repo_id):
+        self.repo_id = repo_id
+        return self.values
+
+
+class FakeResponse:
+    def __init__(self, payload, status=200, content_type="application/json"):
+        self._payload = payload
+        self.status_code = status
+        self.headers = {"content-type": content_type}
+        self.content = json.dumps(payload).encode("utf-8")
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.headers = {}
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.response
+
+
+class SourceBindingTests(unittest.TestCase):
+    def setUp(self):
+        self.sha = "a" * 40
+        self.normalized = binding.normalize_binding(
+            "SZLHOLDINGS/a11oy", "SZL_GIT_SHA", self.sha, "/api/build-info"
+        )
+
+    def test_normalize_requires_exact_repo_key_sha_and_same_host_path(self):
+        self.assertEqual(self.normalized["revision"], self.sha)
+        for args in (
+            ("bad", "SZL_GIT_SHA", self.sha, "/api/build-info"),
+            ("SZLHOLDINGS/a11oy", "bad-key", self.sha, "/api/build-info"),
+            ("SZLHOLDINGS/a11oy", "SZL_GIT_SHA", "short", "/api/build-info"),
+            ("SZLHOLDINGS/a11oy", "SZL_GIT_SHA", self.sha, "https://evil.example/x"),
+            ("SZLHOLDINGS/a11oy", "SZL_GIT_SHA", self.sha, "//evil.example/x"),
+        ):
+            with self.subTest(args=args):
+                with self.assertRaises(binding.SourceBindingError):
+                    binding.normalize_binding(*args)
+
+    def test_bind_updates_one_variable_then_reads_it_back(self):
+        api = FakeApi()
+        report = binding.bind_variable(api, self.normalized)
+        self.assertTrue(report["matched"])
+        self.assertEqual(len(api.add_calls), 1)
+        self.assertEqual(api.add_calls[0]["repo_id"], "SZLHOLDINGS/a11oy")
+        self.assertEqual(api.add_calls[0]["key"], "SZL_GIT_SHA")
+        self.assertEqual(api.add_calls[0]["value"], self.sha)
+        self.assertNotIn("token", api.add_calls[0])
+
+    def test_variable_readback_mismatch_fails_closed(self):
+        api = FakeApi({"SZL_GIT_SHA": SimpleNamespace(value="b" * 40)})
+        with self.assertRaisesRegex(binding.SourceBindingError, "readback mismatch"):
+            binding.verify_variable(api, self.normalized)
+
+    def test_runtime_probe_requires_observed_exact_revision_and_no_receipt(self):
+        payload = {
+            "status": "OBSERVED",
+            "build": {"state": "OBSERVED", "revision": self.sha},
+            "runtime": {"python": "3.12"},
+            "receipt_minted": False,
+        }
+        session = FakeSession(FakeResponse(payload))
+        report = binding.verify_runtime_probe(self.normalized, session=session)
+        self.assertTrue(report["matched"])
+        self.assertEqual(
+            session.calls[0][0],
+            "https://szlholdings-a11oy.hf.space/api/build-info",
+        )
+        self.assertFalse(session.calls[0][1]["allow_redirects"])
+
+        payload["build"]["revision"] = "b" * 40
+        with self.assertRaisesRegex(binding.SourceBindingError, "runtime source binding mismatch"):
+            binding.verify_runtime_probe(
+                self.normalized, session=FakeSession(FakeResponse(payload))
+            )
+
+    def test_runtime_probe_rejects_non_json_and_non_200(self):
+        with self.assertRaises(binding.SourceBindingError):
+            binding.verify_runtime_probe(
+                self.normalized,
+                session=FakeSession(FakeResponse({}, status=503)),
+            )
+        response = FakeResponse({}, status=200, content_type="text/html")
+        response.json = mock.Mock(side_effect=ValueError("not json"))
+        with self.assertRaises(binding.SourceBindingError):
+            binding.verify_runtime_probe(self.normalized, session=FakeSession(response))
+
+    def test_source_contains_no_secret_or_hardware_mutation(self):
+        with open(MODULE_PATH, encoding="utf-8") as fh:
+            source = fh.read()
+        for forbidden in (
+            "add_space_secret",
+            "delete_space_secret",
+            "request_space_hardware",
+            "set_space_sleep_time",
+            "update_repo_settings",
+            "restart_space",
+            "duplicate_space",
+        ):
+            self.assertNotIn(forbidden, source)
+
+    def test_cli_failure_report_contains_no_token(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = os.path.join(directory, "failure.json")
+            argv = [
+                "hf_space_source_binding.py",
+                "--mode",
+                "verify",
+                "--repo-id",
+                "SZLHOLDINGS/a11oy",
+                "--variable",
+                "SZL_GIT_SHA",
+                "--revision",
+                self.sha,
+                "--probe-path",
+                "/api/build-info",
+                "--output",
+                output,
+            ]
+            secret = "super-secret-token"
+            with mock.patch.object(sys, "argv", argv), mock.patch.dict(
+                os.environ, {"HF_TOKEN": secret}, clear=False
+            ), mock.patch.object(
+                binding,
+                "run",
+                side_effect=binding.SourceBindingError("fail closed"),
+            ):
+                self.assertEqual(binding.main(), 1)
+            with open(output, encoding="utf-8") as fh:
+                report = json.load(fh)
+        self.assertFalse(report["ok"])
+        self.assertNotIn(secret, json.dumps(report, sort_keys=True))
+
+
+class ReusableWorkflowSourceBindingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(HERE, "..", "workflows", "reusable-hf-deploy.yml")
+        with open(path, encoding="utf-8") as fh:
+            cls.workflow = fh.read()
+
+    def test_source_binding_inputs_are_optional_but_paired(self):
+        self.assertIn("source-revision-variable:", self.workflow)
+        self.assertIn("source-revision-probe-path:", self.workflow)
+        self.assertIn(
+            "source-revision-variable and source-revision-probe-path must be supplied together",
+            self.workflow,
+        )
+
+    def test_exact_checked_out_sha_is_derived_inside_runner(self):
+        self.assertIn('SOURCE_SHA="$(git -C caller rev-parse HEAD)"', self.workflow)
+        self.assertNotIn("SOURCE_SHA: ${{ github.sha }}", self.workflow)
+
+    def test_publication_binding_attestation_and_runtime_verification_are_ordered(self):
+        deploy = self.workflow.index("Deploy Dockerfile-derived files to the Space")
+        bind = self.workflow.index("Bind exact source revision after publication")
+        attest = self.workflow.index("Attest exact running commit, bytes, and smoke routes")
+        verify = self.workflow.index("Verify running application source identity")
+        self.assertLess(deploy, bind)
+        self.assertLess(bind, attest)
+        self.assertLess(attest, verify)
+
+    def test_inputs_enter_shell_only_through_environment(self):
+        for safe in (
+            "SOURCE_REVISION_VARIABLE: ${{ inputs.source-revision-variable }}",
+            "SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}",
+            '--variable "$SOURCE_REVISION_VARIABLE"',
+            '--probe-path "$SOURCE_REVISION_PROBE_PATH"',
+        ):
+            self.assertIn(safe, self.workflow)
+        for unsafe in (
+            '--variable "${{ inputs.source-revision-variable }}"',
+            '--probe-path "${{ inputs.source-revision-probe-path }}"',
+        ):
+            self.assertNotIn(unsafe, self.workflow)
+
+    def test_workflow_uses_exact_supported_clients_and_immutable_tool_revision(self):
+        self.assertIn('"huggingface_hub==1.19.0"', self.workflow)
+        self.assertIn('"requests==2.32.5"', self.workflow)
+        self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
+        self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -1,24 +1,9 @@
 name: Reusable — HF Deploy from Dockerfile
 
-# Canonical, reusable GitHub -> Hugging Face Space DEPLOYER. Replaces per-repo,
-# hand-maintained file-allowlist sync workflows (the accreted a11oy hf-sync.yml
-# CATHEDRAL_FILES anti-pattern) with ONE derivation: the exact file set pushed to
-# the Space is DERIVED from the caller Dockerfile's own `COPY` sources -- the same
-# derivation the org drift-checker (hf_module_drift_check.py) uses. The Dockerfile
-# is the single source of truth for what the image is built from, so the deploy
-# set can never silently drift from what actually builds.
-#
-# After pushing, the job WAITS for the Space to finish rebuilding and then
-# ATTESTS: it re-fetches every pushed file from the live resolve/main URL and
-# asserts sha256 == the git blob it pushed. Any mismatch FAILS the job loudly.
-# This is the "can never drift again" guard.
-#
-# Wire it from a consuming repo (HF repo derived as SZLHOLDINGS/<name> unless
-# overridden) with a thin caller:
-#   jobs:
-#     deploy:
-#       uses: szl-holdings/.github/.github/workflows/reusable-hf-deploy.yml@main
-#       secrets: inherit
+# Canonical, reusable GitHub -> Hugging Face Space deployer. The pushed file set
+# is derived from the caller Dockerfile COPY sources, never a hand-maintained
+# allowlist. Optional source binding records the exact checked-out Git SHA in one
+# non-secret Space variable and verifies it through the running build-info route.
 
 on:
   workflow_call:
@@ -39,7 +24,7 @@ on:
         type: string
         default: "Dockerfile"
       include-readme:
-        description: "Mirror README.md (front-matter preserved) so the Space card stays in sync."
+        description: "Mirror README.md so the Space card remains source-controlled."
         required: false
         type: boolean
         default: true
@@ -49,7 +34,7 @@ on:
         type: string
         default: '["/"]'
       prune:
-        description: "Delete Space files under DIRECTORY COPY sources that are gone from git (never touches file/glob sources)."
+        description: "Delete Space files under directory COPY sources that are gone from git."
         required: false
         type: boolean
         default: false
@@ -58,9 +43,19 @@ on:
         required: false
         type: number
         default: 600
+      source-revision-variable:
+        description: "Optional non-secret Space variable that receives the exact checked-out Git SHA."
+        required: false
+        type: string
+        default: ""
+      source-revision-probe-path:
+        description: "Required with source-revision-variable: same-host GET path exposing build.state and build.revision."
+        required: false
+        type: string
+        default: ""
     secrets:
       HF_TOKEN:
-        description: "HF write token with org write to the target Space."
+        description: "HF write token with organization write access to the target Space."
         required: true
 
 permissions:
@@ -68,7 +63,7 @@ permissions:
 
 jobs:
   hf-deploy:
-    name: Deploy derived COPY set to the live HF Space + attest
+    name: Deploy derived COPY set, bind source, and attest live state
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -77,48 +72,74 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout caller (GitHub source-of-truth)
+      - name: Checkout caller source of truth
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: caller
           ref: ${{ inputs.ref }}
+          persist-credentials: false
+          fetch-depth: 1
 
-      - name: Checkout exact reusable-workflow revision (shared deployer)
+      - name: Checkout exact reusable-workflow revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # The deployed code must be the code reviewed at the immutable
-          # reusable-workflow revision, never mutable default-branch tooling.
-          # github.job_workflow_sha = the reviewed revision of THIS reusable
-          # workflow (documented context; job.workflow_* does not exist).
           repository: szl-holdings/.github
           ref: ${{ github.job_workflow_sha }}
           path: tools
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
-      - name: Install huggingface_hub
-        run: pip install --quiet "huggingface_hub>=0.25"
+      - name: Install exact supported deployment clients
+        run: >-
+          python -m pip install --disable-pip-version-check
+          "huggingface_hub==1.19.0"
+          "requests==2.32.5"
 
-      - name: Resolve HF repo
+      - name: Resolve target and exact checked-out source
         id: hf
         env:
           HF_REPO_IN: ${{ inputs.hf-repo }}
           GH_REPO: ${{ github.repository }}
           DEPLOY_REF: ${{ inputs.ref }}
+          SOURCE_REVISION_VARIABLE: ${{ inputs.source-revision-variable }}
+          SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}
         run: |
           set -euo pipefail
-          if [ -n "${HF_REPO_IN}" ]; then
-            HF_REPO="${HF_REPO_IN}"
+          if [ -n "$HF_REPO_IN" ]; then
+            HF_REPO="$HF_REPO_IN"
           else
             HF_REPO="SZLHOLDINGS/${GH_REPO##*/}"
           fi
+          SOURCE_SHA="$(git -C caller rev-parse HEAD)"
+          test "$(printf '%s' "$SOURCE_SHA" | wc -c)" -eq 40
+          if { [ -n "$SOURCE_REVISION_VARIABLE" ] && [ -z "$SOURCE_REVISION_PROBE_PATH" ]; } || \
+             { [ -z "$SOURCE_REVISION_VARIABLE" ] && [ -n "$SOURCE_REVISION_PROBE_PATH" ]; }; then
+            echo '::error::source-revision-variable and source-revision-probe-path must be supplied together.'
+            exit 2
+          fi
+          SOURCE_BINDING=false
+          if [ -n "$SOURCE_REVISION_VARIABLE" ]; then SOURCE_BINDING=true; fi
           echo "hf_repo=${HF_REPO}" >> "$GITHUB_OUTPUT"
-          echo "Deploying ${GH_REPO} -> ${HF_REPO} @ ${DEPLOY_REF}"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "source_binding=${SOURCE_BINDING}" >> "$GITHUB_OUTPUT"
+          echo "Deploying ${GH_REPO} -> ${HF_REPO} @ ${DEPLOY_REF} (${SOURCE_SHA})"
 
-      - name: Deploy derived COPY set to the Space
+      - name: Require governed publisher
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${HF_TOKEN:-}" || {
+            echo '::error::HF_TOKEN is not configured for the reusable deployer.'
+            exit 2
+          }
+
+      - name: Deploy Dockerfile-derived files to the Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -130,35 +151,38 @@ jobs:
           SMOKE_PATHS: ${{ inputs.smoke-paths }}
         run: |
           set -euo pipefail
-          if [ -z "${HF_TOKEN:-}" ]; then
-            echo "::error::HF_TOKEN secret is not set on this repo -- cannot push to the HuggingFace Space."
-            echo "::error::Founder action: add repo/org secret HF_TOKEN (HF write token with org write to SZLHOLDINGS)."
-            exit 1
-          fi
           PRUNE_ARGS=()
-          if [ "${PRUNE}" = "true" ]; then
-            PRUNE_ARGS+=(--prune)
-          fi
+          if [ "$PRUNE" = "true" ]; then PRUNE_ARGS+=(--prune); fi
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root caller \
-            --github-repo "${GH_REPO}" \
-            --hf-repo "${HF_REPO}" \
-            --ref "${DEPLOY_REF}" \
-            --dockerfile-path "${DOCKERFILE_PATH}" \
-            --include-readme "${INCLUDE_README}" \
+            --github-repo "$GH_REPO" \
+            --hf-repo "$HF_REPO" \
+            --ref "$DEPLOY_REF" \
+            --dockerfile-path "$DOCKERFILE_PATH" \
+            --include-readme "$INCLUDE_README" \
             --smoke-paths "${SMOKE_PATHS}" \
             "${PRUNE_ARGS[@]}" \
             --manifest-out hf-deploy-manifest.json
 
-      - name: Upload deploy manifest
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: hf-deploy-manifest
-          path: hf-deploy-manifest.json
-          if-no-files-found: warn
+      - name: Bind exact source revision after publication
+        if: steps.hf.outputs.source_binding == 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ steps.hf.outputs.hf_repo }}
+          SOURCE_SHA: ${{ steps.hf.outputs.source_sha }}
+          SOURCE_REVISION_VARIABLE: ${{ inputs.source-revision-variable }}
+          SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}
+        run: |
+          set -euo pipefail
+          python3 tools/.github/scripts/hf_space_source_binding.py \
+            --mode bind \
+            --repo-id "$HF_REPO" \
+            --variable "$SOURCE_REVISION_VARIABLE" \
+            --revision "$SOURCE_SHA" \
+            --probe-path "$SOURCE_REVISION_PROBE_PATH" \
+            --output hf-source-binding-bind.json
 
-      - name: Attest — live Space matches pushed git blobs (sha256)
+      - name: Attest exact running commit, bytes, and smoke routes
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_REPO: ${{ steps.hf.outputs.hf_repo }}
@@ -168,5 +192,35 @@ jobs:
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --attest \
             --manifest hf-deploy-manifest.json \
-            --hf-repo "${HF_REPO}" \
+            --hf-repo "$HF_REPO" \
             --wait-running "${WAIT_RUNNING}"
+
+      - name: Verify running application source identity
+        if: steps.hf.outputs.source_binding == 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ steps.hf.outputs.hf_repo }}
+          SOURCE_SHA: ${{ steps.hf.outputs.source_sha }}
+          SOURCE_REVISION_VARIABLE: ${{ inputs.source-revision-variable }}
+          SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}
+        run: |
+          set -euo pipefail
+          python3 tools/.github/scripts/hf_space_source_binding.py \
+            --mode verify \
+            --repo-id "$HF_REPO" \
+            --variable "$SOURCE_REVISION_VARIABLE" \
+            --revision "$SOURCE_SHA" \
+            --probe-path "$SOURCE_REVISION_PROBE_PATH" \
+            --output hf-source-binding-verify.json
+
+      - name: Upload immutable deployment evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-deploy-evidence
+          path: |
+            hf-deploy-manifest.json
+            hf-source-binding-bind.json
+            hf-source-binding-verify.json
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
## Missing contract

The reusable Dockerfile deployer already derives the exact published file set, pushes it, waits for the exact Hugging Face commit to reach `RUNNING`, reads every file back at that immutable revision, and probes declared routes. It did not bind the application-visible build identity to the exact checked-out Git source, leaving `/api/build-info` free to remain stale after a correct byte deployment.

## Permanent repair

- add one reusable source-binding module rather than an A11oy-only inline workflow;
- derive the exact caller SHA from the checked-out source, never from an ambient event SHA;
- require the variable name and standard build-info probe path as a paired contract;
- publish files first, then update one non-secret Space variable so the subsequent rebuild uses the new commit and exact source revision together;
- read the variable back through supported `HfApi.get_space_variables()`;
- retain the existing exact runtime-commit, byte-parity, pruning, and smoke-route attestation unchanged;
- after that attestation, GET the same-host build-info route with redirects disabled;
- require `build.state=OBSERVED`, exact `build.revision`, and `receipt_minted=false`;
- upload immutable deployment, bind, and runtime-verification evidence;
- pin the supported deployment clients;
- change no Space secret, hardware, visibility, sleep policy, model, dataset, branch, training, weight, or promotion state.

## Tests

The new suite covers repository/key/SHA/path validation, same-host enforcement, one-variable mutation, supported variable readback, mismatch failure, exact runtime identity, redirect refusal, JSON/HTTP failures, mutation bans, paired workflow inputs, exact checked-out SHA derivation, environment-only input handling, immutable reusable-workflow tooling, and the required publish → bind → attest → runtime-verify ordering.

The branch is one DCO-signed commit over current protected main and changes exactly three files.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>