### PR TITLE
fix(security): keep drift verification live during app activation

### DIFF
--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -1,37 +1,8 @@
 #!/usr/bin/env python3
 """Self-test for the managed-security-configuration drift checker.
 
-Task #387 created ``code_security_drift.py`` — the safety net that proves every
-non-archived repo in the org stays attached + enforced under the canonical
-"SZL Holdings Managed Security" code-security configuration (id 252588), that
-the config still exists/org-scoped/enforced, and that it is still the default
-for new repos. If that checker were ever weakened — an edit that makes it always
-return exit 0, or one that swallows an auth/API failure as a pass — drift would
-go undetected and the org would *look* protected when it isn't.
-
-The most important branch ("auth/API failure must be exit 2, never 0") and the
-drift branches require live organization-administration calls that cannot run in
-credentialless pull-request CI. This test stubs the GitHub API surface
-(``_token`` / ``gh_json`` / ``gh_paginate``) so it runs with no network and no
-credential, and pins the exit-code contract of ``main()``:
-
-  clean state                                    -> exit 0
-  a repo detached (not enforced under canonical) -> exit 1
-  a repo swapped onto a different configuration  -> exit 1
-  a new uncovered repo                            -> exit 1
-  default-for-new-repos changed                   -> exit 1
-  canonical configuration missing                 -> exit 1
-  a present-but-failing token (auth/API error)    -> exit 2
-  no token configured for direct local invocation -> exit 3
-
-The production workflow has a stronger contract: it runs source tests before it
-mints a short-lived qillqaq GitHub App installation token, fails when that token
-cannot be created or cannot read the organization endpoint, and writes a
-normalized, source-bound evidence envelope even when a pre-check prevents the
-ordinary report. It never converts a missing or stale personal token into a
-neutral production result.
-
-Stdlib ``unittest`` only — no third-party test framework.
+The network-facing checker is stubbed so this suite can lock its exit-code and
+workflow-authentication contracts without receiving any organization credential.
 """
 from __future__ import annotations
 
@@ -80,7 +51,6 @@ def _repo(name, archived=False, private=False):
 
 
 def _clean_state():
-    """Canonical config exists+enforced+default; every repo enforced under it."""
     repos = [_repo("a11oy"), _repo("ouroboros", private=True), _repo("docs-site")]
     configs = [_config(CFG)]
     defaults = [{"default_for_new_repos": "all", "configuration": {"id": CFG}}]
@@ -89,8 +59,6 @@ def _clean_state():
 
 
 def _make_fetchers(configs, defaults, repos, attachments):
-    """Return API stubs that route by request path."""
-
     def gh_json(path, token):
         if path.endswith("/code-security/configurations/defaults"):
             return defaults
@@ -121,7 +89,6 @@ def _run_main(
     token="tok",
     gh_json_error=None,
 ):
