### PR TITLE
fix(ci): make organization health digest fail closed

### DIFF
--- a/.github/scripts/ci_health_digest.py
+++ b/.github/scripts/ci_health_digest.py
@@ -1,186 +1,360 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# © 2026 SZL Holdings — org CI-health digest + recommendations.
-#
-# Sweeps every active (non-archived) repo in the szl-holdings org, finds the
-# latest workflow run per workflow on the repo's default branch, classifies any
-# red ones by DISPOSITION, and upserts a SINGLE rolling tracking issue in
-# szl-holdings/.github so the maintainer's notification inbox stays to one
-# actionable item instead of dozens of scattered run-failure emails.
-#
-# Honest by construction: it never marks a known-intentional red as "broken",
-# and never claims a founder-gated item is fixable in CI. Dispositions:
-#   ACTIONABLE     — a real bug a maintainer/agent should fix.
-#   FOUNDER-GATED  — blocked on a founder-only secret / account / legal action.
-#   INTENTIONAL    — designed to be red (e.g. a proof gate rejecting an OPEN
-#                    conjecture); leaving it red is correct.
-#   INFRA          — needs dedicated infra / is dispatch-only (low/no noise).
-#
-# Pure stdlib (urllib + json) so it runs with no pip step. Auth: ORG_CI_READ_TOKEN
-# (org-read PAT). Optional ntfy via SLACK_WEBHOOK_URL (box relay); skipped if absent.
+"""Fail-closed organization-wide GitHub Actions health digest.
 
-import os, json, sys, urllib.request, urllib.error
-from concurrent.futures import ThreadPoolExecutor
+The short-lived qillqaq App reader is preferred, with the existing governed
+``SZL_GITHUB_TOKEN`` as an explicit migration fallback. A reader is accepted
+only after it proves the reviewed repository floor and Actions-read capability.
+The ephemeral workflow token writes only the one rolling issue in this repo.
+"""
+from __future__ import annotations
 
-ORG = "szl-holdings"
-TOKEN = os.environ.get("ORG_CI_READ_TOKEN") or os.environ.get("GITHUB_TOKEN")
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from ci_health_digest_http import (
+    ORG,
+    ApiError,
+    DigestError,
+    ReaderSelection,
+    ReaderSelectionError,
+    list_repositories,
+    request_json as _request_json,
+    select_reader,
+)
+from ci_health_digest_sweep import (
+    build_body,
+    build_failure_body,
+    sweep,
+)
+
+ISSUE_REPOSITORY = f"{ORG}/.github"
 ISSUE_TITLE = "🔴 CI Health Digest — org-wide"
 ISSUE_LABEL = "ci-health"
-RED = ("failure", "startup_failure", "timed_out", "action_required")
+REPORT_SCHEMA = "szl.ci-health-digest/v2"
 
-# (repo, workflow-name substring) -> (disposition, note). First match wins.
-# Keep this the SINGLE place where a red is reclassified away from ACTIONABLE,
-# with a reason. Do NOT silence a real bug here.
-POLICY = [
-    ("lambda-bounty", "verify-proof",   ("INTENTIONAL", "Proof gate rejects the still-OPEN Λ (Conjecture 1) by design — red is the honest verdict.")),
-    ("szl-doctrine",  "secret-health",  ("FOUNDER-GATED", "Needs org secret SECRET_HEALTH_TOKEN (founder least-priv PAT). Cannot be minted in CI.")),
-    ("",              "Dependabot Updates", ("INFRA", "Dependabot runner state, not a workflow bug; resolves when the grouped PR opens/merges.")),
-    ("",              "CodeQL",         ("INFRA", "CodeQL default-setup run; reconfigure via repo Security settings, not a workflow-file fix.")),
-    ("",              "ClusterFuzzLite", ("INFRA", "PR fuzzing waits on manual approval (action_required) for outside contributions.")),
-    ("",              "Fuzz",           ("INFRA", "Scheduled fuzzing run; corpus/infra-driven, not a default-branch regression.")),
-    ("",              "Publish npm",    ("INFRA", "Manual workflow_dispatch publish — red reflects a past manual run, not branch health.")),
-    ("",              "Cosign keyless", ("INFRA", "Runs only on release events; needs a tagged release with OIDC id-token perms, not a push-time fix.")),
-    ("",              "SLSA",           ("INFRA", "Provenance/attestation signing path (dispatch/push); pending wiring, not an app-code bug.")),
-]
 
-def api(url, method="GET", body=None):
-    data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(url, data=data, method=method, headers={
-        "Authorization": "Bearer " + TOKEN, "Accept": "application/vnd.github+json"})
-    try:
-        r = urllib.request.urlopen(req, timeout=30)
-        return r.status, (json.loads(r.read()) if r.length != 0 else {})
-    except urllib.error.HTTPError as e:
-        return e.code, e.read()[:300].decode("utf-8", "replace")
+def _issue_token() -> str:
+    token = (
+        os.environ.get("CI_DIGEST_ISSUE_TOKEN")
+        or os.environ.get("GITHUB_TOKEN")
+        or ""
+    )
+    if not token:
+        raise DigestError(
+            "no repository-scoped issue-write token is configured"
+        )
+    return token
 
-def classify(repo, wf):
-    for rp, sub, verdict in POLICY:
-        if (not rp or rp == repo) and sub.lower() in wf.lower():
-            return verdict
-    return ("ACTIONABLE", "")
 
-def list_repos():
-    repos, page = [], 1
-    while True:
-        st, r = api("https://api.github.com/orgs/%s/repos?per_page=100&type=all&page=%d" % (ORG, page))
-        if not isinstance(r, list) or not r:
-            break
-        repos += r
-        if len(r) < 100:
-            break
-        page += 1
-    return [(x["name"], x["default_branch"]) for x in repos if not x.get("archived")]
-
-def repo_reds(item):
-    name, default = item
-    out = []
-    st, wfs = api("https://api.github.com/repos/%s/%s/actions/workflows?per_page=100" % (ORG, name))
-    if not isinstance(wfs, dict):
-        return name, out
-    def latest(w):
-        if w.get("state") != "active":
-            return None
-        for q in ("&branch=" + default, ""):
-            st, rr = api("https://api.github.com/repos/%s/%s/actions/workflows/%d/runs?per_page=1%s" % (ORG, name, w["id"], q))
-            runs = rr.get("workflow_runs", []) if isinstance(rr, dict) else []
-            if runs:
-                r = runs[0]
-                if r["conclusion"] in RED:
-                    return (w["name"], r["conclusion"], r["run_number"], r.get("event"), r.get("html_url"))
-                return None
-        return None
-    with ThreadPoolExecutor(max_workers=8) as ex:
-        for res in ex.map(latest, wfs.get("workflows", [])):
-            if res:
-                out.append(res)
-    return name, out
-
-def build_body(reds):
-    from datetime import datetime, timezone
-    buckets = {"ACTIONABLE": [], "FOUNDER-GATED": [], "INTENTIONAL": [], "INFRA": []}
-    total = 0
-    for repo in sorted(reds):
-        for (wf, concl, num, ev, url) in reds[repo]:
-            disp, note = classify(repo, wf)
-            buckets[disp].append((repo, wf, concl, num, ev, url, note))
-            total += 1
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    lines = ["_Auto-generated by `.github/workflows/ci-health-digest.yml`. Last sweep: **%s**._" % now, ""]
-    act = len(buckets["ACTIONABLE"])
-    lines += ["**%d red workflow(s)** across the org — **%d ACTIONABLE**, %d founder-gated, %d intentional, %d infra." % (
-        total, act, len(buckets["FOUNDER-GATED"]), len(buckets["INTENTIONAL"]), len(buckets["INFRA"])), ""]
-    order = [("ACTIONABLE", "### 🛠 Actionable — fix these (root-cause, no bandaids)"),
-             ("FOUNDER-GATED", "### 🔑 Founder-gated — needs a founder secret/action"),
-             ("INFRA", "### ⚙️ Infra / low-noise — reconfigure or ignore"),
-             ("INTENTIONAL", "### ✅ Intentional — red is correct, leave as-is")]
-    for key, hdr in order:
-        rows = buckets[key]
-        if not rows:
-            continue
-        lines.append(hdr)
-        lines.append("")
-        lines.append("| Repo | Workflow | Result | Trigger | Note |")
-        lines.append("|---|---|---|---|---|")
-        for repo, wf, concl, num, ev, url, note in sorted(rows):
-            wfc = "[%s](%s)" % (wf, url) if url else wf
-            lines.append("| `%s` | %s | %s (run#%s) | %s | %s |" % (repo, wfc, concl, num, ev or "", note))
-        lines.append("")
-    if total == 0:
-        lines = ["_Last sweep: **%s**._" % now, "", "## ✅ All clear — no red workflows on any default branch.", ""]
-    lines.append("---")
-    lines.append("<sub>Dispositions are policy-classified in `.github/scripts/ci_health_digest.py` (`POLICY`). "
-                 "Reclassify a red only with a documented reason; never silence a real bug.</sub>")
-    return "\n".join(lines), act, total
-
-def upsert_issue(body):
-    # find existing open issue by exact title
-    st, issues = api("https://api.github.com/repos/%s/.github/issues?state=open&labels=%s&per_page=50" % (ORG, ISSUE_LABEL))
-    existing = None
-    if isinstance(issues, list):
-        for i in issues:
-            if i.get("title") == ISSUE_TITLE and "pull_request" not in i:
-                existing = i
-                break
+def upsert_issue(
+    body: str,
+    *,
+    red_total: int | None,
+) -> dict[str, Any]:
+    token = _issue_token()
+    _, issues = _request_json(
+        token,
+        (
+            f"https://api.github.com/repos/{ISSUE_REPOSITORY}/issues"
+            f"?state=all&labels={ISSUE_LABEL}&per_page=100"
+        ),
+        operation="find rolling CI health issue",
+    )
+    if not isinstance(issues, list):
+        raise DigestError(
+            "rolling issue search returned a malformed payload"
+        )
+    existing = next(
+        (
+            issue
+            for issue in issues
+            if isinstance(issue, dict)
+            and issue.get("title") == ISSUE_TITLE
+            and "pull_request" not in issue
+        ),
+        None,
+    )
+    desired_state = "closed" if red_total == 0 else "open"
     if existing:
