### PR TITLE
fix(governance): split main and release rulesets

### DIFF
--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -61,10 +61,28 @@ def ground_truth() -> None:
     parameters = pull_rules[0].get("parameters")
     if not isinstance(parameters, dict):
         fail("pull-request parameters are missing")
-    if parameters.get("required_approving_review_count") != 1:
-        fail("the exact-head App approval must be required")
-    if parameters.get("require_last_push_approval") is not True:
-        fail("the attestor must approve the most recent push")
+    if parameters.get("required_approving_review_count") != 0:
+        fail("solo policy cannot require an unavailable human reviewer")
+    status_rule = next(
+        (
+            item
+            for item in rules
+            if isinstance(item, dict)
+            and item.get("type") == "required_status_checks"
+        ),
+        None,
+    )
+    if not isinstance(status_rule, dict):
+        fail("required status checks are missing")
+    status_parameters = status_rule.get("parameters")
+    if not isinstance(status_parameters, dict):
+        fail("required status-check parameters are missing")
+    required = status_parameters.get("required_status_checks", [])
+    if {
+        "context": "attestation/qillqaq",
+        "integration_id": 4395545,
+    } not in required:
+        fail("the App-owned attestation status is not required")
 
 
 def labels() -> None:
@@ -118,6 +136,8 @@ def provenance() -> None:
         fail("App permissions are missing")
     if permissions.get("contents") != "read":
         fail("the App must not have write access to repository contents")
+    if permissions.get("commit_statuses") != "write":
+        fail("the App must be able to publish its required attestation status")
     if "merge_queues" in permissions:
         fail("the App must not retain unused merge-queue authority")
     attestor = (

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -116,8 +116,13 @@ def provenance() -> None:
         fail("App permissions are missing")
     if permissions.get("contents") != "read":
         fail("the App must not have write access to repository contents")
-    if permissions.get("merge_queues") != "write":
-        fail("the App requires only dedicated queue authority")
+    if "merge_queues" in permissions:
+        fail("the App must not retain unused merge-queue authority")
+    attestor = (
+        ROOT / ".github/workflows/attest-and-approve.yml"
+    ).read_text(encoding="utf-8")
+    if "GH_TOKEN: ${{ github.token }}" not in attestor:
+        fail("the queue request must use the ephemeral workflow token")
     for relative in (
         ".github/workflows/gates.yml",
         ".github/workflows/attest-and-approve.yml",

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -83,6 +83,11 @@ def ground_truth() -> None:
         "integration_id": 4395545,
     } not in required:
         fail("the App-owned attestation status is not required")
+    if {
+        "context": "deploy/staging",
+        "integration_id": 15368,
+    } not in required:
+        fail("the GitHub Actions staging check is not required")
 
 
 def labels() -> None:

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -61,8 +61,10 @@ def ground_truth() -> None:
     parameters = pull_rules[0].get("parameters")
     if not isinstance(parameters, dict):
         fail("pull-request parameters are missing")
-    if parameters.get("required_approving_review_count") != 0:
-        fail("solo policy must not claim a human approval")
+    if parameters.get("required_approving_review_count") != 1:
+        fail("the exact-head App approval must be required")
+    if parameters.get("require_last_push_approval") is not True:
+        fail("the attestor must approve the most recent push")
 
 
 def labels() -> None:

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -84,6 +84,8 @@ def schema() -> None:
     gates = load_json(".governance/gates.json")
     profile = load_json(".governance/repository-profile.json")
     manifest = load_json(".governance/github-app-manifest.json")
+    load_json(".governance/ruleset-main.json")
+    load_json(".governance/ruleset-release.json")
     if len(gates) != 8:
         fail("the canonical gate map must contain eight gates")
     if profile.get("operator_model") != "solo":

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -22,6 +22,10 @@ GATES = [
     "gate/a11y-perf",
     "gate/lean",
 ]
+ATTESTATION_STATUS = {
+    "context": "attestation/qillqaq",
+    "integration_id": 4395545,
+}
 
 LEGACY_PATHS = [
     ".github/workflows/owner-authorized-merge-wave.yml",
@@ -111,8 +115,8 @@ def verify_ruleset() -> None:
     expected_review = {
         "dismiss_stale_reviews_on_push": True,
         "require_code_owner_review": False,
-        "require_last_push_approval": True,
-        "required_approving_review_count": 1,
+        "require_last_push_approval": False,
+        "required_approving_review_count": 0,
         "required_review_thread_resolution": True,
     }
     for key, value in expected_review.items():
@@ -126,8 +130,10 @@ def verify_ruleset() -> None:
     contexts = [
         item.get("context") for item in required if isinstance(item, dict)
     ]
-    if contexts != GATES:
-        fail("required status checks do not match the eight canonical gates")
+    if contexts != GATES + [ATTESTATION_STATUS["context"]]:
+        fail("required status checks must contain the eight gates and attestation")
+    if required[-1] != ATTESTATION_STATUS:
+        fail("attestation status must be pinned to the qillqaq App")
 
     deployments = rule(typed_rules, "required_deployments").get("parameters", {})
     if not isinstance(deployments, dict):
@@ -147,7 +153,7 @@ def verify_manifest() -> None:
         "actions": "read",
         "administration": "read",
         "checks": "read",
-        "commit_statuses": "read",
+        "commit_statuses": "write",
         "contents": "read",
         "metadata": "read",
         "pull_requests": "write",
@@ -224,6 +230,13 @@ def verify_gate_contract() -> None:
         fail("the merge attestor must not consume the production deployment gate")
     if "GH_TOKEN: ${{ github.token }}" not in attestor_template:
         fail("the protected queue request must use the ephemeral workflow token")
+    for marker in (
+        "Publish required App attestation status",
+        "context=attestation/qillqaq",
+        "GH_TOKEN: ${{ steps.app-token.outputs.token }}",
+    ):
+        if marker not in attestor_template:
+            fail(f"attestor status publication is missing {marker!r}")
     if 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash' not in (
         attestor_template
     ):
@@ -276,8 +289,8 @@ def verify_gate_contract() -> None:
     expected_release_review = {
         "dismiss_stale_reviews_on_push": True,
         "require_code_owner_review": False,
-        "require_last_push_approval": True,
-        "required_approving_review_count": 1,
+        "require_last_push_approval": False,
+        "required_approving_review_count": 0,
         "required_review_thread_resolution": True,
     }
     for key, value in expected_release_review.items():
@@ -299,8 +312,10 @@ def verify_gate_contract() -> None:
         for item in release_required
         if isinstance(item, dict)
     ]
-    if release_contexts != GATES:
-        fail("release status checks do not match the eight canonical gates")
+    if release_contexts != GATES + [ATTESTATION_STATUS["context"]]:
+        fail("release checks must contain the eight gates and attestation")
+    if release_required[-1] != ATTESTATION_STATUS:
+        fail("release attestation status must be pinned to the qillqaq App")
 
     release_deployments = rule(
         typed_release_rules, "required_deployments"

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -238,9 +238,17 @@ def verify_gate_contract() -> None:
         "Publish required App attestation status",
         "context=attestation/qillqaq",
         "GH_TOKEN: ${{ steps.app-token.outputs.token }}",
+        'SOURCE_EVENT: ${{ github.event.workflow_run.event }}',
+        'if [ "$SOURCE_EVENT" = "merge_group" ]; then',
+        '[[ "$HEAD_BRANCH" == gh-readonly-queue/main/* ]]',
+        "subject_kind: $subject_kind",
     ):
         if marker not in attestor_template:
             fail(f"attestor status publication is missing {marker!r}")
