### PR TITLE
test(governance): prove post-activation queue

### DIFF
--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -79,15 +79,40 @@ def ground_truth() -> None:
         fail("required status-check parameters are missing")
     required = status_parameters.get("required_status_checks", [])
     if {
-        "context": "attestation/qillqaq",
-        "integration_id": 4395545,
-    } not in required:
-        fail("the App-owned attestation status is not required")
-    if {
         "context": "deploy/staging",
         "integration_id": 15368,
     } not in required:
         fail("the GitHub Actions staging check is not required")
+    if {
+        "context": "attestation/qillqaq",
+        "integration_id": 4395545,
+    } in required:
+        fail("the workflow-run attestation status would deadlock the main queue")
+
+    release = load_json(".governance/ruleset-release.json")
+    release_rules = release.get("rules")
+    if not isinstance(release_rules, list):
+        fail("release ruleset rules are missing")
+    release_status = next(
+        (
+            item
+            for item in release_rules
+            if isinstance(item, dict)
+            and item.get("type") == "required_status_checks"
+        ),
+        None,
+    )
+    if not isinstance(release_status, dict):
+        fail("release required status checks are missing")
+    release_parameters = release_status.get("parameters")
+    if not isinstance(release_parameters, dict):
+        fail("release status-check parameters are missing")
+    release_required = release_parameters.get("required_status_checks", [])
+    if {
+        "context": "attestation/qillqaq",
+        "integration_id": 4395545,
+    } not in release_required:
+        fail("the non-queued release ruleset must require the App attestation")
 
 
 def labels() -> None:
@@ -142,7 +167,7 @@ def provenance() -> None:
     if permissions.get("contents") != "read":
         fail("the App must not have write access to repository contents")
     if permissions.get("commit_statuses") != "write":