-        st, _ = api("https://api.github.com/repos/%s/.github/issues/%d" % (ORG, existing["number"]), "PATCH", {"body": body})
-        return "updated #%d (HTTP %s)" % (existing["number"], st)
-    st, r = api("https://api.github.com/repos/%s/.github/issues" % ORG, "POST",
-                {"title": ISSUE_TITLE, "body": body, "labels": [ISSUE_LABEL]})
-    return "created #%s (HTTP %s)" % (r.get("number") if isinstance(r, dict) else "?", st)
+        number = int(existing["number"])
+        patch: dict[str, Any] = {"body": body, "state": desired_state}
+        if desired_state == "closed":
+            patch["state_reason"] = "completed"
+        _, result = _request_json(
+            token,
+            f"https://api.github.com/repos/{ISSUE_REPOSITORY}/issues/{number}",
+            method="PATCH",
+            body=patch,
+            operation=f"update rolling CI health issue #{number}",
+            expected={200},
+        )
+        action = "updated"
+    else:
+        _, result = _request_json(
+            token,
+            f"https://api.github.com/repos/{ISSUE_REPOSITORY}/issues",
+            method="POST",
+            body={
+                "title": ISSUE_TITLE,
+                "body": body,
+                "labels": [ISSUE_LABEL],
+            },
+            operation="create rolling CI health issue",
+            expected={201},
+        )
+        number = (
+            int(result.get("number") or 0)
+            if isinstance(result, dict)
+            else 0
+        )
+        action = "created"
+        if desired_state == "closed" and number:
+            _, result = _request_json(
+                token,
+                (
+                    f"https://api.github.com/repos/{ISSUE_REPOSITORY}/"
+                    f"issues/{number}"
+                ),
+                method="PATCH",
+                body={"state": "closed", "state_reason": "completed"},
+                operation=(
+                    f"close clean rolling CI health issue #{number}"
+                ),
+                expected={200},
+            )
+    if not isinstance(result, dict) or not result.get("number"):
+        raise DigestError(
+            "rolling issue mutation returned no issue identity"
+        )
+    return {
+        "action": action,
+        "number": int(result["number"]),
+        "state": result.get("state"),
+        "url": result.get("html_url"),
+        "updated_at": result.get("updated_at"),
+    }
 
-def maybe_ntfy(act, total):
-    hook = os.environ.get("SLACK_WEBHOOK_URL")
+
+def maybe_notify(actionable: int, total: int) -> dict[str, Any]:
+    hook = os.environ.get("SLACK_WEBHOOK_URL") or ""
     if not hook:
-        print("ntfy: skipped (SLACK_WEBHOOK_URL absent)")
-        return
-    msg = "SZL CI Health: %d actionable / %d red workflows org-wide." % (act, total)
-    try:
-        req = urllib.request.Request(hook, data=json.dumps({"text": msg}).encode(),
-                                     headers={"Content-Type": "application/json"}, method="POST")
-        urllib.request.urlopen(req, timeout=15)
-        print("ntfy: sent")
-    except Exception as e:
-        print("ntfy: failed (non-fatal):", str(e)[:80])
+        return {"attempted": False, "result": "not_configured"}
+    message = (
+        f"SZL CI Health: {actionable} actionable / "
+        f"{total} red workflows org-wide."
+    )
+    attempts: list[dict[str, Any]] = []
+    payloads = (
+        (
+            json.dumps({"text": message}).encode("utf-8"),
+            "application/json",
+            "slack_json",
+        ),
+        (
+            message.encode("utf-8"),
+            "text/plain; charset=utf-8",
+            "plain_text",
+        ),
+    )
+    for data, content_type, mode in payloads:
+        request = urllib.request.Request(
+            hook,
+            data=data,
+            headers={"Content-Type": content_type},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                status = int(response.status)
+                attempts.append({"mode": mode, "http_status": status})
+                if 200 <= status < 300:
+                    return {
+                        "attempted": True,
+                        "result": "sent",
+                        "delivery_mode": mode,
+                        "http_status": status,
+                        "attempts": attempts,
+                    }
+        except urllib.error.HTTPError as exc:
+            attempts.append(
+                {"mode": mode, "http_status": int(exc.code)}
+            )
+            if mode == "slack_json" and int(exc.code) in {405, 415}:
+                continue
+            break
+        except Exception as exc:  # noqa: BLE001
+            attempts.append(
+                {"mode": mode, "failure_type": type(exc).__name__}
+            )
+            break
+    return {
+        "attempted": True,
+        "result": "failed_non_terminal",
+        "attempts": attempts,
+    }
 
-def main():
-    if not TOKEN:
-        print("::error::No ORG_CI_READ_TOKEN/GITHUB_TOKEN available."); sys.exit(1)
-    repos = list_repos()
-    print("sweeping %d active repos..." % len(repos))
-    reds = {}
-    with ThreadPoolExecutor(max_workers=10) as ex:
-        for name, out in ex.map(repo_reds, repos):
-            if out:
-                reds[name] = out
-    body, act, total = build_body(reds)
-    print(upsert_issue(body))
-    maybe_ntfy(act, total)
-    # Write a job summary too.
-    summ = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summ:
-        with open(summ, "a") as f:
-            f.write("# CI Health Digest\n\n%s\n" % body)
-    print("done: %d actionable / %d red" % (act, total))
+
+def _write_summary(body: str, report: Mapping[str, Any]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as summary:
+        summary.write("# CI Health Digest\n\n")
+        summary.write(f"- status: `{report.get('status')}`\n")
+        authentication = report.get("authentication") or {}
+        summary.write(
+            f"- authentication: `{authentication.get('mode')}`\n"
+        )
+        coverage = report.get("coverage") or {}
+        if coverage:
+            summary.write(
+                "- coverage: "
+                f"`{coverage.get('queried_active_repositories')}` active repos / "
+                f"`{coverage.get('active_workflows')}` workflows\n"
+            )
+        summary.write("\n")
+        summary.write(body)
+        summary.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--report",
+        default=(
+            os.environ.get("REPORT_PATH")
+            or "reports/ci-health-digest.json"
+        ),
+    )
+    args = parser.parse_args(argv)
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    report: dict[str, Any] = {
+        "schema": REPORT_SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generation": os.environ.get("GITHUB_SHA"),
+        "organization": ORG,
+        "status": "NOT_VERIFIED",
+        "authentication": {
+            "mode": "unavailable",
+            "credential_name": None,
+            "value_recorded": False,
+            "attempts": [],
+        },
+        "coverage": None,
+        "red_runs": {},
+        "summary": {"actionable": 0, "red_total": 0},
+        "issue": None,
+        "notification": None,
+        "boundaries": [
+            (
+                "An organization reader is accepted only after proving the "
+                "reviewed repository floor."
+            ),
+            "Every active repository and workflow API read is fail-closed.",
+            (
+                "The ephemeral repository token writes only the one rolling "
+                "digest issue."
+            ),
+            (
+                "No credential value, length, prefix, hash, identity, or "
+                "header is recorded."
+            ),
+            (
+                "A failed sweep opens the rolling issue as NOT VERIFIED and "
+                "exits non-zero."
+            ),
+        ],
+    }
+    body = ""
+    exit_code = 2
+    reader_attempts: Sequence[Mapping[str, Any]] = ()
+
+    try:
+        reader = select_reader()
+        reader_attempts = reader.attempts
+        report["authentication"] = {
+            "mode": reader.mode,
+            "credential_name": reader.credential_name,
+            "value_recorded": False,
+            "attempts": list(reader.attempts),
+            "app_token_outcome": (
+                os.environ.get("APP_TOKEN_OUTCOME") or "not_recorded"
+            ),
+        }
+        reds, coverage = sweep(reader.token, reader.repositories)
+        body, actionable, red_total, dispositions = build_body(
+            reds,
+            coverage=coverage,
+            authentication_mode=reader.mode,
+        )
+        issue = upsert_issue(body, red_total=red_total)
+        notification = maybe_notify(actionable, red_total)
+        report.update(
+            {
+                "status": "VERIFIED",
+                "coverage": coverage,
+                "red_runs": {
+                    repository: [asdict(item) for item in items]
+                    for repository, items in reds.items()
+                },
+                "summary": {
+                    "actionable": actionable,
+                    "red_total": red_total,
+                    "dispositions": dispositions,
+                },
+                "issue": issue,
+                "notification": notification,
+            }
+        )
+        exit_code = 0
+    except Exception as exc:  # noqa: BLE001
+        if isinstance(exc, ReaderSelectionError):
+            reader_attempts = exc.attempts
+            report["authentication"]["attempts"] = list(exc.attempts)
+        report["fatal"] = {
+            "type": type(exc).__name__,
+            "detail_class": (
+                exc.detail_class
+                if isinstance(exc, ApiError)
+                else "coverage_or_execution_failure"
+            ),
+        }
+        body = build_failure_body(
+            error=exc,
+            attempts=reader_attempts,
+        )
+        try:
+            report["issue"] = upsert_issue(body, red_total=None)
+        except Exception as issue_exc:  # noqa: BLE001
+            report["issue_error"] = {
+                "type": type(issue_exc).__name__,
+                "detail_class": (
+                    issue_exc.detail_class
+                    if isinstance(issue_exc, ApiError)
+                    else "issue_publication_failure"
+                ),
+            }
+        exit_code = 2
+
+    report["generated_at"] = datetime.now(timezone.utc).isoformat()
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_summary(body, report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.github/scripts/ci_health_digest_http.py
+++ b/.github/scripts/ci_health_digest_http.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
 ORG = "szl-holdings"
+CANONICAL_CONFIG_ID = 252588
 TRANSIENT_HTTP = {429, 500, 502, 503, 504}
 
 
@@ -153,45 +154,143 @@ def repository_floor() -> int:
     return floor
 
 
-def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
-    repositories: list[dict[str, Any]] = []
-    seen: set[str] = set()
+def _paginated_list(
+    token: str,
+    base_url: str,
+    *,
+    operation: str,
+) -> tuple[dict[str, Any], ...]:
+    values: list[dict[str, Any]] = []
     page = 1
+    separator = "&" if "?" in base_url else "?"
     while True:
         _, payload = request_json(
             token,
-            (
-                f"https://api.github.com/orgs/{ORG}/repos"
-                f"?per_page=100&type=all&page={page}"
-            ),
-            operation=f"list organization repositories page {page}",
+            f"{base_url}{separator}per_page=100&page={page}",
+            operation=f"{operation} page {page}",
         )
         if not isinstance(payload, list):
             raise DigestError(
-                f"organization repository page {page} returned "
+                f"{operation} page {page} returned "
                 f"{type(payload).__name__}, not a list"
             )
         for item in payload:
             if not isinstance(item, dict):
                 raise DigestError(
-                    f"organization repository page {page} contains a malformed entry"
+                    f"{operation} page {page} contains a malformed entry"
                 )
-            name = str(item.get("name") or "").strip()
-            if not name:
-                raise DigestError("organization repository entry has no name")
-            if name in seen:
-                raise DigestError(
-                    f"duplicate repository returned by GitHub: {name}"
-                )
-            seen.add(name)
-            repositories.append(item)
+            values.append(item)
         if len(payload) < 100:
-            break
+            return tuple(values)
         page += 1
         if page > 100:
+            raise DigestError(f"{operation} exceeded 100 pages")
+
+
+def validate_canonical_inventory(
+    token: str,
+    repositories: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    _, configurations = request_json(
+        token,
+        f"https://api.github.com/orgs/{ORG}/code-security/configurations",
+        operation="read organization code-security configurations",
+    )
+    if not isinstance(configurations, list):
+        raise DigestError("code-security configuration inventory is malformed")
+    canonical = next(
+        (
+            item
+            for item in configurations
+            if isinstance(item, dict)
+            and item.get("id") == CANONICAL_CONFIG_ID
+        ),
+        None,
+    )
+    if canonical is None:
+        raise DigestError(
+            f"canonical code-security configuration {CANONICAL_CONFIG_ID} is missing"
+        )
+    if canonical.get("target_type") != "organization":
+        raise DigestError(
+            "canonical code-security configuration is not organization-scoped"
+        )
+    if canonical.get("enforcement") != "enforced":
+        raise DigestError(
+            "canonical code-security configuration is not enforced"
+        )
+
+    attachments = _paginated_list(
+        token,
+        (
+            f"https://api.github.com/orgs/{ORG}/code-security/"
+            f"configurations/{CANONICAL_CONFIG_ID}/repositories"
+        ),
+        operation="read canonical code-security repository inventory",
+    )
+    attached_status: dict[str, str | None] = {}
+    for item in attachments:
+        repository = item.get("repository") or {}
+        full_name = str(repository.get("full_name") or "").strip()
+        if not full_name:
             raise DigestError(
-                "organization repository pagination exceeded 100 pages"
+                "canonical code-security repository entry has no full name"
             )
+        if full_name in attached_status:
+            raise DigestError(
+                f"canonical repository inventory contains duplicate {full_name}"
+            )
+        attached_status[full_name] = (
+            str(item.get("status")) if item.get("status") is not None else None
+        )
+
+    observed_names = {
+        str(item.get("full_name") or f"{ORG}/{item.get('name')}")
+        for item in repositories
+    }
+    attached_names = set(attached_status)
+    if observed_names != attached_names:
+        missing_from_org_listing = sorted(attached_names - observed_names)
+        missing_from_canonical = sorted(observed_names - attached_names)
+        raise DigestError(
+            "organization repository inventory does not match canonical "
+            "code-security inventory: "
+            f"missing_from_org_listing={missing_from_org_listing}; "
+            f"missing_from_canonical={missing_from_canonical}"
+        )
+    return {
+        "configuration_id": CANONICAL_CONFIG_ID,
+        "configuration_name": canonical.get("name"),
+        "repository_count": len(attached_names),
+        "inventory_match": True,
+        "status_counts": {
+            status or "missing": sum(
+                1 for value in attached_status.values() if value == status
+            )
+            for status in set(attached_status.values())
+        },
+    }
+
+
+def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
+    repositories = list(
+        _paginated_list(
+            token,
+            f"https://api.github.com/orgs/{ORG}/repos?type=all",
+            operation="list organization repositories",
+        )
+    )
+    seen: set[str] = set()
+    for item in repositories:
+        name = str(item.get("name") or "").strip()
+        full_name = str(item.get("full_name") or f"{ORG}/{name}").strip()
+        if not name or not full_name:
+            raise DigestError("organization repository entry has no identity")
+        if full_name in seen:
+            raise DigestError(
+                f"duplicate repository returned by GitHub: {full_name}"
+            )
+        seen.add(full_name)
 
     floor = repository_floor()
     if len(repositories) < floor:
@@ -207,6 +306,7 @@ def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
             raise DigestError(
                 f"active repository {item.get('name')!r} lacks a default branch"
             )
+    validate_canonical_inventory(token, repositories)
     return tuple(repositories)
 
 
@@ -282,6 +382,7 @@ def select_reader() -> ReaderSelection:
                 "present": True,
                 "result": "selected",
                 "repository_count": len(repositories),
+                "canonical_inventory_match": True,
                 "value_recorded": False,
             }
         )

--- a/.github/scripts/ci_health_digest_http.py
+++ b/.github/scripts/ci_health_digest_http.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fail-closed GitHub HTTP and organization-reader selection for CI health."""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+ORG = "szl-holdings"
+TRANSIENT_HTTP = {429, 500, 502, 503, 504}
+
+
+class DigestError(RuntimeError):
+    """Raised when current, complete CI-health evidence cannot be proved."""
+
+
+class ReaderSelectionError(DigestError):
+    def __init__(self, attempts: Sequence[Mapping[str, Any]]) -> None:
+        self.attempts = tuple(dict(item) for item in attempts)
+        super().__init__(
+            "no governed organization reader could prove complete repository "
+            "and Actions coverage"
+        )
+
+
+class ApiError(DigestError):
+    def __init__(self, *, operation: str, status: int, detail_class: str) -> None:
+        super().__init__(
+            f"GitHub API operation {operation!r} failed: "
+            f"HTTP {status} ({detail_class})"
+        )
+        self.operation = operation
+        self.status = status
+        self.detail_class = detail_class
+
+
+@dataclass(frozen=True)
+class ReaderSelection:
+    mode: str
+    credential_name: str
+    token: str
+    repositories: tuple[dict[str, Any], ...]
+    attempts: tuple[dict[str, Any], ...]
+
+
+def classify_http_detail(value: object) -> str:
+    text = str(value or "").lower()
+    if "bad credentials" in text or "requires authentication" in text:
+        return "unauthenticated"
+    if "resource not accessible" in text or "forbidden" in text:
+        return "unauthorized"
+    if "rate limit" in text:
+        return "rate_limited"
+    if "not found" in text:
+        return "not_found_or_hidden"
+    if not text:
+        return "empty_error_body"
+    return "api_error"
+
+
+def request_json(
+    token: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Mapping[str, Any] | None = None,
+    operation: str,
+    expected: set[int] | None = None,
+    attempts: int = 4,
+) -> tuple[int, Any]:
+    if not token:
+        raise DigestError(f"no credential supplied for {operation}")
+    expected = expected or {200}
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "szl-ci-health-digest/2",
+    }
+    last_status = 0
+    last_detail = "request_failed"
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers=headers,
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                status = int(response.status)
+                raw = response.read()
+                payload = json.loads(raw) if raw else {}
+                if status not in expected:
+                    raise ApiError(
+                        operation=operation,
+                        status=status,
+                        detail_class="unexpected_success_status",
+                    )
+                return status, payload
+        except urllib.error.HTTPError as exc:
+            last_status = int(exc.code)
+            raw = exc.read()[:1000].decode("utf-8", errors="replace")
+            last_detail = classify_http_detail(raw)
+            if last_status in TRANSIENT_HTTP and attempt < attempts:
+                retry_after = exc.headers.get("Retry-After") if exc.headers else None
+                delay = (
+                    float(retry_after)
+                    if retry_after and retry_after.isdigit()
+                    else 2 ** (attempt - 1)
+                )
+                time.sleep(min(delay, 15.0))
+                continue
+            raise ApiError(
+                operation=operation,
+                status=last_status,
+                detail_class=last_detail,
+            ) from exc
+        except (urllib.error.URLError, TimeoutError) as exc:
+            last_status = 0
+            last_detail = type(exc).__name__
+            if attempt < attempts:
+                time.sleep(min(2 ** (attempt - 1), 15))
+                continue
+            raise ApiError(
+                operation=operation,
+                status=0,
+                detail_class=last_detail,
+            ) from exc
+    raise ApiError(
+        operation=operation,
+        status=last_status,
+        detail_class=last_detail,
+    )
+
+
+def repository_floor() -> int:
+    value = str(os.environ.get("ORG_REPOSITORY_FLOOR") or "57").strip()
+    try:
+        floor = int(value)
+    except ValueError as exc:
+        raise DigestError(
+            f"ORG_REPOSITORY_FLOOR is not an integer: {value!r}"
+        ) from exc
+    if floor < 1:
+        raise DigestError("ORG_REPOSITORY_FLOOR must be positive")
+    return floor
+
+
+def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
+    repositories: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    page = 1
+    while True:
+        _, payload = request_json(
+            token,
+            (
+                f"https://api.github.com/orgs/{ORG}/repos"
+                f"?per_page=100&type=all&page={page}"
+            ),
+            operation=f"list organization repositories page {page}",
+        )
+        if not isinstance(payload, list):
+            raise DigestError(
+                f"organization repository page {page} returned "
+                f"{type(payload).__name__}, not a list"
+            )
+        for item in payload:
+            if not isinstance(item, dict):
+                raise DigestError(
+                    f"organization repository page {page} contains a malformed entry"
+                )
+            name = str(item.get("name") or "").strip()
+            if not name:
+                raise DigestError("organization repository entry has no name")
+            if name in seen:
+                raise DigestError(
+                    f"duplicate repository returned by GitHub: {name}"
+                )
+            seen.add(name)
+            repositories.append(item)
+        if len(payload) < 100:
+            break
+        page += 1
+        if page > 100:
+            raise DigestError(
+                "organization repository pagination exceeded 100 pages"
+            )
+
+    floor = repository_floor()
+    if len(repositories) < floor:
+        raise DigestError(
+            "organization repository coverage below reviewed floor: "
+            f"observed={len(repositories)} floor={floor}"
+        )
+    active = [item for item in repositories if not item.get("archived")]
+    if not active:
+        raise DigestError("organization listing contains no active repositories")
+    for item in active:
+        if not str(item.get("default_branch") or "").strip():
+            raise DigestError(
+                f"active repository {item.get('name')!r} lacks a default branch"
+            )
+    return tuple(repositories)
+
+
+def select_reader() -> ReaderSelection:
+    candidates = (
+        (
+            "github_app",
+            "qillqaq_app_installation",
+            os.environ.get("DIGEST_APP_TOKEN") or "",
+        ),
+        (
+            "governed_pat_fallback",
+            "SZL_GITHUB_TOKEN",
+            os.environ.get("SZL_GITHUB_TOKEN") or "",
+        ),
+    )
+    attempts: list[dict[str, Any]] = []
+    for mode, name, token in candidates:
+        if not token:
+            attempts.append(
+                {
+                    "mode": mode,
+                    "credential_name": name,
+                    "present": False,
+                    "result": "not_configured",
+                    "value_recorded": False,
+                }
+            )
+            continue
+        try:
+            repositories = list_repositories(token)
+            active_probe = next(
+                item for item in repositories if not item.get("archived")
+            )
+            _, actions_payload = request_json(
+                token,
+                (
+                    f"https://api.github.com/repos/{ORG}/"
+                    f"{active_probe['name']}/actions/workflows?per_page=1"
+                ),
+                operation=(
+                    "probe Actions-read capability for "
+                    f"{active_probe['name']}"
+                ),
+            )
+            if not isinstance(actions_payload, dict) or not isinstance(
+                actions_payload.get("workflows"), list
+            ):
+                raise DigestError(
+                    "Actions-read capability probe returned a malformed payload"
+                )
+        except Exception as exc:  # noqa: BLE001
+            attempts.append(
+                {
+                    "mode": mode,
+                    "credential_name": name,
+                    "present": True,
+                    "result": "rejected",
+                    "failure_type": type(exc).__name__,
+                    "failure_class": (
+                        exc.detail_class
+                        if isinstance(exc, ApiError)
+                        else "coverage_or_shape_failure"
+                    ),
+                    "value_recorded": False,
+                }
+            )
+            continue
+        attempts.append(
+            {
+                "mode": mode,
+                "credential_name": name,
+                "present": True,
+                "result": "selected",
+                "repository_count": len(repositories),
+                "value_recorded": False,
+            }
+        )
+        return ReaderSelection(
+            mode=mode,
+            credential_name=name,
+            token=token,
+            repositories=repositories,
+            attempts=tuple(attempts),
+        )
+    raise ReaderSelectionError(attempts)

--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Complete workflow sweep and honest digest rendering."""
+from __future__ import annotations
+
+import json
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from ci_health_digest_http import (
+    ORG,
+    DigestError,
+    repository_floor,
+    request_json,
+)
+
+RED = {"failure", "startup_failure", "timed_out", "action_required"}
+POLICY = [
+    (
+        "lambda-bounty",
+        "verify-proof",
+        (
+            "INTENTIONAL",
+            "Proof gate rejects the still-OPEN Λ (Conjecture 1) by design — red is the honest verdict.",
+        ),
+    ),
+    (
+        "szl-doctrine",
+        "secret-health",
+        (
+            "FOUNDER-GATED",
+            "Needs org secret SECRET_HEALTH_TOKEN (founder least-privilege token).",
+        ),
+    ),
+    (
+        "",
+        "Dependabot Updates",
+        (
+            "INFRA",
+            "Dependabot runner state, not a workflow defect; resolves with the grouped update PR.",
+        ),
+    ),
+    (
+        "",
+        "CodeQL",
+        (
+            "INFRA",
+            "CodeQL default-setup state; reconfigure through repository Security settings.",
+        ),
+    ),
+    (
+        "",
+        "ClusterFuzzLite",
+        (
+            "INFRA",
+            "Outside-contribution fuzzing waits on GitHub's manual workflow approval.",
+        ),
+    ),
+    (
+        "",
+        "Fuzz",
+        (
+            "INFRA",
+            "Scheduled fuzzing is corpus/infra-driven, not automatically a default-branch regression.",
+        ),
+    ),
+    (
+        "",
+        "Publish npm",
+        (
+            "INFRA",
+            "Manual publication workflow; a historical manual failure is not branch health.",
+        ),
+    ),
+    (
+        "",
+        "Cosign keyless",
+        (
+            "INFRA",
+            "Release-only OIDC signing path; requires an actual tagged release.",
+        ),
+    ),
+    (
+        "",
+        "SLSA",
+        (
+            "INFRA",
+            "Provenance/attestation infrastructure path, not ordinary branch CI.",
+        ),
+    ),
+]
+
+
+@dataclass(frozen=True)
+class RedRun:
+    repository: str
+    workflow: str
+    conclusion: str
+    run_number: int | None
+    event: str | None
+    url: str | None
+
+
+def classify(repository: str, workflow: str) -> tuple[str, str]:
+    for repository_match, substring, verdict in POLICY:
+        if (
+            not repository_match or repository_match == repository
+        ) and substring.lower() in workflow.lower():
+            return verdict
+    return "ACTIONABLE", ""
+
+
+def list_workflows(
+    token: str,
+    repository: str,
+) -> tuple[dict[str, Any], ...]:
+    workflows: list[dict[str, Any]] = []
+    expected_total: int | None = None
+    page = 1
+    while True:
+        _, payload = request_json(
+            token,
+            (
+                f"https://api.github.com/repos/{ORG}/{repository}/actions/"
+                f"workflows?per_page=100&page={page}"
+            ),
+            operation=f"list workflows for {repository} page {page}",
+        )
+        page_items = payload.get("workflows") if isinstance(payload, dict) else None
+        if not isinstance(page_items, list):
+            raise DigestError(
+                f"workflow inventory for {repository} page {page} is malformed"
+            )
+        total_count = payload.get("total_count") if isinstance(payload, dict) else None
+        if isinstance(total_count, int):
+            expected_total = total_count
+        for item in page_items:
+            if not isinstance(item, dict):
+                raise DigestError(
+                    f"workflow inventory for {repository} page {page} "
+                    "contains a malformed entry"
+                )
+            workflows.append(item)
+        if len(page_items) < 100:
+            break
+        page += 1
+        if page > 100:
+            raise DigestError(
+                f"workflow pagination for {repository} exceeded 100 pages"
+            )
+    if expected_total is not None and len(workflows) != expected_total:
+        raise DigestError(
+            f"workflow inventory count mismatch for {repository}: "
+            f"observed={len(workflows)} expected={expected_total}"
+        )
+    identifiers = [item.get("id") for item in workflows]
+    if len(identifiers) != len(set(identifiers)):
+        raise DigestError(
+            f"workflow inventory for {repository} contains duplicate ids"
+        )
+    return tuple(workflows)
+
+
+def latest_run(
+    token: str,
+    repository: str,
+    default_branch: str,
+    workflow: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    if workflow.get("state") != "active":
+        return None
+    workflow_id = workflow.get("id")
+    if not isinstance(workflow_id, int):
+        raise DigestError(
+            f"active workflow in {repository} lacks a numeric id"
+        )
+    for branch_suffix in (
+        f"&branch={urllib.parse.quote(default_branch, safe='')}",
+        "",
+    ):
+        _, payload = request_json(
+            token,
+            (
+                f"https://api.github.com/repos/{ORG}/{repository}/actions/"
+                f"workflows/{workflow_id}/runs?per_page=1{branch_suffix}"
+            ),
+            operation=f"read latest run for {repository}/{workflow_id}",
+        )
+        runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+        if not isinstance(runs, list):
+            raise DigestError(
+                f"workflow-run inventory for {repository}/{workflow_id} is malformed"
+            )
+        if runs:
+            run = runs[0]
+            if not isinstance(run, dict):
+                raise DigestError(
+                    f"latest workflow run for {repository}/{workflow_id} is malformed"
+                )
+            return run
+    return None
+
+
+def repository_reds(
+    token: str,
+    repository: Mapping[str, Any],
+) -> tuple[str, tuple[RedRun, ...], int]:
+    name = str(repository["name"])
+    default_branch = str(repository["default_branch"])
+    workflows = list_workflows(token, name)
+
+    def inspect(workflow: Mapping[str, Any]) -> RedRun | None:
+        run = latest_run(token, name, default_branch, workflow)
+        if run is None:
+            return None
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion not in RED:
+            return None
+        return RedRun(
+            repository=name,
+            workflow=str(
+                workflow.get("name") or f"workflow-{workflow.get('id')}"
+            ),
+            conclusion=conclusion,
+            run_number=(
+                int(run["run_number"])
+                if run.get("run_number") is not None
+                else None
+            ),
+            event=str(run.get("event")) if run.get("event") else None,
+            url=str(run.get("html_url")) if run.get("html_url") else None,
+        )
+
+    results: list[RedRun] = []
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        for result in executor.map(inspect, workflows):
+            if result is not None:
+                results.append(result)
+    return name, tuple(results), len(workflows)
+
+
+def sweep(
+    token: str,
+    repositories: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, tuple[RedRun, ...]], dict[str, int]]:
+    active = tuple(item for item in repositories if not item.get("archived"))
+    reds: dict[str, tuple[RedRun, ...]] = {}
+    workflow_count = 0
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        for name, repository_results, count in executor.map(
+            lambda item: repository_reds(token, item),
+            active,
+        ):
+            workflow_count += count
+            if repository_results:
+                reds[name] = repository_results
+    coverage = {
+        "organization_repositories": len(repositories),
+        "active_repositories": len(active),
+        "archived_repositories": len(repositories) - len(active),
+        "queried_active_repositories": len(active),
+        "active_workflows": workflow_count,
+        "repository_floor": repository_floor(),
+    }
+    return reds, coverage
+
+
+def build_body(
+    reds: Mapping[str, Sequence[RedRun]],
+    *,
+    coverage: Mapping[str, int],
+    authentication_mode: str,
+) -> tuple[str, int, int, dict[str, int]]:
+    buckets: dict[str, list[tuple[RedRun, str]]] = {
+        "ACTIONABLE": [],
+        "FOUNDER-GATED": [],
+        "INTENTIONAL": [],
+        "INFRA": [],
+    }
+    total = 0
+    for repository in sorted(reds):
+        for red in reds[repository]:
+            disposition, note = classify(repository, red.workflow)
+            buckets[disposition].append((red, note))
+            total += 1
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        (
+            "_Auto-generated by `.github/workflows/ci-health-digest.yml`. "
+            f"Verified sweep: **{now}**._"
+        ),
+        "",
+        (
+            "Coverage: **{organization_repositories} repositories** "
+            "({active_repositories} active, {archived_repositories} archived); "
+            "**{queried_active_repositories} active repositories queried**; "
+            "**{active_workflows} active workflows inspected**."
+        ).format(**coverage),
+        "",
+        (
+            f"Authentication mode: `{authentication_mode}`; "
+            "credential value recorded: `false`."
+        ),
+        "",
+    ]
+    counts = {key: len(value) for key, value in buckets.items()}
+    actionable = counts["ACTIONABLE"]
+    lines.extend(
+        [
+            (
+                f"**{total} red workflow(s)** across the verified estate — "
+                f"**{actionable} ACTIONABLE**, "
+                f"{counts['FOUNDER-GATED']} founder-gated, "
+                f"{counts['INTENTIONAL']} intentional, "
+                f"{counts['INFRA']} infra."
+            ),
+            "",
+        ]
+    )
+
+    order = (
+        (
+            "ACTIONABLE",
+            "### 🛠 Actionable — fix these (root-cause, no bandaids)",
+        ),
+        (
+            "FOUNDER-GATED",
+            "### 🔑 Founder-gated — needs a founder secret/action",
+        ),
+        ("INFRA", "### ⚙️ Infra / low-noise — reconfigure or retire"),
+        ("INTENTIONAL", "### ✅ Intentional — red is correct, leave as-is"),
+    )
+    for key, heading in order:
+        rows = buckets[key]
+        if not rows:
+            continue
+        lines.extend(
+            [
+                heading,
+                "",
+                "| Repo | Workflow | Result | Trigger | Note |",
+                "|---|---|---|---|---|",
+            ]
+        )
+        for red, note in sorted(
+            rows,
+            key=lambda item: (item[0].repository, item[0].workflow),
+        ):
+            workflow_cell = (
+                f"[{red.workflow}]({red.url})" if red.url else red.workflow
+            )
+            lines.append(
+                f"| `{red.repository}` | {workflow_cell} | "
+                f"{red.conclusion} (run#{red.run_number or ''}) | "
+                f"{red.event or ''} | {note} |"
+            )
+        lines.append("")
+
+    if total == 0:
+        lines.extend(
+            [
+                "## ✅ All clear — no red latest workflow runs in the verified estate.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "---",
+            (
+                "<sub>Dispositions are policy-classified in "
+                "`.github/scripts/ci_health_digest_sweep.py` (`POLICY`). "
+                "Reclassify a red only with a documented reason; never silence "
+                "a real defect.</sub>"
+            ),
+        ]
+    )
+    return "\n".join(lines), actionable, total, counts
+
+
+def build_failure_body(
+    *,
+    error: Exception,
+    attempts: Sequence[Mapping[str, Any]],
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    return "\n".join(
+        [
+            (
+                "_Auto-generated by `.github/workflows/ci-health-digest.yml`. "
+                f"Failed sweep: **{now}**._"
+            ),
+            "",
+            "# ❌ CI health digest NOT VERIFIED",
+            "",
+            (
+                "The organization inventory or workflow evidence could not be "
+                "read completely. The previous digest is not being reused as "
+                "current evidence."
+            ),
+            "",
+            f"- Failure class: `{type(error).__name__}`",
+            f"- Reader attempts: `{json.dumps(list(attempts), sort_keys=True)}`",
+            "- Credential value recorded: `false`",
+            "",
+            (
+                "The workflow is fail-closed and must remain red until a "
+                "complete authenticated sweep succeeds."
+            ),
+        ]
+    )

--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -210,7 +210,10 @@ def repository_reds(
 ) -> tuple[str, tuple[RedRun, ...], int]:
     name = str(repository["name"])
     default_branch = str(repository["default_branch"])
-    workflows = list_workflows(token, name)
+    workflows = tuple(
+        item for item in list_workflows(token, name)
+        if item.get("state") == "active"
+    )
 
     def inspect(workflow: Mapping[str, Any]) -> RedRun | None:
         run = latest_run(token, name, default_branch, workflow)

--- a/.github/scripts/test_ci_health_digest.py
+++ b/.github/scripts/test_ci_health_digest.py
@@ -2,7 +2,6 @@
 """Network-free self-tests for the fail-closed CI health digest."""
 from __future__ import annotations
 
-import importlib.util
 import json
 import os
 from pathlib import Path
@@ -13,13 +12,11 @@ from unittest.mock import patch
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parents[1]
-MODULE_PATH = HERE / "ci_health_digest.py"
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
 
-spec = importlib.util.spec_from_file_location("ci_health_digest", MODULE_PATH)
-assert spec and spec.loader
-chd = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = chd
-spec.loader.exec_module(chd)
+import ci_health_digest as chd
+import ci_health_digest_http as http
 
 
 def repositories(count: int, *, archived: int = 0):
@@ -42,12 +39,12 @@ class ReaderSelectionTests(unittest.TestCase):
             os.environ,
             {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
             clear=False,
-        ), patch.object(chd, "list_repositories", return_value=estate), patch.object(
-            chd,
-            "_request_json",
+        ), patch.object(http, "list_repositories", return_value=estate), patch.object(
+            http,
+            "request_json",
             return_value=(200, {"workflows": []}),
         ):
-            selected = chd.select_reader()
+            selected = http.select_reader()
         self.assertEqual(selected.mode, "github_app")
         self.assertEqual(selected.credential_name, "qillqaq_app_installation")
         self.assertEqual(len(selected.repositories), 57)
@@ -58,7 +55,7 @@ class ReaderSelectionTests(unittest.TestCase):
 
         def inventory(token):
             if token == "app":
-                raise chd.ApiError(
+                raise http.ApiError(
                     operation="inventory",
                     status=403,
                     detail_class="unauthorized",
@@ -69,12 +66,12 @@ class ReaderSelectionTests(unittest.TestCase):
             os.environ,
             {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
             clear=False,
-        ), patch.object(chd, "list_repositories", side_effect=inventory), patch.object(
-            chd,
-            "_request_json",
+        ), patch.object(http, "list_repositories", side_effect=inventory), patch.object(
+            http,
+            "request_json",
             return_value=(200, {"workflows": []}),
         ):
-            selected = chd.select_reader()
+            selected = http.select_reader()
         self.assertEqual(selected.mode, "governed_pat_fallback")
         self.assertEqual(selected.attempts[0]["result"], "rejected")
         self.assertEqual(selected.attempts[0]["failure_class"], "unauthorized")
@@ -86,8 +83,8 @@ class ReaderSelectionTests(unittest.TestCase):
             {"DIGEST_APP_TOKEN": "", "SZL_GITHUB_TOKEN": ""},
             clear=False,
         ):
-            with self.assertRaises(chd.ReaderSelectionError) as context:
-                chd.select_reader()
+            with self.assertRaises(http.ReaderSelectionError) as context:
+                http.select_reader()
         self.assertEqual(len(context.exception.attempts), 2)
         self.assertTrue(
             all(item["result"] == "not_configured" for item in context.exception.attempts)
@@ -97,29 +94,29 @@ class ReaderSelectionTests(unittest.TestCase):
 class RepositoryCoverageTests(unittest.TestCase):
     def test_present_token_with_zero_repositories_fails_closed(self):
         with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
-            chd,
-            "_request_json",
+            http,
+            "request_json",
             return_value=(200, []),
         ):
-            with self.assertRaisesRegex(chd.DigestError, "below reviewed floor"):
-                chd.list_repositories("present-token")
+            with self.assertRaisesRegex(http.DigestError, "below reviewed floor"):
+                http.list_repositories("present-token")
 
     def test_partial_repository_listing_fails_closed(self):
         with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
-            chd,
-            "_request_json",
+            http,
+            "request_json",
             return_value=(200, list(repositories(56))),
         ):
-            with self.assertRaisesRegex(chd.DigestError, "observed=56 floor=57"):
-                chd.list_repositories("present-token")
+            with self.assertRaisesRegex(http.DigestError, "observed=56 floor=57"):
+                http.list_repositories("present-token")
 
     def test_complete_repository_listing_passes(self):
         with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
-            chd,
-            "_request_json",
+            http,
+            "request_json",
             return_value=(200, list(repositories(57, archived=5))),
         ):