-    """Run ``csd.main()`` with the GitHub API surface stubbed out."""
     saved = {
         "_token": csd._token,
         "gh_json": csd.gh_json,
@@ -129,27 +96,20 @@ def _run_main(
     }
     try:
         if token is None:
-
             def _no_token():
                 raise csd.MissingTokenError("No GitHub token configured (test).")
-
             csd._token = _no_token
         else:
             csd._token = lambda: token
 
         if gh_json_error is not None:
-
             def _raise(path, tok):
                 raise gh_json_error
-
             csd.gh_json = _raise
             csd.gh_paginate = lambda path, tok: []
         else:
             gh_json, gh_paginate = _make_fetchers(
-                configs,
-                defaults,
-                repos,
-                attachments,
+                configs, defaults, repos, attachments
             )
             csd.gh_json = gh_json
             csd.gh_paginate = gh_paginate
@@ -176,8 +136,7 @@ def _run_main(
 
 class TestDriftCheckerExitContract(unittest.TestCase):
     def test_clean_state_passes(self):
-        rc = _run_main(*_clean_state())
-        self.assertEqual(rc, csd.EXIT_OK)
+        self.assertEqual(_run_main(*_clean_state()), csd.EXIT_OK)
 
     def test_detached_repo_fails(self):
         configs, defaults, repos, attachments = _clean_state()
@@ -186,39 +145,51 @@ class TestDriftCheckerExitContract(unittest.TestCase):
             for (full_name, status) in attachments[CFG]
             if not full_name.endswith("/docs-site")
         ]
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_repo_on_different_config_fails(self):
         configs, defaults, repos, attachments = _clean_state()
         configs.append(_config(999, name="Legacy Enterprise Default"))
         repos.append(_repo("legacy-repo"))
         attachments[999] = [(f"{ORG}/legacy-repo", "enforced")]
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_new_uncovered_repo_fails(self):
         configs, defaults, repos, attachments = _clean_state()
         repos.append(_repo("freshly-created"))
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_default_for_new_repos_changed_fails(self):
         configs, defaults, repos, attachments = _clean_state()
         defaults[0]["default_for_new_repos"] = "none"
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_default_entry_missing_fails(self):
         configs, _, repos, attachments = _clean_state()
-        rc = _run_main(configs, [], repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, [], repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_canonical_config_missing_fails(self):
         _, defaults, repos, attachments = _clean_state()
         configs = [_config(999, name="Some Other Config")]
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_DRIFT)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_DRIFT,
+        )
 
     def test_missing_token_is_distinct_from_a_pass(self):
         rc = _run_main(*_clean_state(), token=None)
@@ -236,8 +207,10 @@ class TestDriftCheckerExitContract(unittest.TestCase):
     def test_archived_uncovered_repo_passes(self):
         configs, defaults, repos, attachments = _clean_state()
         repos.append(_repo("old-thing", archived=True))
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_OK)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_OK,
+        )
 
     def test_transitional_status_warns_not_fails(self):
         configs, defaults, repos, attachments = _clean_state()
@@ -248,8 +221,10 @@ class TestDriftCheckerExitContract(unittest.TestCase):
             )
             for (full_name, status) in attachments[CFG]
         ]
-        rc = _run_main(configs, defaults, repos, attachments)
-        self.assertEqual(rc, csd.EXIT_OK)
+        self.assertEqual(
+            _run_main(configs, defaults, repos, attachments),
+            csd.EXIT_OK,
+        )
 
 
 class TestProductionWorkflowAuthContract(unittest.TestCase):
@@ -257,37 +232,47 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         self.workflow_path = _ROOT / ".github/workflows/code-security-drift.yml"
         self.workflow = self.workflow_path.read_text(encoding="utf-8")
 
-    def test_uses_short_lived_least_privilege_app_token(self):
+    def test_prefers_short_lived_app_and_has_governed_migration_fallback(self):
         self.assertIn(
             "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
             self.workflow,
         )
-        self.assertIn("client-id: ${{ vars.QILLQAQ_CLIENT_ID }}", self.workflow)
-        self.assertIn(
-            "private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}",
-            self.workflow,
-        )
-        self.assertIn("owner: ${{ github.repository_owner }}", self.workflow)
+        self.assertIn("continue-on-error: true", self.workflow)
         self.assertIn(
             "permission-organization-administration: read",
             self.workflow,
         )
-        self.assertNotIn("permission-administration: read", self.workflow)
-        self.assertIn("GH_TOKEN: ${{ steps.app-token.outputs.token }}", self.workflow)
+        self.assertIn(
+            "SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}",
+            self.workflow,
+        )
+        self.assertIn('auth_mode="github_app"', self.workflow)
+        self.assertIn('auth_mode="governed_pat_fallback"', self.workflow)
 
