### PR TITLE
fix(ops): bind v5 to the actual readiness schema

### DIFF
--- a/.github/scripts/final_estate_v5_evidence.py
+++ b/.github/scripts/final_estate_v5_evidence.py
@@ -20,6 +20,9 @@ from final_estate_v5_core import (
     summary_clean,
 )
 
+READINESS_SCHEMA = "szl.hf-release-readiness/v1"
+PUBLICATION_SCHEMA = "szl.hf-release-finalization/v2"
+
 
 def validate_official_inventory(report: Mapping[str, Any]) -> tuple[bool, str]:
     counts = report.get("counts") or {}
@@ -87,7 +90,7 @@ def validate_release_readiness(report: Mapping[str, Any]) -> tuple[bool, str]:
         for repo_id in KERNEL_IDS
     )
     ok = (
-        report.get("schema") == "szl.hf-release-finalization/v1"
+        report.get("schema") == READINESS_SCHEMA
         and report.get("publish") is True
         and summary_clean(report)
         and dataset_ok
@@ -138,7 +141,7 @@ def validate_release_publication(report: Mapping[str, Any]) -> tuple[bool, str]:
         and all(SHA40.fullmatch(str(sources[key] or "")) is not None for key in source_keys)
     )
     ok = (
-        report.get("schema") == "szl.hf-release-finalization/v2"
+        report.get("schema") == PUBLICATION_SCHEMA
         and report.get("publish") is True
         and report.get("kernel_transport") == "authenticated-kernel-hub-git"
         and summary_clean(report)
@@ -227,20 +230,26 @@ def evaluate_release_revision_consistency(client: GitHubClient) -> Gate:
             set(readiness_kernel_revisions) == KERNEL_IDS
             and readiness_kernel_revisions == publication_kernel_revisions
         )