+    if attestor_template.count(
+        "if: steps.subject.outputs.kind == 'pull_request'"
+    ) != 2:
+        fail("only PR-head attestations may approve or request a queue entry")
     if 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash' not in (
         attestor_template
     ):

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -50,10 +50,7 @@ ATTESTOR_SELF_EDIT_GUARD = (
     r"^(\.github/workflows/(attest-and-approve|gates|forge9-staging)"
     r"\.ya?ml|\.governance/)"
 )
-GOVERNED_BASE_FILTER = (
-    '.base.ref == "main"\n'
-    '                  or (.base.ref | startswith("release/"))'
-)
+GOVERNED_BASE_FILTER = '.base.ref == "main"'
 
 
 def fail(message: str) -> None:
@@ -87,8 +84,8 @@ def verify_ruleset() -> None:
     conditions = data.get("conditions", {})
     refs = conditions.get("ref_name", {}) if isinstance(conditions, dict) else {}
     include = refs.get("include", []) if isinstance(refs, dict) else []
-    if include != ["~DEFAULT_BRANCH", "refs/heads/release/*"]:
-        fail("ruleset must target the default branch and release/*")
+    if include != ["~DEFAULT_BRANCH"]:
+        fail("merge-queue ruleset must target only the default branch")
 
     rules = data.get("rules")
     if not isinstance(rules, list):
@@ -218,9 +215,30 @@ def verify_gate_contract() -> None:
             fail(f"attestor governance authorization marker missing: {marker}")
 
     if GOVERNED_BASE_FILTER not in attestor_template:
-        fail("attestor must resolve PRs targeting both main and release/*")
-    if '.base.ref == "main") | .number' in attestor_template:
-        fail("attestor still hard-codes PR resolution to main only")
+        fail("attestor must resolve PRs targeting main")
+    if 'startswith("release/")' in attestor_template:
+        fail("release PRs cannot be enqueued into the default-branch merge queue")
+
+    release = load_json(GOVERNANCE / "ruleset-release.json")
+    if not isinstance(release, dict):
+        fail("ruleset-release.json must contain an object")
+    release_conditions = release.get("conditions", {})
+    release_refs = (
+        release_conditions.get("ref_name", {})
+        if isinstance(release_conditions, dict)
+        else {}
+    )
+    if (
+        not isinstance(release_refs, dict)
+        or release_refs.get("include") != ["refs/heads/release/*"]
+    ):
+        fail("release ruleset must target release/*")
+    release_rules = release.get("rules", [])
+    if not isinstance(release_rules, list) or any(
+        isinstance(item, dict) and item.get("type") == "merge_queue"
+        for item in release_rules
+    ):
+        fail("release wildcard ruleset must not contain a merge queue")
 
 
 def verify_legacy_paths_removed() -> None:

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -146,7 +146,6 @@ def verify_manifest() -> None:
         "checks": "read",
         "commit_statuses": "read",
         "contents": "read",
-        "merge_queues": "write",
         "metadata": "read",
         "pull_requests": "write",
     }
@@ -154,6 +153,8 @@ def verify_manifest() -> None:
         fail("GitHub App permissions differ from the reviewed minimum")
     if "id_token" in permissions or "id-token" in permissions:
         fail("OIDC is a workflow permission, not an App permission")
+    if "merge_queues" in permissions:
+        fail("the App does not require merge-queue authority")
 
 
 def verify_gate_contract() -> None:
@@ -218,6 +219,12 @@ def verify_gate_contract() -> None:
         fail("attestor must resolve PRs targeting main")
     if 'startswith("release/")' in attestor_template:
         fail("release PRs cannot be enqueued into the default-branch merge queue")
+    if "GH_TOKEN: ${{ github.token }}" not in attestor_template:
+        fail("the protected queue request must use the ephemeral workflow token")
+    if 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash' not in (
+        attestor_template
+    ):
+        fail("the attestor must use GitHub's supported merge-queue CLI path")
 
     release = load_json(GOVERNANCE / "ruleset-release.json")
     if not isinstance(release, dict):

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -238,6 +238,7 @@ def verify_gate_contract() -> None:
         "Publish required App attestation status",
         "context=attestation/qillqaq",
         "GH_TOKEN: ${{ steps.app-token.outputs.token }}",
+        "client-id: ${{ vars.QILLQAQ_CLIENT_ID }}",
         'SOURCE_EVENT: ${{ github.event.workflow_run.event }}',
         'if [ "$SOURCE_EVENT" = "merge_group" ]; then',
         '[[ "$HEAD_BRANCH" == gh-readonly-queue/main/* ]]',
@@ -245,6 +246,8 @@ def verify_gate_contract() -> None:
     ):
         if marker not in attestor_template:
             fail(f"attestor status publication is missing {marker!r}")
+    if "app-id:" in attestor_template:
+        fail("the attestor must use the supported GitHub App client-id input")
     if attestor_template.count(
         "if: steps.subject.outputs.kind == 'pull_request'"
     ) != 2:

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -50,7 +50,10 @@ ATTESTOR_SELF_EDIT_GUARD = (
     r"^(\.github/workflows/(attest-and-approve|gates|forge9-staging)"
     r"\.ya?ml|\.governance/)"
 )
-GOVERNED_BASE_FILTER = '.base.ref == "main"'
+GOVERNED_BASE_FILTER = (
+    '.base.ref == "main"\n'
+    '                  or (.base.ref | startswith("release/"))'
+)
 
 
 def fail(message: str) -> None:
@@ -108,8 +111,8 @@ def verify_ruleset() -> None:
     expected_review = {
         "dismiss_stale_reviews_on_push": True,
         "require_code_owner_review": False,
-        "require_last_push_approval": False,
-        "required_approving_review_count": 0,
+        "require_last_push_approval": True,
+        "required_approving_review_count": 1,
         "required_review_thread_resolution": True,
     }
     for key, value in expected_review.items():
@@ -216,9 +219,9 @@ def verify_gate_contract() -> None:
             fail(f"attestor governance authorization marker missing: {marker}")
 
     if GOVERNED_BASE_FILTER not in attestor_template:
-        fail("attestor must resolve PRs targeting main")
-    if 'startswith("release/")' in attestor_template:
-        fail("release PRs cannot be enqueued into the default-branch merge queue")
+        fail("attestor must resolve PRs targeting main and release/*")
+    if "environment: production" in attestor_template:
+        fail("the merge attestor must not consume the production deployment gate")
     if "GH_TOKEN: ${{ github.token }}" not in attestor_template:
         fail("the protected queue request must use the ephemeral workflow token")
     if 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash' not in (
@@ -229,6 +232,13 @@ def verify_gate_contract() -> None:
     release = load_json(GOVERNANCE / "ruleset-release.json")
     if not isinstance(release, dict):
         fail("ruleset-release.json must contain an object")
+    if (
+        release.get("name") != "forge9-release"
+        or release.get("enforcement") != "active"
+    ):
+        fail("release ruleset name or enforcement changed")
+    if release.get("bypass_actors") != []:
+        fail("release bypass_actors must be an explicit empty array")
     release_conditions = release.get("conditions", {})
     release_refs = (
         release_conditions.get("ref_name", {})
@@ -240,12 +250,68 @@ def verify_gate_contract() -> None:
         or release_refs.get("include") != ["refs/heads/release/*"]
     ):
         fail("release ruleset must target release/*")
-    release_rules = release.get("rules", [])
-    if not isinstance(release_rules, list) or any(
-        isinstance(item, dict) and item.get("type") == "merge_queue"
-        for item in release_rules
-    ):
+    release_rules = release.get("rules")
+    if not isinstance(release_rules, list):
+        fail("release ruleset rules must be an array")
+    typed_release_rules = [
+        item for item in release_rules if isinstance(item, dict)
+    ]
+    if any(item.get("type") == "merge_queue" for item in typed_release_rules):
         fail("release wildcard ruleset must not contain a merge queue")
