### PR TITLE
fix(ci): isolate GitHub-managed dynamic workflow evidence

### DIFF
--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Complete default-branch workflow sweep and honest digest rendering.
+"""Complete workflow sweep with explicit evidence provenance.
 
-GitHub's Actions workflow registry can retain entries for workflow files that
-exist only on feature branches, closed pull-request branches, or other refs.
-Those registrations are not part of protected default-branch health. This
-module therefore proves that every inspected workflow file exists at the
-repository's current default branch and reads runs only through an explicit
-``branch=<default>`` filter. It never falls back to an arbitrary branch run.
+Source-controlled workflows are included only after their exact workflow file is
+proved at the repository's protected default branch, and their runs are read
+only through an explicit ``branch=<default>`` filter. GitHub-managed dynamic
+workflows, such as Dependabot Updates and default-setup CodeQL, have no
+repository file by design; they are admitted through a separate, explicitly
+labeled evidence lane and their own workflow endpoint. No source-controlled
+workflow ever falls back to an arbitrary branch run.
 """
 from __future__ import annotations
 
@@ -27,6 +28,8 @@ from ci_health_digest_http import (
 )
 
 RED = {"failure", "startup_failure", "timed_out", "action_required"}
+SOURCE_WORKFLOW_PREFIX = ".github/workflows/"
+DYNAMIC_WORKFLOW_PREFIX = "dynamic/"
 POLICY = [
     (
         "lambda-bounty",
@@ -49,7 +52,7 @@ POLICY = [
         "Dependabot Updates",
         (
             "INFRA",
-            "Dependabot runner state, not a workflow defect; resolves with the grouped update PR.",
+            "GitHub-managed Dependabot runner state; resolves with the grouped update PR.",
         ),
     ),
     (
@@ -57,7 +60,7 @@ POLICY = [
         "CodeQL",
         (
             "INFRA",
-            "CodeQL default-setup state; reconfigure through repository Security settings.",
+            "GitHub-managed CodeQL default-setup state; reconfigure through repository Security settings.",
         ),
     ),
     (
@@ -107,6 +110,7 @@ POLICY = [
 class RedRun:
     repository: str
     workflow: str
+    provenance: str
     conclusion: str
     run_number: int | None
     event: str | None
@@ -174,16 +178,35 @@ def list_workflows(
     return tuple(workflows)
 
 
-def _workflow_path(workflow: Mapping[str, Any], *, repository: str) -> str:
+def workflow_provenance(
+    workflow: Mapping[str, Any],
+    *,
+    repository: str,
+) -> tuple[str, str]:
+    """Classify one active registry entry into a reviewed evidence lane."""
     path = str(workflow.get("path") or "").strip().lstrip("/")
-    if (
-        not path.startswith(".github/workflows/")
-        or path.endswith("/")
-        or ".." in path.split("/")
-        or not path.lower().endswith((".yml", ".yaml"))
-    ):
+    if not path or path.endswith("/") or ".." in path.split("/"):
         raise DigestError(
             f"active workflow in {repository} has an invalid workflow path: {path!r}"
+        )
+    if path.startswith(SOURCE_WORKFLOW_PREFIX):
+        if not path.lower().endswith((".yml", ".yaml")):
+            raise DigestError(
+                f"source workflow in {repository} is not YAML: {path!r}"
+            )
+        return "protected_default_branch", path
+    if path.startswith(DYNAMIC_WORKFLOW_PREFIX):
+        return "github_managed_dynamic", path
+    raise DigestError(
+        f"active workflow in {repository} has an unsupported workflow path: {path!r}"
+    )
+
+
+def _workflow_path(workflow: Mapping[str, Any], *, repository: str) -> str:
+    provenance, path = workflow_provenance(workflow, repository=repository)
+    if provenance != "protected_default_branch":
+        raise DigestError(
+            f"workflow in {repository} has no repository-file path: {path!r}"
         )
     return path
 
@@ -194,11 +217,10 @@ def workflow_exists_on_default_branch(
     default_branch: str,
     workflow: Mapping[str, Any],
 ) -> bool:
-    """Prove that the registered workflow file exists at the default branch.
+    """Prove that a source-controlled workflow exists at the default branch.
 
-    A 404 means the Actions registry entry belongs to another ref and is safely
-    excluded from default-branch health. Every other API or payload failure is
-    terminal because the evidence boundary could not be proved.
+    A 404 means the registry entry belongs to another ref and is safely excluded
+    from default-branch health. Every other API or payload failure is terminal.
     """
     path = _workflow_path(workflow, repository=repository)
     encoded_path = urllib.parse.quote(path, safe="/")
@@ -236,32 +258,21 @@ def workflow_exists_on_default_branch(
     return True
 
 
-def latest_run(
-    token: str,
-    repository: str,
-    default_branch: str,
-    workflow: Mapping[str, Any],
-) -> Mapping[str, Any] | None:
-    """Read only the latest run explicitly bound to the default branch."""
-    if workflow.get("state") != "active":
-        return None
+def _workflow_id(workflow: Mapping[str, Any], repository: str) -> int:
     workflow_id = workflow.get("id")
     if not isinstance(workflow_id, int):
         raise DigestError(
             f"active workflow in {repository} lacks a numeric id"
         )
-    branch = urllib.parse.quote(default_branch, safe="")
-    _, payload = request_json(
-        token,
-        (
-            f"https://api.github.com/repos/{ORG}/{repository}/actions/"
-            f"workflows/{workflow_id}/runs?per_page=1&branch={branch}"
-        ),
-        operation=(
-            f"read latest default-branch run for "
-            f"{repository}/{workflow_id}@{default_branch}"
-        ),
-    )
+    return workflow_id
+
+
+def _one_run(
+    payload: Any,
+    *,
+    repository: str,
+    workflow_id: int,
+) -> Mapping[str, Any] | None:
     runs = payload.get("workflow_runs") if isinstance(payload, dict) else None
     if not isinstance(runs, list):
         raise DigestError(
@@ -274,6 +285,39 @@ def latest_run(
         raise DigestError(
             f"latest workflow run for {repository}/{workflow_id} is malformed"
         )
+    return run
+
+
+def latest_run(
+    token: str,
+    repository: str,
+    default_branch: str,
+    workflow: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Read only the latest source workflow run bound to the default branch."""
+    if workflow.get("state") != "active":
+        return None
+    provenance, _ = workflow_provenance(workflow, repository=repository)
+    if provenance != "protected_default_branch":
+        raise DigestError(
+            f"default-branch reader received {provenance} workflow in {repository}"
+        )
+    workflow_id = _workflow_id(workflow, repository)
+    branch = urllib.parse.quote(default_branch, safe="")
+    _, payload = request_json(
+        token,
+        (
+            f"https://api.github.com/repos/{ORG}/{repository}/actions/"
+            f"workflows/{workflow_id}/runs?per_page=1&branch={branch}"
+        ),
+        operation=(
+            f"read latest default-branch run for "
+            f"{repository}/{workflow_id}@{default_branch}"
+        ),
+    )
+    run = _one_run(payload, repository=repository, workflow_id=workflow_id)
+    if run is None:
+        return None
     observed_branch = str(run.get("head_branch") or "")
     if observed_branch and observed_branch != default_branch:
         raise DigestError(
@@ -283,10 +327,72 @@ def latest_run(
     return run
 
 
+def latest_dynamic_run(
+    token: str,
+    repository: str,
+    workflow: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Read one GitHub-managed dynamic workflow through its own registry ID.
+
+    Dynamic workflows have no repository file and therefore no file-ref lineage.
+    Their unfiltered endpoint is an explicit separate evidence contract, never a
+    fallback for a source-controlled workflow.
+    """
+    if workflow.get("state") != "active":
+        return None
+    provenance, _ = workflow_provenance(workflow, repository=repository)
+    if provenance != "github_managed_dynamic":
+        raise DigestError(
+            f"dynamic reader received {provenance} workflow in {repository}"
+        )
+    workflow_id = _workflow_id(workflow, repository)
+    _, payload = request_json(
+        token,
+        (
+            f"https://api.github.com/repos/{ORG}/{repository}/actions/"
+            f"workflows/{workflow_id}/runs?per_page=1"
+        ),
+        operation=(
+            f"read latest GitHub-managed dynamic run for "
+            f"{repository}/{workflow_id}"
+        ),
+    )
+    return _one_run(payload, repository=repository, workflow_id=workflow_id)
+
+
+def _red_run(
+    *,
+    repository: str,
+    workflow: Mapping[str, Any],
+    provenance: str,
+    run: Mapping[str, Any] | None,
+) -> RedRun | None:
+    if run is None:
+        return None
+    conclusion = str(run.get("conclusion") or "")
+    if conclusion not in RED:
+        return None
+    return RedRun(
+        repository=repository,
+        workflow=str(
+            workflow.get("name") or f"workflow-{workflow.get('id')}"
+        ),
+        provenance=provenance,
+        conclusion=conclusion,
+        run_number=(
+            int(run["run_number"])
+            if run.get("run_number") is not None
+            else None
+        ),
+        event=str(run.get("event")) if run.get("event") else None,
+        url=str(run.get("html_url")) if run.get("html_url") else None,
+    )
+
+
 def repository_reds(
     token: str,
     repository: Mapping[str, Any],
-) -> tuple[str, tuple[RedRun, ...], int, int, int]:
+) -> tuple[str, tuple[RedRun, ...], int, int, int, int]:
     name = str(repository["name"])
     default_branch = str(repository["default_branch"])
     registered = tuple(
@@ -294,6 +400,18 @@ def repository_reds(
         for item in list_workflows(token, name)
         if item.get("state") == "active"
     )
+    source_registered: list[Mapping[str, Any]] = []
+    dynamic_registered: list[Mapping[str, Any]] = []
+    for item in registered:
+        provenance, _ = workflow_provenance(item, repository=name)
+        if provenance == "protected_default_branch":
+            source_registered.append(item)
+        elif provenance == "github_managed_dynamic":
+            dynamic_registered.append(item)
+        else:  # defensive; workflow_provenance is exhaustive and fail-closed
+            raise DigestError(
+                f"workflow in {name} has unsupported provenance {provenance!r}"
+            )
 
     with ThreadPoolExecutor(max_workers=8) as executor:
         existence = tuple(
@@ -304,42 +422,48 @@ def repository_reds(
                     default_branch,
                     item,
                 ),
-                registered,
+                source_registered,
             )
         )
-    workflows = tuple(
-        item for item, present in zip(registered, existence) if present
+    source_workflows = tuple(
+        item
+        for item, present in zip(source_registered, existence)
+        if present
     )
-    excluded = len(registered) - len(workflows)
+    excluded = len(source_registered) - len(source_workflows)
 
-    def inspect(workflow: Mapping[str, Any]) -> RedRun | None:
-        run = latest_run(token, name, default_branch, workflow)
-        if run is None:
-            return None
-        conclusion = str(run.get("conclusion") or "")
-        if conclusion not in RED:
-            return None
-        return RedRun(
+    def inspect_source(workflow: Mapping[str, Any]) -> RedRun | None:
+        return _red_run(
             repository=name,
-            workflow=str(
-                workflow.get("name") or f"workflow-{workflow.get('id')}"
-            ),
-            conclusion=conclusion,
-            run_number=(
-                int(run["run_number"])
-                if run.get("run_number") is not None
-                else None
-            ),
-            event=str(run.get("event")) if run.get("event") else None,
-            url=str(run.get("html_url")) if run.get("html_url") else None,
+            workflow=workflow,
+            provenance="protected_default_branch",
+            run=latest_run(token, name, default_branch, workflow),
+        )
+
+    def inspect_dynamic(workflow: Mapping[str, Any]) -> RedRun | None:
+        return _red_run(
+            repository=name,
+            workflow=workflow,
+            provenance="github_managed_dynamic",
+            run=latest_dynamic_run(token, name, workflow),
         )
 
     results: list[RedRun] = []
     with ThreadPoolExecutor(max_workers=8) as executor:
-        for result in executor.map(inspect, workflows):
+        for result in executor.map(inspect_source, source_workflows):
             if result is not None:
                 results.append(result)
-    return name, tuple(results), len(workflows), len(registered), excluded
+        for result in executor.map(inspect_dynamic, dynamic_registered):
+            if result is not None:
+                results.append(result)
+    return (
+        name,
+        tuple(results),
+        len(source_workflows),
+        len(dynamic_registered),
+        len(registered),
+        excluded,
+    )
 
 
 def sweep(
@@ -349,6 +473,7 @@ def sweep(
     active = tuple(item for item in repositories if not item.get("archived"))
     reds: dict[str, tuple[RedRun, ...]] = {}
     default_branch_workflows = 0
+    github_managed_dynamic_workflows = 0
     registered_active_workflows = 0
     excluded_non_default_workflows = 0
     with ThreadPoolExecutor(max_workers=8) as executor:
@@ -356,21 +481,27 @@ def sweep(
             name,
             repository_results,
             default_count,
+            dynamic_count,
             registered_count,
             excluded_count,
         ) in executor.map(lambda item: repository_reds(token, item), active):
             default_branch_workflows += default_count
+            github_managed_dynamic_workflows += dynamic_count
             registered_active_workflows += registered_count
             excluded_non_default_workflows += excluded_count
             if repository_results:
                 reds[name] = repository_results
+    inspected_workflows = (
+        default_branch_workflows + github_managed_dynamic_workflows
+    )
     coverage = {
         "organization_repositories": len(repositories),
         "active_repositories": len(active),
         "archived_repositories": len(repositories) - len(active),
         "queried_active_repositories": len(active),
-        "active_workflows": default_branch_workflows,
+        "active_workflows": inspected_workflows,
         "default_branch_workflows": default_branch_workflows,
+        "github_managed_dynamic_workflows": github_managed_dynamic_workflows,
         "registered_active_workflows": registered_active_workflows,
         "excluded_non_default_workflows": excluded_non_default_workflows,
         "repository_floor": repository_floor(),
@@ -398,6 +529,24 @@ def build_body(
             total += 1
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    default_count = int(
+        coverage.get(
+            "default_branch_workflows",
+            coverage.get("active_workflows", 0),
+        )
+    )
+    dynamic_count = int(
+        coverage.get("github_managed_dynamic_workflows", 0)
+    )
+    registered_count = int(
+        coverage.get(
+            "registered_active_workflows",
+            default_count + dynamic_count,
+        )
+    )
+    excluded_count = int(
+        coverage.get("excluded_non_default_workflows", 0)
+    )
     lines = [
         (
             "_Auto-generated by `.github/workflows/ci-health-digest.yml`. "
@@ -405,15 +554,16 @@ def build_body(
         ),
         "",
         (
-            "Coverage: **{organization_repositories} repositories** "
-            "({active_repositories} active, {archived_repositories} archived); "
-            "**{queried_active_repositories} active repositories queried**; "
-            "**{default_branch_workflows} protected-default-branch workflows "
-            "inspected**. GitHub registered **{registered_active_workflows}** "
-            "active workflow entries; **{excluded_non_default_workflows}** were "
-            "excluded because their files are absent from the repository default "
-            "branch."
-        ).format(**coverage),
+            f"Coverage: **{coverage['organization_repositories']} repositories** "
+            f"({coverage['active_repositories']} active, "
+            f"{coverage['archived_repositories']} archived); "
+            f"**{coverage['queried_active_repositories']} active repositories queried**; "
+            f"**{default_count} protected-default-branch workflow files** and "
+            f"**{dynamic_count} GitHub-managed dynamic workflows** inspected. "
+            f"GitHub registered **{registered_count}** active workflow entries; "
+            f"**{excluded_count}** source-controlled registrations were excluded "
+            "because their files are absent from the repository default branch."
+        ),
         "",
         (
             f"Authentication mode: `{authentication_mode}`; "
@@ -456,8 +606,8 @@ def build_body(
             [
                 heading,
                 "",
-                "| Repo | Workflow | Result | Trigger | Note |",
-                "|---|---|---|---|---|",
+                "| Repo | Workflow | Evidence | Result | Trigger | Note |",
+                "|---|---|---|---|---|---|",
             ]
         )
         for red, note in sorted(
@@ -469,6 +619,7 @@ def build_body(
             )
             lines.append(
                 f"| `{red.repository}` | {workflow_cell} | "
+                f"`{red.provenance}` | "
                 f"{red.conclusion} (run#{red.run_number or ''}) | "
                 f"{red.event or ''} | {note} |"
             )
@@ -485,12 +636,14 @@ def build_body(
         [
             "---",
             (
-                "<sub>The digest includes only workflow files proven present on "
-                "each repository's protected default branch and only runs bound "
-                "to that branch. Dispositions are policy-classified in "
-                "`.github/scripts/ci_health_digest_sweep.py` (`POLICY`). "
-                "Reclassify a red only with a documented reason; never silence "
-                "a real defect.</sub>"
+                "<sub>Source-controlled workflows are included only when their "
+                "files are proven on each repository's protected default branch, "
+                "and their runs are branch-bound. GitHub-managed `dynamic/` "
+                "workflows are inspected through a separately labeled registry "
+                "lane with no repository-file claim. Dispositions are "
+                "policy-classified in `.github/scripts/ci_health_digest_sweep.py` "
+                "(`POLICY`). Reclassify a red only with a documented reason; "
+                "never silence a real defect.</sub>"
             ),
         ]
     )

--- a/.github/scripts/test_ci_health_digest_default_branch.py
+++ b/.github/scripts/test_ci_health_digest_default_branch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Network-free tests for protected-default-branch CI health semantics."""
+"""Network-free tests for workflow evidence provenance semantics."""
 from __future__ import annotations
 
 import unittest
@@ -18,7 +18,7 @@ def workflow(identifier: int, path: str, name: str = "Workflow"):
     }
 
 
-class DefaultBranchWorkflowTests(unittest.TestCase):
+class WorkflowProvenanceTests(unittest.TestCase):
     def test_registered_branch_only_workflow_is_excluded_on_404(self):
         with patch.object(
             sweep,
@@ -72,7 +72,7 @@ class DefaultBranchWorkflowTests(unittest.TestCase):
                     workflow(1, ".github/workflows/ci.yml"),
                 )
 
-    def test_latest_run_never_falls_back_to_another_branch(self):
+    def test_latest_source_run_never_falls_back_to_another_branch(self):
         with patch.object(
             sweep,
             "request_json",
@@ -106,17 +106,77 @@ class DefaultBranchWorkflowTests(unittest.TestCase):
                     workflow(1, ".github/workflows/ci.yml"),
                 )
 
-    def test_repository_counts_only_default_branch_workflows(self):
+    def test_dependabot_dynamic_path_has_distinct_provenance(self):
+        provenance, path = sweep.workflow_provenance(
+            workflow(
+                2,
+                "dynamic/dependabot/dependabot-updates",
+                "Dependabot Updates",
+            ),
+            repository="platform",
+        )
+        self.assertEqual(provenance, "github_managed_dynamic")
+        self.assertEqual(path, "dynamic/dependabot/dependabot-updates")
+
+    def test_unrecognized_non_file_path_fails_closed(self):
+        with self.assertRaisesRegex(http.DigestError, "unsupported workflow path"):
+            sweep.workflow_provenance(
+                workflow(2, "generated/unknown/workflow"),
+                repository="repo",
+            )
+
+    def test_dynamic_reader_is_explicitly_unfiltered_not_a_source_fallback(self):
+        run = {
+            "head_branch": "dependabot/npm_and_yarn/pkg-1.2.3",
+            "conclusion": "failure",
+        }
+        dynamic = workflow(
+            2,
+            "dynamic/dependabot/dependabot-updates",
+            "Dependabot Updates",
+        )
+        with patch.object(
+            sweep,
+            "request_json",
+            return_value=(200, {"workflow_runs": [run]}),
+        ) as request:
+            observed = sweep.latest_dynamic_run("token", "repo", dynamic)
+        self.assertIs(observed, run)
+        request.assert_called_once()
+        self.assertNotIn("branch=", request.call_args.args[1])
+
+    def test_source_reader_rejects_dynamic_workflow(self):
+        dynamic = workflow(
+            2,
+            "dynamic/dependabot/dependabot-updates",
+            "Dependabot Updates",
+        )
+        with self.assertRaisesRegex(http.DigestError, "dynamic"):
+            sweep.latest_run("token", "repo", "main", dynamic)
+
+    def test_repository_counts_source_dynamic_and_excluded_separately(self):
         workflows = (
             workflow(1, ".github/workflows/main.yml", "Main"),
             workflow(2, ".github/workflows/branch.yml", "Branch only"),
+            workflow(
+                3,
+                "dynamic/dependabot/dependabot-updates",
+                "Dependabot Updates",
+            ),
         )
-        red = {
+        source_red = {
             "head_branch": "main",
             "conclusion": "failure",
             "run_number": 7,
             "event": "push",
             "html_url": "https://example.invalid/run/7",
+        }
+        dynamic_red = {
+            "head_branch": "dependabot/npm_and_yarn/pkg-1.2.3",
+            "conclusion": "failure",
+            "run_number": 8,
+            "event": "dynamic",
+            "html_url": "https://example.invalid/run/8",
         }
         with patch.object(
             sweep,
@@ -126,22 +186,39 @@ class DefaultBranchWorkflowTests(unittest.TestCase):
             sweep,
             "workflow_exists_on_default_branch",
             side_effect=lambda _token, _repo, _branch, item: item["id"] == 1,
-        ), patch.object(sweep, "latest_run", return_value=red):
-            name, reds, default_count, registered_count, excluded = (
-                sweep.repository_reds(
-                    "token",
-                    {"name": "repo", "default_branch": "main"},
-                )
+        ), patch.object(
+            sweep,
+            "latest_run",
+            return_value=source_red,
+        ), patch.object(
+            sweep,
+            "latest_dynamic_run",
+            return_value=dynamic_red,
+        ):
+            (
+                name,
+                reds,
+                default_count,
+                dynamic_count,
+                registered_count,
+                excluded,
+            ) = sweep.repository_reds(
+                "token",
+                {"name": "repo", "default_branch": "main"},
             )
         self.assertEqual(name, "repo")
-        self.assertEqual(len(reds), 1)
-        self.assertEqual(reds[0].workflow, "Main")
+        self.assertEqual(len(reds), 2)
+        self.assertEqual(
+            {red.provenance for red in reds},
+            {"protected_default_branch", "github_managed_dynamic"},
+        )
         self.assertEqual(default_count, 1)
-        self.assertEqual(registered_count, 2)
+        self.assertEqual(dynamic_count, 1)
+        self.assertEqual(registered_count, 3)
         self.assertEqual(excluded, 1)
 
-    def test_coverage_reports_registry_exclusions_explicitly(self):
-        repository_result = ("repo", (), 3, 5, 2)
+    def test_coverage_reports_all_provenance_counts(self):
+        repository_result = ("repo", (), 3, 2, 7, 2)
         with patch.object(
             sweep,
             "repository_reds",
@@ -161,9 +238,10 @@ class DefaultBranchWorkflowTests(unittest.TestCase):
                     },
                 ),
             )
-        self.assertEqual(coverage["active_workflows"], 3)
+        self.assertEqual(coverage["active_workflows"], 5)
         self.assertEqual(coverage["default_branch_workflows"], 3)
-        self.assertEqual(coverage["registered_active_workflows"], 5)
+        self.assertEqual(coverage["github_managed_dynamic_workflows"], 2)
+        self.assertEqual(coverage["registered_active_workflows"], 7)
         self.assertEqual(coverage["excluded_non_default_workflows"], 2)
 
 

--- a/.github/workflows/ci-health-digest-default-branch-pr.yml
+++ b/.github/workflows/ci-health-digest-default-branch-pr.yml
@@ -62,7 +62,7 @@ jobs:
               "/contents/",
               "excluded_non_default_workflows",
               "branch={branch}",
-              "No source-controlled workflow ever falls back",
+              "workflow ever falls back",
               "DYNAMIC_WORKFLOW_PREFIX = \"dynamic/\"",
               "latest_dynamic_run",
               "github_managed_dynamic_workflows",

--- a/.github/workflows/ci-health-digest-default-branch-pr.yml
+++ b/.github/workflows/ci-health-digest-default-branch-pr.yml
@@ -1,4 +1,4 @@
-name: CI Health Digest — Default-Branch Evidence Verification
+name: CI Health Digest — Evidence Provenance Verification
 
 on:
   pull_request:
@@ -16,12 +16,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-health-default-branch-pr-${{ github.event.pull_request.number }}
+  group: ci-health-evidence-provenance-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   verify:
-    name: Default-branch workflow and run provenance
+    name: Default-branch files and GitHub-managed dynamic workflows
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -49,7 +49,7 @@ jobs:
           python .github/scripts/test_ci_health_digest_default_branch.py
           git diff --check
 
-      - name: Prove no arbitrary-branch fallback or credential path exists
+      - name: Prove source and dynamic evidence lanes cannot collapse
         shell: python
         run: |
           from pathlib import Path
@@ -63,6 +63,11 @@ jobs:
               "excluded_non_default_workflows",
               "branch={branch}",
               "never falls back",
+              "DYNAMIC_WORKFLOW_PREFIX = \"dynamic/\"",
+              "latest_dynamic_run",
+              "github_managed_dynamic_workflows",
+              "github_managed_dynamic",
+              "protected_default_branch",
           )
           forbidden = (
               "for branch_suffix in",

--- a/.github/workflows/ci-health-digest-default-branch-pr.yml
+++ b/.github/workflows/ci-health-digest-default-branch-pr.yml
@@ -62,7 +62,7 @@ jobs:
               "/contents/",
               "excluded_non_default_workflows",
               "branch={branch}",
-              "never falls back",
+              "No source-controlled workflow ever falls back",
               "DYNAMIC_WORKFLOW_PREFIX = \"dynamic/\"",
               "latest_dynamic_run",
               "github_managed_dynamic_workflows",


### PR DESCRIPTION
## Satisfies

Satisfies: C-158

## Measured root cause

The protected-main default-branch provenance repair merged as `fa4b719adf5bdfcc970b2b32d49c35871b1b3fe9` and correctly failed closed instead of publishing a false digest. A sealed read-only replay then isolated the first exact failure:

- repository: `platform`;
- workflow: `Dependabot Updates`;
- registry path: `dynamic/dependabot/dependabot-updates`;
- failure: the path has no repository workflow file by GitHub design;
- replay run: `30227934684`;
- artifact: `ci-health-first-failure-FAILURE_ISOLATED`;
- artifact digest: `sha256:5e7f6baa70aaf54a338d43452a0f18b762a719e0c6c431f9d4b815e337289673`.

The controller had one evidence lane—source-controlled `.github/workflows/*.yml` files—so it correctly rejected the GitHub-managed `dynamic/` path but could not finish the estate sweep.

## Permanent repair

- classify each active Actions registry entry into exactly one reviewed provenance lane:
  - `protected_default_branch` for source-controlled `.github/workflows/*.yml|yaml` files;
  - `github_managed_dynamic` for GitHub-owned `dynamic/*` workflows;
- continue proving every source-controlled workflow file through the Contents API at the repository default branch;
- continue excluding a source registration only on exact default-branch HTTP 404;
- continue failing closed on every other source-path, lookup, payload, branch, or immutable-blob error;
- keep source-controlled run reads explicitly bound to `branch=<default>` and prohibit fallback;
- read a dynamic workflow only through its own registry ID and unfiltered endpoint because no repository-file or branch-ref lineage exists for that GitHub-managed object;
- prohibit either reader from accepting the other provenance class;
- report protected-default-branch, GitHub-managed dynamic, registered-active, and excluded-non-default counts independently;
- attach provenance to every red-run receipt and issue-table row;
- retain Dependabot and default-setup CodeQL as explicit `INFRA` policy entries rather than silently discarding them;
- add regression coverage for the exact Dependabot path, dynamic/source reader isolation, unsupported path failure, and independent coverage accounting.

This is not arbitrary-branch fallback. Dynamic workflows are admitted through a separate typed contract; source-controlled workflows remain branch-bound.

## Verification

- source and test modules compile locally;
- the original digest suite remains wired into protected CI;
- the provenance suite now covers source files, branch-only registrations, GitHub-managed dynamic paths, reader isolation, unsupported paths, and coverage arithmetic;
- credentialless PR verification asserts both evidence lanes and still rejects the old fallback markers;
- protected CI on the exact published branch is authoritative;
- live estate health is not claimed until the merged production sweep updates issue #158 and emits a current immutable v2 artifact.

## Labels

Labels: PROVED typed source/dynamic provenance contracts and reader isolation; MEASURED exact Dependabot dynamic-path failure; NOT CLAIMED live corrected inventory until protected-main execution.

## Rollback

Revert through a protected, signed pull request. Reverting makes every GitHub-managed dynamic workflow an unprocessable path and returns the organization digest to `NOT_VERIFIED`.

## Risk class

Risk: C — read-only Actions evidence provenance. No workflow result, repository, run, check, status, ruleset, protection, review, secret, deployment, or code-security setting is mutated.

Solo-Operator-Authorization: confirmed

## Evidence checklist

- [ ] `gate/ground-truth` green
- [ ] `gate/labels` green
- [ ] `gate/schema` green
- [ ] `gate/adversarial` green
- [ ] `gate/verify-all` green
- [ ] `gate/provenance` green
- [ ] `gate/a11y-perf` green
- [ ] `gate/lean` green
- [x] No UI surface changed
- [x] No force merge, admin bypass, required-check removal, status fabrication, or protection reduction
- [x] Secret values remain sealed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>