### PR TITLE
fix(hf): dispatch terminal readiness workflow

### DIFF
--- a/.github/scripts/test_hf_release_readiness_terminal.py
+++ b/.github/scripts/test_hf_release_readiness_terminal.py
@@ -254,6 +254,9 @@ class TerminalReleaseReadinessTests(unittest.TestCase):
         finalization = (
             ROOT / ".github/workflows/hf-release-finalization.yml"
         ).read_text(encoding="utf-8")
+        kernel_publication = (
+            ROOT / ".github/workflows/hf-kernel-card-publish-v2.yml"
+        ).read_text(encoding="utf-8")
         readiness = (
             ROOT / ".github/workflows/hf-release-readiness-terminal.yml"
         ).read_text(encoding="utf-8")
@@ -266,7 +269,15 @@ class TerminalReleaseReadinessTests(unittest.TestCase):
 
         self.assertIn("schedule:", finalization)
         self.assertNotIn("gh workflow run hf-release-readiness", finalization)
+        self.assertNotIn(
+            "gh workflow run hf-release-readiness.yml", kernel_publication
+        )
+        self.assertIn(
+            "gh workflow run hf-release-readiness-terminal.yml",
+            kernel_publication,
+        )
         self.assertIn("workflow_run:", readiness)
+        self.assertIn("workflow_dispatch: {}", readiness)
         self.assertIn("HF Release Finalization — Supported Kernel Git", readiness)
         self.assertNotIn("pull_request:", readiness)
         self.assertNotIn("secrets.", readiness_pr)

--- a/.github/workflows/hf-kernel-card-publish-v2.yml
+++ b/.github/workflows/hf-kernel-card-publish-v2.yml
@@ -412,7 +412,9 @@ jobs:
       - name: Trigger immediate independent release readiness
         if: steps.mode.outputs.publish == 'true' && steps.verify.outputs.exit_code == '0'
         run: |
-          gh workflow run hf-release-readiness.yml --repo "$GITHUB_REPOSITORY" --ref main -f publish=true
+          gh workflow run hf-release-readiness-terminal.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
 
       - name: Enforce fail-closed publication result
         if: always() && steps.mode.outputs.publish == 'true'


### PR DESCRIPTION
DRAFT / HOLD — do not mark ready or merge without independent authorized review.

## Diagnosis

Fresh current-main run 30404484668 completed the authenticated Hugging Face kernel publish, immutable readback, exact runtime selfchecks, evidence upload, and issue persistence. It failed only when attempting to dispatch deleted legacy workflow `hf-release-readiness.yml`, which GitHub rejects with HTTP 422 because that workflow has no `workflow_dispatch` trigger.

## Change

- Dispatch the current terminal owner, `hf-release-readiness-terminal.yml`, instead.
- Add a regression contract that forbids the deleted legacy target, requires the terminal target, and proves the target exposes `workflow_dispatch`.

No Hugging Face license, visibility, archive, branch protection, or ruleset mutation is included.

## Exact local verification

- `python -m py_compile .github/scripts/hf_release_readiness_terminal.py .github/scripts/test_hf_release_readiness_terminal.py`
- `python .github/scripts/test_hf_release_readiness_terminal.py` — 12/12 PASS
- `git diff --check` — PASS
- `git verify-commit HEAD` — PASS (SSH signature)
- DCO sign-off present

`actionlint` was unavailable locally; hosted checks remain authoritative for workflow lint.

## Source evidence

- Failed current-main controller run: https://github.com/szl-holdings/.github/actions/runs/30404484668
- Exact protected base: `ac784309ef448bbfd9e6f818e51841e67d1a4fef`

HOLD: this PR intentionally remains draft. No self-approval, ready-for-review transition, or merge is authorized.