+    for kind in (
+        "deletion",
+        "non_fast_forward",
+        "required_linear_history",
+        "required_signatures",
+        "required_deployments",
+        "commit_message_pattern",
+    ):
+        rule(typed_release_rules, kind)
+
+    release_pull_request = rule(
+        typed_release_rules, "pull_request"
+    ).get("parameters", {})
+    if not isinstance(release_pull_request, dict):
+        fail("release pull_request parameters missing")
+    expected_release_review = {
+        "dismiss_stale_reviews_on_push": True,
+        "require_code_owner_review": False,
+        "require_last_push_approval": True,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": True,
+    }
+    for key, value in expected_release_review.items():
+        if release_pull_request.get(key) != value:
+            fail(f"release pull_request.{key} must be {value!r}")
+    if release_pull_request.get("allowed_merge_methods") != ["squash"]:
+        fail("release ruleset must allow only squash merges")
+
+    release_checks = rule(
+        typed_release_rules, "required_status_checks"
+    ).get("parameters", {})
+    release_required = (
+        release_checks.get("required_status_checks", [])
+        if isinstance(release_checks, dict)
+        else []
+    )
+    release_contexts = [
+        item.get("context")
+        for item in release_required
+        if isinstance(item, dict)
+    ]
+    if release_contexts != GATES:
+        fail("release status checks do not match the eight canonical gates")
+
+    release_deployments = rule(
+        typed_release_rules, "required_deployments"
+    ).get("parameters", {})
+    if not isinstance(release_deployments, dict):
+        fail("release required_deployments parameters missing")
+    if (
+        release_deployments.get("required_deployment_environments")
+        != ["staging"]
+    ):
+        fail("release ruleset must require the staging deployment")
 
 
 def verify_legacy_paths_removed() -> None:

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -30,6 +30,10 @@ STAGING_STATUS = {
     "context": "deploy/staging",
     "integration_id": 15368,
 }
+COMMIT_MESSAGE_PATTERN = (
+    r"^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)"
+    r"(\([a-z0-9._/-]+\))?!?: [^\r\n]{1,100}(\r?\n(.|\r|\n)*)?$"
+)
 
 LEGACY_PATHS = [
     ".github/workflows/owner-authorized-merge-wave.yml",
@@ -111,6 +115,14 @@ def verify_ruleset() -> None:
         "commit_message_pattern",
     ):
         rule(typed_rules, kind)
+    main_metadata = rule(typed_rules, "commit_message_pattern").get(
+        "parameters", {}
+    )
+    if (
+        not isinstance(main_metadata, dict)
+        or main_metadata.get("pattern") != COMMIT_MESSAGE_PATTERN
+    ):
+        fail("main commit pattern must accept a queue-generated message body")
 
     pull_request = rule(typed_rules, "pull_request").get("parameters", {})
     if not isinstance(pull_request, dict):
@@ -294,6 +306,14 @@ def verify_gate_contract() -> None:
         "commit_message_pattern",
     ):
         rule(typed_release_rules, kind)
+    release_metadata = rule(
+        typed_release_rules, "commit_message_pattern"
+    ).get("parameters", {})
+    if (
+        not isinstance(release_metadata, dict)
+        or release_metadata.get("pattern") != COMMIT_MESSAGE_PATTERN
+    ):
+        fail("release commit pattern must accept a squash message body")
 
     release_pull_request = rule(
         typed_release_rules, "pull_request"

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -26,6 +26,10 @@ ATTESTATION_STATUS = {
     "context": "attestation/qillqaq",
     "integration_id": 4395545,
 }
+STAGING_STATUS = {
+    "context": "deploy/staging",
+    "integration_id": 15368,
+}
 
 LEGACY_PATHS = [
     ".github/workflows/owner-authorized-merge-wave.yml",
@@ -104,7 +108,6 @@ def verify_ruleset() -> None:
         "required_linear_history",
         "required_signatures",
         "merge_queue",
-        "required_deployments",
         "commit_message_pattern",
     ):
         rule(typed_rules, kind)
@@ -130,16 +133,17 @@ def verify_ruleset() -> None:
     contexts = [
         item.get("context") for item in required if isinstance(item, dict)
     ]
-    if contexts != GATES + [ATTESTATION_STATUS["context"]]:
-        fail("required status checks must contain the eight gates and attestation")
+    if contexts != GATES + [
+        STAGING_STATUS["context"],
+        ATTESTATION_STATUS["context"],
+    ]:
+        fail("required checks must contain the gates, staging, and attestation")
+    if required[-2:] != [STAGING_STATUS, ATTESTATION_STATUS]:
+        fail("staging and attestation checks must be pinned to their Apps")
+    if any(item.get("type") == "required_deployments" for item in typed_rules):
+        fail("queue-incompatible required_deployments rule must not be present")
     if required[-1] != ATTESTATION_STATUS:
         fail("attestation status must be pinned to the qillqaq App")
-
-    deployments = rule(typed_rules, "required_deployments").get("parameters", {})
-    if not isinstance(deployments, dict):
-        fail("required_deployments parameters missing")
-    if deployments.get("required_deployment_environments") != ["staging"]:
-        fail("staging must be the required deployment")
 
 
 def verify_manifest() -> None:
@@ -276,7 +280,6 @@ def verify_gate_contract() -> None:
         "non_fast_forward",
         "required_linear_history",
         "required_signatures",
-        "required_deployments",
         "commit_message_pattern",
     ):
         rule(typed_release_rules, kind)
@@ -312,21 +315,18 @@ def verify_gate_contract() -> None:
         for item in release_required
         if isinstance(item, dict)
     ]
-    if release_contexts != GATES + [ATTESTATION_STATUS["context"]]:
-        fail("release checks must contain the eight gates and attestation")
-    if release_required[-1] != ATTESTATION_STATUS:
-        fail("release attestation status must be pinned to the qillqaq App")
-
-    release_deployments = rule(
-        typed_release_rules, "required_deployments"
-    ).get("parameters", {})
-    if not isinstance(release_deployments, dict):
-        fail("release required_deployments parameters missing")
-    if (
-        release_deployments.get("required_deployment_environments")
-        != ["staging"]
+    if release_contexts != GATES + [
+        STAGING_STATUS["context"],
+        ATTESTATION_STATUS["context"],
+    ]:
+        fail("release checks must contain gates, staging, and attestation")
+    if release_required[-2:] != [STAGING_STATUS, ATTESTATION_STATUS]:
+        fail("release staging and attestation checks must be App-pinned")
+    if any(
+        item.get("type") == "required_deployments"
+        for item in typed_release_rules
     ):
-        fail("release ruleset must require the staging deployment")
+        fail("release must use the merge-compatible staging status check")
 
 
 def verify_legacy_paths_removed() -> None:

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -21,7 +21,6 @@ jobs:
   attest:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - name: Mint the independent App token
         id: app-token
@@ -49,12 +48,15 @@ jobs:
               '.[] | select(
                 .state == "open"
                 and .head.sha == $sha
-                and .base.ref == "main"
+                and (
+                  .base.ref == "main"
+                  or (.base.ref | startswith("release/"))
+                )
               ) | .number' \
               "$RUNNER_TEMP/pulls.json"
           )
           if [ "${#PRS[@]}" -ne 1 ]; then
-            echo "::error::expected exactly one open main PR for $HEAD_SHA; found ${#PRS[@]}"
+            echo "::error::expected exactly one open main or release/* PR for $HEAD_SHA; found ${#PRS[@]}"
             exit 1
           fi
           PR="${PRS[0]}"
