### PR TITLE
fix(queue): enqueue exact attested pull requests

### DIFF
--- a/.github/scripts/test_merge_queue_enqueue.py
+++ b/.github/scripts/test_merge_queue_enqueue.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Source contract for the protected merge-queue enqueue controller."""
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/merge-queue-enqueue.yml"
+
+
+class MergeQueueEnqueueContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_uses_only_the_queue_mutation(self) -> None:
+        self.assertIn("enqueuePullRequest", self.source)
+        self.assertIn("expectedHeadOid", self.source)
+        forbidden = (
+            "mergePullRequest",
+            "gh pr merge",
+            "--admin",
+            "/merge\"",
+            "updatePullRequestBranch",
+            "updateRef",
+            "force=true",
+        )
+        for marker in forbidden:
+            self.assertNotIn(marker, self.source, marker)
+
+    def test_requires_exact_head_attestation_and_app_approval(self) -> None:
+        required = (
+            "attestation/qillqaq",
+            "qillqaq-attestor[bot]",
+            "commit_id == $head",
+            "CURRENT_HEAD",
+            "EXPECTED_HEAD",
+            "headRefOid",
+            "isDraft",
+            "GRAPH_STATE",
+            "CURRENT_STATE",
+            "'OPEN'",
+        )
+        for marker in required:
+            self.assertIn(marker, self.source, marker)
+
+    def test_is_same_repository_only_and_does_not_expose_token(self) -> None:
+        required = (
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            "secrets.SZL_GITHUB_TOKEN",
+            "direct_merge_attempted",
+            "bypass_used",
+            "token_value_recorded",
+        )
+        for marker in required:
+            self.assertIn(marker, self.source, marker)
+        self.assertNotIn("set -x", self.source)
+        self.assertNotIn("echo $GH_TOKEN", self.source)
+        self.assertNotIn("echo \"$GH_TOKEN\"", self.source)
+
+    def test_receipt_is_retained_and_never_claims_a_merge(self) -> None:
+        self.assertIn("retention-days: 90", self.source)
+        self.assertIn("merge-queue-enqueue-${{ github.run_id }}", self.source)
+        self.assertIn("merge_performed", self.source)
+        self.assertIn("false", self.source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_organization_control_sweep.py
+++ b/.github/scripts/test_organization_control_sweep.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Source contract for the protected-main organization control sweep."""
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/organization-control-sweep.yml"
+
+
+class OrganizationControlSweepTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_runs_sweeps_only_outside_pull_requests(self) -> None:
+        self.assertIn("github.event_name != 'pull_request'", self.source)
+        self.assertIn("branches: [main]", self.source)
+        self.assertIn("workflow_dispatch: {}", self.source)
+
+    def test_executes_all_four_canonical_controls(self) -> None:
+        required = (
+            ".github/scripts/ci_health_digest.py",
+            ".github/scripts/license_consistency.py",
+            ".github/scripts/hf_license_consistency.py",
+            ".github/scripts/public_repo_link_check.py",
+            "--include-private",
+            "--min-private 1",
+            "--min-private 5",
+            "--scan-docs",
+            "--check-deep-links",
+            "--fail-on-missing",
+        )
+        for marker in required:
+            self.assertIn(marker, self.source, marker)
+
+    def test_reports_are_immutable_and_not_pushed(self) -> None:
+        self.assertIn("retention-days: 90", self.source)
+        self.assertNotIn("git push", self.source)
+        self.assertNotIn("git commit", self.source)
+        self.assertNotIn("createPullRequest", self.source)
+
+    def test_private_coverage_and_fail_closed_tokens_remain_explicit(self) -> None:
+        required = (
+            "secrets.SZL_GITHUB_TOKEN",
+            "secrets.HF_ORG_TOKEN",
+            "QILLQAQ_CLIENT_ID",
+            "QILLQAQ_PRIVATE_KEY",
+            "Enforce organization-health result",
+            "Enforce GitHub-license result",
+            "Enforce Hugging Face-license result",
+            "Enforce public-link result",
+        )
+        for marker in required:
+            self.assertIn(marker, self.source, marker)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/materialize-signed-queue-replacement.yml
+++ b/.github/workflows/materialize-signed-queue-replacement.yml
@@ -1,0 +1,143 @@
+name: Materialize Signed Queue Replacement
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/materialize-signed-queue-replacement.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: materialize-signed-queue-replacement
+  cancel-in-progress: false
+
+jobs:
+  materialize:
+    name: Publish one GitHub-signed reviewed tree
+    if: >-
+      github.repository == 'szl-holdings/.github' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == 'fix/merge-queue-enqueue-controller-v2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SOURCE_HEAD: ${{ github.event.pull_request.head.sha }}
+      TARGET_BRANCH: fix/merge-queue-enqueue-controller-v3-signed
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Checkout exact reviewed source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Verify source and clean target lineage
+        id: lineage
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_observed="$(git rev-parse HEAD)"
+          test "$source_observed" = "$SOURCE_HEAD"
+          main_sha="$(gh api "repos/$REPOSITORY/branches/main" --jq .commit.sha)"
+          target_sha="$(gh api "repos/$REPOSITORY/branches/$TARGET_BRANCH" --jq .commit.sha)"
+          test "$target_sha" = "$main_sha" \
+            || { echo "::error::signed target branch is not cleanly rooted at current main"; exit 1; }
+          echo "target_sha=$target_sha" >> "$GITHUB_OUTPUT"
+          python .github/scripts/test_merge_queue_enqueue.py
+          python .github/scripts/test_organization_control_sweep.py
+          git diff --check
+
+      - name: Create one GitHub-signed commit on the clean branch
+        id: commit
+        shell: python
+        env:
+          EXPECTED_TARGET: ${{ steps.lineage.outputs.target_sha }}
+        run: |
+          import base64
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          files = [
+              '.github/scripts/test_merge_queue_enqueue.py',
+              '.github/scripts/test_organization_control_sweep.py',
+              '.github/workflows/merge-queue-enqueue.yml',
+              '.github/workflows/organization-control-sweep.yml',
+          ]
+          query = '''
+          mutation($input: CreateCommitOnBranchInput!) {
+            createCommitOnBranch(input: $input) {
+              commit { oid url }
+            }
+          }
+          '''
+          variables = {
+              'input': {
+                  'branch': {
+                      'repositoryNameWithOwner': os.environ['REPOSITORY'],
+                      'branchName': os.environ['TARGET_BRANCH'],
+                  },
+                  'message': {
+                      'headline': 'fix(queue): enqueue exact attested pull requests',
+                      'body': 'Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>',
+                  },
+                  'expectedHeadOid': os.environ['EXPECTED_TARGET'],
+                  'fileChanges': {
+                      'additions': [
+                          {
+                              'path': path,
+                              'contents': base64.b64encode(Path(path).read_bytes()).decode('ascii'),
+                          }
+                          for path in files
+                      ],
+                  },
+              }
+          }
+          request = urllib.request.Request(
+              'https://api.github.com/graphql',
+              data=json.dumps({'query': query, 'variables': variables}).encode('utf-8'),
+              method='POST',
+              headers={
+                  'Authorization': f"Bearer {os.environ['GH_TOKEN']}",
+                  'Accept': 'application/vnd.github+json',
+                  'Content-Type': 'application/json',
+                  'X-GitHub-Api-Version': '2022-11-28',
+                  'User-Agent': 'szl-signed-queue-replacement/1',
+              },
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  payload = json.loads(response.read())
+          except urllib.error.HTTPError as exc:
+              raise SystemExit(f'GraphQL HTTP {exc.code}') from exc
+          if payload.get('errors'):
+              print(json.dumps(payload['errors'], indent=2))
+              raise SystemExit(1)
+          commit = payload['data']['createCommitOnBranch']['commit']
+          print(json.dumps(commit, indent=2, sort_keys=True))
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f"sha={commit['oid']}\n")
+
+      - name: Verify signed commit and exact four-file tree
+        env:
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          test "$(gh api "repos/$REPOSITORY/branches/$TARGET_BRANCH" --jq .commit.sha)" = "$COMMIT_SHA"
+          test "$(gh api "repos/$REPOSITORY/commits/$COMMIT_SHA" --jq .commit.verification.verified)" = 'true'
+          test "$(gh api "repos/$REPOSITORY/commits/$COMMIT_SHA" --jq .commit.verification.reason)" = 'valid'
+          printf '%s\n' "$COMMIT_SHA" > signed-replacement-sha.txt
+
+      - name: Upload immutable signed-replacement receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signed-queue-replacement-${{ github.run_id }}
+          path: signed-replacement-sha.txt
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/merge-queue-enqueue.yml
+++ b/.github/workflows/merge-queue-enqueue.yml
@@ -1,0 +1,181 @@
+name: Protected Merge Queue Enqueue
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+  checks: read
+
+concurrency:
+  group: merge-queue-enqueue-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
+jobs:
+  enqueue:
+    name: Enqueue exact attested head without direct merge
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+      EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout the exact controller source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Verify the enqueue-only source contract
+        run: |
+          set -euo pipefail
+          mkdir -p reports/merge-queue-enqueue
+          printf '%s\n' '{"schema":"szl.merge-queue-enqueue-contract/v1","stage":"source-contract","result":"STARTED"}' \
+            > reports/merge-queue-enqueue/contract.json
+          python .github/scripts/test_merge_queue_enqueue.py
+          git diff --check
+
+      - name: Wait for exact-head App attestation and enqueue
+        id: enqueue
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "${GH_TOKEN:-}" ] \
+            || { echo "::error::governed SZL_GITHUB_TOKEN is unavailable"; exit 1; }
+
+          OWNER="${REPOSITORY%%/*}"
+          NAME="${REPOSITORY#*/}"
+          mkdir -p reports/merge-queue-enqueue
+
+          attested=0
+          for attempt in $(seq 1 120); do
+            gh api "repos/$REPOSITORY/pulls/$PR" \
+              > reports/merge-queue-enqueue/pull-request.json
+            CURRENT_HEAD="$(jq -r .head.sha reports/merge-queue-enqueue/pull-request.json)"
+            CURRENT_STATE="$(jq -r '.state | ascii_upcase' reports/merge-queue-enqueue/pull-request.json)"
+            CURRENT_DRAFT="$(jq -r .draft reports/merge-queue-enqueue/pull-request.json)"
+
+            [ "$CURRENT_HEAD" = "$EXPECTED_HEAD" ] \
+              || { echo "::error::pull request head moved from $EXPECTED_HEAD to $CURRENT_HEAD"; exit 1; }
+            [ "$CURRENT_STATE" = 'OPEN' ] \
+              || { echo "::error::pull request state is $CURRENT_STATE, not OPEN"; exit 1; }
+            [ "$CURRENT_DRAFT" = 'false' ] \
+              || { echo "::error::pull request returned to draft"; exit 1; }
+
+            gh api "repos/$REPOSITORY/commits/$EXPECTED_HEAD/status" \
+              > reports/merge-queue-enqueue/commit-status.json
+            STATUS_COUNT="$(jq '[.statuses[] | select(.context == "attestation/qillqaq" and .state == "success")] | length' reports/merge-queue-enqueue/commit-status.json)"
+
+            gh api "repos/$REPOSITORY/pulls/$PR/reviews?per_page=100" \
+              > reports/merge-queue-enqueue/reviews.json
+            APPROVAL_COUNT="$(jq --arg head "$EXPECTED_HEAD" '[.[] | select(
+              (.user.login == "qillqaq-attestor[bot]" or .user.login == "qillqaq-attestor")
+              and .state == "APPROVED"
+              and .commit_id == $head
+            )] | length' reports/merge-queue-enqueue/reviews.json)"
+
+            if [ "$STATUS_COUNT" -ge 1 ] && [ "$APPROVAL_COUNT" -ge 1 ]; then
+              attested=1
+              break
+            fi
+            sleep 10
+          done
+          [ "$attested" -eq 1 ] \
+            || { echo "::error::exact-head qillqaq attestation did not arrive"; exit 1; }
+
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id headRefOid isDraft state mergeQueueEntry{id}}}}' \
+            -F owner="$OWNER" \
+            -F name="$NAME" \
+            -F number="$PR" \
+            > reports/merge-queue-enqueue/queue-before.json
+
+          PULL_REQUEST_ID="$(jq -r .data.repository.pullRequest.id reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_HEAD="$(jq -r .data.repository.pullRequest.headRefOid reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_DRAFT="$(jq -r .data.repository.pullRequest.isDraft reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_STATE="$(jq -r .data.repository.pullRequest.state reports/merge-queue-enqueue/queue-before.json)"
+          QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-before.json)"
+
+          [ "$GRAPH_HEAD" = "$EXPECTED_HEAD" ] \
+            || { echo "::error::GraphQL head mismatch"; exit 1; }
+          [ "$GRAPH_DRAFT" = 'false' ] \
+            || { echo "::error::GraphQL reports draft state"; exit 1; }
+          [ "$GRAPH_STATE" = 'OPEN' ] \
+            || { echo "::error::GraphQL state is $GRAPH_STATE, not OPEN"; exit 1; }
+
+          if [ -n "$QUEUE_ENTRY" ]; then
+            RESULT='ALREADY_QUEUED'
+          else
+            set +e
+            gh api graphql \
+              -f query='mutation($id:ID!,$head:GitObjectID!){enqueuePullRequest(input:{pullRequestId:$id,expectedHeadOid:$head}){mergeQueueEntry{id}}}' \
+              -F id="$PULL_REQUEST_ID" \
+              -F head="$EXPECTED_HEAD" \
+              > reports/merge-queue-enqueue/enqueue-result.json 2> reports/merge-queue-enqueue/enqueue-error.txt
+            enqueue_code=$?
+            set -e
+
+            gh api graphql \
+              -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid mergeQueueEntry{id}}}}' \
+              -F owner="$OWNER" \
+              -F name="$NAME" \
+              -F number="$PR" \
+              > reports/merge-queue-enqueue/queue-after.json
+            QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-after.json)"
+            if [ "$enqueue_code" -ne 0 ] && [ -z "$QUEUE_ENTRY" ]; then
+              echo "::error::enqueuePullRequest failed and no queue entry exists"
+              cat reports/merge-queue-enqueue/enqueue-error.txt
+              exit "$enqueue_code"
+            fi
+            [ -n "$QUEUE_ENTRY" ] \
+              || { echo "::error::enqueue mutation returned no queue entry"; exit 1; }
+            RESULT='ENQUEUED'
+          fi
+
+          jq -n \
+            --arg schema 'szl.merge-queue-enqueue/v1' \
+            --arg repository "$REPOSITORY" \
+            --argjson pull_request "$PR" \
+            --arg head_sha "$EXPECTED_HEAD" \
+            --arg result "$RESULT" \
+            --arg queue_entry_id "$QUEUE_ENTRY" \
+            '{
+              schema: $schema,
+              repository: $repository,
+              pull_request: $pull_request,
+              head_sha: $head_sha,
+              result: $result,
+              queue_entry_id: $queue_entry_id,
+              exact_head_attestation_verified: true,
+              exact_head_app_approval_verified: true,
+              direct_merge_attempted: false,
+              bypass_used: false,
+              merge_performed: false,
+              token_value_recorded: false
+            }' > reports/merge-queue-enqueue/receipt.json
+          cat reports/merge-queue-enqueue/receipt.json
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable enqueue receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: merge-queue-enqueue-${{ github.run_id }}
+          path: reports/merge-queue-enqueue
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/organization-control-sweep.yml
+++ b/.github/workflows/organization-control-sweep.yml
@@ -1,0 +1,296 @@
+name: Organization Control Sweep
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/organization-control-sweep.yml
+      - .github/scripts/test_organization_control_sweep.py
+      - .github/scripts/ci_health_digest.py
+      - .github/scripts/ci_health_digest_http.py
+      - .github/scripts/ci_health_digest_sweep.py
+      - .github/scripts/license_consistency.py
+      - .github/scripts/hf_license_consistency.py
+      - .github/scripts/public_repo_link_check.py
+      - .github/data/license_allowlist.json
+      - .github/data/hf_license_allowlist.json
+      - .github/data/public_repo_link_allowlist.json
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/organization-control-sweep.yml
+      - .github/scripts/test_organization_control_sweep.py
+      - .github/scripts/ci_health_digest.py
+      - .github/scripts/ci_health_digest_http.py
+      - .github/scripts/ci_health_digest_sweep.py
+      - .github/scripts/license_consistency.py
+      - .github/scripts/hf_license_consistency.py
+      - .github/scripts/public_repo_link_check.py
+      - .github/data/license_allowlist.json
+      - .github/data/hf_license_allowlist.json
+      - .github/data/public_repo_link_allowlist.json
+  schedule:
+    - cron: "13 8 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: organization-control-sweep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Compile and test all control contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout exact source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Compile and execute network-free control tests
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/ci_health_digest.py \
+            .github/scripts/ci_health_digest_http.py \
+            .github/scripts/ci_health_digest_sweep.py \
+            .github/scripts/license_consistency.py \
+            .github/scripts/hf_license_consistency.py \
+            .github/scripts/public_repo_link_check.py \
+            .github/scripts/test_organization_control_sweep.py
+          python .github/scripts/test_ci_health_digest.py
+          python .github/scripts/test_ci_health_digest_default_branch.py
+          python .github/scripts/test_license_consistency.py
+          python .github/scripts/test_hf_license_consistency.py
+          python .github/scripts/test_public_repo_link_check.py
+          python .github/scripts/test_organization_control_sweep.py
+          git diff --check
+
+  organization-health:
+    name: Authenticated organization health
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout current protected main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Mint preferred qillqaq organization reader
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
+          private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-actions: read
+          permission-contents: read
+          permission-organization-administration: read
+      - name: Execute current organization-health controller
+        id: health
+        env:
+          DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set +e
+          mkdir -p reports/organization-control-sweep
+          python .github/scripts/ci_health_digest.py \
+            --report reports/organization-control-sweep/ci-health-digest.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload immutable organization-health evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: organization-health-${{ github.run_id }}
+          path: reports/organization-control-sweep/ci-health-digest.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Enforce organization-health result
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.health.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          test "$code" = '0' || { echo "::error::organization health is not verified"; exit "$code"; }
+          echo 'Organization health is verified from current protected main.'
+
+  github-license:
+    name: GitHub license consistency
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout current protected main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Execute private-inclusive GitHub license control
+        id: license
+        env:
+          GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+        run: |
+          set +e
+          mkdir -p reports/organization-control-sweep
+          python .github/scripts/license_consistency.py \
+            --include-private \
+            --min-private 1 \
+            --report reports/organization-control-sweep/github-license.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload immutable GitHub-license evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-license-${{ github.run_id }}
+          path: reports/organization-control-sweep/github-license.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Enforce GitHub-license result
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.license.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          test "$code" = '0' || { echo "::error::GitHub license consistency is red"; exit "$code"; }
+          echo 'GitHub license consistency is verified from current protected main.'
+
+  hugging-face-license:
+    name: Hugging Face license consistency
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout current protected main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Execute private-inclusive Hugging Face license control
+        id: license
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}
+        run: |
+          set +e
+          mkdir -p reports/organization-control-sweep
+          python .github/scripts/hf_license_consistency.py \
+            --include-private \
+            --min-private 5 \
+            --report reports/organization-control-sweep/hugging-face-license.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload immutable Hugging Face-license evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hugging-face-license-${{ github.run_id }}
+          path: reports/organization-control-sweep/hugging-face-license.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Enforce Hugging Face-license result
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.license.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          test "$code" = '0' || { echo "::error::Hugging Face license consistency is red"; exit "$code"; }
+          echo 'Hugging Face license consistency is verified from current protected main.'
+
+  public-links:
+    name: Public repository link reachability
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout current protected main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Execute deterministic public-link control
+        id: links
+        env:
+          SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          mkdir -p reports/organization-control-sweep
+          python .github/scripts/public_repo_link_check.py \
+            --scan-docs \
+            --check-deep-links \
+            --fail-on-missing \
+            --report reports/organization-control-sweep/public-links.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload immutable public-link evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: public-links-${{ github.run_id }}
+          path: reports/organization-control-sweep/public-links.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Enforce public-link result
+        if: always()
+        env:
+          EXIT_CODE: ${{ steps.links.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          test "$code" = '0' || { echo "::error::public-link reachability is red"; exit "$code"; }
+          echo 'Public-link reachability is verified from current protected main.'


### PR DESCRIPTION
## Satisfies

Satisfies: C-158.

## Measured root cause

FORGE-9 produces an exact-head qillqaq approval, signed merge BAP, and `attestation/qillqaq` success status, then calls `gh pr merge --auto --squash`. On this repository, that enables auto-merge but does not create a merge-queue entry. PRs #341 and #342 therefore remain open despite every required check and attestation being green.

The first implementation in #343 reached the native GraphQL `enqueuePullRequest` mutation, which rejected the branch because it contained unsigned commits. This replacement starts from protected `main` and recreates the same reviewed four-file tree through GitHub’s signed contents API. No history was rewritten.

## Permanent repair

- run only for non-draft, same-repository pull requests to `main`;
- bind every decision to the exact immutable PR head;
- wait for exact-head `attestation/qillqaq=success` and exact-head qillqaq App approval;
- verify the PR remains open and non-draft;
- use GraphQL `enqueuePullRequest` with `expectedHeadOid`;
- treat an existing queue entry as idempotent success;
- never call a direct merge mutation, REST merge endpoint, branch update, force update, or administrative bypass;
- upload a 90-day machine-readable enqueue receipt containing no token material;
- add one protected-main organization sweep for CI health, GitHub licenses, Hugging Face licenses, and public links.

The governed organization token is used only to enter the ruleset-required queue and to execute read-only organization controls. Merge groups remain subject to all existing protected checks.

## Bootstrap boundary

This exact signed branch is expected to enqueue itself after FORGE-9, qillqaq approval, and attestation become green. Once protected on `main`, the controller advances already-attested #341 and #342 through the same queue path.

## Verification

The final tree is content-equivalent to the reviewed source in #343. Every replacement commit includes a DCO trailer and was created through GitHub’s contents API so the queue’s required-signature rule can verify it.

## Labels

Labels: PROVED enqueue-only exact-head source contract and signed replacement lineage; MEASURED native enqueue rejection of the unsigned predecessor; NOT CLAIMED merge completion until merge-group checks pass and GitHub records the merge.

## Rollback

Rollback: revert through a protected pull request. Reverting restores the observed state where attestations succeed but no merge-queue entry is created.

## Risk class

Risk: D — protected merge-path control. The change adds no bypass and delegates the actual merge exclusively to the existing merge queue and merge-group checks.

Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>