-            observed = chd.list_repositories("present-token")
+            observed = http.list_repositories("present-token")
         self.assertEqual(len(observed), 57)
         self.assertEqual(sum(bool(item["archived"]) for item in observed), 5)
 

--- a/.github/scripts/test_ci_health_digest.py
+++ b/.github/scripts/test_ci_health_digest.py
@@ -97,7 +97,7 @@ class RepositoryCoverageTests(unittest.TestCase):
             http,
             "request_json",
             return_value=(200, []),
-        ):
+        ), patch.object(http, "validate_canonical_inventory"):
             with self.assertRaisesRegex(http.DigestError, "below reviewed floor"):
                 http.list_repositories("present-token")
 
@@ -106,7 +106,7 @@ class RepositoryCoverageTests(unittest.TestCase):
             http,
             "request_json",
             return_value=(200, list(repositories(56))),
-        ):
+        ), patch.object(http, "validate_canonical_inventory"):
             with self.assertRaisesRegex(http.DigestError, "observed=56 floor=57"):
                 http.list_repositories("present-token")
 
@@ -115,10 +115,77 @@ class RepositoryCoverageTests(unittest.TestCase):
             http,
             "request_json",
             return_value=(200, list(repositories(57, archived=5))),
-        ):
+        ), patch.object(http, "validate_canonical_inventory") as canonical:
             observed = http.list_repositories("present-token")
         self.assertEqual(len(observed), 57)
         self.assertEqual(sum(bool(item["archived"]) for item in observed), 5)