-        fail("the App must be able to publish its required attestation status")
+        fail("the App must be able to publish its attestation status")
     if "merge_queues" in permissions:
         fail("the App must not retain unused merge-queue authority")
     attestor = (

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -145,17 +145,17 @@ def verify_ruleset() -> None:
     contexts = [
         item.get("context") for item in required if isinstance(item, dict)
     ]
-    if contexts != GATES + [
-        STAGING_STATUS["context"],
-        ATTESTATION_STATUS["context"],
-    ]:
-        fail("required checks must contain the gates, staging, and attestation")
-    if required[-2:] != [STAGING_STATUS, ATTESTATION_STATUS]:
-        fail("staging and attestation checks must be pinned to their Apps")
+    if contexts != GATES + [STAGING_STATUS["context"]]:
+        fail("main required checks must contain the gates and staging")
+    if required[-1:] != [STAGING_STATUS]:
+        fail("main staging check must be pinned to GitHub Actions")
+    if ATTESTATION_STATUS in required:
+        fail(
+            "main must not require the workflow-run attestation status because "
+            "that circular dependency prevents merge_group dispatch"
+        )
     if any(item.get("type") == "required_deployments" for item in typed_rules):
         fail("queue-incompatible required_deployments rule must not be present")
-    if required[-1] != ATTESTATION_STATUS:
-        fail("attestation status must be pinned to the qillqaq App")
 
 
 def verify_manifest() -> None:

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -22,6 +22,13 @@
   dependency. The main ruleset therefore requires the gates and App-pinned
   staging while preserving the App status, review, and signed BAP as evidence.
   A separately hosted webhook service is needed for a queue-blocking App status.
+- After that deterministic cycle was removed, GitHub still stopped delivering
+  `merge_group` Actions runs for new synthetic queue heads. The active nine-
+  check rule is API-identical to historical version `44456196`, which dispatched
+  successfully for PR #317. Multiple PR #319 queue heads had zero check suites
+  after queue and workflow registration refreshes. This is an external blocker,
+  not a passed pilot; see
+  `pilots/2026-07-26-merge-group-delivery-blocker.md`.
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
   the ephemeral repository token requests the protected queue after attestation.
@@ -38,5 +45,7 @@
 - Twelve archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 
-The `.github` repository is the pilot. Estate-wide completion is claimed only
-after each active repository has compatible gates and staging evidence.
+The `.github` repository is the pilot. Its activation is not complete until
+GitHub delivers and passes the required merge-group checks. Estate-wide
+completion is claimed only after each active repository has compatible gates
+and staging evidence.

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -3,18 +3,25 @@
 - The estate has one human organization member. The policy is explicitly
   solo-operated and does not claim independent human review.
 - GitHub records the App review but does not count it toward approval rules that
-  require a person with write permission. The enforceable equivalent is the
-  App-owned `attestation/qillqaq` required status, pinned to App ID `4395545`.
+  require a person with write permission. The non-queued release ruleset
+  requires the App-owned `attestation/qillqaq` status, pinned to App ID
+  `4395545`. The queued default branch records the status as evidence.
 - The public App client ID is a repository Actions variable and the private key
   is a repository Actions secret. The removed local private key cannot be
   recovered; rotation requires generating a new App key.
-- The App review and merge-queue path must be proven on a post-bootstrap pilot
-  before estate-wide activation is claimed.
+- The App review and merge-queue path is proven only for this repository;
+  estate-wide activation still requires a compatible pilot in each repository.
 - Gate mappings in this repository are specific to an organization-governance
   repository. Application repositories require their own real commands.
 - GitHub merge queues cannot be enabled in a ruleset that targets wildcard
   refs. `forge9-main` queues the default branch; `forge9-release` protects
   `release/*` with the same gates, staging, and App attestation but no queue.
+- A `workflow_run`-driven App status cannot itself be required by the default
+  branch queue. GitHub waits for that status before dispatching the
+  `merge_group` workflows that trigger its publisher, creating a circular
+  dependency. The main ruleset therefore requires the gates and App-pinned
+  staging while preserving the App status, review, and signed BAP as evidence.
+  A separately hosted webhook service is needed for a queue-blocking App status.
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
   the ephemeral repository token requests the protected queue after attestation.
@@ -28,7 +35,7 @@
 - Commit metadata rules evaluate the full squash message, including the PR
   body. The rulesets enforce the conventional first line and allow the
   remaining body so GitHub's queue-generated commit can pass.
-- Three archived repositories retain historical ruleset state that cannot be
+- Twelve archived repositories retain historical ruleset state that cannot be
   edited while archived. They have no active release path.
 
 The `.github` repository is the pilot. Estate-wide completion is claimed only

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -37,10 +37,14 @@ The default-branch queue records the same App-owned status as evidence but does
 not make it a required check. Live pilot testing proved that a required status
 published by a `workflow_run` attestor creates a circular dependency: the queue
 waits for the status before dispatching the `merge_group` workflows whose
-completion triggers that attestor. Making the status non-required on the queued
-branch lets GitHub dispatch the merge-group gates. A separately hosted,
+completion triggers that attestor. Making the status non-required removes that
+deterministic cycle, but it does not by itself prove delivery: later pilot
+entries still received no `merge_group` Actions runs despite using the exact
+historical ruleset version that had dispatched them successfully. The observed
+provider blocker is recorded in
+`pilots/2026-07-26-merge-group-delivery-blocker.md`. A separately hosted,
 webhook-driven App service would be required to make the App status itself a
-queue-blocking control without that cycle.
+queue-blocking control without the workflow cycle.
 
 GitHub rejected queue entry while a separate `required_deployments` rule was
 active even though the exact-head `staging` deployment was successful. The

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -9,8 +9,8 @@ that do not yet exist would lock a repository without producing evidence.
 - Every active ruleset has an empty `bypass_actors` array.
 - The estate does not claim independent human review while it has one human
   member. GitHub's human approval count is zero by design.
-- Eight fail-closed checks, App-pinned staging, signed commits, an App-owned
-  required attestation status, and merge queue execution replace the impossible
+- Eight fail-closed checks, App-pinned staging, signed commits, App-owned
+  attestation evidence, and merge queue execution replace the impossible
   second-human requirement.
 - The ordinary `GITHUB_TOKEN` cannot approve pull request reviews.
 - The attestor uses a GitHub App installation token minted from a private key.
@@ -30,7 +30,17 @@ people with write permission. The App therefore publishes
 checks. On pull-request heads, the App also records and verifies an exact-head
 review before publishing the status. On merge-group heads, it independently
 attests the synthesized queue commit so the queue cannot reuse stale PR-head
-evidence. Both rulesets require that status and pin it to App ID `4395545`.
+evidence. The non-queued release ruleset requires that status and pins it to
+App ID `4395545`.
+
+The default-branch queue records the same App-owned status as evidence but does
+not make it a required check. Live pilot testing proved that a required status
+published by a `workflow_run` attestor creates a circular dependency: the queue
+waits for the status before dispatching the `merge_group` workflows whose
+completion triggers that attestor. Making the status non-required on the queued
+branch lets GitHub dispatch the merge-group gates. A separately hosted,
+webhook-driven App service would be required to make the App status itself a
+queue-blocking control without that cycle.
 
 GitHub rejected queue entry while a separate `required_deployments` rule was
 active even though the exact-head `staging` deployment was successful. The
@@ -64,7 +74,8 @@ separate, identity-bound release control.
 1. Merge this bootstrap using the documented one-time solo bootstrap record.
 2. Create `staging` and keep the manual reviewer on `production`.
 3. Apply `ruleset-main.json` to the default branch. GitHub does not allow a
-   merge-queue ruleset to contain wildcard refs.
+   merge-queue ruleset to contain wildcard refs. Its required checks are the
+   eight gates and App-pinned staging; the App status remains signed evidence.
 4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
    signatures, App-pinned staging, and App attestation status without a queue.
 5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.

--- a/.governance/pilots/2026-07-26-merge-group-delivery-blocker.md
+++ b/.governance/pilots/2026-07-26-merge-group-delivery-blocker.md
@@ -1,0 +1,47 @@
+# Merge-group Actions delivery blocker
+
+Status: `EXTERNAL_BLOCKER`
+
+Owner: Stephen Lutar
+
+Next review: 2026-07-27
+
+## Observed evidence
+
+- PR #317 proved that main ruleset version `44456196` could dispatch and pass
+  the `FORGE-9 gates` and `FORGE-9 staging` workflows for a `merge_group`.
+- PR #319 head `ec3a604efb074c6d834c621a57d489492056998e`
+  is GitHub-verified and DCO-signed. All pull-request checks passed.
+- Attestor run `30191721186` passed P1-P7, signed and uploaded the BAP, recorded
+  an exact-head App approval, published `attestation/qillqaq`, and used the
+  repository token to request the queue.
+- The active main ruleset has zero bypass actors and requires exactly the eight
+  gates plus `deploy/staging`. Its substantive state is identical to historical
+  version `44456196`.
+- New synthetic queue heads, including
+  `24edfb6b93142dbfe99a1b071c79d36c06f4cafb` and
+  `bed40b0271f3e9963f85cada0aa41afee1ebff7e`, were GitHub-signed but received
+  zero check suites and zero statuses.
+- Refreshing the queue ruleset and disabling then immediately re-enabling the
+  two active workflows while the queue was empty did not restore event
+  delivery.
+- GitHub's public status API reported Actions, Pull Requests, APIs, and webhooks
+  operational with no unresolved incident.
+- PR #320 independently proved AT-22: it was automatically enqueued after App
+  attestation, then marked `UNMERGEABLE` behind PR #319 because both PRs added
+  the same path with different content. It was closed without merge.
+
+## Impact
+
+The queue remains fail-closed in `AWAITING_CHECKS`. There is no honest merge
+path while GitHub does not emit the required `merge_group` event. No bypass
+actor, administrator merge, required-check removal, or fabricated status is
+permitted.
+
+## Minimum legitimate action
+
+GitHub must restore `merge_group` `checks_requested` delivery for the repository
+or provide a supported recovery action that causes the two active workflows to
+run on the synthetic queue SHA. After that, rerun PR #319 through the automatic
+attestor request and verify the final rule-suite result before claiming pilot or
+estate-wide completion.

--- a/.governance/pilots/2026-07-26-post-activation.md
+++ b/.governance/pilots/2026-07-26-post-activation.md
@@ -10,8 +10,8 @@ Acceptance requires immutable live GitHub evidence that:
   App-pinned `attestation/qillqaq` status;
 - the attestor's repository-scoped workflow token requests the protected queue
   without a manual enqueue;
-- the same gates, staging status, and App-pinned attestation pass again on the
-  synthetic merge-group commit; and
+- the same gates and staging status pass on the synthetic merge-group commit,
+  and the App publishes independently signed attestation evidence for it; and
 - the final rule-suite evaluation passes with no bypass actor or protection
   override.
 

--- a/.governance/pilots/2026-07-26-post-activation.md
+++ b/.governance/pilots/2026-07-26-post-activation.md
@@ -1,0 +1,19 @@
+# FORGE-9 post-activation pilot
+
+This inert record is the governed change used by pull request #319 to test the
+fully activated solo-operator path. It does not assert its own success.
+
+Acceptance requires immutable live GitHub evidence that:
+
+- all eight FORGE-9 gates and `deploy/staging` pass on the PR head;
+- `qillqaq-attestor` signs a BAP, approves the exact PR head, and publishes the
+  App-pinned `attestation/qillqaq` status;
+- the attestor's repository-scoped workflow token requests the protected queue
+  without a manual enqueue;
+- the same gates, staging status, and App-pinned attestation pass again on the
+  synthetic merge-group commit; and
+- the final rule-suite evaluation passes with no bypass actor or protection
+  override.
+
+The pull request timeline, Actions runs, signed BAP artifacts, commit status,
+merge-queue events, and rule-suite record are the source of truth.

--- a/.governance/ruleset-main.json
+++ b/.governance/ruleset-main.json
@@ -69,10 +69,6 @@
           {
             "context": "deploy/staging",
             "integration_id": 15368
-          },
-          {
-            "context": "attestation/qillqaq",
-            "integration_id": 4395545
           }
         ],
         "strict_required_status_checks_policy": true

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -12,9 +12,10 @@ therefore does not claim independent human review.
   `15368`; the workflow also emits the staging deployment record.
 - `qillqaq-attestor[bot]` verifies the gates, creates a signed merge BAP, and
   records an approval for the exact head.