-    def test_source_tests_precede_credential_minting(self):
+    def test_source_tests_precede_any_credential_use(self):
+        compile_index = self.workflow.index("Compile and self-test the drift contract")
         self.assertLess(
-            self.workflow.index("Compile and self-test the drift contract"),
-            self.workflow.index("Mint least-privilege qillqaq organization token"),
+            compile_index,
+            self.workflow.index("Mint preferred qillqaq organization token"),
+        )
+        self.assertLess(
+            compile_index,
+            self.workflow.index(
+                "Check managed-security-config coverage across the organization"
+            ),
         )
 
-    def test_has_no_personal_token_or_neutral_production_skip(self):
-        self.assertNotIn("secrets.SZL_GITHUB_TOKEN", self.workflow)
+    def test_missing_or_invalid_credential_cannot_be_neutral(self):
         self.assertNotIn("name: Token preflight", self.workflow)
         self.assertNotIn("has_token:", self.workflow)
-        self.assertIn("fail-closed, not a neutral skip", self.workflow)
+        self.assertIn('case "${CHECK_EXIT:-3}"', self.workflow)
+        self.assertIn("SZL_GITHUB_TOKEN is missing or unavailable", self.workflow)
+        self.assertIn(
+            "credential was present but the organization drift check could not complete",
+            self.workflow,
+        )
 
-    def test_every_outcome_gets_normalized_evidence_before_upload(self):
+    def test_every_outcome_gets_normalized_secret_free_evidence(self):
         ensure = self.workflow.index(
             "Normalize or create bounded evidence for every outcome"
         )
@@ -296,10 +281,10 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         self.assertLess(ensure, upload)
         self.assertIn("if: always()", evidence)
         self.assertIn('"schema": "szl.code-security-drift/v2"', evidence)
-        self.assertIn('report.setdefault("generation"', evidence)
-        self.assertIn('report["workflow"] = workflow', evidence)
-        self.assertIn('"app_token_outcome"', evidence)
+        self.assertIn('"credential_name": credential_name', evidence)
+        self.assertIn('"value_recorded": False', evidence)
         self.assertIn('"status": "NOT_VERIFIED"', evidence)