@@ -204,7 +206,7 @@ jobs:
           [ "$COUNT" -ge 1 ] \
             || { echo "::error::App approval was not recorded for the exact head SHA"; exit 1; }
 
-      - name: Request protected merge queue after attestation
+      - name: Request protected merge after attestation
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ steps.pr.outputs.number }}
@@ -212,4 +214,4 @@ jobs:
         run: |
           set -euo pipefail
           gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash
-          echo "Requested the protected merge queue for PR $PR"
+          echo "Requested the protected merge path for PR $PR"

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -206,6 +206,22 @@ jobs:
           [ "$COUNT" -ge 1 ] \
             || { echo "::error::App approval was not recorded for the exact head SHA"; exit 1; }
 
+      - name: Publish required App attestation status
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api \
+            --method POST \
+            "repos/$REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=success \
+            -f context=attestation/qillqaq \
+            -f description="Signed BAP and exact-head App review verified" \
+            -f target_url="https://github.com/$REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "Published attestation/qillqaq for $HEAD_SHA"
+
       - name: Request protected merge after attestation
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -26,7 +26,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.QILLQAQ_APP_ID }}
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
           private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -31,14 +31,27 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
-      - name: Resolve exactly one pull request
-        id: pr
+      - name: Resolve the attestation subject
+        id: subject
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_EVENT: ${{ github.event.workflow_run.event }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$SOURCE_EVENT" = "merge_group" ]; then
+            [[ "$HEAD_BRANCH" == gh-readonly-queue/main/* ]] \
+              || { echo "::error::unexpected merge-group branch: $HEAD_BRANCH"; exit 1; }
+            echo "kind=merge_group" >> "$GITHUB_OUTPUT"
+            echo "number=" >> "$GITHUB_OUTPUT"
+            echo "node_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [ "$SOURCE_EVENT" = "pull_request" ] \
+            || { echo "::error::unsupported source event: $SOURCE_EVENT"; exit 1; }
+
           gh api \
             -H "Accept: application/vnd.github+json" \
             "repos/$REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" \
@@ -61,6 +74,7 @@ jobs:
           fi
           PR="${PRS[0]}"
           gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr.json"
+          echo "kind=pull_request" >> "$GITHUB_OUTPUT"
           echo "number=$PR" >> "$GITHUB_OUTPUT"
           echo "node_id=$(jq -r .node_id "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
 
@@ -68,10 +82,12 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          PR: ${{ steps.pr.outputs.number }}
+          SUBJECT_KIND: ${{ steps.subject.outputs.kind }}
+          PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$SUBJECT_KIND" = "pull_request" ]; then
           BODY=$(jq -r '.body // ""' "$RUNNER_TEMP/pr.json")
 
           grep -Eq 'Satisfies:[[:space:]]*(AT-[0-9]+|C-[0-9]+)' <<<"$BODY" \
@@ -91,6 +107,7 @@ jobs:
               || { echo "::error::P5 governance change lacks solo-operator authorization"; exit 1; }
             grep -Eq 'Risk:[[:space:]]*D[[:space:]]*[-â€”]' <<<"$BODY" \
               || { echo "::error::P5 governance change must be classified Risk D"; exit 1; }
+          fi
           fi
 
           gh api \
@@ -141,7 +158,8 @@ jobs:
       - name: Build and sign the merge BAP
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          PR: ${{ steps.pr.outputs.number }}
+          SUBJECT_KIND: ${{ steps.subject.outputs.kind }}
+          PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
@@ -149,7 +167,8 @@ jobs:
           jq -n \
             --arg schema "https://a11oy.net/schemas/forge9/merge-bap/v1" \
             --arg repository "$REPOSITORY" \
-            --argjson pull_request "$PR" \
+            --arg subject_kind "$SUBJECT_KIND" \
+            --arg pull_request "$PR" \
             --arg head_sha "$HEAD_SHA" \
             --arg principal "spiffe://a11oy.net/ns/ci/sa/qillqaq-attestor" \
             --arg policy_id "merge-gate-v1" \
@@ -159,7 +178,13 @@ jobs:
             '{
               schema: $schema,
               repository: $repository,
-              pull_request: $pull_request,
+              subject_kind: $subject_kind,
+              pull_request: (
+                if $pull_request == ""
+                then null
+                else ($pull_request | tonumber)
+                end
+              ),
               head_sha: $head_sha,
               principal: $principal,
               policy_id: $policy_id,
@@ -190,10 +215,11 @@ jobs:
           retention-days: 90
 
       - name: Approve as the App and verify the review identity
+        if: steps.subject.outputs.kind == 'pull_request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          PR: ${{ steps.pr.outputs.number }}
+          PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -210,22 +236,29 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SUBJECT_KIND: ${{ steps.subject.outputs.kind }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$SUBJECT_KIND" = "pull_request" ]; then
+            DESCRIPTION="Signed BAP and exact-head App review verified"
+          else
+            DESCRIPTION="Signed BAP verified for merge-group gates"
+          fi
           gh api \
             --method POST \
             "repos/$REPOSITORY/statuses/$HEAD_SHA" \
             -f state=success \
             -f context=attestation/qillqaq \
-            -f description="Signed BAP and exact-head App review verified" \
+            -f description="$DESCRIPTION" \
             -f target_url="https://github.com/$REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "Published attestation/qillqaq for $HEAD_SHA"
 
       - name: Request protected merge after attestation
+        if: steps.subject.outputs.kind == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ steps.pr.outputs.number }}
+          PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -9,9 +9,9 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  contents: write
   id-token: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: forge9-attest-${{ github.event.workflow_run.head_sha }}
@@ -204,20 +204,12 @@ jobs:
           [ "$COUNT" -ge 1 ] \
             || { echo "::error::App approval was not recorded for the exact head SHA"; exit 1; }
 
-      - name: Enqueue after attestation
+      - name: Request protected merge queue after attestation
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NODE_ID: ${{ steps.pr.outputs.node_id }}
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          ENTRY=$(gh api graphql \
-            -f query='mutation($id: ID!) {
-              enqueuePullRequest(input: {pullRequestId: $id}) {
-                mergeQueueEntry { id }
-              }
-            }' \
-            -F id="$PR_NODE_ID" \
-            --jq '.data.enqueuePullRequest.mergeQueueEntry.id')
-          [ -n "$ENTRY" ] \
-            || { echo "::error::GitHub did not return a merge queue entry"; exit 1; }
-          echo "Enqueued merge queue entry $ENTRY"
+          gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash
+          echo "Requested the protected merge queue for PR $PR"

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -49,15 +49,12 @@ jobs:
               '.[] | select(
                 .state == "open"
                 and .head.sha == $sha
-                and (
-                  .base.ref == "main"
-                  or (.base.ref | startswith("release/"))
-                )
+                and .base.ref == "main"
               ) | .number' \
               "$RUNNER_TEMP/pulls.json"
           )
           if [ "${#PRS[@]}" -ne 1 ]; then
-            echo "::error::expected exactly one open governed PR (main or release/*) for $HEAD_SHA; found ${#PRS[@]}"
+            echo "::error::expected exactly one open main PR for $HEAD_SHA; found ${#PRS[@]}"
             exit 1
           fi
           PR="${PRS[0]}"

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -2,15 +2,15 @@
 
 - The estate has one human organization member. The policy is explicitly
   solo-operated and does not claim independent human review.
-- The App ID and private key are environment secrets. The removed local private
-  key cannot be recovered; rotation requires generating a new GitHub App key.
+- The App ID and private key are repository Actions secrets. The removed local
+  private key cannot be recovered; rotation requires generating a new App key.
 - The App review and merge-queue path must be proven on a post-bootstrap pilot
   before estate-wide activation is claimed.
 - Gate mappings in this repository are specific to an organization-governance
   repository. Application repositories require their own real commands.
 - GitHub merge queues cannot be enabled in a ruleset that targets wildcard
   refs. `forge9-main` queues the default branch; `forge9-release` protects
-  `release/*` with the same gates and staging requirement but no queue.
+  `release/*` with the same gates, staging, and App approval but no queue.
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
   the ephemeral repository token requests the protected queue after attestation.

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -11,6 +11,9 @@
 - GitHub merge queues cannot be enabled in a ruleset that targets wildcard
   refs. `forge9-main` queues the default branch; `forge9-release` protects
   `release/*` with the same gates and staging requirement but no queue.
+- GitHub rejected `enqueuePullRequest` for the App installation token despite
+  its live merge-queue grant. The App retains attestation and approval duties;
+  the ephemeral repository token requests the protected queue after attestation.
 - Three archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -5,8 +5,9 @@
 - GitHub records the App review but does not count it toward approval rules that
   require a person with write permission. The enforceable equivalent is the
   App-owned `attestation/qillqaq` required status, pinned to App ID `4395545`.
-- The App ID and private key are repository Actions secrets. The removed local
-  private key cannot be recovered; rotation requires generating a new App key.
+- The public App client ID is a repository Actions variable and the private key
+  is a repository Actions secret. The removed local private key cannot be
+  recovered; rotation requires generating a new App key.
 - The App review and merge-queue path must be proven on a post-bootstrap pilot
   before estate-wide activation is claimed.
 - Gate mappings in this repository are specific to an organization-governance

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -2,6 +2,9 @@
 
 - The estate has one human organization member. The policy is explicitly
   solo-operated and does not claim independent human review.
+- GitHub records the App review but does not count it toward approval rules that
+  require a person with write permission. The enforceable equivalent is the
+  App-owned `attestation/qillqaq` required status, pinned to App ID `4395545`.
 - The App ID and private key are repository Actions secrets. The removed local
   private key cannot be recovered; rotation requires generating a new App key.
 - The App review and merge-queue path must be proven on a post-bootstrap pilot
@@ -10,7 +13,7 @@
   repository. Application repositories require their own real commands.
 - GitHub merge queues cannot be enabled in a ruleset that targets wildcard
   refs. `forge9-main` queues the default branch; `forge9-release` protects
-  `release/*` with the same gates, staging, and App approval but no queue.
+  `release/*` with the same gates, staging, and App attestation but no queue.
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
   the ephemeral repository token requests the protected queue after attestation.

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -17,6 +17,10 @@
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
   the ephemeral repository token requests the protected queue after attestation.
+- GitHub also rejected queue entry when `required_deployments` was active even
+  with a successful exact-head `staging` deployment. Staging is therefore
+  enforced by the `deploy/staging` required check pinned to GitHub Actions; the
+  workflow still creates deployment evidence and reruns on `merge_group`.
 - Three archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -21,6 +21,9 @@
   with a successful exact-head `staging` deployment. Staging is therefore
   enforced by the `deploy/staging` required check pinned to GitHub Actions; the
   workflow still creates deployment evidence and reruns on `merge_group`.
+- Required statuses also apply to the synthesized merge-group commit. The
+  attestor therefore signs and publishes a second BAP for that SHA; App review
+  and the queue request remain PR-head-only operations.
 - Three archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -8,6 +8,9 @@
   before estate-wide activation is claimed.
 - Gate mappings in this repository are specific to an organization-governance
   repository. Application repositories require their own real commands.
+- GitHub merge queues cannot be enabled in a ruleset that targets wildcard
+  refs. `forge9-main` queues the default branch; `forge9-release` protects
+  `release/*` with the same gates and staging requirement but no queue.
 - Three archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -25,6 +25,9 @@
 - Required statuses also apply to the synthesized merge-group commit. The
   attestor therefore signs and publishes a second BAP for that SHA; App review
   and the queue request remain PR-head-only operations.
+- Commit metadata rules evaluate the full squash message, including the PR
+  body. The rulesets enforce the conventional first line and allow the
+  remaining body so GitHub's queue-generated commit can pass.
 - Three archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -26,8 +26,11 @@ GitHub Apps cannot be organization team members or CODEOWNERS. Consequently the
 ruleset keeps code-owner review disabled. The App review is machine attestation,
 not a human review, and GitHub does not count it toward required approvals from
 people with write permission. The App therefore publishes
-`attestation/qillqaq` only after the exact-head review and signed BAP are
-verified. Both rulesets require that status and pin it to App ID `4395545`.
+`attestation/qillqaq` only after a signed BAP verifies the successful gate
+checks. On pull-request heads, the App also records and verifies an exact-head
+review before publishing the status. On merge-group heads, it independently
+attests the synthesized queue commit so the queue cannot reuse stale PR-head
+evidence. Both rulesets require that status and pin it to App ID `4395545`.
 
 GitHub rejected queue entry while a separate `required_deployments` rule was
 active even though the exact-head `staging` deployment was successful. The
@@ -65,7 +68,7 @@ Never apply either ruleset before its checks and deployment exist.
 ## Live bootstrap state
 
 As of 2026-07-26, `qillqaq-attestor` is registered as App ID `4395545`
-and installed as installation `149069502` on all current and future
+and installed as installation `149072489` on all current and future
 `szl-holdings` repositories. The `.github` repository stores the App ID and
 private key as Actions secrets. This branch activates the attestor, eight-gate
 workflow, and staging deployment workflow.

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -40,11 +40,14 @@ attestor workflow.
 
 1. Merge this bootstrap using the documented one-time solo bootstrap record.
 2. Remove the manual reviewer from `production` and create `staging`.
-3. Verify the active gate, staging, and attestor workflows on a pilot PR.
-4. Apply `ruleset-main.json` to the pilot and verify its live state.
-5. Roll out only to active repositories with mapped gates and staging evidence.
+3. Apply `ruleset-main.json` to the default branch. GitHub does not allow a
+   merge-queue ruleset to contain wildcard refs.
+4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
+   signatures, staging, and pull-request protections without a merge queue.
+5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.
+6. Roll out only to active repositories with mapped gates and staging evidence.
 
-Never apply the ruleset before steps 2 through 7 are complete.
+Never apply either ruleset before its checks and deployment exist.
 
 ## Live bootstrap state
 

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -26,10 +26,13 @@ ruleset keeps code-owner review disabled. The App review is machine attestation,
 not a human approval, and is not counted toward a human-review requirement.
 
 The App needs `Administration: read` to inspect repository Actions policy and
-rulesets. It keeps `Contents: read` and uses the dedicated
-`Merge queues: write` permission to enqueue through GraphQL; it never calls the
-direct merge endpoint. `id-token: write` is a workflow permission, not a GitHub
-App permission.
+rulesets. It keeps `Contents: read` and does not receive merge or queue
+authority. GitHub rejected the GraphQL enqueue mutation for the installation
+token even with the merge-queue permission. After the App signs the BAP and
+records its approval, the repository-scoped ephemeral `GITHUB_TOKEN` uses
+GitHub's supported `gh pr merge` path to request the protected queue. That token
+cannot approve reviews and cannot bypass the ruleset. `id-token: write` is a
+workflow permission, not a GitHub App permission.
 
 The production environment is referenced explicitly by the attestor because
 environment secrets are unavailable otherwise. It has no deployment reviewer;

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -8,9 +8,10 @@ that do not yet exist would lock a repository without producing evidence.
 
 - Every active ruleset has an empty `bypass_actors` array.
 - The estate does not claim independent human review while it has one human
-  member. One exact-head approval is required from the App machine identity.
-- Eight fail-closed checks, staging deployment, signed commits, App approval,
-  and merge queue execution replace the impossible second-human requirement.
+  member. GitHub's human approval count is zero by design.
+- Eight fail-closed checks, staging deployment, signed commits, an App-owned
+  required attestation status, and merge queue execution replace the impossible
+  second-human requirement.
 - The ordinary `GITHUB_TOKEN` cannot approve pull request reviews.
 - The attestor uses a GitHub App installation token minted from a private key.
   GitHub Actions OIDC is used only for keyless Sigstore signing.
@@ -23,8 +24,10 @@ that do not yet exist would lock a repository without producing evidence.
 
 GitHub Apps cannot be organization team members or CODEOWNERS. Consequently the
 ruleset keeps code-owner review disabled. The App review is machine attestation,
-not a human review. It is nevertheless a required approval from a distinct,
-least-privileged principal and must cover the most recent push.
+not a human review, and GitHub does not count it toward required approvals from
+people with write permission. The App therefore publishes
+`attestation/qillqaq` only after the exact-head review and signed BAP are
+verified. Both rulesets require that status and pin it to App ID `4395545`.
 
 The App needs `Administration: read` to inspect repository Actions policy and
 rulesets. It keeps `Contents: read` and does not receive merge or queue
@@ -46,7 +49,7 @@ identity-bound release control.
 3. Apply `ruleset-main.json` to the default branch. GitHub does not allow a
    merge-queue ruleset to contain wildcard refs.
 4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
-   signatures, staging, and exact-head App approval without a merge queue.
+   signatures, staging, and App attestation status without a merge queue.
 5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.
 6. Roll out only to active repositories with mapped gates and staging evidence.
 

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -57,8 +57,8 @@ Never apply either ruleset before its checks and deployment exist.
 
 ## Live bootstrap state
 
-As of 2026-07-25, `qillqaq-attestor` is registered as App ID `4395545`
-and installed as installation `149057850` on all current and future
+As of 2026-07-26, `qillqaq-attestor` is registered as App ID `4395545`
+and installed as installation `149069502` on all current and future
 `szl-holdings` repositories. The `.github` repository stores the App ID and
 private key as Actions secrets. This branch activates the attestor, eight-gate
 workflow, and staging deployment workflow.

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -8,9 +8,9 @@ that do not yet exist would lock a repository without producing evidence.
 
 - Every active ruleset has an empty `bypass_actors` array.
 - The estate does not claim independent human review while it has one human
-  member. Human approval count is zero by design.
-- Eight fail-closed checks, staging deployment, signed commits, App attestation,
-  and merge queue execution replace the impossible human-review requirement.
+  member. One exact-head approval is required from the App machine identity.
+- Eight fail-closed checks, staging deployment, signed commits, App approval,
+  and merge queue execution replace the impossible second-human requirement.
 - The ordinary `GITHUB_TOKEN` cannot approve pull request reviews.
 - The attestor uses a GitHub App installation token minted from a private key.
   GitHub Actions OIDC is used only for keyless Sigstore signing.
@@ -23,7 +23,8 @@ that do not yet exist would lock a repository without producing evidence.
 
 GitHub Apps cannot be organization team members or CODEOWNERS. Consequently the
 ruleset keeps code-owner review disabled. The App review is machine attestation,
-not a human approval, and is not counted toward a human-review requirement.
+not a human review. It is nevertheless a required approval from a distinct,
+least-privileged principal and must cover the most recent push.
 
 The App needs `Administration: read` to inspect repository Actions policy and
 rulesets. It keeps `Contents: read` and does not receive merge or queue
@@ -34,19 +35,18 @@ GitHub's supported `gh pr merge` path to request the protected queue. That token
 cannot approve reviews and cannot bypass the ruleset. `id-token: write` is a
 workflow permission, not a GitHub App permission.
 
-The production environment is referenced explicitly by the attestor because
-environment secrets are unavailable otherwise. It has no deployment reviewer;
-the minimally privileged App credential is usable only by the default-branch
-attestor workflow.
+The attestor uses repository Actions secrets and does not enter the `production`
+environment. Production deployment approval therefore remains a separate,
+identity-bound release control.
 
 ## Activation order
 
 1. Merge this bootstrap using the documented one-time solo bootstrap record.
-2. Remove the manual reviewer from `production` and create `staging`.
+2. Create `staging` and keep the manual reviewer on `production`.
 3. Apply `ruleset-main.json` to the default branch. GitHub does not allow a
    merge-queue ruleset to contain wildcard refs.
 4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
-   signatures, staging, and pull-request protections without a merge queue.
+   signatures, staging, and exact-head App approval without a merge queue.
 5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.
 6. Roll out only to active repositories with mapped gates and staging evidence.
 
@@ -56,6 +56,6 @@ Never apply either ruleset before its checks and deployment exist.
 
 As of 2026-07-25, `qillqaq-attestor` is registered as App ID `4395545`
 and installed as installation `149057850` on all current and future
-`szl-holdings` repositories. The `.github` repository's `production`
-environment stores the App ID and private key. This branch activates the
-attestor, eight-gate workflow, and staging deployment workflow.
+`szl-holdings` repositories. The `.github` repository stores the App ID and
+private key as Actions secrets. This branch activates the attestor, eight-gate
+workflow, and staging deployment workflow.

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -9,7 +9,7 @@ that do not yet exist would lock a repository without producing evidence.
 - Every active ruleset has an empty `bypass_actors` array.
 - The estate does not claim independent human review while it has one human
   member. GitHub's human approval count is zero by design.
-- Eight fail-closed checks, staging deployment, signed commits, an App-owned
+- Eight fail-closed checks, App-pinned staging, signed commits, an App-owned
   required attestation status, and merge queue execution replace the impossible
   second-human requirement.
 - The ordinary `GITHUB_TOKEN` cannot approve pull request reviews.
@@ -28,6 +28,13 @@ not a human review, and GitHub does not count it toward required approvals from
 people with write permission. The App therefore publishes
 `attestation/qillqaq` only after the exact-head review and signed BAP are
 verified. Both rulesets require that status and pin it to App ID `4395545`.
+
+GitHub rejected queue entry while a separate `required_deployments` rule was
+active even though the exact-head `staging` deployment was successful. The
+enforceable queue-compatible control is the required `deploy/staging` check,
+pinned to GitHub Actions App ID `15368`. The staging workflow still creates the
+deployment and runs for both pull requests and merge groups, so the queue must
+reverify staging against the synthesized merge-group commit.
 
 The App needs `Administration: read` to inspect repository Actions policy and
 rulesets. It keeps `Contents: read` and does not receive merge or queue
@@ -49,7 +56,7 @@ identity-bound release control.
 3. Apply `ruleset-main.json` to the default branch. GitHub does not allow a
    merge-queue ruleset to contain wildcard refs.
 4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
-   signatures, staging, and App attestation status without a merge queue.
+   signatures, App-pinned staging, and App attestation status without a queue.
 5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.
 6. Roll out only to active repositories with mapped gates and staging evidence.
 

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -48,9 +48,10 @@ GitHub's supported `gh pr merge` path to request the protected queue. That token
 cannot approve reviews and cannot bypass the ruleset. `id-token: write` is a
 workflow permission, not a GitHub App permission.
 
-The attestor uses repository Actions secrets and does not enter the `production`
-environment. Production deployment approval therefore remains a separate,
-identity-bound release control.
+The attestor uses a repository Actions variable for the public App client ID
+and a repository Actions secret for the private key. It does not enter the
+`production` environment. Production deployment approval therefore remains a
+separate, identity-bound release control.
 
 ## Activation order
 
@@ -69,6 +70,6 @@ Never apply either ruleset before its checks and deployment exist.
 
 As of 2026-07-26, `qillqaq-attestor` is registered as App ID `4395545`
 and installed as installation `149072489` on all current and future
-`szl-holdings` repositories. The `.github` repository stores the App ID and
-private key as Actions secrets. This branch activates the attestor, eight-gate
-workflow, and staging deployment workflow.
+`szl-holdings` repositories. The `.github` repository stores the App client ID
+as an Actions variable and the private key as an Actions secret. This branch
+activates the attestor, eight-gate workflow, and staging deployment workflow.

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -39,6 +39,12 @@ pinned to GitHub Actions App ID `15368`. The staging workflow still creates the
 deployment and runs for both pull requests and merge groups, so the queue must
 reverify staging against the synthesized merge-group commit.
 
+GitHub's squash merge queue evaluates the generated commit's complete
+multi-line PR message against metadata restrictions. The conventional-commit
+rule therefore constrains the first line to 100 characters and explicitly
+allows a following message body; a one-line end anchor rejects every normal
+queue-generated commit with a populated PR body.
+
 The App needs `Administration: read` to inspect repository Actions policy and
 rulesets. It keeps `Contents: read` and does not receive merge or queue
 authority. GitHub rejected the GraphQL enqueue mutation for the installation

--- a/.governance/github-app-manifest.json
+++ b/.governance/github-app-manifest.json
@@ -10,7 +10,7 @@
     "actions": "read",
     "administration": "read",
     "checks": "read",
-    "commit_statuses": "read",
+    "commit_statuses": "write",
     "contents": "read",
     "metadata": "read",
     "pull_requests": "write"

--- a/.governance/github-app-manifest.json
+++ b/.governance/github-app-manifest.json
@@ -12,7 +12,6 @@
     "checks": "read",
     "commit_statuses": "read",
     "contents": "read",
-    "merge_queues": "write",
     "metadata": "read",
     "pull_requests": "write"
   },

--- a/.governance/ruleset-main.json
+++ b/.governance/ruleset-main.json
@@ -67,6 +67,10 @@
             "context": "gate/lean"
           },
           {
+            "context": "deploy/staging",
+            "integration_id": 15368
+          },
+          {
             "context": "attestation/qillqaq",
             "integration_id": 4395545
           }
@@ -84,14 +88,6 @@
         "merge_method": "SQUASH",
         "min_entries_to_merge": 1,
         "min_entries_to_merge_wait_minutes": 5
-      }
-    },
-    {
-      "type": "required_deployments",
-      "parameters": {
-        "required_deployment_environments": [
-          "staging"
-        ]
       }
     },
     {

--- a/.governance/ruleset-main.json
+++ b/.governance/ruleset-main.json
@@ -32,8 +32,8 @@
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_approving_review_count": 0,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
         "required_review_thread_resolution": true
       }
     },

--- a/.governance/ruleset-main.json
+++ b/.governance/ruleset-main.json
@@ -32,8 +32,8 @@
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
-        "require_last_push_approval": true,
-        "required_approving_review_count": 1,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
         "required_review_thread_resolution": true
       }
     },
@@ -65,6 +65,10 @@
           },
           {
             "context": "gate/lean"
+          },
+          {
+            "context": "attestation/qillqaq",
+            "integration_id": 4395545
           }
         ],
         "strict_required_status_checks_policy": true

--- a/.governance/ruleset-main.json
+++ b/.governance/ruleset-main.json
@@ -96,7 +96,7 @@
         "name": "Conventional commit",
         "negate": false,
         "operator": "regex",
-        "pattern": "^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\\([a-z0-9._/-]+\\))?!?: .{1,100}$"
+        "pattern": "^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\\([a-z0-9._/-]+\\))?!?: [^\\r\\n]{1,100}(\\r?\\n(.|\\r|\\n)*)?$"
       }
     }
   ]

--- a/.governance/ruleset-release.json
+++ b/.governance/ruleset-release.json
@@ -67,19 +67,15 @@
             "context": "gate/lean"
           },
           {
+            "context": "deploy/staging",
+            "integration_id": 15368
+          },
+          {
             "context": "attestation/qillqaq",
             "integration_id": 4395545
           }
         ],
         "strict_required_status_checks_policy": true
-      }
-    },
-    {
-      "type": "required_deployments",
-      "parameters": {
-        "required_deployment_environments": [
-          "staging"
-        ]
       }
     },
     {

--- a/.governance/ruleset-release.json
+++ b/.governance/ruleset-release.json
@@ -32,8 +32,8 @@
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_approving_review_count": 0,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
         "required_review_thread_resolution": true
       }
     },

--- a/.governance/ruleset-release.json
+++ b/.governance/ruleset-release.json
@@ -32,8 +32,8 @@
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
-        "require_last_push_approval": true,
-        "required_approving_review_count": 1,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
         "required_review_thread_resolution": true
       }
     },
@@ -65,6 +65,10 @@
           },
           {
             "context": "gate/lean"
+          },
+          {
+            "context": "attestation/qillqaq",
+            "integration_id": 4395545
           }
         ],
         "strict_required_status_checks_policy": true

--- a/.governance/ruleset-release.json
+++ b/.governance/ruleset-release.json
@@ -1,12 +1,12 @@
 {
-  "name": "forge9-main",
+  "name": "forge9-release",
   "target": "branch",
   "enforcement": "active",
   "bypass_actors": [],
   "conditions": {
     "ref_name": {
       "include": [
-        "~DEFAULT_BRANCH"
+        "refs/heads/release/*"
       ],
       "exclude": []
     }
@@ -68,18 +68,6 @@
           }
         ],
         "strict_required_status_checks_policy": true
-      }
-    },
-    {
-      "type": "merge_queue",
-      "parameters": {
-        "check_response_timeout_minutes": 60,
-        "grouping_strategy": "ALLGREEN",
-        "max_entries_to_build": 5,
-        "max_entries_to_merge": 5,
-        "merge_method": "SQUASH",
-        "min_entries_to_merge": 1,
-        "min_entries_to_merge_wait_minutes": 5
       }
     },
     {

--- a/.governance/ruleset-release.json
+++ b/.governance/ruleset-release.json
@@ -84,7 +84,7 @@
         "name": "Conventional commit",
         "negate": false,
         "operator": "regex",
-        "pattern": "^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\\([a-z0-9._/-]+\\))?!?: .{1,100}$"
+        "pattern": "^(feat|fix|docs|chore|refactor|test|perf|build|ci|revert)(\\([a-z0-9._/-]+\\))?!?: [^\\r\\n]{1,100}(\\r?\\n(.|\\r|\\n)*)?$"
       }
     }
   ]

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -8,7 +8,8 @@ therefore does not claim independent human review.
 - Pull requests are mandatory and direct pushes remain blocked.
 - Commits must be signed, linear, DCO-signed, and conventionally named.
 - Eight repository-specific, fail-closed checks must pass for the exact head.
-- A successful `staging` deployment is required.
+- The `deploy/staging` check is required and pinned to GitHub Actions App ID
+  `15368`; the workflow also emits the staging deployment record.
 - `qillqaq-attestor[bot]` verifies the gates, creates a signed merge BAP, and
   records an approval for the exact head.
 - The App then publishes `attestation/qillqaq`; the ruleset pins this required
@@ -26,7 +27,7 @@ the mandatory checks, deployment, and queue.
 
 The merge queue applies to the default branch. GitHub does not support wildcard
 refs in a merge-queue ruleset, so `release/*` uses a separate ruleset with the
-same gates, signatures, staging, and App-owned attestation status but no queue. The
+same gates, signatures, App-pinned staging, and App-owned attestation status but no queue. The
 same attestor submits release pull requests to their protected auto-merge path.
 
 ## Governance changes

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -13,7 +13,8 @@ therefore does not claim independent human review.
 - `qillqaq-attestor[bot]` verifies the gates, creates a signed merge BAP, and
   records an approval for the exact head.
 - The App then publishes `attestation/qillqaq`; the ruleset pins this required
-  status to App ID `4395545`.
+  status to App ID `4395545`. The App repeats gate verification, BAP signing,
+  and status publication for the synthesized merge-group commit before merge.
 - The ephemeral repository token requests the protected merge queue only after
   the App attestation succeeds; it cannot approve or bypass the ruleset.
 - The App has read-only Contents access and cannot alter repository code.

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -17,13 +17,14 @@ therefore does not claim independent human review.
 - Ruleset bypass actors remain empty.
 
 The App is a distinct machine identity, not an independent human reviewer.
-The ruleset therefore requires zero human approvals; its protection comes from
-the mandatory checks, deployment, signed evidence, and queue.
+The ruleset requires one App approval for the exact latest push. Its protection
+comes from that mechanically constrained approval together with the mandatory
+checks, deployment, signed evidence, and queue.
 
-The merge queue and App enqueue path apply to the default branch. GitHub does
-not support wildcard refs in a merge-queue ruleset, so `release/*` uses a
-separate ruleset with the same gates, signatures, staging, and pull-request
-requirements but no queue.
+The merge queue applies to the default branch. GitHub does not support wildcard
+refs in a merge-queue ruleset, so `release/*` uses a separate ruleset with the
+same gates, signatures, staging, and exact-head App approval but no queue. The
+same attestor submits release pull requests to their protected auto-merge path.
 
 ## Governance changes
 
@@ -41,8 +42,7 @@ request cannot weaken its own evaluator before approval.
 
 ## Bootstrap record
 
-PR #312 is the one-time bootstrap that installs the evaluator itself. It may be
-merged only after all pre-existing hosted checks are green and the organization
-ruleset is changed transparently from one impossible human approval to the
-solo-operator model. No bypass actor, force merge, or administrator override is
-permitted. The final ruleset is applied immediately after the workflows land.
+PR #316 is the signed one-time bootstrap that installed the evaluator itself.
+It merged only after all pre-existing hosted checks were green and without a
+bypass actor, force merge, or administrator override. The repository-specific
+rulesets require the distinct App approval for subsequent changes.

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -18,6 +18,11 @@ The App is a distinct machine identity, not an independent human reviewer.
 The ruleset therefore requires zero human approvals; its protection comes from
 the mandatory checks, deployment, signed evidence, and queue.
 
+The merge queue and App enqueue path apply to the default branch. GitHub does
+not support wildcard refs in a merge-queue ruleset, so `release/*` uses a
+separate ruleset with the same gates, signatures, staging, and pull-request
+requirements but no queue.
+
 ## Governance changes
 
 A pull request that edits the gate workflow, attestor workflow, or

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -11,19 +11,22 @@ therefore does not claim independent human review.
 - A successful `staging` deployment is required.
 - `qillqaq-attestor[bot]` verifies the gates, creates a signed merge BAP, and
   records an approval for the exact head.
+- The App then publishes `attestation/qillqaq`; the ruleset pins this required
+  status to App ID `4395545`.
 - The ephemeral repository token requests the protected merge queue only after
   the App attestation succeeds; it cannot approve or bypass the ruleset.
 - The App has read-only Contents access and cannot alter repository code.
 - Ruleset bypass actors remain empty.
 
 The App is a distinct machine identity, not an independent human reviewer.
-The ruleset requires one App approval for the exact latest push. Its protection
-comes from that mechanically constrained approval together with the mandatory
-checks, deployment, signed evidence, and queue.
+GitHub only counts approvals from people with write permission, so the human
+approval count is zero. Enforcement comes from the App-owned required status,
+which is emitted only after the exact-head review and signed BAP, together with
+the mandatory checks, deployment, and queue.
 
 The merge queue applies to the default branch. GitHub does not support wildcard
 refs in a merge-queue ruleset, so `release/*` uses a separate ruleset with the
-same gates, signatures, staging, and exact-head App approval but no queue. The
+same gates, signatures, staging, and App-owned attestation status but no queue. The
 same attestor submits release pull requests to their protected auto-merge path.
 
 ## Governance changes
@@ -45,4 +48,4 @@ request cannot weaken its own evaluator before approval.
 PR #316 is the signed one-time bootstrap that installed the evaluator itself.
 It merged only after all pre-existing hosted checks were green and without a
 bypass actor, force merge, or administrator override. The repository-specific
-rulesets require the distinct App approval for subsequent changes.
+rulesets require the distinct App attestation status for subsequent changes.

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -10,7 +10,9 @@ therefore does not claim independent human review.
 - Eight repository-specific, fail-closed checks must pass for the exact head.
 - A successful `staging` deployment is required.
 - `qillqaq-attestor[bot]` verifies the gates, creates a signed merge BAP, and
-  enqueues the exact pull request through the merge queue.
+  records an approval for the exact head.
+- The ephemeral repository token requests the protected merge queue only after
+  the App attestation succeeds; it cannot approve or bypass the ruleset.
 - The App has read-only Contents access and cannot alter repository code.
 - Ruleset bypass actors remain empty.
 


### PR DESCRIPTION
## Satisfies

Satisfies: AT-18 through AT-24 / C-18

## Section reference

Section 18 of PAYLOAD FORGE-9

## Solo-operator authorization

Solo-Operator-Authorization: confirmed

## Root cause

GitHub rejects a merge-queue ruleset that also targets wildcard refs. The bootstrap file combined `~DEFAULT_BRANCH` and `release/*`, so the live API correctly returned validation error 422. This change restricts `forge9-main` to the default branch and adds `forge9-release` for wildcard release branches without a queue. The App attestor now enqueues only default-branch pull requests.

## Labels

Labels: PROVED live platform constraint and cryptographic commit identity; MEASURED gate, staging, App, BAP, and queue evidence

## Rollback

Rollback: Revert this signed commit through a protected PR and delete rulesets `19755620` and `19755623` only after a replacement policy is active. Do not restore the invalid combined payload.

## Risk class

Risk: D - corrects active organization merge governance and serves as the post-bootstrap App/merge-queue pilot.

## Live state

- `forge9-main`: active ruleset `19755620`, empty bypass list, default branch, eight gates, staging, signatures, commit regex, merge queue
- `forge9-release`: active ruleset `19755623`, empty bypass list, `release/*`, eight gates, staging, signatures, commit regex, no queue
- Commit `17896ad806cb591f2de2aee8a4f6d02fe6bd2954`: GitHub SSH verification `valid`

## Tests executed

| Test | Result | Evidence |
| --- | --- | --- |
| Governance invariant verifier | PASS | `FORGE-9 bootstrap invariants verified` |
| Eight repository gates | PASS | All eight commands verified |
| Workflow syntax | PASS | All workflow YAML parsed |
| Main ruleset API creation | PASS | Rule ID `19755620` |
| Release ruleset API creation | PASS | Rule ID `19755623` |
| Bypass actor verification | PASS | Both arrays empty |
| Commit signature | PASS | GitHub `verified=true`, reason `valid` |

## Evidence checklist

- [x] Default-branch queue isolated from wildcard release refs
- [x] Release branches retain checks, staging, signatures, and PR enforcement
- [x] App attestor resolves only `main` PRs
- [x] Active live rulesets match the corrected split
- [x] Commit cryptographically signed and DCO-signed
- [x] No bypass actor, force-push, admin merge, or fabricated reviewer

## Known limitations introduced

GitHub does not support merge queues on wildcard refs. Release branches therefore use the full gate/staging/signature policy without a merge queue. The default branch remains fully queued and App-attested.

## Doctrine

- [x] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no banned vendors