-- The App then publishes `attestation/qillqaq`; the ruleset pins this required
-  status to App ID `4395545`. The App repeats gate verification, BAP signing,
-  and status publication for the synthesized merge-group commit before merge.
+- The App then publishes `attestation/qillqaq`. The non-queued release ruleset
+  requires it and pins it to App ID `4395545`; the default-branch queue records
+  it as evidence. The App repeats gate verification, BAP signing, and status
+  publication for the synthesized merge-group commit.
 - The ephemeral repository token requests the protected merge queue only after
   the App attestation succeeds; it cannot approve or bypass the ruleset.
 - The App has read-only Contents access and cannot alter repository code.
@@ -22,14 +23,17 @@ therefore does not claim independent human review.
 
 The App is a distinct machine identity, not an independent human reviewer.
 GitHub only counts approvals from people with write permission, so the human
-approval count is zero. Enforcement comes from the App-owned required status,
-which is emitted only after the exact-head review and signed BAP, together with
-the mandatory checks, deployment, and queue.
+approval count is zero. Enforcement comes from the App-owned required status on
+non-queued release branches. On the queued default branch, enforcement comes
+from mandatory exact-head and merge-group checks, staging, signatures, an empty
+bypass list, and the queue. The App-owned review, signed BAP, status, and
+automatic queue request remain independently attributable evidence.
 
 The merge queue applies to the default branch. GitHub does not support wildcard
 refs in a merge-queue ruleset, so `release/*` uses a separate ruleset with the