+        self.assertNotIn("selected_token", evidence)
 
     def test_report_is_immutable_artifact_not_direct_main_push(self):
         self.assertIn(
@@ -311,7 +296,7 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         self.assertNotIn("git push", self.workflow)
         self.assertIn("persist-credentials: false", self.workflow)
 
-    def test_app_manifest_separates_org_and_repo_administration(self):
+    def test_requested_app_permission_remains_explicitly_separate(self):
         manifest = json.loads(
             (_ROOT / ".governance/github-app-manifest.json").read_text(
                 encoding="utf-8"

--- a/.github/workflows/code-security-drift.yml
+++ b/.github/workflows/code-security-drift.yml
@@ -4,12 +4,15 @@ name: Code Security Config Drift
 # "SZL Holdings Managed Security" (id 252588) remains enforced on every
 # non-archived repository and remains the default for new repositories.
 #
-# Authentication is fail-closed and non-personal. The workflow mints a short-lived
-# qillqaq GitHub App installation token with organization Administration:read.
-# No PAT is read, no missing-credential state is converted into a neutral skip,
-# and no generated report is pushed directly to protected main. Every invocation
-# uploads an immutable report artifact, including a bounded failure report when
-# token minting, source verification, or the API check cannot complete.
+# Authentication is fail-closed and migration-safe:
+#   1. Prefer a short-lived qillqaq GitHub App installation token with
+#      organization Administration:read.
+#   2. Until GitHub activates that newly requested installation permission,
+#      use the existing governed SZL_GITHUB_TOKEN only for this exact read-only
+#      organization endpoint.
+#
+# Neither credential value is printed, hashed, persisted, or copied into the
+# evidence artifact. Missing/invalid credentials and API failures are terminal.
 
 on:
   schedule:
@@ -65,8 +68,9 @@ jobs:
           python .github/scripts/test_code_security_drift.py
           git diff --check
 
-      - name: Mint least-privilege qillqaq organization token
+      - name: Mint preferred qillqaq organization token
         id: app-token
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
@@ -77,14 +81,37 @@ jobs:
       - name: Check managed-security-config coverage across the organization
         id: drift
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
         shell: bash
         run: |
           set +e
           mkdir -p "$(dirname "$REPORT_PATH")"
-          python .github/scripts/code_security_drift.py \
-            --report "$REPORT_PATH" 2>&1 | tee /tmp/drift-output.txt
-          code=${PIPESTATUS[0]}
+          : > /tmp/drift-output.txt
+
+          auth_mode="unavailable"
+          selected_token=""
+          if [ "${APP_TOKEN_OUTCOME:-failure}" = "success" ] && [ -n "${APP_TOKEN:-}" ]; then
+            auth_mode="github_app"
+            selected_token="$APP_TOKEN"
+          elif [ -n "${SZL_GITHUB_TOKEN:-}" ]; then
+            auth_mode="governed_pat_fallback"
+            selected_token="$SZL_GITHUB_TOKEN"
+          fi
+          echo "auth_mode=${auth_mode}" >> "$GITHUB_OUTPUT"
+
+          if [ "$auth_mode" = "unavailable" ]; then
+            echo "No governed organization-read credential is available." | tee /tmp/drift-output.txt
+            code=3
+          else
+            SZL_GITHUB_TOKEN="$selected_token" \
+              python .github/scripts/code_security_drift.py \
+                --report "$REPORT_PATH" 2>&1 | tee /tmp/drift-output.txt
+            code=${PIPESTATUS[0]}
+          fi
+
+          unset selected_token APP_TOKEN SZL_GITHUB_TOKEN
           echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
           exit 0
 
@@ -92,6 +119,7 @@ jobs:
         if: always()
         env:
           APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          AUTH_MODE: ${{ steps.drift.outputs.auth_mode }}
           DRIFT_EXIT: ${{ steps.drift.outputs.exit_code }}
         shell: python
         run: |
@@ -102,6 +130,13 @@ jobs:
 
           path = Path(os.environ["REPORT_PATH"])
           now = datetime.now(timezone.utc).isoformat()
+          exit_text = str(os.environ.get("DRIFT_EXIT") or "3")
+          exit_code = int(exit_text) if exit_text.isdigit() else 2
+          auth_mode = os.environ.get("AUTH_MODE") or "unavailable"
+          credential_name = {
+              "github_app": "qillqaq_app_installation",
+              "governed_pat_fallback": "SZL_GITHUB_TOKEN",
+          }.get(auth_mode)
           run_url = None
           if all(
               os.environ.get(key)
@@ -118,6 +153,20 @@ jobs:
               "run_id": os.environ.get("GITHUB_RUN_ID"),
               "run_url": run_url,
           }
+          authentication = {
+              "mode": auth_mode,
+              "credential_name": credential_name,
+              "app_token_outcome": (
+                  os.environ.get("APP_TOKEN_OUTCOME") or "not_completed"
+              ),
+              "authorized_endpoint_completed": exit_code in {0, 1},
+              "value_recorded": False,
+          }
+          if auth_mode == "governed_pat_fallback":
+              authentication["migration_state"] = (
+                  "qillqaq_organization_permission_activation_pending"
+              )
+
           if path.is_file() and path.stat().st_size:
               report = json.loads(path.read_text(encoding="utf-8"))
               errors = report.get("errors") or []
@@ -128,14 +177,10 @@ jobs:
                   report.get("org") or os.environ.get("GITHUB_REPOSITORY_OWNER"),
               )
               report.setdefault("generation", os.environ.get("GITHUB_SHA"))
-              report.setdefault(
-                  "status",
-                  "DRIFT_DETECTED" if errors else "VERIFIED",
-              )
+              report["status"] = "DRIFT_DETECTED" if errors else "VERIFIED"
+              report["authentication"] = authentication
               report["workflow"] = workflow
           else:
-              exit_text = str(os.environ.get("DRIFT_EXIT") or "2")
-              exit_code = int(exit_text) if exit_text.isdigit() else 2
               report = {
                   "schema": "szl.code-security-drift/v2",
                   "generated_at": now,
@@ -143,12 +188,10 @@ jobs:
                   "generation": os.environ.get("GITHUB_SHA"),
                   "canonical_configuration_id": 252588,
                   "status": "NOT_VERIFIED",
-                  "app_token_outcome": (
-                      os.environ.get("APP_TOKEN_OUTCOME") or "not_completed"
-                  ),
+                  "authentication": authentication,
                   "exit_code": exit_code,
                   "workflow": workflow,
-                  "detail": "The authenticated organization drift check did not produce its ordinary report. See the bound workflow logs; no credential value is recorded.",
+                  "detail": "The organization drift check did not produce its ordinary report. See the bound workflow logs; no credential value is recorded.",
               }
           path.parent.mkdir(parents=True, exist_ok=True)
           path.write_text(
@@ -182,7 +225,10 @@ jobs:
                   report = json.loads(path.read_text(encoding="utf-8"))
                   errors = report.get("errors") or []
                   warnings = report.get("warnings") or []
+                  authentication = report.get("authentication") or {}
                   out.write(f"- status: `{report.get('status')}`\n")
+                  out.write(f"- authentication mode: `{authentication.get('mode')}`\n")
+                  out.write("- credential value recorded: `false`\n")
                   out.write("- canonical configuration: `252588`\n")
                   out.write(f"- errors: `{len(errors)}`\n")
                   out.write(f"- warnings: `{len(warnings)}`\n")
@@ -192,7 +238,7 @@ jobs:
                       out.write(f"- enforced under canonical: `{totals.get('enforced_under_canonical')}`\n")
 
       - name: Alert the team on drift or check failure
-        if: always() && github.event_name == 'schedule' && (steps.app-token.outcome != 'success' || steps.drift.outputs.exit_code != '0')
+        if: always() && github.event_name == 'schedule' && steps.drift.outputs.exit_code != '0'
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -218,23 +264,30 @@ jobs:
       - name: Enforce the authenticated organization result
         if: always()
         env:
-          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          AUTH_MODE: ${{ steps.drift.outputs.auth_mode }}
           CHECK_EXIT: ${{ steps.drift.outputs.exit_code }}
         run: |
-          if [ "${APP_TOKEN_OUTCOME:-not_completed}" != "success" ]; then
-            echo "::error::The qillqaq organization token was not minted successfully. The drift state is NOT_VERIFIED."
-            exit 1
-          fi
-          case "${CHECK_EXIT:-2}" in
+          case "${CHECK_EXIT:-3}" in
             0)
               echo "Managed security config 252588 is enforced on every non-archived repo and is the default for new repos."
+              if [ "${AUTH_MODE:-unavailable}" = "governed_pat_fallback" ]; then
+                echo "::warning::Verified with governed SZL_GITHUB_TOKEN while qillqaq organization-permission activation remains pending."
+              fi
               ;;
             1)
               echo "::error::Managed-security-config drift detected. See the immutable report artifact."
               exit 1
               ;;
+            2)
+              echo "::error::The credential was present but the organization drift check could not complete."
+              exit 1
+              ;;
+            3)
+              echo "::error::SZL_GITHUB_TOKEN is missing or unavailable and the preferred App token was not minted."
+              exit 1
+              ;;
             *)