+        schemas_current = (
+            readiness.get("schema") == READINESS_SCHEMA
+            and publication.get("schema") == PUBLICATION_SCHEMA
+        )
         issues_closed = (
             readiness_issue.get("state") == "closed"
             and publication_issue.get("state") == "closed"
         )
         return Gate(
             "evidence:hf_release_revision_consistency",
-            dataset_match and kernels_match and issues_closed,
+            dataset_match and kernels_match and schemas_current and issues_closed,
             (
-                f"issues_closed={issues_closed}; dataset_match={dataset_match}; "
-                f"kernels_match={kernels_match}"
+                f"issues_closed={issues_closed}; schemas_current={schemas_current}; "
+                f"dataset_match={dataset_match}; kernels_match={kernels_match}"
             ),
             {
                 "readiness_issue_url": readiness_issue.get("html_url") or readiness_issue.get("url"),
                 "publication_issue_url": publication_issue.get("html_url") or publication_issue.get("url"),
+                "readiness_schema": readiness.get("schema"),
+                "publication_schema": publication.get("schema"),
                 "dataset_revision": readiness_dataset_revision,
                 "kernel_revisions": readiness_kernel_revisions,
             },

--- a/.github/scripts/test_final_estate_v5_evidence.py
+++ b/.github/scripts/test_final_estate_v5_evidence.py
@@ -15,6 +15,8 @@ from final_estate_v5_core import (
     latest_report,
 )
 from final_estate_v5_evidence import (
+    PUBLICATION_SCHEMA,
+    READINESS_SCHEMA,
     evaluate_release_revision_consistency,
     evaluate_replit_decommission,
     validate_official_inventory,
@@ -38,6 +40,58 @@ def issue_with_report(report: dict[str, Any], *, state: str = "closed") -> dict[
         "body": "```json\n" + json.dumps(report, sort_keys=True) + "\n```\n",
         "html_url": "https://github.com/example/issues/1",
         "updated_at": "2026-07-22T00:00:00Z",
+    }
+
+
+def readiness_report() -> dict[str, Any]:
+    return {
+        "schema": READINESS_SCHEMA,
+        "publish": True,
+        "summary": {"error": 0, "warning": 0},
+        "results": {
+            "dataset": {
+                "viewer_http_status": 200,
+                "revision": "b" * 40,
+                "remote_file_count": 393,
+            },
+            "kernels": {
+                repo_id: {
+                    "revision": chr(99 + index) * 40,
+                    "remote_file_count": 10,
+                    "selfcheck": {"ok": True},
+                }
+                for index, repo_id in enumerate(sorted(KERNEL_IDS))
+            },
+        },
+    }
+
+
+def publication_report() -> dict[str, Any]:
+    ready = readiness_report()
+    return {
+        "schema": PUBLICATION_SCHEMA,
+        "publish": True,
+        "kernel_transport": "authenticated-kernel-hub-git",
+        "summary": {"error": 0, "warning": 0},
+        "runtime": {"numpy": "2.2.6", "torch": "2.7.1+cpu"},
+        "sources": {
+            "szl_lake": "a" * 40,
+            "szl_energy_attest": "b" * 40,
+            "szl_lambda_gate": "c" * 40,
+        },
+        "results": {
+            "dataset": dict(ready["results"]["dataset"]),
+            "kernels": {
+                repo_id: {
+                    **dict(ready["results"]["kernels"][repo_id]),
+                    "transport": "authenticated-kernel-hub-git",
+                    "build_variants_preserved": True,
+                    "card_contract_byte_parity": True,
+                    "build_tree_sha256": "f" * 64,
+                }
+                for repo_id in KERNEL_IDS
+            },
+        },
     }
 
 
@@ -86,78 +140,24 @@ more
         report["counts"]["buckets"] = 0
         self.assertFalse(validate_official_inventory(report)[0])
 
-    def test_readiness_requires_viewer_and_exact_selfchecks(self) -> None:
-        report = {
-            "schema": "szl.hf-release-finalization/v1",
-            "publish": True,
-            "summary": {"error": 0, "warning": 0},
-            "results": {
-                "dataset": {
-                    "viewer_http_status": 200,
-                    "revision": "b" * 40,
-                    "remote_file_count": 393,
-                },
-                "kernels": {
-                    repo_id: {
-                        "revision": "c" * 40,
-                        "remote_file_count": 10,
-                        "selfcheck": {"ok": True},
-                    }
-                    for repo_id in KERNEL_IDS
-                },
-            },
-        }
+    def test_readiness_requires_actual_schema_viewer_and_exact_selfchecks(self) -> None:
+        report = readiness_report()
         self.assertTrue(validate_release_readiness(report)[0])
+        report["schema"] = "szl.hf-release-finalization/v1"
+        self.assertFalse(validate_release_readiness(report)[0])
+        report["schema"] = READINESS_SCHEMA
         report["results"]["kernels"][next(iter(KERNEL_IDS))].pop("selfcheck")
         self.assertFalse(validate_release_readiness(report)[0])
 
     def test_publication_requires_supported_git_transport_and_build_hashes(self) -> None:
-        report = {
-            "schema": "szl.hf-release-finalization/v2",
-            "publish": True,
-            "kernel_transport": "authenticated-kernel-hub-git",
-            "summary": {"error": 0, "warning": 0},
-            "runtime": {"numpy": "2.2.6", "torch": "2.7.1+cpu"},
-            "sources": {
-                "szl_lake": "a" * 40,
-                "szl_energy_attest": "b" * 40,
-                "szl_lambda_gate": "c" * 40,
-            },
-            "results": {
-                "dataset": {
-                    "viewer_http_status": 200,
-                    "revision": "d" * 40,
-                    "remote_file_count": 393,
-                },
-                "kernels": {
-                    repo_id: {
-                        "revision": "e" * 40,
-                        "transport": "authenticated-kernel-hub-git",
-                        "remote_file_count": 10,
-                        "build_variants_preserved": True,
-                        "card_contract_byte_parity": True,
-                        "build_tree_sha256": "f" * 64,
-                        "selfcheck": {"passed": True},
-                    }
-                    for repo_id in KERNEL_IDS
-                },
-            },
-        }
+        report = publication_report()
         self.assertTrue(validate_release_publication(report)[0])
         report["results"]["kernels"][next(iter(KERNEL_IDS))]["transport"] = "unsupported"
         self.assertFalse(validate_release_publication(report)[0])
 
-    def test_readiness_and_publication_revisions_must_match(self) -> None:
-        readiness = {
-            "results": {
-                "dataset": {"revision": "a" * 40},
-                "kernels": {
-                    repo_id: {"revision": chr(98 + index) * 40}
-                    for index, repo_id in enumerate(sorted(KERNEL_IDS))
-                },
-            }
-        }
-        publication = json.loads(json.dumps(readiness))
+    def test_readiness_and_publication_revisions_and_schemas_must_match(self) -> None:
+        readiness = readiness_report()
+        publication = publication_report()
         issues = {
             EVIDENCE_ISSUES["hf_release_readiness"]: issue_with_report(readiness),
             EVIDENCE_ISSUES["hf_release_publication"]: issue_with_report(publication),
@@ -167,6 +167,15 @@ more
         )
         publication["results"]["dataset"]["revision"] = "f" * 40
         issues[EVIDENCE_ISSUES["hf_release_publication"]] = issue_with_report(publication)
+        self.assertFalse(
+            evaluate_release_revision_consistency(FakeIssueClient(issues)).ok
+        )
+        publication = publication_report()
+        readiness["schema"] = "wrong"
+        issues = {
+            EVIDENCE_ISSUES["hf_release_readiness"]: issue_with_report(readiness),
+            EVIDENCE_ISSUES["hf_release_publication"]: issue_with_report(publication),
+        }
         self.assertFalse(
             evaluate_release_revision_consistency(FakeIssueClient(issues)).ok
         )


### PR DESCRIPTION
## Observed failure

The first protected-main v5 reconciliation correctly showed every Lake and Kernel readiness condition passing, but the gate remained false because the validator expected the older `szl.hf-release-finalization/v1` label. Deterministic issue #257 now emits `szl.hf-release-readiness/v1`.

## Repair

- require the exact current readiness schema;
- keep publication bound separately to `szl.hf-release-finalization/v2`;
- require both current schemas in the cross-evidence consistency gate, in addition to exact Dataset and Kernel revision equality;
- rebuild the tests from the actual deterministic issue shapes;
- explicitly reject the obsolete readiness label.

This changes no external asset or evidence issue. It corrects the validator to the already-observed immutable contract.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>