+        canonical.assert_called_once()
+
+
+class CanonicalInventoryTests(unittest.TestCase):
+    def test_exact_code_security_inventory_match_passes(self):
+        estate = repositories(2)
+        payloads = [
+            (
+                200,
+                [
+                    {
+                        "id": http.CANONICAL_CONFIG_ID,
+                        "name": "SZL Holdings Managed Security",
+                        "target_type": "organization",
+                        "enforcement": "enforced",
+                    }
+                ],
+            ),
+            (
+                200,
+                [
+                    {
+                        "repository": {"full_name": "szl-holdings/repo-000"},
+                        "status": "enforced",
+                    },
+                    {
+                        "repository": {"full_name": "szl-holdings/repo-001"},
+                        "status": "enforced",
+                    },
+                ],
+            ),
+        ]
+        with patch.object(http, "request_json", side_effect=payloads):
+            result = http.validate_canonical_inventory("token", estate)
+        self.assertTrue(result["inventory_match"])
+        self.assertEqual(result["repository_count"], 2)
+
+    def test_repository_missing_from_canonical_inventory_fails(self):
+        estate = repositories(2)
+        payloads = [
+            (
+                200,
+                [
+                    {
+                        "id": http.CANONICAL_CONFIG_ID,
+                        "name": "SZL Holdings Managed Security",
+                        "target_type": "organization",
+                        "enforcement": "enforced",
+                    }
+                ],
+            ),
+            (
+                200,
+                [
+                    {
+                        "repository": {"full_name": "szl-holdings/repo-000"},
+                        "status": "enforced",
+                    }
+                ],
+            ),
+        ]
+        with patch.object(http, "request_json", side_effect=payloads):
+            with self.assertRaisesRegex(
+                http.DigestError,
+                "does not match canonical code-security inventory",
+            ):
+                http.validate_canonical_inventory("token", estate)
 
 
 class IssueAndReportTests(unittest.TestCase):