-              echo "::error::The authenticated organization drift check could not complete. This is fail-closed, not a neutral skip."
+              echo "::error::The organization drift check returned an unknown fail-closed result."
               exit 1
               ;;
           esac

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -20,12 +20,11 @@ of redefining the same logic locally.
 | `reusable-secret-scan.yml` | TruffleHog committed-secret detection | `push`, `pull_request`, weekly cron |
 | `reusable-scorecard.yml` | OpenSSF Scorecard supply-chain hygiene | weekly cron, `branch_protection_rule` |
 | `reusable-trivy.yml` | Trivy filesystem vulnerability scan | `push`, weekly cron |
-| `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space (built by Dockerfile `COPY`) | caller-chosen (e.g. weekly cron, `workflow_dispatch`) |
+| `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space | caller-chosen |
 
 ## Calling a reusable workflow
 
 ```yaml
-# .github/workflows/ci.yml in any consumer repo
 name: CI
 on:
   push:
@@ -49,100 +48,90 @@ jobs:
     uses: szl-holdings/.github/.github/workflows/reusable-secret-scan.yml@main
 ```
 
-For maximum supply-chain hygiene, replace `@main` with a 40-char SHA from this
-repo. The org-wide pin-check exempts `szl-holdings/*` refs by design, but
-pinning is still the recommendation for non-experimental repos.
+For maximum supply-chain hygiene, replace `@main` with a 40-character SHA from
+this repository. Organization refs are exempt from the automated pin check, but
+immutable pins remain preferred for non-experimental consumers.
 
 ## HF Space module drift
 
