### PR TITLE
fix(hf): verify empty-metadata kernels from exact Git

### DIFF
--- a/.github/scripts/hf_release_finalization_git.py
+++ b/.github/scripts/hf_release_finalization_git.py
@@ -58,6 +58,39 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             raise RuntimeError(f"Kernel metadata lacks an immutable revision: {repo_id}")
         return revision, source
 
+    @staticmethod
+    def _execute_selfcheck(repo_id: str, revision: str, module: Any) -> Any:
+        check = getattr(module, "selfcheck", None)
+        if not callable(check):
+            raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+        result = check()
+        if result is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck returned false")
+        if isinstance(result, dict) and result.get("ok") is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck failed: {result}")
+        return result
+
+    def _kernel_selfcheck(self, repo_id: str, revision: str) -> Any:
+        from kernels import get_kernel, get_local_kernel
+
+        try:
+            module = get_kernel(
+                repo_id,
+                revision=revision,
+                trust_remote_code=True,
+            )
+        except ValueError as exc:
+            if str(exc) != "min() iterable argument is empty":
+                raise
+            with self.kernel_transport.materialize_build(repo_id, revision) as repo:
+                module = get_local_kernel(repo)
+                result = self._execute_selfcheck(repo_id, revision, module)
+            self._last_selfcheck_transport = "authenticated-kernel-hub-git-fallback"
+            return result
+
+        self._last_selfcheck_transport = "kernel-api"
+        return self._execute_selfcheck(repo_id, revision, module)
+
     def finalize_kernel(self, repo_id: str, spec: Mapping[str, str]) -> None:
         source_dir = self.roots[spec["source_root"]] / spec["source_dir"]
         for filename in ("README.md", "contract.json"):
@@ -112,6 +145,11 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             "revision": publication.revision,
             "transport": "authenticated-kernel-hub-git",
             "metadata_revision_source": metadata_source,
+            "selfcheck_transport": getattr(
+                self,
+                "_last_selfcheck_transport",
+                "unknown",
+            ),
             "changed": publication.changed,
             "remote_file_count": publication.remote_file_count,
             "build_variants_preserved": publication.build_variants_preserved,

--- a/.github/scripts/kernel_hub_git.py
+++ b/.github/scripts/kernel_hub_git.py
@@ -204,6 +204,58 @@ class KernelHubGitTransport:
             repo, _ = self._fetch_main(repo_id, Path(raw))
             return self._snapshot_from_repo(repo_id, repo)
 
+    @contextmanager
+    def materialize_build(
+        self,
+        repo_id: str,
+        expected_revision: str,
+    ) -> Iterator[Path]:
+        """Yield the exact remote build tree without using the Kernel metadata API."""
+        expected = str(expected_revision or "").strip().lower()
+        if not SHA40.fullmatch(expected):
+            raise ValueError(
+                f"expected Kernel revision is not an immutable SHA: {expected!r}"
+            )
+
+        with tempfile.TemporaryDirectory(
+            prefix="szl-kernel-build-",
+            dir=self.temp_root,
+        ) as raw:
+            repo, _ = self._fetch_main(repo_id, Path(raw))
+            observed = self._git(
+                ["rev-parse", "FETCH_HEAD"],
+                cwd=repo,
+            ).stdout.strip().lower()
+            if observed != expected:
+                raise KernelGitError(
+                    "Kernel main moved before exact build materialization: "
+                    f"expected {expected}, observed {observed}; repo={repo_id}"
+                )
+
+            with self._auth_environment() as env:
+                self._git(
+                    ["sparse-checkout", "init", "--no-cone"],
+                    cwd=repo,
+                    env=env,
+                )
+                self._git(
+                    ["sparse-checkout", "set", "build"],
+                    cwd=repo,
+                    env=env,
+                )
+                self._git(
+                    ["checkout", "-q", "--detach", "FETCH_HEAD"],
+                    cwd=repo,
+                    env=env,
+                )
+
+            build = repo / "build"
+            if not build.is_dir() or not any(path.is_file() for path in build.rglob("*")):
+                raise KernelGitError(
+                    f"Kernel repository has no materialized build variants: {repo_id}"
+                )
+            yield repo
+
     def _sparse_checkout(self, repo_id: str, root: Path) -> Path:
         repo, _ = self._fetch_main(repo_id, root)
         with self._auth_environment() as env:

--- a/.github/scripts/test_hf_release_finalization_git.py
+++ b/.github/scripts/test_hf_release_finalization_git.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -23,6 +24,7 @@ class FakeTransport:
         self.snapshot_value = snapshot
         self.publish_calls = []
         self.snapshot_calls = []
+        self.materialize_calls = []
 
     def publish(self, **kwargs):
         self.publish_calls.append(kwargs)
@@ -31,6 +33,11 @@ class FakeTransport:
     def snapshot(self, repo_id):
         self.snapshot_calls.append(repo_id)
         return self.snapshot_value
+
+    @contextmanager
+    def materialize_build(self, repo_id, revision):
+        self.materialize_calls.append((repo_id, revision))
+        yield pathlib.Path("materialized-kernel")
 
 
 class FakeApi:
@@ -45,7 +52,7 @@ class FakeApi:
 
 
 class KernelGitFinalizerTests(unittest.TestCase):
-    def make_instance(self, *, publish=True):
+    def make_instance(self, *, publish=True, stub_selfcheck=True):
         tmp = tempfile.TemporaryDirectory()
         root = pathlib.Path(tmp.name)
         source = root / "energy" / "hf-kernels" / "example"
@@ -72,7 +79,8 @@ class KernelGitFinalizerTests(unittest.TestCase):
         instance.kernel_transport = FakeTransport(publication=publication)
         instance.actions = []
         instance.results = {}
-        instance._kernel_selfcheck = lambda repo_id, revision: {"ok": True}
+        if stub_selfcheck:
+            instance._kernel_selfcheck = lambda repo_id, revision: {"ok": True}
         return tmp, instance
 
     def test_kernel_publication_delegates_to_git_transport(self):
@@ -126,6 +134,87 @@ class KernelGitFinalizerTests(unittest.TestCase):
                     {"source_root": "energy", "source_dir": "hf-kernels/example"},
                 )
             self.assertFalse(instance.kernel_transport.publish_calls)
+        finally:
+            tmp.cleanup()
+
+    def test_controller_selfcheck_falls_back_to_exact_git_build(self):
+        tmp, instance = self.make_instance(stub_selfcheck=False)
+        module = SimpleNamespace(selfcheck=lambda: {"ok": True, "source": "git"})
+        fake_kernels = SimpleNamespace(
+            get_kernel=unittest.mock.Mock(
+                side_effect=ValueError("min() iterable argument is empty")
+            ),
+            get_local_kernel=unittest.mock.Mock(return_value=module),
+        )
+        try:
+            with unittest.mock.patch.dict(sys.modules, {"kernels": fake_kernels}):
+                instance.finalize_kernel(
+                    "SZLHOLDINGS/example",
+                    {"source_root": "energy", "source_dir": "hf-kernels/example"},
+                )
+
+            self.assertEqual(
+                instance.kernel_transport.materialize_calls,
+                [("SZLHOLDINGS/example", "b" * 40)],
+            )
+            fake_kernels.get_local_kernel.assert_called_once_with(
+                pathlib.Path("materialized-kernel")
+            )
+            result = instance.results["kernels"]["SZLHOLDINGS/example"]
+            self.assertEqual(
+                result["selfcheck_transport"],
+                "authenticated-kernel-hub-git-fallback",
+            )
+            self.assertEqual(result["selfcheck"], {"ok": True, "source": "git"})
+        finally:
+            tmp.cleanup()
+
+    def test_controller_selfcheck_rejects_unrelated_value_error(self):
+        tmp, instance = self.make_instance(stub_selfcheck=False)
+        fake_kernels = SimpleNamespace(
+            get_kernel=unittest.mock.Mock(
+                side_effect=ValueError("malformed build metadata")
+            ),
+            get_local_kernel=unittest.mock.Mock(),
+        )
+        try:
+            with unittest.mock.patch.dict(sys.modules, {"kernels": fake_kernels}):
+                with self.assertRaisesRegex(ValueError, "malformed build metadata"):
+                    instance.finalize_kernel(
+                        "SZLHOLDINGS/example",
+                        {"source_root": "energy", "source_dir": "hf-kernels/example"},
+                    )
+            self.assertFalse(instance.kernel_transport.materialize_calls)
+        finally:
+            tmp.cleanup()
+
+    def test_selfcheck_fallback_is_revision_bound_and_metadata_api_free(self):
+        tmp, instance = self.make_instance(stub_selfcheck=False)
+        instance.api = unittest.mock.Mock()
+        module = SimpleNamespace(selfcheck=lambda: {"ok": True})
+        fake_kernels = SimpleNamespace(
+            get_kernel=unittest.mock.Mock(
+                side_effect=ValueError("min() iterable argument is empty")
+            ),
+            get_local_kernel=unittest.mock.Mock(return_value=module),
+        )
+        try:
+            with unittest.mock.patch.dict(sys.modules, {"kernels": fake_kernels}):
+                result = finalizer.KernelGitFinalizer._kernel_selfcheck(
+                    instance,
+                    "SZLHOLDINGS/example",
+                    "e" * 40,
+                )
+
+            self.assertEqual(result, {"ok": True})
+            self.assertEqual(instance.api.mock_calls, [])
+            self.assertEqual(
+                instance.kernel_transport.materialize_calls,
+                [("SZLHOLDINGS/example", "e" * 40)],
+            )
+            fake_kernels.get_local_kernel.assert_called_once_with(
+                pathlib.Path("materialized-kernel")
+            )
         finally:
             tmp.cleanup()
 

