### PR TITLE
fix(ci): bind organization health to protected default branches

### DIFF
--- a/.github/scripts/ci_health_digest.py
+++ b/.github/scripts/ci_health_digest.py
@@ -223,6 +223,28 @@ def _write_summary(body: str, report: Mapping[str, Any]) -> None:
         summary.write("\n")
 
 
+def _normalize_coverage(coverage: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep the v2 receipt additive for legacy fixtures and consumers."""
+    normalized = dict(coverage)
+    default_count = int(
+        normalized.get(
+            "default_branch_workflows",
+            normalized.get("active_workflows", 0),
+        )
+    )
+    registered_count = int(
+        normalized.get("registered_active_workflows", default_count)
+    )
+    normalized.setdefault("active_workflows", default_count)
+    normalized.setdefault("default_branch_workflows", default_count)
+    normalized.setdefault("registered_active_workflows", registered_count)
+    normalized.setdefault(
+        "excluded_non_default_workflows",
+        max(registered_count - default_count, 0),
+    )
+    return normalized
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -258,7 +280,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "An organization reader is accepted only after proving the "
                 "reviewed repository floor."
             ),
-            "Every active repository and workflow API read is fail-closed.",
+            "Every protected-default-branch workflow API read is fail-closed.",
             (
                 "The ephemeral repository token writes only the one rolling "
                 "digest issue."
@@ -289,6 +311,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
         }
         reds, coverage = sweep(reader.token, reader.repositories)
+        coverage = _normalize_coverage(coverage)
         body, actionable, red_total, dispositions = build_body(
             reds,
             coverage=coverage,

--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Complete workflow sweep and honest digest rendering."""
+"""Complete default-branch workflow sweep and honest digest rendering.
+
+GitHub's Actions workflow registry can retain entries for workflow files that
+exist only on feature branches, closed pull-request branches, or other refs.
+Those registrations are not part of protected default-branch health. This
+module therefore proves that every inspected workflow file exists at the
+repository's current default branch and reads runs only through an explicit
+``branch=<default>`` filter. It never falls back to an arbitrary branch run.
+"""
 from __future__ import annotations
 
 import json
@@ -12,6 +20,7 @@ from typing import Any, Mapping, Sequence
 
 from ci_health_digest_http import (
     ORG,
+    ApiError,
     DigestError,
     repository_floor,
     request_json,
@@ -117,6 +126,7 @@ def list_workflows(
     token: str,
     repository: str,
 ) -> tuple[dict[str, Any], ...]:
+    """Return the complete GitHub workflow registry for one repository."""
     workflows: list[dict[str, Any]] = []
     expected_total: int | None = None
     page = 1
@@ -164,12 +174,75 @@ def list_workflows(
     return tuple(workflows)
 
 
+def _workflow_path(workflow: Mapping[str, Any], *, repository: str) -> str:
+    path = str(workflow.get("path") or "").strip().lstrip("/")
+    if (
+        not path.startswith(".github/workflows/")
+        or path.endswith("/")
+        or ".." in path.split("/")
+        or not path.lower().endswith((".yml", ".yaml"))
+    ):
+        raise DigestError(
+            f"active workflow in {repository} has an invalid workflow path: {path!r}"
+        )
+    return path
+
+
+def workflow_exists_on_default_branch(
+    token: str,
+    repository: str,
+    default_branch: str,
+    workflow: Mapping[str, Any],
+) -> bool:
+    """Prove that the registered workflow file exists at the default branch.
+
+    A 404 means the Actions registry entry belongs to another ref and is safely
+    excluded from default-branch health. Every other API or payload failure is
+    terminal because the evidence boundary could not be proved.
+    """
+    path = _workflow_path(workflow, repository=repository)
+    encoded_path = urllib.parse.quote(path, safe="/")
+    encoded_ref = urllib.parse.quote(default_branch, safe="")
+    try:
+        _, payload = request_json(
+            token,
+            (
+                f"https://api.github.com/repos/{ORG}/{repository}/contents/"
+                f"{encoded_path}?ref={encoded_ref}"
+            ),
+            operation=(
+                f"prove default-branch workflow path "
+                f"{repository}/{path}@{default_branch}"
+            ),
+        )
+    except ApiError as exc:
+        if exc.status == 404:
+            return False
+        raise
+    if not isinstance(payload, dict):
+        raise DigestError(
+            f"default-branch workflow lookup for {repository}/{path} is malformed"
+        )
+    if payload.get("type") != "file" or payload.get("path") != path:
+        raise DigestError(
+            f"default-branch workflow lookup for {repository}/{path} "
+            "did not resolve the exact file"
+        )
+    sha = str(payload.get("sha") or "")
+    if len(sha) != 40:
+        raise DigestError(
+            f"default-branch workflow {repository}/{path} lacks an immutable blob"
+        )
+    return True
+
+
 def latest_run(
     token: str,
     repository: str,
     default_branch: str,
     workflow: Mapping[str, Any],
 ) -> Mapping[str, Any] | None:
+    """Read only the latest run explicitly bound to the default branch."""
     if workflow.get("state") != "active":
         return None
     workflow_id = workflow.get("id")
@@ -177,43 +250,67 @@ def latest_run(
         raise DigestError(
             f"active workflow in {repository} lacks a numeric id"
         )
-    for branch_suffix in (
-        f"&branch={urllib.parse.quote(default_branch, safe='')}",
-        "",
-    ):
-        _, payload = request_json(
-            token,
-            (
-                f"https://api.github.com/repos/{ORG}/{repository}/actions/"
-                f"workflows/{workflow_id}/runs?per_page=1{branch_suffix}"
-            ),
-            operation=f"read latest run for {repository}/{workflow_id}",
+    branch = urllib.parse.quote(default_branch, safe="")
+    _, payload = request_json(
+        token,
+        (
+            f"https://api.github.com/repos/{ORG}/{repository}/actions/"
+            f"workflows/{workflow_id}/runs?per_page=1&branch={branch}"
+        ),
+        operation=(
+            f"read latest default-branch run for "
+            f"{repository}/{workflow_id}@{default_branch}"
+        ),
+    )
+    runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
+    if not isinstance(runs, list):
+        raise DigestError(
+            f"workflow-run inventory for {repository}/{workflow_id} is malformed"
         )
-        runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
-        if not isinstance(runs, list):
-            raise DigestError(
-                f"workflow-run inventory for {repository}/{workflow_id} is malformed"
-            )
-        if runs:
-            run = runs[0]
-            if not isinstance(run, dict):
-                raise DigestError(
-                    f"latest workflow run for {repository}/{workflow_id} is malformed"
-                )
-            return run
-    return None
+    if not runs:
+        return None
+    run = runs[0]
+    if not isinstance(run, dict):
+        raise DigestError(
+            f"latest workflow run for {repository}/{workflow_id} is malformed"
+        )
+    observed_branch = str(run.get("head_branch") or "")
+    if observed_branch and observed_branch != default_branch:
+        raise DigestError(
+            f"branch-filtered workflow run for {repository}/{workflow_id} "
+            f"escaped {default_branch!r}: {observed_branch!r}"
+        )
+    return run
 
 
 def repository_reds(
     token: str,
     repository: Mapping[str, Any],
-) -> tuple[str, tuple[RedRun, ...], int]:
+) -> tuple[str, tuple[RedRun, ...], int, int, int]:
     name = str(repository["name"])
     default_branch = str(repository["default_branch"])
-    workflows = tuple(
-        item for item in list_workflows(token, name)
+    registered = tuple(
+        item
+        for item in list_workflows(token, name)
         if item.get("state") == "active"
     )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        existence = tuple(
+            executor.map(
+                lambda item: workflow_exists_on_default_branch(
+                    token,
+                    name,
+                    default_branch,
+                    item,
+                ),
+                registered,
+            )
+        )
+    workflows = tuple(
+        item for item, present in zip(registered, existence) if present
+    )
+    excluded = len(registered) - len(workflows)
 
     def inspect(workflow: Mapping[str, Any]) -> RedRun | None:
         run = latest_run(token, name, default_branch, workflow)
@@ -242,7 +339,7 @@ def repository_reds(
         for result in executor.map(inspect, workflows):
             if result is not None:
                 results.append(result)
-    return name, tuple(results), len(workflows)
+    return name, tuple(results), len(workflows), len(registered), excluded
 
 
 def sweep(
@@ -251,13 +348,20 @@ def sweep(
 ) -> tuple[dict[str, tuple[RedRun, ...]], dict[str, int]]:
     active = tuple(item for item in repositories if not item.get("archived"))
     reds: dict[str, tuple[RedRun, ...]] = {}
-    workflow_count = 0
+    default_branch_workflows = 0
+    registered_active_workflows = 0
+    excluded_non_default_workflows = 0
     with ThreadPoolExecutor(max_workers=8) as executor:
-        for name, repository_results, count in executor.map(
-            lambda item: repository_reds(token, item),
-            active,
-        ):
-            workflow_count += count
+        for (
+            name,
+            repository_results,
+            default_count,
+            registered_count,
+            excluded_count,
+        ) in executor.map(lambda item: repository_reds(token, item), active):
+            default_branch_workflows += default_count
+            registered_active_workflows += registered_count
+            excluded_non_default_workflows += excluded_count
             if repository_results:
                 reds[name] = repository_results
     coverage = {
@@ -265,7 +369,10 @@ def sweep(
         "active_repositories": len(active),
         "archived_repositories": len(repositories) - len(active),
         "queried_active_repositories": len(active),
-        "active_workflows": workflow_count,
+        "active_workflows": default_branch_workflows,
+        "default_branch_workflows": default_branch_workflows,
+        "registered_active_workflows": registered_active_workflows,
+        "excluded_non_default_workflows": excluded_non_default_workflows,
         "repository_floor": repository_floor(),
     }
     return reds, coverage
@@ -301,7 +408,11 @@ def build_body(
             "Coverage: **{organization_repositories} repositories** "
             "({active_repositories} active, {archived_repositories} archived); "
             "**{queried_active_repositories} active repositories queried**; "
-            "**{active_workflows} active workflows inspected**."
+            "**{default_branch_workflows} protected-default-branch workflows "
+            "inspected**. GitHub registered **{registered_active_workflows}** "
+            "active workflow entries; **{excluded_non_default_workflows}** were "
+            "excluded because their files are absent from the repository default "
+            "branch."
         ).format(**coverage),
         "",
         (
@@ -374,7 +485,9 @@ def build_body(
         [
             "---",
             (
-                "<sub>Dispositions are policy-classified in "
+                "<sub>The digest includes only workflow files proven present on "
+                "each repository's protected default branch and only runs bound "
+                "to that branch. Dispositions are policy-classified in "
                 "`.github/scripts/ci_health_digest_sweep.py` (`POLICY`). "
                 "Reclassify a red only with a documented reason; never silence "
                 "a real defect.</sub>"

--- a/.github/scripts/test_ci_health_digest_default_branch.py
+++ b/.github/scripts/test_ci_health_digest_default_branch.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Network-free tests for protected-default-branch CI health semantics."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import ci_health_digest_http as http
+import ci_health_digest_sweep as sweep
+
+
+def workflow(identifier: int, path: str, name: str = "Workflow"):
+    return {
+        "id": identifier,
+        "name": name,
+        "path": path,
+        "state": "active",
+    }
+
+
+class DefaultBranchWorkflowTests(unittest.TestCase):
+    def test_registered_branch_only_workflow_is_excluded_on_404(self):
+        with patch.object(
+            sweep,
+            "request_json",
+            side_effect=http.ApiError(
+                operation="lookup",
+                status=404,
+                detail_class="not_found_or_hidden",
+            ),
+        ):
+            self.assertFalse(
+                sweep.workflow_exists_on_default_branch(
+                    "token",
+                    "repo",
+                    "main",
+                    workflow(1, ".github/workflows/branch-only.yml"),
+                )
+            )
+
+    def test_default_branch_workflow_requires_exact_immutable_file(self):
+        payload = {
+            "type": "file",
+            "path": ".github/workflows/ci.yml",
+            "sha": "a" * 40,
+        }
+        with patch.object(sweep, "request_json", return_value=(200, payload)):
+            self.assertTrue(
+                sweep.workflow_exists_on_default_branch(
+                    "token",
+                    "repo",
+                    "main",
+                    workflow(1, ".github/workflows/ci.yml"),
+                )
+            )
+
+    def test_non_404_default_branch_lookup_failure_is_terminal(self):
+        with patch.object(
+            sweep,
+            "request_json",
+            side_effect=http.ApiError(
+                operation="lookup",
+                status=403,
+                detail_class="unauthorized",
+            ),
+        ):
+            with self.assertRaises(http.ApiError):
+                sweep.workflow_exists_on_default_branch(
+                    "token",
+                    "repo",
+                    "main",
+                    workflow(1, ".github/workflows/ci.yml"),
+                )
+
+    def test_latest_run_never_falls_back_to_another_branch(self):
+        with patch.object(
+            sweep,
+            "request_json",
+            return_value=(200, {"workflow_runs": []}),
+        ) as request:
+            observed = sweep.latest_run(
+                "token",
+                "repo",
+                "main",
+                workflow(1, ".github/workflows/ci.yml"),
+            )
+        self.assertIsNone(observed)
+        request.assert_called_once()
+        self.assertIn("branch=main", request.call_args.args[1])
+
+    def test_branch_filter_escape_fails_closed(self):
+        run = {
+            "head_branch": "feature/not-main",
+            "conclusion": "failure",
+        }
+        with patch.object(
+            sweep,
+            "request_json",
+            return_value=(200, {"workflow_runs": [run]}),
+        ):
+            with self.assertRaisesRegex(http.DigestError, "escaped"):
+                sweep.latest_run(
+                    "token",
+                    "repo",
+                    "main",
+                    workflow(1, ".github/workflows/ci.yml"),
+                )
+
+    def test_repository_counts_only_default_branch_workflows(self):
+        workflows = (
+            workflow(1, ".github/workflows/main.yml", "Main"),
+            workflow(2, ".github/workflows/branch.yml", "Branch only"),
+        )
+        red = {
+            "head_branch": "main",
+            "conclusion": "failure",
+            "run_number": 7,
+            "event": "push",
+            "html_url": "https://example.invalid/run/7",
+        }
+        with patch.object(
+            sweep,
+            "list_workflows",
+            return_value=workflows,
+        ), patch.object(
+            sweep,
+            "workflow_exists_on_default_branch",
+            side_effect=lambda _token, _repo, _branch, item: item["id"] == 1,
+        ), patch.object(sweep, "latest_run", return_value=red):
+            name, reds, default_count, registered_count, excluded = (
+                sweep.repository_reds(
+                    "token",
+                    {"name": "repo", "default_branch": "main"},
+                )
+            )
+        self.assertEqual(name, "repo")
+        self.assertEqual(len(reds), 1)
+        self.assertEqual(reds[0].workflow, "Main")
+        self.assertEqual(default_count, 1)
+        self.assertEqual(registered_count, 2)
+        self.assertEqual(excluded, 1)
+
+    def test_coverage_reports_registry_exclusions_explicitly(self):
+        repository_result = ("repo", (), 3, 5, 2)
+        with patch.object(
+            sweep,
+            "repository_reds",
+            return_value=repository_result,
+        ), patch.object(
+            sweep,
+            "repository_floor",
+            return_value=57,
+        ):
+            _, coverage = sweep.sweep(
+                "token",
+                (
+                    {
+                        "name": "repo",
+                        "default_branch": "main",
+                        "archived": False,
+                    },
+                ),
+            )
+        self.assertEqual(coverage["active_workflows"], 3)
+        self.assertEqual(coverage["default_branch_workflows"], 3)
+        self.assertEqual(coverage["registered_active_workflows"], 5)
+        self.assertEqual(coverage["excluded_non_default_workflows"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci-health-digest-default-branch-pr.yml
+++ b/.github/workflows/ci-health-digest-default-branch-pr.yml
@@ -1,0 +1,77 @@
+name: CI Health Digest — Default-Branch Evidence Verification
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/ci_health_digest.py
+      - .github/scripts/ci_health_digest_http.py
+      - .github/scripts/ci_health_digest_sweep.py
+      - .github/scripts/test_ci_health_digest.py
+      - .github/scripts/test_ci_health_digest_default_branch.py
+      - .github/workflows/ci-health-digest.yml
+      - .github/workflows/ci-health-digest-default-branch-pr.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-health-default-branch-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Default-branch workflow and run provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout proposed digest
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Compile and run all digest contracts without credentials
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/ci_health_digest.py \
+            .github/scripts/ci_health_digest_http.py \
+            .github/scripts/ci_health_digest_sweep.py \
+            .github/scripts/test_ci_health_digest.py \
+            .github/scripts/test_ci_health_digest_default_branch.py
+          python .github/scripts/test_ci_health_digest.py
+          python .github/scripts/test_ci_health_digest_default_branch.py
+          git diff --check
+
+      - name: Prove no arbitrary-branch fallback or credential path exists
+        shell: python
+        run: |
+          from pathlib import Path
+
+          source = Path(
+              ".github/scripts/ci_health_digest_sweep.py"
+          ).read_text(encoding="utf-8")
+          required = (
+              "workflow_exists_on_default_branch",
+              "/contents/",
+              "excluded_non_default_workflows",
+              "branch={branch}",
+              "never falls back",
+          )
+          forbidden = (
+              "for branch_suffix in",
+              "branch_suffix = ''",
+              "secrets.",
+              "contents: write",
+              "git push",
+          )
+          for marker in required:
+              assert marker in source, marker
+          for marker in forbidden:
+              assert marker not in source, marker

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -7,6 +7,11 @@ name: CI Health Digest
 # is active, the existing governed SZL_GITHUB_TOKEN is used read-only. The
 # ephemeral workflow token writes only issue #158 (or its exact-title
 # replacement) in this repository.
+#
+# Default-branch evidence boundary: GitHub's Actions registry can retain workflow
+# entries from feature or closed-PR branches. The digest proves every inspected
+# workflow file exists at the repository's current default branch and never
+# falls back to a run from another branch.
 
 on:
   schedule:
@@ -19,7 +24,9 @@ on:
       - .github/scripts/ci_health_digest_http.py
       - .github/scripts/ci_health_digest_sweep.py
       - .github/scripts/test_ci_health_digest.py
+      - .github/scripts/test_ci_health_digest_default_branch.py
       - .github/workflows/ci-health-digest.yml
+      - .github/workflows/ci-health-digest-default-branch-pr.yml
       - .governance/github-app-manifest.json
 
 permissions:
@@ -63,8 +70,10 @@ jobs:
             .github/scripts/ci_health_digest.py \
             .github/scripts/ci_health_digest_http.py \
             .github/scripts/ci_health_digest_sweep.py \
-            .github/scripts/test_ci_health_digest.py
+            .github/scripts/test_ci_health_digest.py \
+            .github/scripts/test_ci_health_digest_default_branch.py
           python .github/scripts/test_ci_health_digest.py
+          python .github/scripts/test_ci_health_digest_default_branch.py
           git diff --check
 
       - name: Mint preferred qillqaq organization reader
@@ -114,4 +123,4 @@ jobs:
             echo "::error::CI health digest is NOT VERIFIED. The rolling issue contains the fail-closed receipt."
             exit "$code"
           fi
-          echo "Organization CI health digest is current, authenticated, and evidence-bound."
+          echo "Organization CI health digest is current, authenticated, default-branch-bound, and evidence-bound."


### PR DESCRIPTION
## Satisfies

Satisfies: C-158

Tracks the verified follow-on defect exposed by the merged `szl.ci-health-digest/v2` controller.

## Measured root cause

Protected-main run at generation `8b5a09fa05cc98768b4d6004db52972b91b160b3` successfully authenticated and covered all 57 organization repositories, but reported 94 red workflows. The report itself exposed that many entries were temporary recovery/diagnostic workflows from feature or closed-PR branches.

Two source defects caused the inflation:

1. GitHub's Actions workflow registry can retain active registrations whose workflow file is absent from the repository default branch.
2. When no run existed on the default branch, `latest_run()` deliberately fell back to the latest run from **any branch**.

That converted closed diagnostic branches, signed-recovery controllers, and historical feature-branch failures into alleged protected-default-branch regressions.

## Permanent repair

- prove every inspected workflow path through the Contents API at the repository's current default branch;
- exclude a registry entry only when that exact path returns HTTP 404 at the default branch;
- fail closed on every non-404 lookup error, malformed path, non-file payload, path mismatch, or missing immutable blob SHA;
- query workflow runs only with an explicit `branch=<default>` filter;
- remove the arbitrary-branch fallback entirely;
- fail closed if GitHub returns a run whose `head_branch` escapes the requested default branch;
- distinguish in the evidence contract:
  - registered active workflow entries;
  - workflow files proven present on protected default branches;
  - registered entries excluded because their file is absent from the default branch;
- preserve `active_workflows` as a backward-compatible alias for the default-branch-proven count;
- add seven network-free regression tests and a credentialless pull-request verification workflow;
- run both the existing 13-test digest suite and the new provenance suite before every production sweep.

No workflow result is reclassified, waived, overwritten, or manufactured. No branch, ruleset, protection, review, status, check conclusion, secret, deployment, or repository is mutated by the digest.

## Verification

- rewritten sweep module compiles locally;
- seven new provenance tests pass locally;
- both workflow YAML files parse;
- protected CI on the exact published branch is authoritative;
- the merged production run must publish a current issue #158 and immutable artifact before the reduced red inventory is treated as real.

## Labels

Labels: PROVED default-branch lookup and no-fallback invariants; MEASURED 94-red registry/branch contamination; NOT CLAIMED corrected live count until protected-main execution.

## Rollback

Rollback through a protected, signed revert PR. Reverting restores arbitrary-branch fallback and allows branch-only workflow registrations to contaminate default-branch health.

## Risk class

Risk: C — read-only evidence-selection semantics for organization Actions health. Every unverifiable state remains terminal.

Solo-Operator-Authorization: confirmed

## Evidence checklist

- [ ] `gate/ground-truth` green
- [ ] `gate/labels` green
- [ ] `gate/schema` green
- [ ] `gate/adversarial` green
- [ ] `gate/verify-all` green
- [ ] `gate/provenance` green
- [ ] `gate/a11y-perf` green
- [ ] `gate/lean` green
- [x] No UI surface changed
- [x] No force merge, admin bypass, required-check removal, status fabrication, or protection reduction
- [x] Secret values remain sealed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>