@@ -267,6 +334,7 @@ class WorkflowContractTests(unittest.TestCase):
             "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
             "permission-actions: read",
             "permission-contents: read",
+            "permission-organization-administration: read",
             "DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}",
             "SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}",
             "CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}",

--- a/.github/scripts/test_ci_health_digest.py
+++ b/.github/scripts/test_ci_health_digest.py
@@ -1,72 +1,289 @@
 #!/usr/bin/env python3
-"""Self-test for the org CI health digest job.
-
-``ci_health_digest.py`` sweeps the org's repos and upserts a rolling "CI Health
-Digest" issue. Its one load-bearing safety contract is the token preflight: the
-built-in Actions ``GITHUB_TOKEN`` cannot read other repos' runs, so when NO
-usable token is present the digest must FAIL LOUD (exit 1) rather than silently
-sweep nothing and post a false "0 actionable / 0 red" all-clear.
-
-This stubs the GitHub/ntfy network surface so it runs offline and pins:
-
-  1. no token (module-level TOKEN falsy)                       -> exit 1
-  2. a usable token, clean sweep                               -> exit 0 (no raise)
-"""
+"""Network-free self-tests for the fail-closed CI health digest."""
 from __future__ import annotations
 
-import contextlib
 import importlib.util
-import io
+import json
 import os
+from pathlib import Path
 import sys
+import tempfile
 import unittest
+from unittest.mock import patch
 
-_HERE = os.path.dirname(os.path.abspath(__file__))
-_MODULE_PATH = os.path.join(_HERE, "ci_health_digest.py")
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+MODULE_PATH = HERE / "ci_health_digest.py"
 