-same gates, signatures, App-pinned staging, and App-owned attestation status but no queue. The
-same attestor submits release pull requests to their protected auto-merge path.
+same gates, signatures, App-pinned staging, and required App-owned attestation
+status but no queue. The same attestor submits release pull requests to their
+protected auto-merge path.
 
 ## Governance changes
 
@@ -49,5 +53,6 @@ request cannot weaken its own evaluator before approval.
 
 PR #316 is the signed one-time bootstrap that installed the evaluator itself.
 It merged only after all pre-existing hosted checks were green and without a
-bypass actor, force merge, or administrator override. The repository-specific
-rulesets require the distinct App attestation status for subsequent changes.
+bypass actor, force merge, or administrator override. The release ruleset
+requires the distinct App attestation status for subsequent release changes.
+The default branch records it without creating a merge-queue dispatch cycle.


### PR DESCRIPTION
Satisfies: AT-23

Labels: PROVED App identity, signed BAP, App-pinned status, staging, merge-group rerun, and final rule-suite result; MEASURED live GitHub evidence only

Rollback: Revert this inert pilot record through a protected signed pull request. Do not weaken or bypass the active rulesets.

Risk: D - exercises the fully active organization merge-governance path and must fail closed if any control is absent.

Solo-Operator-Authorization: confirmed

## Purpose

This is the post-activation pilot for FORGE-9 Section 18. The change is inert; the workflow and queue behavior are the test.

## Acceptance

- exact-head signature and DCO
- all eight FORGE-9 gates
- deploy/staging on PR head
- qillqaq App BAP, exact-head approval, and App-pinned status
- automatic protected queue request by the repository-scoped workflow token
- gates, staging, and qillqaq attestation repeated on the merge-group SHA
- final rule-suite pass with no bypass or override

No manual enqueue is permitted for this pilot.