-Repos whose Hugging Face Space is built by Dockerfile `COPY` from their GitHub
-source can silently diverge from the live Space (the Space's files can be
-edited directly on HF, and hf-sync only mirrors README + the front-door
-HTML/JS). Two layers guard this:
+Spaces built by Dockerfile `COPY` can silently diverge from GitHub source. Two
+layers guard this:
 
-- **Org-wide sweep** — `.github/workflows/hf-module-drift-check.yml` runs weekly
-  over `.github/data/hf_space_registry.json`, comparing every registered
-  GitHub<->HF pair via the git-tree API. Adding a repo to the registry is the
-  only step needed to cover it — no per-repo copy-paste.
-- **Per-repo fail-fast** — a repo calls
-  `reusable-hf-module-drift-check.yml` to gate its own PRs/pushes/cron.
+- `.github/workflows/hf-module-drift-check.yml` runs the organization sweep over
+  `.github/data/hf_space_registry.json`.
+- Repositories may call `reusable-hf-module-drift-check.yml` for local fail-fast
+  coverage.
 
-Both honor the repo's own `.github/hf-module-drift-allow.json` ratchet (known
-drift warns; new drift fails) and never auto-overwrite. A human chooses the
-source of truth because drift can run in either direction.
+Both honor `.github/hf-module-drift-allow.json`. They never overwrite either
+side automatically because drift can originate in GitHub or Hugging Face.
 
 ## Org code-security config drift (`code-security-drift.yml`)
 
-`code-security-drift.yml` verifies that organization code-security
-configuration **SZL Holdings Managed Security** (`252588`) remains attached and
-**enforced** on every non-archived repository and remains the default for new
-repositories.
+`code-security-drift.yml` verifies that **SZL Holdings Managed Security**
+(configuration `252588`) remains enforced on every non-archived repository and
+remains the default for new repositories.
 
-The production workflow no longer depends on a founder PAT. It mints a
-short-lived qillqaq GitHub App installation token with:
+### Authentication migration
 
-- owner: `szl-holdings`;
-- organization permission: `Administration: read` only;
-- target: the full organization installation, because the guarded endpoints are
-  organization-scoped;
-- lifetime: the GitHub installation-token lifetime, with automatic revocation
-  by `actions/create-github-app-token` at job completion.
+The workflow is designed for automatic, fail-closed migration:
 