--- a/.github/scripts/test_kernel_hub_git.py
+++ b/.github/scripts/test_kernel_hub_git.py
@@ -151,6 +151,29 @@ class KernelHubGitTransportTests(unittest.TestCase):
             }
         self.assertEqual(visible, {"README.md", "contract.json"})
 
+    def test_exact_build_materialization_is_read_only_and_revision_bound(self) -> None:
+        before = self.head()
+        with self.transport.materialize_build(self.repo_id, before) as repo:
+            visible = {
+                str(path.relative_to(repo)).replace("\\", "/")
+                for path in repo.rglob("*")
+                if path.is_file() and ".git" not in path.parts
+            }
+            self.assertEqual(
+                visible,
+                {"build/torch27-cpu/__init__.py"},
+            )
+            self.assertEqual(
+                (repo / "build" / "torch27-cpu" / "__init__.py").read_text(),
+                "BUILD = 'immutable'\n",
+            )
+        self.assertEqual(before, self.head())
+
+    def test_exact_build_materialization_rejects_moved_main(self) -> None:
+        with self.assertRaisesRegex(KernelGitError, "main moved"):
+            with self.transport.materialize_build(self.repo_id, "0" * 40):
+                self.fail("mismatched revision must not materialize")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Outcome

Repairs the still-failing real controller path after #354. Post-merge run [30379450034](https://github.com/szl-holdings/.github/actions/runs/30379450034) disproved the first hypothesis: Kernel metadata revision resolution succeeded, but `kernels.get_kernel(...)` raised `ValueError: min() iterable argument is empty` during exact-revision selfcheck.

## Root cause

The exception occurs after `[validated] kernel-card-publish` and before `kernel-verify`. The pinned `kernels==0.16.0` package asks the Kernel metadata API to enumerate build variants even when the already verified Git repository contains a valid `build/torch-cpu` tree. The #354 fallback surrounded the earlier metadata-revision call, not this loader call.

## Change

- catch only the exact observed empty-build `ValueError` around `kernels.get_kernel`;
- materialize only `build/**` from authenticated Kernel Hub Git;
- require the fetched `main` revision to equal the already bound immutable 40-character revision;
- pass the repository root to pinned `kernels.get_local_kernel`, whose local resolver checks `repo/build`;
- run the same callable/selfcheck result validation and record the selected selfcheck transport;
- preserve every unrelated metadata, load, dependency, revision-drift, and selfcheck error as fail-closed.

## Validation

- 11 finalizer tests passed locally, including the real `finalize_kernel` call path;
- 2 focused Git transport tests passed locally;
- Python compilation passed;
- exact-revision binding, moved-main rejection, read-only materialization, repository-root loading, no metadata-API call in the fallback, and unrelated-error rejection are covered;
- live public Kernel Git trees were observed at `governed-inference-meter@dd133d351d5d77ff666ce16d452edfdfdc3f1a61` and `szl-governed-norm@52ebdccd8d181e2b367387353ad87484e2d9d8b3`, both with `build/torch-cpu/**` variants;
- commit `2670c692009764b74b7522383f921069b3e9cc1e` has a verified SSH signature and DCO trailer.

## Boundaries

This does not mutate model, dataset receipt, Kernel build, visibility, hardware, secrets, rulesets, or workflow policy. It does not convert a failed selfcheck into success; it gives the exact existing build a second supported local loading path and still requires its actual `selfcheck()` to pass.

Reopens/follows #301.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>