-_spec = importlib.util.spec_from_file_location("ci_health_digest", _MODULE_PATH)
-assert _spec and _spec.loader
-chd = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(chd)
-
-
-def _run_main(*, token, repos=()):
-    """Run ``chd.main()`` with TOKEN forced and the network stubbed. Returns the
-    exit code: 0 when main() completes (returns None), or the SystemExit code."""
-    saved = {name: getattr(chd, name) for name in
-             ("TOKEN", "list_repos", "repo_reds", "upsert_issue", "maybe_ntfy")}
-    saved_summary = os.environ.pop("GITHUB_STEP_SUMMARY", None)
-    try:
-        chd.TOKEN = token
-        chd.list_repos = lambda: list(repos)
-        chd.repo_reds = lambda item: (item, None)
-        chd.upsert_issue = lambda body: "issue upserted"
-        chd.maybe_ntfy = lambda act, total: None
-        with contextlib.redirect_stdout(io.StringIO()), \
-                contextlib.redirect_stderr(io.StringIO()):
-            try:
-                chd.main()
-                return 0
-            except SystemExit as e:
-                return e.code if isinstance(e.code, int) else 1
-    finally:
-        for name, val in saved.items():
-            setattr(chd, name, val)
-        if saved_summary is not None:
-            os.environ["GITHUB_STEP_SUMMARY"] = saved_summary
+spec = importlib.util.spec_from_file_location("ci_health_digest", MODULE_PATH)
+assert spec and spec.loader
+chd = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = chd
+spec.loader.exec_module(chd)
 
 
-class TestCiHealthDigestGuard(unittest.TestCase):
-    def test_no_token_exit_1(self):
-        """No usable token -> exit 1, never a silent green all-clear digest."""
-        self.assertEqual(_run_main(token=""), 1)
+def repositories(count: int, *, archived: int = 0):
+    values = []
+    for index in range(count):
+        values.append(
+            {
+                "name": f"repo-{index:03d}",
+                "default_branch": "main",
+                "archived": index < archived,
+            }
+        )
+    return tuple(values)
 
-    def test_none_token_exit_1(self):
-        self.assertEqual(_run_main(token=None), 1)
 