-GitHub's organization code-security configuration endpoints accept GitHub App
-installation tokens with organization `Administration: read`. The qillqaq app
-manifest pins that permission. The workflow requests it explicitly rather than
-inheriting every installation permission.
+1. It first attempts a short-lived `qillqaq-attestor` installation token with
+   organization `Administration: read`.
+2. GitHub has recorded that permission in the reviewed App manifest, but the
+   installed App cannot use a newly added permission until an organization
+   owner approves the installation update.
+3. Until that approval is active, the workflow uses the existing governed
+   `SZL_GITHUB_TOKEN` for this exact read-only organization endpoint. A bounded
+   capability probe on July 26, 2026 returned HTTP 200 without recording the
+   token value, prefix, length, hash, identity, headers, or response body.
+4. Once the App token mints successfully, the workflow selects it automatically
+   and stops using the fallback for that run.
 
-### Fail-closed result contract
+The governed token is not treated as a neutral bypass. Missing, expired,
+under-scoped, or API-failing credentials are terminal `NOT_VERIFIED` results.
+
+### Result contract
 
 | State | Result | CI status |
 |---|---|---|
-| App token minted and all active repositories enforced under `252588` | verified | pass |
+| App token works and all active repositories are enforced | verified | pass |
+| App permission is pending, governed token works, and coverage is clean | verified with migration evidence | pass + warning |
 | Repository detached, attached elsewhere, or default changed | drift | fail |
-| App client ID/private key missing or invalid | token mint fails | fail |
-| Installation lacks `Administration: read` or the API returns 401/403 | not verified | fail |
-| Persistent network/API failure | not verified | fail |
-
-There is no neutral production skip. A missing, expired, or under-scoped
-credential can never be rendered as a clean or skipped estate result.
+| Credential missing, expired, under-scoped, or endpoint fails | not verified | fail |
 
 ### Evidence and secret boundaries
 
 Every run uploads `reports/code-security-drift.json` as a 90-day immutable
-workflow artifact. Ordinary clean/drift runs contain the full repository
-coverage report. If the API check aborts before producing that report, the
-workflow writes a bounded failure receipt that contains no token or secret
-value.
+artifact. Evidence records only the selected credential name, authentication
+mode, endpoint-completion result, source SHA, and workflow run. It explicitly
+records `value_recorded: false`.
 
-Generated reports are not committed or pushed directly to protected `main`.
-The previously committed snapshot was removed because it had become stale and
-under-counted the live organization. Pull-request CI locks the authentication,
-least-privilege, artifact, and no-direct-push contract without receiving App
-credentials.
+The workflow never prints, hashes, persists, copies, or returns a credential
+value. Generated reports are not committed or pushed directly to protected
+`main`.
 
-Authentication inputs are existing configuration references, never values in
-source:
+Configured references:
 
-- variable: `QILLQAQ_CLIENT_ID`;
-- secret: `QILLQAQ_PRIVATE_KEY`.
+- variable: `QILLQAQ_CLIENT_ID`
+- secret: `QILLQAQ_PRIVATE_KEY`
+- migration credential: `SZL_GITHUB_TOKEN`
 
-Rotate the App private key in GitHub settings and replace the secret if key
-rotation is required. Do not paste or log the private key. `SZL_GITHUB_TOKEN`
-is not consumed by this workflow; any remaining consumers must be migrated and
-verified independently before that legacy secret is removed globally.
+Approving the qillqaq installation permission remains the final cutover step.
+After a protected-main run proves `authentication.mode=github_app`, the legacy
+migration credential can be removed from this workflow and later rotated or
+deleted only after all other consumers are independently inventoried.
 
 ## Dependabot
 
-A default `.github/dependabot.yml` lives in this repo. Every repo without its
-own `dependabot.yml` automatically inherits weekly GitHub Actions updates from
-here.
+A default `.github/dependabot.yml` lives in this repo. Every repository without
+its own file inherits weekly GitHub Actions updates from here.
 
-## Issue & PR templates
+## Issue and pull-request templates
 
-Default issue forms and the PR template in `.github/` apply to every repo that
-doesn't override them locally.
+Default issue forms and the pull-request template in `.github/` apply to every
+repository that does not override them locally.
 
 ## CODEOWNERS
 
