### PR TITLE
fix(hf): verify kernels through exact git checkout

### DIFF
--- a/.github/scripts/hf_release_finalization_git.py
+++ b/.github/scripts/hf_release_finalization_git.py
@@ -46,17 +46,26 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
         return {"numpy": numpy.__version__, "torch": torch.__version__}
 
     def _kernel_metadata_revision(self, repo_id: str) -> tuple[str, str]:
-        try:
-            revision = str(getattr(self.api.kernel_info(repo_id), "sha", "") or "")
-            source = "kernel-api+git"
-        except ValueError as exc:
-            if str(exc) != "min() iterable argument is empty":
-                raise
-            revision = self.kernel_transport.snapshot(repo_id).revision
-            source = "authenticated-kernel-hub-git-fallback"
+        revision = self.kernel_transport.snapshot(repo_id).revision
+        source = "authenticated-kernel-hub-git"
         if len(revision) != 40:
             raise RuntimeError(f"Kernel metadata lacks an immutable revision: {repo_id}")
         return revision, source
+
+    def _kernel_selfcheck(self, repo_id: str, revision: str) -> Any:
+        from kernels import get_local_kernel
+
+        with self.kernel_transport.materialize_revision(repo_id, revision) as repo:
+            module = get_local_kernel(repo, backend="cpu")
+            check = getattr(module, "selfcheck", None)
+            if not callable(check):
+                raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+            result = check()
+        if result is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck returned false")
+        if isinstance(result, dict) and result.get("ok") is False:
+            raise RuntimeError(f"{repo_id}@{revision} selfcheck failed: {result}")
+        return result
 
     def finalize_kernel(self, repo_id: str, spec: Mapping[str, str]) -> None:
         source_dir = self.roots[spec["source_root"]] / spec["source_dir"]
@@ -112,6 +121,7 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             "revision": publication.revision,
             "transport": "authenticated-kernel-hub-git",
             "metadata_revision_source": metadata_source,
+            "selfcheck_transport": "exact-revision-authenticated-kernel-hub-git-local",
             "changed": publication.changed,
             "remote_file_count": publication.remote_file_count,
             "build_variants_preserved": publication.build_variants_preserved,
@@ -147,7 +157,7 @@ class KernelGitFinalizer(retry.RetryingFinalizer):
             "First-class Kernels use credential-safe authenticated Git.",
             "Generic repository helpers are never called with repo_type=kernel.",
             "Only README.md and contract.json may change in Kernel repositories.",
-            "The complete Kernel build tree and immutable revision binding are verified.",
+            "The complete Kernel build tree, immutable revision binding, and exact-revision local selfcheck are verified through authenticated Git.",
             "No model, Space, visibility, hardware, training, weight, qualification, or promotion state is mutated.",
         ]
         return report

--- a/.github/scripts/hf_release_readiness_terminal.py
+++ b/.github/scripts/hf_release_readiness_terminal.py
@@ -4,8 +4,8 @@
 The release publisher owns all Hugging Face mutation. This terminal verifier
 runs only after that publisher completes, binds every observation to immutable
 revisions, verifies the Dataset Viewer while the dataset revision is stable,
-reads Kernel trees through the first-class Kernel REST endpoint, executes each
-Kernel selfcheck at the exact observed revision, and updates one deterministic
+reads Kernel trees through credential-safe authenticated Git, executes each
+Kernel selfcheck from an exact-revision local checkout, and updates one deterministic
 GitHub evidence issue.
 
 No generic ``huggingface_hub`` repository helper is called with the unsupported
@@ -25,6 +25,7 @@ from typing import Any, Mapping
 
 import requests
 from huggingface_hub import HfApi
+from kernel_hub_git import KernelHubGitTransport
 
 REPORT_SCHEMA = "szl.hf-release-readiness/v1"
 PRERELEASE_SCHEMA = "szl.hf-release-readiness/v1-prerelease"
@@ -116,7 +117,13 @@ def _workflow_context() -> dict[str, str]:
 
 
 class TerminalReadiness:
-    def __init__(self, *, token: str, generation: str) -> None:
+    def __init__(
+        self,
+        *,
+        token: str,
+        generation: str,
+        kernel_transport: KernelHubGitTransport | None = None,
+    ) -> None:
         if not token:
             raise ValueError("a non-empty Hugging Face token is required")
         self.generation = _immutable_revision(
@@ -125,6 +132,7 @@ class TerminalReadiness:
         )
         self.token = token
         self.api = HfApi(token=token)
