### PR TITLE
fix(hf): handle empty kernel metadata revisions

### DIFF
--- a/.github/scripts/hf_release_finalization_git.py
+++ b/.github/scripts/hf_release_finalization_git.py
@@ -45,24 +45,33 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             raise RuntimeError("release finalizer must use the CPU PyTorch runtime")
         return {"numpy": numpy.__version__, "torch": torch.__version__}
 
+    def _kernel_metadata_revision(self, repo_id: str) -> tuple[str, str]:
+        try:
+            revision = str(getattr(self.api.kernel_info(repo_id), "sha", "") or "")
+            source = "kernel-api+git"
+        except ValueError as exc:
+            if str(exc) != "min() iterable argument is empty":
+                raise
+            revision = self.kernel_transport.snapshot(repo_id).revision
+            source = "authenticated-kernel-hub-git-fallback"
+        if len(revision) != 40:
+            raise RuntimeError(f"Kernel metadata lacks an immutable revision: {repo_id}")
+        return revision, source
+
     def finalize_kernel(self, repo_id: str, spec: Mapping[str, str]) -> None:
         source_dir = self.roots[spec["source_root"]] / spec["source_dir"]
         for filename in ("README.md", "contract.json"):
             if not (source_dir / filename).is_file():
                 raise RuntimeError(f"Kernel source contract is incomplete: {source_dir}")
 
-        metadata_before = str(getattr(self.api.kernel_info(repo_id), "sha", "") or "")
-        if len(metadata_before) != 40:
-            raise RuntimeError(f"Kernel metadata lacks an immutable revision: {repo_id}")
+        metadata_before, metadata_source = self._kernel_metadata_revision(repo_id)
 
         if self.publish:
             publication = self.kernel_transport.publish(
                 repo_id=repo_id,
                 source_dir=source_dir,
                 metadata_revision=metadata_before,
-                metadata_revision_after=lambda: str(
-                    getattr(self.api.kernel_info(repo_id), "sha", "") or ""
-                ),
+                metadata_revision_after=lambda: self._kernel_metadata_revision(repo_id)[0],
                 generation=self.generation,
             )
             action_status = "updated" if publication.changed else "validated"
@@ -93,7 +102,8 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             "kernel-card-publish",
             action_status,
             f"before={publication.before_revision}; after={publication.revision}; "
-            f"changed={publication.changed}; transport=git",
+            f"changed={publication.changed}; transport=git; "
+            f"metadata_source={metadata_source}",
         )
         selfcheck = self._kernel_selfcheck(repo_id, publication.revision)
         self.results.setdefault("kernels", {})[repo_id] = {
@@ -101,6 +111,7 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             "after_sha": publication.revision,
             "revision": publication.revision,
             "transport": "authenticated-kernel-hub-git",
+            "metadata_revision_source": metadata_source,
             "changed": publication.changed,
             "remote_file_count": publication.remote_file_count,
             "build_variants_preserved": publication.build_variants_preserved,

--- a/.github/scripts/test_hf_release_finalization_git.py
+++ b/.github/scripts/test_hf_release_finalization_git.py
@@ -34,10 +34,13 @@ class FakeTransport:
 
 
 class FakeApi:
-    def __init__(self, revision="a" * 40):
+    def __init__(self, revision="a" * 40, error=None):
         self.revision = revision
+        self.error = error
 
     def kernel_info(self, repo_id):
+        if self.error is not None:
+            raise self.error
         return SimpleNamespace(sha=self.revision)
 
 
@@ -85,6 +88,44 @@ class KernelGitFinalizerTests(unittest.TestCase):
             self.assertEqual(result["revision"], "b" * 40)
             self.assertTrue(result["build_variants_preserved"])
             self.assertTrue(result["card_contract_byte_parity"])
+        finally:
+            tmp.cleanup()
+
+    def test_empty_kernel_api_builds_fall_back_to_authenticated_git(self):
+        tmp, instance = self.make_instance()
+        instance.api = FakeApi(error=ValueError("min() iterable argument is empty"))
+        instance.kernel_transport.snapshot_value = KernelSnapshot(
+            repo_id="SZLHOLDINGS/example",
+            revision="a" * 40,
+            files=("README.md", "contract.json", "build/cpu/__init__.py"),
+            build_tree_sha256="c" * 64,
+            remote_url="https://huggingface.co/kernels/SZLHOLDINGS/example",
+        )
+        try:
+            instance.finalize_kernel(
+                "SZLHOLDINGS/example",
+                {"source_root": "energy", "source_dir": "hf-kernels/example"},
+            )
+            call = instance.kernel_transport.publish_calls[0]
+            self.assertEqual(call["metadata_revision"], "a" * 40)
+            result = instance.results["kernels"]["SZLHOLDINGS/example"]
+            self.assertEqual(
+                result["metadata_revision_source"],
+                "authenticated-kernel-hub-git-fallback",
+            )
+        finally:
+            tmp.cleanup()
+
+    def test_unrelated_kernel_api_value_error_still_fails_closed(self):
+        tmp, instance = self.make_instance()
+        instance.api = FakeApi(error=ValueError("malformed kernel metadata"))
+        try:
+            with self.assertRaisesRegex(ValueError, "malformed kernel metadata"):
+                instance.finalize_kernel(
+                    "SZLHOLDINGS/example",
+                    {"source_root": "energy", "source_dir": "hf-kernels/example"},
+                )
+            self.assertFalse(instance.kernel_transport.publish_calls)
         finally:
             tmp.cleanup()
 


### PR DESCRIPTION
## Outcome

Provides a signed current-main replacement for #353 and repairs the Hugging Face release finalizer failure recorded in #301 without weakening publication, build-preservation, or fail-closed gates.

## Root cause

The supported Hugging Face Kernel API raises `ValueError: min() iterable argument is empty` for a first-class Kernel whose build metadata collection is empty. Lake publication and the first Kernel Git verification completed, then the second Kernel failed before its authenticated Git transport could run.

## Change

- retain the Kernel API revision when it returns a valid immutable SHA;
- only for the exact observed empty-build aggregation error, resolve the immutable revision from the authenticated Kernel Hub Git snapshot;
- preserve failure for every other metadata exception or malformed revision;
- record `metadata_revision_source` in the release receipt;
- add regressions for the narrow fallback and unrelated-error fail-closed path.

## Validation

- targeted finalizer regression suite: 8/8 passed locally;
- Python compilation passed locally;
- tree is byte-identical to #353, whose protected read-only transport/source verification and substantive security/test checks passed;
- commit `c41c63cbb760f21853cafbd884c37e103e99b80e` has a verified SSH signature and DCO trailer.

## Boundaries

No model, dataset receipt, Kernel build, visibility, hardware, secret, ruleset, or workflow policy is changed. Candidate publication scope is unchanged. Protected CI and the post-merge publication workflow remain authoritative.

Closes #301.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>