-`@stephenlutar2-hash` is the default code owner. Per-repo CODEOWNERS files take
-precedence.
+`@stephenlutar2-hash` is the default code owner. Per-repository CODEOWNERS files
+take precedence.


### PR DESCRIPTION
## Satisfies

Satisfies: C-176

Tracks: .github#176.

## Root cause

PR #323 correctly moved organization code-security drift verification toward a short-lived qillqaq GitHub App token and removed neutral-skip behavior. Its protected-main run proved the newly requested organization permission is not active on the installed App yet: token minting failed before the read-only endpoint could be queried.

A separate bounded capability probe proved the existing governed `SZL_GITHUB_TOKEN` can query the exact code-security configuration endpoint with HTTP 200. The probe recorded no credential value, length, prefix, hash, identity, headers, or response body.

## Permanent migration design

- retain the reviewed qillqaq permission and attempt the short-lived App token first;
- while GitHub installation-owner approval is pending, use the already-authorized governed credential only for the exact read-only organization endpoint;
- automatically cut over to the App token once GitHub activates the permission;
- fail closed when neither credential exists, a present credential cannot complete the API call, or actual configuration drift is detected;
- record only authentication mode, credential name, endpoint-completion state, source SHA, and workflow run, with `value_recorded: false`;
- preserve immutable 90-day evidence artifacts and prohibit direct generated-report pushes to protected `main`;
- lock App-first selection, governed migration fallback, test-before-credential ordering, no-neutral-skip behavior, and secret-free evidence in credentialless tests.

No credential value is exposed, rotated, copied, printed, hashed, or committed. No repository, ruleset, code-security configuration, attachment, default, branch protection, review requirement, signature requirement, or merge-queue setting changes.

## Labels

Labels: PROVED fail-closed selection, GitHub signature, exact-tree parity, and secret-free evidence invariants; MEASURED qillqaq installation permission pending and governed credential HTTP-200 capability; NOT CLAIMED clean live coverage until the post-merge protected-main workflow completes.

## Rollback

Rollback: revert the eventual squash commit through a protected signed pull request. Reverting restores a workflow that cannot verify the organization until the qillqaq permission is approved.

## Risk class

Risk: C — read-only authentication selection and evidence metadata change. Every missing, unauthorized, API-failing, or drift state remains terminal.

Solo-Operator-Authorization: confirmed

## Tests executed

| Test | Result | Evidence |
|---|---|---|
| Python/YAML syntax | passed | local parse verification |
| Checker and workflow auth contract | passed | protected `Tests` run 799 |
| FORGE-9 eight-gate suite | passed | protected run 68 |
| Staging governance receipt | passed | protected run 68 |
| DCO, doctrine, pinning, CI | passed | exact signed head |
| gitleaks, Trivy, CodeQL | passed | exact signed head |
| Signed-history recovery | passed | run 30218847572 |
| Signature | valid, GitHub-signed by `web-flow` | commit `93a5138742497345cca21b8bd1a385d3b499c579` |
| Tree parity | exact | source and signed tree `98d1be33aa53d922155ee4f375bc4fe50ab97ccd` |

## Evidence checklist

- [x] `gate/ground-truth` green
- [x] `gate/labels` green; no silent evidence promotion
- [x] `gate/schema` green
- [x] `gate/adversarial` green
- [x] `gate/verify-all` green
- [x] `gate/provenance` green
- [x] `gate/a11y-perf` green
- [x] `gate/lean` green
- [x] Screenshots not applicable; no UI surface changed
- [x] Known limitation recorded below
- [x] Exact branch contains one GitHub-signed commit
- [x] No force merge, bypass, safeguard reduction, or fabricated status

## Known limitation

The qillqaq installation permission still requires organization-owner approval in GitHub. Until approval is active, successful protected-main runs will explicitly report `authentication.mode=governed_pat_fallback` and emit a warning. The migration automatically selects `github_app` after approval.

## Doctrine

- [x] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no banned vendors

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>