+        self.kernel_transport = kernel_transport or KernelHubGitTransport(token=token)
         self.actions: list[Action] = []
         self.results: dict[str, Any] = {}
 
@@ -222,44 +230,8 @@ class TerminalReadiness:
             f"revision={revision}; files={len(files)}; metadata_stable=true",
         )
 
-    def _kernel_tree_paths(self, repo_id: str, revision: str) -> tuple[str, ...]:
-        owner, name = repo_id.split("/", 1)
-        url = (
-            f"https://huggingface.co/api/kernels/{owner}/{name}/tree/"
-            f"{revision}?recursive=true"
-        )
-        response = requests.get(
-            url,
-            headers=_headers(
-                self.token,
-                user_agent="szl-hf-release-readiness-terminal/2",
-            ),
-            timeout=90,
-        )
-        if response.status_code != 200:
-            raise RuntimeError(
-                f"kernel tree readback failed for {repo_id}@{revision}: "
-                f"HTTP {response.status_code} {response.text[:300]}"
-            )
-        try:
-            payload = response.json()
-        except ValueError as exc:
-            raise RuntimeError(f"kernel tree did not return JSON for {repo_id}") from exc
-        if not isinstance(payload, list):
-            raise RuntimeError(f"kernel tree payload is not a list for {repo_id}")
-        paths = tuple(
-            sorted(
-                {
-                    str(item.get("path") or "")
-                    for item in payload
-                    if isinstance(item, dict)
-                    and item.get("type") in {"file", "blob"}
-                    and str(item.get("path") or "")
-                }
-            )
-        )
-        if not paths:
-            raise RuntimeError(f"kernel tree contains no files for {repo_id}@{revision}")
+    @staticmethod
+    def _validate_kernel_paths(repo_id: str, revision: str, paths: tuple[str, ...]) -> None:
         missing = {"README.md", "contract.json"} - set(paths)
         if missing:
             raise RuntimeError(
@@ -269,33 +241,31 @@ class TerminalReadiness:
             raise RuntimeError(
                 f"kernel build variants are missing for {repo_id}@{revision}"
             )
-        return paths
 
     def verify_kernel(self, repo_id: str) -> None:
-        revision = _immutable_revision(
-            getattr(self.api.kernel_info(repo_id), "sha", ""),
-            label=repo_id,
-        )
-        paths = self._kernel_tree_paths(repo_id, revision)
+        before = self.kernel_transport.snapshot(repo_id)
+        revision = _immutable_revision(before.revision, label=repo_id)
+        paths = before.files
+        self._validate_kernel_paths(repo_id, revision, paths)
 
-        from kernels import get_kernel
+        from kernels import get_local_kernel
 
-        module = get_kernel(repo_id, revision=revision, trust_remote_code=True)
-        check = getattr(module, "selfcheck", None)
-        if not callable(check):
-            raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
-        result = check()
+        with self.kernel_transport.materialize_revision(repo_id, revision) as repo:
+            module = get_local_kernel(repo, backend="cpu")
+            check = getattr(module, "selfcheck", None)
+            if not callable(check):
+                raise RuntimeError(f"{repo_id}@{revision} does not expose selfcheck()")
+            result = check()
         if not _selfcheck_passed(result):
             raise RuntimeError(f"{repo_id}@{revision} selfcheck did not pass: {result}")
 
-        revision_after = _immutable_revision(
-            getattr(self.api.kernel_info(repo_id), "sha", ""),
-            label=repo_id,
-        )
-        if revision_after != revision:
+        after = self.kernel_transport.snapshot(repo_id)
+        revision_after = _immutable_revision(after.revision, label=repo_id)
+        if revision_after != revision or after.build_tree_sha256 != before.build_tree_sha256:
             raise RuntimeError(
-                f"kernel revision moved during selfcheck: {repo_id}; "
-                f"before={revision}; after={revision_after}"
+                f"kernel source moved during selfcheck: {repo_id}; "
+                f"before={revision}/{before.build_tree_sha256}; "
+                f"after={revision_after}/{after.build_tree_sha256}"
             )
 
         self.results.setdefault("kernels", {})[repo_id] = {
@@ -303,6 +273,8 @@ class TerminalReadiness:
             "remote_file_count": len(paths),
             "build_variants_present": True,
             "metadata_stable": True,
+            "build_tree_sha256": before.build_tree_sha256,
+            "transport": "exact-revision-authenticated-kernel-hub-git-local",
             "selfcheck": result,
         }
         self.record(
@@ -334,8 +306,8 @@ class TerminalReadiness:
             "boundaries": [
                 "This terminal verifier performs no Hugging Face mutation.",
                 "The Lake file inventory is bound to one immutable dataset revision and the Viewer is checked while that revision remains stable.",
-                "First-class Kernel trees are read through the exact-revision Kernel REST endpoint; generic repository helpers never receive repo_type=kernel.",
-                "Kernel selfcheck is executed at the exact immutable revision and metadata must remain stable through verification.",
+                "First-class Kernel metadata and complete trees are read through credential-safe authenticated Git; generic repository helpers never receive repo_type=kernel.",
+                "Kernel selfcheck is executed from an exact-revision authenticated Git checkout, and both revision and build tree must remain stable through verification.",
                 "No model weights are trained, merged, relabeled, uploaded, deployed, or promoted.",
             ],
         }

--- a/.github/scripts/kernel_hub_git.py
+++ b/.github/scripts/kernel_hub_git.py
@@ -3,8 +3,8 @@
 
 The generic ``huggingface_hub`` repository helpers currently accept model,
 dataset, and Space repository types. First-class Kernel repositories therefore
-use their native Git endpoint for card/contract publication while metadata is
-bound independently through ``HfApi.kernel_info`` by the caller.
+use their native Git endpoint for metadata, exact-revision execution, and
+card/contract publication.
 
 Only ``README.md`` and ``contract.json`` may change. The complete remote tree is
 inventoried with ``git ls-tree`` without checking out kernel build blobs, and the
@@ -132,7 +132,14 @@ class KernelHubGitTransport:
         env: Mapping[str, str] | None = None,
         check: bool = True,
     ) -> subprocess.CompletedProcess[str]:
-        command = [self.git_bin, "-c", "protocol.file.allow=always", *args]
+        command = [
+            self.git_bin,
+            "-c",
+            "protocol.file.allow=always",
+            "-c",
+            "core.autocrlf=false",
+            *args,
+        ]
         try:
             result = subprocess.run(
                 command,
@@ -204,6 +211,40 @@ class KernelHubGitTransport:
             repo, _ = self._fetch_main(repo_id, Path(raw))
             return self._snapshot_from_repo(repo_id, repo)
 
+    @contextmanager
+    def materialize_revision(
+        self,
+        repo_id: str,
+        expected_revision: str,
+    ) -> Iterator[Path]:
+        """Check out the complete current Kernel tree at one exact revision."""
+
+        expected = str(expected_revision or "").strip().lower()
+        if not SHA40.fullmatch(expected):
+            raise KernelGitError(
+                f"Kernel materialization requires an immutable revision: {repo_id}@{expected!r}"
+            )
+        with tempfile.TemporaryDirectory(
+            prefix="szl-kernel-materialize-",
+            dir=self.temp_root,
+        ) as raw:
+            repo, _ = self._fetch_main(repo_id, Path(raw))
+            observed = self._git(["rev-parse", "FETCH_HEAD"], cwd=repo).stdout.strip().lower()
+            if observed != expected:
+                raise KernelGitError(
+                    "Kernel main moved before materialization: "
+                    f"expected {expected}, observed {observed}; repo={repo_id}"
+                )
+            with self._auth_environment() as env:
+                self._git(["checkout", "-q", "--detach", "FETCH_HEAD"], cwd=repo, env=env)
+            checked_out = self._git(["rev-parse", "HEAD"], cwd=repo).stdout.strip().lower()
+            if checked_out != expected:
+                raise KernelGitError(
+                    "Kernel checkout revision mismatch: "
+                    f"expected {expected}, observed {checked_out}; repo={repo_id}"
+                )
+            yield repo
+
     def _sparse_checkout(self, repo_id: str, root: Path) -> Path:
         repo, _ = self._fetch_main(repo_id, root)
         with self._auth_environment() as env:
@@ -240,7 +281,15 @@ class KernelHubGitTransport:
             with self._auth_environment() as env:
                 for path in sorted(ALLOWED_PATHS):
                     result = subprocess.run(
-                        [self.git_bin, "-c", "protocol.file.allow=always", "show", f"FETCH_HEAD:{path}"],
+                        [
+                            self.git_bin,
+                            "-c",
+                            "protocol.file.allow=always",
+                            "-c",
+                            "core.autocrlf=false",
+                            "show",
+                            f"FETCH_HEAD:{path}",
+                        ],
                         cwd=repo,
                         env=env,
                         capture_output=True,

--- a/.github/scripts/test_hf_release_finalization_git.py
+++ b/.github/scripts/test_hf_release_finalization_git.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import unittest
 import unittest.mock
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 HERE = pathlib.Path(__file__).resolve().parent
@@ -18,11 +19,13 @@ from kernel_hub_git import KernelPublication, KernelSnapshot
 
 
 class FakeTransport:
-    def __init__(self, publication=None, snapshot=None):
+    def __init__(self, publication=None, snapshot=None, materialized_path=None):
         self.publication = publication
         self.snapshot_value = snapshot
+        self.materialized_path = materialized_path
         self.publish_calls = []
         self.snapshot_calls = []
+        self.materialize_calls = []
 
     def publish(self, **kwargs):
         self.publish_calls.append(kwargs)
@@ -31,6 +34,11 @@ class FakeTransport:
     def snapshot(self, repo_id):
         self.snapshot_calls.append(repo_id)
         return self.snapshot_value
+
+    @contextmanager
+    def materialize_revision(self, repo_id, revision):
+        self.materialize_calls.append((repo_id, revision))
+        yield self.materialized_path
 
 
 class FakeApi:
@@ -69,7 +77,16 @@ class KernelGitFinalizerTests(unittest.TestCase):
         instance.generation = "d" * 40
         instance.roots = {"energy": root / "energy"}
         instance.api = FakeApi()
-        instance.kernel_transport = FakeTransport(publication=publication)
+        instance.kernel_transport = FakeTransport(
+            publication=publication,
+            snapshot=KernelSnapshot(
+                repo_id="SZLHOLDINGS/example",
+                revision="a" * 40,
+                files=("README.md", "contract.json", "build/cpu/__init__.py"),
+                build_tree_sha256="c" * 64,
+                remote_url="https://huggingface.co/kernels/SZLHOLDINGS/example",
+            ),
+        )
         instance.actions = []
         instance.results = {}
         instance._kernel_selfcheck = lambda repo_id, revision: {"ok": True}
@@ -91,9 +108,8 @@ class KernelGitFinalizerTests(unittest.TestCase):
         finally:
             tmp.cleanup()
 
-    def test_empty_kernel_api_builds_fall_back_to_authenticated_git(self):
+    def test_kernel_metadata_is_bound_directly_to_authenticated_git(self):
         tmp, instance = self.make_instance()
-        instance.api = FakeApi(error=ValueError("min() iterable argument is empty"))
         instance.kernel_transport.snapshot_value = KernelSnapshot(
             repo_id="SZLHOLDINGS/example",
             revision="a" * 40,
@@ -111,21 +127,54 @@ class KernelGitFinalizerTests(unittest.TestCase):
             result = instance.results["kernels"]["SZLHOLDINGS/example"]
             self.assertEqual(
                 result["metadata_revision_source"],
-                "authenticated-kernel-hub-git-fallback",
+                "authenticated-kernel-hub-git",
             )
         finally:
             tmp.cleanup()
 
-    def test_unrelated_kernel_api_value_error_still_fails_closed(self):
+    def test_kernel_metadata_does_not_call_broken_kernel_api(self):
         tmp, instance = self.make_instance()
         instance.api = FakeApi(error=ValueError("malformed kernel metadata"))
+        instance.kernel_transport.snapshot_value = KernelSnapshot(
+            repo_id="SZLHOLDINGS/example",
+            revision="a" * 40,
+            files=("README.md", "contract.json", "build/cpu/__init__.py"),
+            build_tree_sha256="c" * 64,
+            remote_url="https://huggingface.co/kernels/SZLHOLDINGS/example",
+        )
         try:
-            with self.assertRaisesRegex(ValueError, "malformed kernel metadata"):
-                instance.finalize_kernel(
-                    "SZLHOLDINGS/example",
-                    {"source_root": "energy", "source_dir": "hf-kernels/example"},
-                )
-            self.assertFalse(instance.kernel_transport.publish_calls)
+            instance.finalize_kernel(
+                "SZLHOLDINGS/example",
+                {"source_root": "energy", "source_dir": "hf-kernels/example"},
+            )
+            self.assertEqual(len(instance.kernel_transport.publish_calls), 1)
+        finally:
+            tmp.cleanup()
+
+    def test_kernel_selfcheck_loads_exact_materialized_revision(self):
+        tmp, instance = self.make_instance()
+        repo = pathlib.Path(tmp.name) / "materialized"
+        repo.mkdir()
+        instance.kernel_transport.materialized_path = repo
+        instance._kernel_selfcheck = finalizer.KernelGitFinalizer._kernel_selfcheck.__get__(
+            instance,
+            finalizer.KernelGitFinalizer,
+        )
+        get_local_kernel = unittest.mock.Mock(
+            return_value=SimpleNamespace(selfcheck=lambda: {"ok": True})
+        )
+        try:
+            with unittest.mock.patch.dict(
+                sys.modules,
+                {"kernels": SimpleNamespace(get_local_kernel=get_local_kernel)},
+            ):
+                result = instance._kernel_selfcheck("SZLHOLDINGS/example", "b" * 40)
+            self.assertEqual(result, {"ok": True})
+            self.assertEqual(
+                instance.kernel_transport.materialize_calls,
+                [("SZLHOLDINGS/example", "b" * 40)],
+            )
+            get_local_kernel.assert_called_once_with(repo, backend="cpu")
         finally:
             tmp.cleanup()
 
@@ -147,7 +196,7 @@ class KernelGitFinalizerTests(unittest.TestCase):
             )
             self.assertEqual(
                 instance.kernel_transport.snapshot_calls,
-                ["SZLHOLDINGS/example"],
+                ["SZLHOLDINGS/example", "SZLHOLDINGS/example"],
             )
             self.assertFalse(instance.kernel_transport.publish_calls)
         finally:

--- a/.github/scripts/test_hf_release_readiness_terminal.py
+++ b/.github/scripts/test_hf_release_readiness_terminal.py
@@ -5,7 +5,11 @@ import importlib
 import json
 import pathlib
 import sys
+import tempfile
 import unittest
+import unittest.mock
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 HERE = pathlib.Path(__file__).resolve().parent
 ROOT = HERE.parents[1]
@@ -13,6 +17,24 @@ if str(HERE) not in sys.path:
     sys.path.insert(0, str(HERE))
 
 terminal = importlib.import_module("hf_release_readiness_terminal")
+from kernel_hub_git import KernelSnapshot
+
+
+class FakeKernelTransport:
+    def __init__(self, *, snapshot: KernelSnapshot, repo: pathlib.Path) -> None:
+        self.snapshot_value = snapshot
+        self.repo = repo
+        self.snapshot_calls: list[str] = []
+        self.materialize_calls: list[tuple[str, str]] = []
+
+    def snapshot(self, repo_id: str) -> KernelSnapshot:
+        self.snapshot_calls.append(repo_id)
+        return self.snapshot_value
+
+    @contextmanager
+    def materialize_revision(self, repo_id: str, revision: str):
+        self.materialize_calls.append((repo_id, revision))
+        yield self.repo
 
 
 class TerminalReleaseReadinessTests(unittest.TestCase):
@@ -70,6 +92,45 @@ class TerminalReleaseReadinessTests(unittest.TestCase):
         )
         self.assertFalse(terminal._selfcheck_passed({"checks": {}}))
 
+    def test_kernel_verification_uses_one_exact_git_revision(self) -> None:
+        repo_id = "SZLHOLDINGS/example"
+        revision = "b" * 40
+        with tempfile.TemporaryDirectory() as raw:
+            repo = pathlib.Path(raw)
+            transport = FakeKernelTransport(
+                snapshot=KernelSnapshot(
+                    repo_id=repo_id,
+                    revision=revision,
+                    files=("README.md", "contract.json", "build/cpu/__init__.py"),
+                    build_tree_sha256="c" * 64,
+                    remote_url="https://huggingface.co/kernels/SZLHOLDINGS/example",
+                ),
+                repo=repo,
+            )
+            verifier = terminal.TerminalReadiness(
+                token="test-token",
+                generation="a" * 40,
+                kernel_transport=transport,
+            )
+            get_local_kernel = unittest.mock.Mock(
+                return_value=SimpleNamespace(selfcheck=lambda: {"ok": True})
+            )
+            with unittest.mock.patch.dict(
+                sys.modules,
+                {"kernels": SimpleNamespace(get_local_kernel=get_local_kernel)},
+            ):
+                verifier.verify_kernel(repo_id)
+
+        self.assertEqual(transport.snapshot_calls, [repo_id, repo_id])
+        self.assertEqual(transport.materialize_calls, [(repo_id, revision)])
+        get_local_kernel.assert_called_once_with(repo, backend="cpu")
+        result = verifier.results["kernels"][repo_id]
+        self.assertEqual(result["revision"], revision)
+        self.assertEqual(
+            result["transport"],
+            "exact-revision-authenticated-kernel-hub-git-local",
+        )
+
     def test_issue_body_contains_machine_readable_readiness_report(self) -> None:
         report = {
             "schema": terminal.REPORT_SCHEMA,
@@ -108,8 +169,8 @@ class TerminalReleaseReadinessTests(unittest.TestCase):
         for token in forbidden:
             self.assertNotIn(token, source)
         self.assertIn('repo_type="dataset"', source)
-        self.assertIn("revision=revision", source)
-        self.assertIn("/api/kernels/", source)
+        self.assertIn("materialize_revision(repo_id, revision)", source)
+        self.assertNotIn("/api/kernels/", source)
 
     def test_report_shape_matches_final_estate_reconciler(self) -> None:
         report = {

--- a/.github/scripts/test_kernel_hub_git.py
+++ b/.github/scripts/test_kernel_hub_git.py
@@ -151,6 +151,32 @@ class KernelHubGitTransportTests(unittest.TestCase):
             }
         self.assertEqual(visible, {"README.md", "contract.json"})
 
+    def test_materialize_revision_checks_out_complete_exact_tree(self) -> None:
+        expected = self.head()
+        with self.transport.materialize_revision(self.repo_id, expected) as repo:
+            self.assertEqual(
+                git("rev-parse", "HEAD", cwd=repo).stdout.strip(),
+                expected,
+            )
+            visible = {
+                str(path.relative_to(repo)).replace("\\", "/")
+                for path in repo.rglob("*")
+                if path.is_file() and ".git" not in path.parts
+            }
+            self.assertEqual(
+                visible,
+                {
+                    "README.md",
+                    "contract.json",
+                    "build/torch27-cpu/__init__.py",
+                },
+            )
+
+    def test_materialize_revision_rejects_moved_main(self) -> None:
+        with self.assertRaisesRegex(KernelGitError, "main moved before materialization"):
+            with self.transport.materialize_revision(self.repo_id, "0" * 40):
+                self.fail("mismatched revision must not be materialized")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Outcome

Completes the Hugging Face Kernel repair on top of merged #355. Kernel metadata, exact sparse-build checkout, CPU selfcheck, and terminal readiness now share one credential-safe authenticated Git transport; the broken Kernel API loader is no longer attempted.

## Failure closed

- requires an immutable 40-character revision before checkout
- rejects main movement and verifies the checked-out `HEAD`
- inventories the complete remote tree and checks the build-tree digest before and after terminal selfcheck
- preserves the card/contract-only publication boundary
- never uses generic `repo_type=kernel`, Kernel REST metadata, or `get_kernel()`
- makes the transport byte-stable across host `core.autocrlf` settings
- does not change workflows, rulesets, branch protection, secrets, Apps, or governance policy

## Verification

- `py_compile` for the controller, transport, readiness, and their tests
- Kernel Git transport: 8 tests passed
- release finalizer: 9 tests passed
- terminal readiness: 9 tests passed
- legacy finalizer: 4 tests passed
- bounded retry adapter: 6 tests passed
- `git diff --check`

The signed merge head incorporates current `main` without a rebase or force-push: `42fc178374a53ae2ed3792334ffe5ef7ccf0a24c`.