### PR TITLE
fix: harden estate reconciliation probes

### DIFF
--- a/.github/scripts/final_estate_v5_core.py
+++ b/.github/scripts/final_estate_v5_core.py
@@ -88,7 +88,7 @@ PROBES = {
         required_keys=("honest", "matrix_available", "probe_verdict_available", "view"),
     ),
     "a11oy_holographic": ProbeSpec(
-        "https://szlholdings-a11oy.hf.space/static/3d/holographic.html", True, "html"
+        "https://szlholdings-a11oy.hf.space/holographic", True, "html"
     ),
 }
 
@@ -159,7 +159,14 @@ class GitHubClient:
             values = payload.get("items") or []
             if not isinstance(values, list):
                 raise RuntimeError("GitHub pull-request search items are not a list")
-            output.extend(item for item in values if isinstance(item, dict))
+            # GitHub's search response uses the issues schema for both issues
+            # and pull requests.  Treat an item as a pull request only when the
+            # discriminator is present rather than trusting the query string.
+            output.extend(
+                item
+                for item in values
+                if isinstance(item, dict) and "pull_request" in item
+            )
             if len(values) < 100:
                 return output
         raise RuntimeError("public pull-request search exceeded 1,000 results")

--- a/.github/scripts/test_final_estate_v5_probes.py
+++ b/.github/scripts/test_final_estate_v5_probes.py
@@ -7,7 +7,13 @@ import unittest
 from typing import Any
 
 from final_estate_reconciliation_v5 import issue_body
-from final_estate_v5_core import PROBES, REPORT_MARKER, REPORT_SCHEMA, https_origin
+from final_estate_v5_core import (
+    PROBES,
+    REPORT_MARKER,
+    REPORT_SCHEMA,
+    GitHubClient,
+    https_origin,
+)
 from final_estate_v5_probes import safe_probe
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -53,6 +59,29 @@ class FakeSession:
 
 
 class FinalEstateProbeV5Tests(unittest.TestCase):
+    def test_open_public_prs_discard_issue_shaped_search_items(self) -> None:
+        client = GitHubClient(None)
+        response = FakeResponse(
+            status_code=200,
+            url="https://api.github.com/search/issues",
+            content_type="application/json",
+            payload={
+                "items": [
+                    {
+                        "number": 309,
+                        "title": "real pull request",
+                        "pull_request": {"url": "https://api.github.com/pulls/309"},
+                    },
+                    {"number": 310, "title": "ordinary issue"},
+                ]
+            },
+        )
+        client.request = lambda *_args, **_kwargs: response  # type: ignore[method-assign]
+
+        values = client.open_public_pull_requests()
+
+        self.assertEqual([item["number"] for item in values], [309])
+
     def test_get_only_api_accepts_observed_head_405(self) -> None:
         spec = PROBES["a11oy_livez"]
         session = FakeSession(
@@ -130,13 +159,13 @@ class FinalEstateProbeV5Tests(unittest.TestCase):
     def test_3d_probe_matches_the_dockerfile_shipped_console_surface(self) -> None:
         urls = {spec.url for spec in PROBES.values()}
         self.assertIn(
-            "https://szlholdings-a11oy.hf.space/static/3d/holographic.html", urls
+            "https://szlholdings-a11oy.hf.space/holographic", urls
         )
         self.assertFalse(any(url.endswith("/estate.html") for url in urls))
         self.assertFalse(any(url.endswith("/brain.html") for url in urls))
         self.assertEqual(
             PROBES["a11oy_holographic"].url,
-            "https://szlholdings-a11oy.hf.space/static/3d/holographic.html",
+            "https://szlholdings-a11oy.hf.space/holographic",
         )
         self.assertTrue(PROBES["a11oy_holographic"].require_head)
 


### PR DESCRIPTION
## Outcome
- filter GitHub issue-search results using the pull-request discriminator before counting the public PR queue
- replace the removed static holographic asset probe with the canonical `/holographic` route
- preserve fail-closed HEAD verification; the route must support HEAD before reconciliation can pass
- add regression coverage for issue-shaped search contamination

## Verification
- `python -m pytest .github/scripts/test_final_estate_v5_probes.py .github/scripts/test_final_estate_v5_evidence.py -q` -> 15 passed
- `git diff --check` -> clean
- live observation before this PR: old static path GET/HEAD 404; canonical route GET 200 and HEAD 405

## Dependency
The canonical route's HEAD support is implemented separately in `szl-holdings/a11oy#1051`. This PR does not weaken the gate and will remain honest until that application change is deployed.

## Broader suite note
The complete local script suite reached 397 passes; 10 unrelated environment/pre-existing failures remained (missing retired workflow fixture, Windows PATH dependencies for Git/bash, and two unrelated allowlist fixtures). The two focused reconciliation suites are green.