### PR TITLE
docs: publish the SZL estate lifecycle map

### DIFF
--- a/docs/ESTATE_LIFECYCLE.md
+++ b/docs/ESTATE_LIFECYCLE.md
@@ -1,0 +1,51 @@
+# SZL estate lifecycle map
+
+Status date: 2026-07-25
+
+This map distinguishes active product surfaces from frozen public records.
+Archiving preserves source, release, citation, and provenance history; it is
+not deletion and does not mean the artifact was unimportant.
+
+## Current estate
+
+| State | Count | Policy |
+|---|---:|---|
+| Public repositories | 54 | Open by default after license, secret, dependency, and release-history review |
+| Private repositories | 3 | Retained only for lead data, fundraising material, or security operations |
+| Archived repositories | 12 | Public and read-only; retained for reproducibility and provenance |
+| Active repositories | 45 | Product, proof, documentation, or shared infrastructure |
+
+[`szl-substrate`](https://github.com/szl-holdings/szl-substrate) is the newest
+public shared package. It remains an active, independently versioned boundary
+used by a11oy and killinchu.
+
+## Archived-to-canonical map
+
+| Frozen public repository | Canonical active destination | Retention reason |
+|---|---|---|
+| [`developers`](https://github.com/szl-holdings/developers) | [`docs-site/docs/developers`](https://github.com/szl-holdings/docs-site/tree/main/docs/developers) | Developer documentation migrated; history retained |
+| [`evidence-typed-formula-governance`](https://github.com/szl-holdings/evidence-typed-formula-governance) | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) and [`szl-papers`](https://github.com/szl-holdings/szl-papers) | Final DOI reproduction package; immutable research record |
+| [`fail-closed-governed-ai-services`](https://github.com/szl-holdings/fail-closed-governed-ai-services) | [`a11oy`](https://github.com/szl-holdings/a11oy) and [`platform`](https://github.com/szl-holdings/platform) | Final DOI reproduction package; implementation continues in the active runtime |
+| [`governed-inference-meter`](https://github.com/szl-holdings/governed-inference-meter) | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest) | Metering and attestation work consolidated |
+| [`szl-cookbook`](https://github.com/szl-holdings/szl-cookbook) | [`docs-site/docs/cookbook/recipes`](https://github.com/szl-holdings/docs-site/tree/main/docs/cookbook/recipes) | Recipes migrated; runnable source retained for reproducibility |
+| [`szl-fleet-overlay`](https://github.com/szl-holdings/szl-fleet-overlay) | [`a11oy`](https://github.com/szl-holdings/a11oy), [`killinchu`](https://github.com/szl-holdings/killinchu), and [`szl-mesh`](https://github.com/szl-holdings/szl-mesh) | Frozen UDS deployment-family source and release evidence |
+| [`szl-governed-norm`](https://github.com/szl-holdings/szl-governed-norm) | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Governance gate work consolidated |
+| [`szl-otel-mesh`](https://github.com/szl-holdings/szl-otel-mesh) | [`szl-mesh`](https://github.com/szl-holdings/szl-mesh) | Explicitly superseded mesh implementation; DOI and history retained |
+| [`szl-trust`](https://github.com/szl-holdings/szl-trust) | [`docs-site/docs/trust`](https://github.com/szl-holdings/docs-site/tree/main/docs/trust) | Trust documentation migrated; run artifacts retained |
+| [`szl-uds-deployment`](https://github.com/szl-holdings/szl-uds-deployment) | [`a11oy`](https://github.com/szl-holdings/a11oy), [`killinchu`](https://github.com/szl-holdings/killinchu), and [`szl-mesh`](https://github.com/szl-holdings/szl-mesh) | Frozen UDS deployment-family source and release evidence |
+| [`uds-bundles`](https://github.com/szl-holdings/uds-bundles) | [`a11oy`](https://github.com/szl-holdings/a11oy), [`killinchu`](https://github.com/szl-holdings/killinchu), and [`szl-mesh`](https://github.com/szl-holdings/szl-mesh) | Frozen signed bundle manifests and provenance |
+| [`warhacker-demo`](https://github.com/szl-holdings/warhacker-demo) | [`a11oy`](https://github.com/szl-holdings/a11oy) and [`killinchu`](https://github.com/szl-holdings/killinchu) | Concluded demonstration retained as a historical record |
+
+## Lifecycle rules
+
+1. Do not unarchive a repository merely because it contains important work.
+   Frozen DOI packages, signed release artifacts, and concluded demonstrations
+   are more trustworthy when their historical state remains read-only.
+2. Consolidate maintained documentation and implementation into the named
+   canonical repository, while keeping provenance links back to the archive.
+3. Unarchive only when active maintenance must resume and no canonical active
+   destination can accept the change.
+4. Never move secrets, customer or lead data, fundraising material, or
+   security-operational data into a public repository.
+5. Every visibility change requires a license check, secret scan, dependency
+   review, and a successful default-branch test history.

--- a/profile/README.md
+++ b/profile/README.md
@@ -57,6 +57,11 @@ For technical review, begin with the
 and [contribution contract](https://github.com/szl-holdings/.github/blob/main/CONTRIBUTING.md).
 Claims without a reproducible artifact or current receipt remain unverified.
 
+Repository lifecycle is explicit: 12 public archives are frozen records, not
+deleted work. Use the
+[estate lifecycle map](https://github.com/szl-holdings/.github/blob/main/docs/ESTATE_LIFECYCLE.md)
+to find each canonical active successor and its retention rationale.
+
 ---
 
 ## Spaces


### PR DESCRIPTION
## Summary

- publish the current 57-repository lifecycle inventory
- map all 12 public archives to their canonical active destinations
- explain why DOI, release, and demonstration records stay frozen and public
- link the lifecycle map from the organization profile
- record the public-by-default and private-data boundaries

## Verification

- `git diff --check`
- all 7 GitHub Actions workflows passed, including CodeQL, Trivy, gitleaks, DCO, doctrine, and CI
- counts refreshed from the live GitHub organization inventory on 2026-07-25
- every archive and successor link reviewed against the repository inventory

## Governance

CI-green draft pending an independent authorized reviewer and completion of the organization ruleset hardening. No branch-protection bypass is requested.