### PR TITLE
fix(ops): probe the 3D surface actually shipped by A11oy

### DIFF
--- a/.github/scripts/final_estate_v5_core.py
+++ b/.github/scripts/final_estate_v5_core.py
@@ -87,11 +87,8 @@ PROBES = {
         "json",
         required_keys=("honest", "matrix_available", "probe_verdict_available", "view"),
     ),
-    "a11oy_3d_estate": ProbeSpec(
-        "https://szlholdings-a11oy.hf.space/static/3d/estate.html", True, "html"
-    ),
-    "a11oy_3d_brain": ProbeSpec(
-        "https://szlholdings-a11oy.hf.space/static/3d/brain.html", True, "html"
+    "a11oy_holographic": ProbeSpec(
+        "https://szlholdings-a11oy.hf.space/static/3d/holographic.html", True, "html"
     ),
 }
 

--- a/.github/scripts/test_final_estate_v5_probes.py
+++ b/.github/scripts/test_final_estate_v5_probes.py
@@ -127,11 +127,18 @@ class FinalEstateProbeV5Tests(unittest.TestCase):
     def test_readiness_query_url_has_valid_https_origin(self) -> None:
         self.assertIsNotNone(https_origin(PROBES["a11oy_readiness"].url))
 
-    def test_real_3d_routes_replace_dead_holographic_filename(self) -> None:
+    def test_3d_probe_matches_the_dockerfile_shipped_console_surface(self) -> None:
         urls = {spec.url for spec in PROBES.values()}
-        self.assertFalse(any(url.endswith("/holographic.html") for url in urls))
-        self.assertIn("https://szlholdings-a11oy.hf.space/static/3d/estate.html", urls)
-        self.assertIn("https://szlholdings-a11oy.hf.space/static/3d/brain.html", urls)
+        self.assertIn(
+            "https://szlholdings-a11oy.hf.space/static/3d/holographic.html", urls
+        )
+        self.assertFalse(any(url.endswith("/estate.html") for url in urls))
+        self.assertFalse(any(url.endswith("/brain.html") for url in urls))
+        self.assertEqual(
+            PROBES["a11oy_holographic"].url,
+            "https://szlholdings-a11oy.hf.space/static/3d/holographic.html",
+        )
+        self.assertTrue(PROBES["a11oy_holographic"].require_head)
 
     def test_issue_body_is_machine_readable_and_marks_decommission(self) -> None:
         report = {


### PR DESCRIPTION
## Observed failure

Active-estate reconciliation v5 correctly passed every evidence, source, domain, API, Lake, Kernel, and Replit-decommission gate, but it probed `static/3d/estate.html` and `static/3d/brain.html`. Those files exist in the GitHub repository but are not in the Dockerfile COPY set, so they are not production surfaces.

## Permanent repair

A11oy's reviewed Dockerfile copies `console/` into the runtime static root. The current reviewed 3D operational surface is therefore:

`console/3d/holographic.html` → `/static/3d/holographic.html`

This PR:

- replaces both unshipped probes with that single canonical deployed artifact;
- still requires exact HEAD and GET success with HTML content;
- adds a regression test requiring the holographic path and explicitly rejecting `/estate.html` and `/brain.html`;
- changes no runtime asset, deployment, evidence issue, or operational threshold.

The branch is one DCO-signed two-file commit over current protected main.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>