-    def test_healthy_clean_sweep_passes(self):
-        """A usable token with a clean sweep completes without raising."""
-        self.assertEqual(_run_main(token="tok", repos=[]), 0)
+class ReaderSelectionTests(unittest.TestCase):
+    def test_prefers_verified_short_lived_app_reader(self):
+        estate = repositories(57, archived=5)
+        with patch.dict(
+            os.environ,
+            {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
+            clear=False,
+        ), patch.object(chd, "list_repositories", return_value=estate), patch.object(
+            chd,
+            "_request_json",
+            return_value=(200, {"workflows": []}),
+        ):
+            selected = chd.select_reader()
+        self.assertEqual(selected.mode, "github_app")
+        self.assertEqual(selected.credential_name, "qillqaq_app_installation")
+        self.assertEqual(len(selected.repositories), 57)
+        self.assertEqual(selected.attempts[-1]["result"], "selected")
+
+    def test_falls_back_only_after_app_reader_is_rejected(self):
+        estate = repositories(57, archived=5)
+
+        def inventory(token):
+            if token == "app":
+                raise chd.ApiError(
+                    operation="inventory",
+                    status=403,
+                    detail_class="unauthorized",
+                )
+            return estate
+
+        with patch.dict(
+            os.environ,
+            {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
+            clear=False,
+        ), patch.object(chd, "list_repositories", side_effect=inventory), patch.object(
+            chd,
+            "_request_json",
+            return_value=(200, {"workflows": []}),
+        ):
+            selected = chd.select_reader()
+        self.assertEqual(selected.mode, "governed_pat_fallback")
+        self.assertEqual(selected.attempts[0]["result"], "rejected")
+        self.assertEqual(selected.attempts[0]["failure_class"], "unauthorized")
+        self.assertFalse(any("token" in key.lower() for key in selected.attempts[0]))
+
+    def test_no_reader_is_a_typed_terminal_failure(self):
+        with patch.dict(
+            os.environ,
+            {"DIGEST_APP_TOKEN": "", "SZL_GITHUB_TOKEN": ""},
+            clear=False,
+        ):
+            with self.assertRaises(chd.ReaderSelectionError) as context:
+                chd.select_reader()
+        self.assertEqual(len(context.exception.attempts), 2)
+        self.assertTrue(
+            all(item["result"] == "not_configured" for item in context.exception.attempts)
+        )
+
+
+class RepositoryCoverageTests(unittest.TestCase):
+    def test_present_token_with_zero_repositories_fails_closed(self):
+        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+            chd,
+            "_request_json",
+            return_value=(200, []),
+        ):
+            with self.assertRaisesRegex(chd.DigestError, "below reviewed floor"):
+                chd.list_repositories("present-token")
+
+    def test_partial_repository_listing_fails_closed(self):
+        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+            chd,
+            "_request_json",
+            return_value=(200, list(repositories(56))),
+        ):
+            with self.assertRaisesRegex(chd.DigestError, "observed=56 floor=57"):
+                chd.list_repositories("present-token")
+
+    def test_complete_repository_listing_passes(self):
+        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+            chd,
+            "_request_json",
+            return_value=(200, list(repositories(57, archived=5))),
+        ):
+            observed = chd.list_repositories("present-token")
+        self.assertEqual(len(observed), 57)
+        self.assertEqual(sum(bool(item["archived"]) for item in observed), 5)
+
+
+class IssueAndReportTests(unittest.TestCase):
+    def test_all_clear_closes_the_existing_rolling_issue(self):
+        calls = []
+
+        def request(token, url, **kwargs):
+            calls.append((url, kwargs))
+            if "?state=all" in url:
+                return 200, [
+                    {
+                        "number": 158,
+                        "title": chd.ISSUE_TITLE,
+                        "state": "open",
+                    }
+                ]
+            return 200, {
+                "number": 158,
+                "state": kwargs["body"]["state"],
+                "html_url": "https://github.com/szl-holdings/.github/issues/158",
+                "updated_at": "2026-07-26T00:00:00Z",
+            }
+
+        with patch.object(chd, "_issue_token", return_value="issue-token"), patch.object(
+            chd,
+            "_request_json",
+            side_effect=request,
+        ):
+            result = chd.upsert_issue("all clear", red_total=0)
+        self.assertEqual(result["state"], "closed")
+        mutation = calls[-1][1]["body"]
+        self.assertEqual(mutation["state"], "closed")
+        self.assertEqual(mutation["state_reason"], "completed")
+
+    def test_red_digest_reopens_the_existing_issue(self):
+        calls = []
+
+        def request(token, url, **kwargs):
+            calls.append((url, kwargs))
+            if "?state=all" in url:
+                return 200, [
+                    {
+                        "number": 158,
+                        "title": chd.ISSUE_TITLE,
+                        "state": "closed",
+                    }
+                ]
+            return 200, {
+                "number": 158,
+                "state": kwargs["body"]["state"],
+                "html_url": "https://github.com/szl-holdings/.github/issues/158",
+                "updated_at": "2026-07-26T00:00:00Z",
+            }
+
+        with patch.object(chd, "_issue_token", return_value="issue-token"), patch.object(
+            chd,
+            "_request_json",
+            side_effect=request,
+        ):
+            result = chd.upsert_issue("red", red_total=1)
+        self.assertEqual(result["state"], "open")
+        self.assertEqual(calls[-1][1]["body"], {"body": "red", "state": "open"})
+
+    def test_failed_reader_writes_not_verified_receipt_and_exits_two(self):
+        attempts = (
+            {
+                "mode": "github_app",
+                "credential_name": "qillqaq_app_installation",
+                "result": "rejected",
+                "value_recorded": False,
+            },
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "report.json"
+            with patch.object(
+                chd,
+                "select_reader",
+                side_effect=chd.ReaderSelectionError(attempts),
+            ), patch.object(
+                chd,
+                "upsert_issue",
+                return_value={"number": 158, "state": "open"},
+            ):
+                code = chd.main(["--report", str(report_path)])
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(code, 2)
+        self.assertEqual(report["status"], "NOT_VERIFIED")
+        self.assertEqual(report["authentication"]["attempts"], list(attempts))
+        self.assertEqual(report["issue"]["state"], "open")
+
+    def test_complete_sweep_writes_verified_receipt(self):
+        estate = repositories(57, archived=5)
+        selected = chd.ReaderSelection(
+            mode="governed_pat_fallback",
+            credential_name="SZL_GITHUB_TOKEN",
+            token="never-recorded",
+            repositories=estate,
+            attempts=(
+                {
+                    "mode": "governed_pat_fallback",
+                    "credential_name": "SZL_GITHUB_TOKEN",
+                    "result": "selected",
+                    "value_recorded": False,
+                },
+            ),
+        )
+        coverage = {
+            "organization_repositories": 57,
+            "active_repositories": 52,
+            "archived_repositories": 5,
+            "queried_active_repositories": 52,
+            "active_workflows": 100,
+            "repository_floor": 57,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "report.json"
+            with patch.object(chd, "select_reader", return_value=selected), patch.object(
+                chd,
+                "sweep",
+                return_value=({}, coverage),
+            ), patch.object(
+                chd,
+                "upsert_issue",
+                return_value={"number": 158, "state": "closed"},
+            ), patch.object(
+                chd,
+                "maybe_notify",
+                return_value={"attempted": False, "result": "not_configured"},
+            ):
+                code = chd.main(["--report", str(report_path)])
+            report_text = report_path.read_text(encoding="utf-8")
+            report = json.loads(report_text)
+        self.assertEqual(code, 0)
+        self.assertEqual(report["status"], "VERIFIED")
+        self.assertEqual(report["coverage"]["queried_active_repositories"], 52)
+        self.assertEqual(report["summary"]["red_total"], 0)
+        self.assertNotIn("never-recorded", report_text)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_production_workflow_is_app_first_fail_closed_and_evidence_bound(self):
+        workflow = (ROOT / ".github/workflows/ci-health-digest.yml").read_text(
+            encoding="utf-8"
+        )
+        required = (
+            "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+            "permission-actions: read",
+            "permission-contents: read",
+            "DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}",
+            "SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}",
+            "CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}",
+            'ORG_REPOSITORY_FLOOR: "57"',
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            "if-no-files-found: error",
+            "Enforce complete authenticated coverage",
+        )
+        for marker in required:
+            self.assertIn(marker, workflow)
+        self.assertNotIn("secrets.ORG_CI_READ_TOKEN", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("git push", workflow)
+        self.assertIn("persist-credentials: false", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -1,19 +1,23 @@
 name: CI Health Digest
 
-# Org-wide CI health sweep + recommendations. Runs daily, classifies every red
-# workflow by disposition, and upserts a SINGLE rolling tracking issue
-# ("🔴 CI Health Digest — org-wide") so the maintainer's GitHub notification
-# inbox stays to one actionable item instead of dozens of scattered failure
-# emails. See .github/scripts/ci_health_digest.py for the classification policy.
-#
-# Requires repo secret ORG_CI_READ_TOKEN (org-read PAT) — the built-in
-# GITHUB_TOKEN cannot read other repos' Actions runs. Optional SLACK_WEBHOOK_URL
-# (box ntfy relay) for a one-line push; skipped gracefully when absent.
+# Org-wide CI health sweep + one rolling issue. Authentication is App-first,
+# migration-safe, and fail-closed. The short-lived qillqaq installation token is
+# accepted only after it proves the reviewed repository floor and Actions-read
+# capability. Until that path is active, the existing governed
+# SZL_GITHUB_TOKEN is used read-only. The ephemeral workflow token writes only
+# issue #158 (or its exact-title replacement) in this repository.
 
 on:
   schedule:
-    - cron: '37 13 * * *'   # daily 13:37 UTC
+    - cron: "37 13 * * *"
   workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/ci_health_digest.py
+      - .github/scripts/test_ci_health_digest.py
+      - .github/workflows/ci-health-digest.yml
+      - .governance/github-app-manifest.json
 
 permissions:
   contents: read
@@ -23,9 +27,15 @@ concurrency:
   group: ci-health-digest
   cancel-in-progress: true
 
+env:
+  REPORT_PATH: reports/ci-health-digest.json
+  ORG_REPOSITORY_FLOOR: "57"
+
 jobs:
   digest:
+    name: Authenticated organization sweep and rolling evidence issue
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -34,14 +44,68 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
-      - name: Org CI health sweep + upsert digest issue
+      - name: Compile and self-test the complete-coverage contract
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/ci_health_digest.py \
+            .github/scripts/test_ci_health_digest.py
+          python .github/scripts/test_ci_health_digest.py
+          git diff --check
+
+      - name: Mint preferred qillqaq organization reader
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
+          private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-actions: read
+          permission-contents: read
+
+      - name: Sweep the verified organization estate and publish issue evidence
+        id: digest
         env:
-          ORG_CI_READ_TOKEN: ${{ secrets.ORG_CI_READ_TOKEN }}
+          DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: python3 .github/scripts/ci_health_digest.py
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/ci_health_digest.py --report "$REPORT_PATH"
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload immutable digest evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-health-digest-${{ github.run_id }}
+          path: ${{ env.REPORT_PATH }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Enforce complete authenticated coverage
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.digest.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::CI health digest is NOT VERIFIED. The rolling issue contains the fail-closed receipt."
+            exit "$code"
+          fi
+          echo "Organization CI health digest is current, authenticated, and evidence-bound."

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -15,6 +15,8 @@ on:
     branches: [main]
     paths:
       - .github/scripts/ci_health_digest.py
+      - .github/scripts/ci_health_digest_http.py
+      - .github/scripts/ci_health_digest_sweep.py
       - .github/scripts/test_ci_health_digest.py
       - .github/workflows/ci-health-digest.yml
       - .governance/github-app-manifest.json
@@ -58,6 +60,8 @@ jobs:
           set -euo pipefail
           python -m py_compile \
             .github/scripts/ci_health_digest.py \
+            .github/scripts/ci_health_digest_http.py \
+            .github/scripts/ci_health_digest_sweep.py \
             .github/scripts/test_ci_health_digest.py
           python .github/scripts/test_ci_health_digest.py
           git diff --check

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -2,10 +2,11 @@ name: CI Health Digest
 
 # Org-wide CI health sweep + one rolling issue. Authentication is App-first,
 # migration-safe, and fail-closed. The short-lived qillqaq installation token is
-# accepted only after it proves the reviewed repository floor and Actions-read
-# capability. Until that path is active, the existing governed
-# SZL_GITHUB_TOKEN is used read-only. The ephemeral workflow token writes only
-# issue #158 (or its exact-title replacement) in this repository.
+# accepted only after it proves the reviewed repository floor, canonical
+# code-security inventory parity, and Actions-read capability. Until that path
+# is active, the existing governed SZL_GITHUB_TOKEN is used read-only. The
+# ephemeral workflow token writes only issue #158 (or its exact-title
+# replacement) in this repository.
 
 on:
   schedule:
@@ -76,6 +77,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-actions: read
           permission-contents: read
+          permission-organization-administration: read
 
       - name: Sweep the verified organization estate and publish issue evidence
         id: digest


### PR DESCRIPTION
## Satisfies

Satisfies: C-158

Tracks: .github#158.

## Root cause

The rolling organization CI digest was false-green. Its latest production run `30206890809` concluded `success` while the controller logged:

- `sweeping 0 active repos...`;
- issue mutation `HTTP 401`;
- notification relay `HTTP 405`;
- `done: 0 actionable / 0 red`.

The controller treated any non-empty token as usable, converted authentication/API response failures into empty repository or workflow lists, never checked the organization repository count, never required successful issue publication, and emitted no immutable evidence artifact. As a result, issue #158 still displayed a July 6 snapshot while the scheduled workflow claimed success.

## Permanent repair

- prefer a short-lived qillqaq GitHub App installation reader;
- request `Actions: read`, `Contents: read`, and organization `Administration: read` only;
- use the existing governed `SZL_GITHUB_TOKEN` read-only while the App permission activation is pending;
- keep the ephemeral `github.token` separate and scoped only to the rolling issue write;
- accept a reader only after it proves all of the following:
  - the organization repository listing is paginated and structurally valid;
  - repository count is at least the reviewed 57-repository ratchet;
  - the exact repository set equals canonical code-security configuration `252588`'s repository set;
  - the canonical configuration remains organization-scoped and enforced;
  - at least one active repository Actions workflow endpoint is readable;
- paginate every active repository's workflow definitions and verify `total_count` parity;
- fail closed on every repository, workflow, run, shape, pagination, authentication, permission, or issue-publication error;
- replace stale issue content with an explicit `NOT VERIFIED` receipt on failed sweeps;
- reopen issue #158 when red workflows exist and close it only after a complete verified all-clear;
- record schema `szl.ci-health-digest/v2`, exact source generation, authentication mode, coverage counts, red-run inventory, issue result, and notification result in a 90-day immutable artifact;
- record no credential value, length, prefix, hash, identity, or header;
- retry the notification relay as plain text after an HTTP 405/415 JSON rejection without allowing notification delivery to determine estate truth;
- split HTTP/authentication, workflow sweeping, and issue/report orchestration into independently testable modules.

## Verification

- 13 network-free contract tests pass locally;
- Python compilation passes for all changed modules;
- workflow YAML parses successfully;
- exact canonical-inventory match passes;
- zero repositories, 56 repositories, canonical-set mismatch, missing credentials, unauthorized App reader, malformed issue state, and incomplete evidence all fail closed;
- App-first reader selection and governed fallback are covered;
- verified and `NOT_VERIFIED` artifacts are covered, including an assertion that credential material never appears in the report.

Protected CI on the exact published branch is authoritative; local verification is not used as a merge substitute.

## Labels

Labels: PROVED fail-closed source invariants and 13 network-free tests; MEASURED run `30206890809` zero-repository/HTTP-401 false green; NOT CLAIMED live organization health until protected-main execution publishes a current v2 artifact.

## Rollback

Rollback: revert the eventual squash commit through a protected, signed pull request. Reverting restores a controller that can report success with zero repositories and stale issue evidence, so rollback is a deliberate loss of observability integrity.

## Risk class

Risk: C — this changes read-only organization inventory, Actions inspection, one rolling issue, and evidence publication. It does not alter repositories, workflow runs, rulesets, protections, reviews, statuses, deployments, code-security configuration, or secret values. Every incomplete state remains terminal.

Solo-Operator-Authorization: confirmed

## Evidence checklist

- [ ] `gate/ground-truth` green
- [ ] `gate/labels` green
- [ ] `gate/schema` green
- [ ] `gate/adversarial` green
- [ ] `gate/verify-all` green
- [ ] `gate/provenance` green
- [ ] `gate/a11y-perf` green
- [ ] `gate/lean` green
- [x] Screenshots not applicable; no UI surface changed
- [x] No force merge, bypass, required-check removal, status fabrication, or protection reduction
- [x] Secret values remain sealed

## Known limitation

The qillqaq organization `Administration: read` permission still depends on GitHub installation-owner activation. Until activation, successful runs explicitly report the governed PAT migration fallback. The controller automatically selects the App after the exact permission and complete-coverage probes succeed.

## Doctrine

- [x] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no banned vendors

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>