### PR TITLE
feat(hf): guard deploy at default branch tip

### DIFF
--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -604,8 +604,9 @@ def require_current_default_branch_tip(args):
             f"caller_ref={caller_ref!r} expected_ref={expected_ref!r}"
         )
 
+    encoded_default_branch = urllib.parse.quote(default_branch, safe="")
     tip = fetch_github_json(
-        f"{api_url}/repos/{args.github_repo}/commits/{default_branch}",
+        f"{api_url}/repos/{args.github_repo}/commits/{encoded_default_branch}",
         token,
     )
     current_sha = str(tip.get("sha") or "").lower()

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -556,6 +556,66 @@ def build_add_operations(repo_root, files, operation_class):
     return operations
 
 
+def fetch_github_json(url, token):
+    """Fetch one authenticated GitHub API object."""
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def require_current_default_branch_tip(args):
+    """Fail unless the deployment source is the caller's current default tip."""
+    if not getattr(args, "require_default_branch_tip", False):
+        return
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    caller_ref = os.environ.get("GITHUB_REF", "")
+    source_sha = str(args.ref or "").lower()
+    if not token:
+        raise DeployContractError(
+            "GITHUB_TOKEN is required by --require-default-branch-tip"
+        )
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise DeployContractError(
+            "--require-default-branch-tip requires ref to be an exact commit SHA"
+        )
+
+    repository = fetch_github_json(
+        f"{api_url}/repos/{args.github_repo}",
+        token,
+    )
+    default_branch = str(repository.get("default_branch") or "")
+    if not default_branch:
+        raise DeployContractError(
+            "GitHub repository response omitted the default branch"
+        )
+    expected_ref = f"refs/heads/{default_branch}"
+    if caller_ref != expected_ref:
+        raise DeployContractError(
+            "refusing production deploy from non-default branch: "
+            f"caller_ref={caller_ref!r} expected_ref={expected_ref!r}"
+        )
+
+    tip = fetch_github_json(
+        f"{api_url}/repos/{args.github_repo}/commits/{default_branch}",
+        token,
+    )
+    current_sha = str(tip.get("sha") or "").lower()
+    if current_sha != source_sha:
+        raise DeployContractError(
+            "refusing stale production deploy at mutation boundary: "
+            f"current_sha={current_sha!r} source_sha={source_sha!r}"
+        )
+
+
 def deploy(args):
     manifest, files = derive(args)
     print(f"== HF deploy: {args.github_repo} -> {args.hf_repo} ({args.ref}) ==")
@@ -620,6 +680,10 @@ def deploy(args):
                 ops.append(CommitOperationDelete(path_in_repo=p))
                 deleted.append(p)
 
+    # Keep this immediately adjacent to the first remote mutation. In
+    # particular, do not move it into a separately scheduled preflight job:
+    # a caller's default branch can advance between jobs.
+    require_current_default_branch_tip(args)
     commit = api.create_commit(
         repo_id=args.hf_repo, repo_type="space", operations=ops,
         commit_message=f"deploy(hf): sync {args.github_repo}@{args.ref} derived COPY set",
@@ -727,6 +791,14 @@ def main():
                     help="delete Space files under directory COPY sources that are "
                          "gone from git main (never touches file/glob sources)")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--require-default-branch-tip",
+        action="store_true",
+        help=(
+            "fail immediately before the HF commit unless --ref is the exact "
+            "current tip of the caller repository's default branch"
+        ),
+    )
     ap.add_argument("--attest", action="store_true",
                     help="verification mode: re-fetch manifest files from the live "
                          "Space and assert sha256 == pushed value")

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -578,14 +578,14 @@ def require_current_default_branch_tip(args):
     token = os.environ.get("GITHUB_TOKEN", "")
     api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
     caller_ref = os.environ.get("GITHUB_REF", "")
-    source_sha = str(args.ref or "").lower()
+    source_sha = str(getattr(args, "source_sha", "") or "").lower()
     if not token:
         raise DeployContractError(
             "GITHUB_TOKEN is required by --require-default-branch-tip"
         )
     if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
         raise DeployContractError(
-            "--require-default-branch-tip requires ref to be an exact commit SHA"
+            "--require-default-branch-tip requires --source-sha to be exact"
         )
 
     repository = fetch_github_json(
@@ -779,6 +779,11 @@ def main():
     ap.add_argument("--github-repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
     ap.add_argument("--hf-repo", default="")
     ap.add_argument("--ref", default="main")
+    ap.add_argument(
+        "--source-sha",
+        default="",
+        help="exact checked-out source SHA used by mutation-boundary guards",
+    )
     ap.add_argument("--dockerfile-path", default="Dockerfile")
     ap.add_argument("--readme-path", default="README.md")
     ap.add_argument("--include-readme", default="true")

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -595,6 +595,32 @@ class TestDefaultBranchTipGuard(unittest.TestCase):
                 dep.require_current_default_branch_tip(self._args())
         fetch.assert_called_once()
 
+    def test_default_branch_is_encoded_as_one_path_component(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "test-token",
+                    "GITHUB_REF": "refs/heads/release#prod",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                dep,
+                "fetch_github_json",
+                side_effect=[
+                    {"default_branch": "release#prod"},
+                    {"sha": "a" * 40},
+                ],
+            ) as fetch,
+        ):
+            dep.require_current_default_branch_tip(self._args())
+        self.assertTrue(
+            fetch.call_args_list[1].args[0].endswith(
+                "/commits/release%23prod"
+            )
+        )
+
     def test_stale_sha_fails_at_mutation_boundary(self):
         with (
             mock.patch.dict(

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -533,6 +533,8 @@ class TestReusableWorkflowContract(unittest.TestCase):
             "REQUIRE_DEFAULT_BRANCH_TIP: ${{ inputs.require-default-branch-tip }}",
             "TIP_GUARD_ARGS+=(--require-default-branch-tip)",
             "GITHUB_TOKEN: ${{ github.token }}",
+            "SOURCE_SHA: ${{ steps.hf.outputs.source_sha }}",
+            '--source-sha "$SOURCE_SHA"',
         ):
             self.assertIn(contract, self.workflow)
 
@@ -541,7 +543,8 @@ class TestDefaultBranchTipGuard(unittest.TestCase):
     def _args(self, *, source_sha="a" * 40, enabled=True):
         return types.SimpleNamespace(
             github_repo="szl-holdings/killinchu",
-            ref=source_sha,
+            ref="main",
+            source_sha=source_sha,
             require_default_branch_tip=enabled,
         )
 

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -527,6 +527,92 @@ class TestReusableWorkflowContract(unittest.TestCase):
         attest_block = self.workflow.split("--attest", 1)[1]
         self.assertNotIn("--ref", attest_block)
 
+    def test_default_branch_tip_guard_is_optional_and_forwarded(self):
+        for contract in (
+            "require-default-branch-tip:",
+            "REQUIRE_DEFAULT_BRANCH_TIP: ${{ inputs.require-default-branch-tip }}",
+            "TIP_GUARD_ARGS+=(--require-default-branch-tip)",
+            "GITHUB_TOKEN: ${{ github.token }}",
+        ):
+            self.assertIn(contract, self.workflow)
+
+
+class TestDefaultBranchTipGuard(unittest.TestCase):
+    def _args(self, *, source_sha="a" * 40, enabled=True):
+        return types.SimpleNamespace(
+            github_repo="szl-holdings/killinchu",
+            ref=source_sha,
+            require_default_branch_tip=enabled,
+        )
+
+    def test_disabled_guard_needs_no_github_context(self):
+        with mock.patch.object(dep, "fetch_github_json") as fetch:
+            dep.require_current_default_branch_tip(self._args(enabled=False))
+        fetch.assert_not_called()
+
+    def test_exact_default_branch_tip_passes(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "test-token",
+                    "GITHUB_API_URL": "https://api.github.test",
+                    "GITHUB_REF": "refs/heads/main",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                dep,
+                "fetch_github_json",
+                side_effect=[{"default_branch": "main"}, {"sha": "a" * 40}],
+            ) as fetch,
+        ):
+            dep.require_current_default_branch_tip(self._args())
+        self.assertEqual(fetch.call_count, 2)
+
+    def test_non_default_branch_fails_before_tip_lookup(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "test-token",
+                    "GITHUB_REF": "refs/heads/release",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                dep,
+                "fetch_github_json",
+                return_value={"default_branch": "main"},
+            ) as fetch,
+        ):
+            with self.assertRaisesRegex(
+                dep.DeployContractError, "non-default branch"
+            ):
+                dep.require_current_default_branch_tip(self._args())
+        fetch.assert_called_once()
+
+    def test_stale_sha_fails_at_mutation_boundary(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GITHUB_TOKEN": "test-token",
+                    "GITHUB_REF": "refs/heads/main",
+                },
+                clear=True,
+            ),
+            mock.patch.object(
+                dep,
+                "fetch_github_json",
+                side_effect=[{"default_branch": "main"}, {"sha": "b" * 40}],
+            ),
+        ):
+            with self.assertRaisesRegex(
+                dep.DeployContractError, "stale production deploy"
+            ):
+                dep.require_current_default_branch_tip(self._args())
+
 
 class TestContentIdentity(unittest.TestCase):
     def test_git_blob_sha1_matches_git(self):

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -155,6 +155,7 @@ jobs:
           INCLUDE_README: ${{ inputs.include-readme }}
           PRUNE: ${{ inputs.prune }}
           REQUIRE_DEFAULT_BRANCH_TIP: ${{ inputs.require-default-branch-tip }}
+          SOURCE_SHA: ${{ steps.hf.outputs.source_sha }}
           SMOKE_PATHS: ${{ inputs.smoke-paths }}
         run: |
           set -euo pipefail
@@ -169,6 +170,7 @@ jobs:
             --github-repo "$GH_REPO" \
             --hf-repo "$HF_REPO" \
             --ref "$DEPLOY_REF" \
+            --source-sha "$SOURCE_SHA" \
             --dockerfile-path "$DOCKERFILE_PATH" \
             --include-readme "$INCLUDE_README" \
             --smoke-paths "${SMOKE_PATHS}" \

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -53,6 +53,11 @@ on:
         required: false
         type: string
         default: ""
+      require-default-branch-tip:
+        description: "Fail before the Hugging Face commit unless ref is the caller repository's exact current default-branch tip."
+        required: false
+        type: boolean
+        default: false
     secrets:
       HF_TOKEN:
         description: "HF write token with organization write access to the target Space."
@@ -142,17 +147,23 @@ jobs:
       - name: Deploy Dockerfile-derived files to the Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           HF_REPO: ${{ steps.hf.outputs.hf_repo }}
           DEPLOY_REF: ${{ inputs.ref }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
           INCLUDE_README: ${{ inputs.include-readme }}
           PRUNE: ${{ inputs.prune }}
+          REQUIRE_DEFAULT_BRANCH_TIP: ${{ inputs.require-default-branch-tip }}
           SMOKE_PATHS: ${{ inputs.smoke-paths }}
         run: |
           set -euo pipefail
           PRUNE_ARGS=()
           if [ "$PRUNE" = "true" ]; then PRUNE_ARGS+=(--prune); fi
+          TIP_GUARD_ARGS=()
+          if [ "$REQUIRE_DEFAULT_BRANCH_TIP" = "true" ]; then
+            TIP_GUARD_ARGS+=(--require-default-branch-tip)
+          fi
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root caller \
             --github-repo "$GH_REPO" \
@@ -162,6 +173,7 @@ jobs:
             --include-readme "$INCLUDE_README" \
             --smoke-paths "${SMOKE_PATHS}" \
             "${PRUNE_ARGS[@]}" \
+            "${TIP_GUARD_ARGS[@]}" \
             --manifest-out hf-deploy-manifest.json
 
       - name: Bind exact source revision after publication


### PR DESCRIPTION
## Contract metadata

Satisfies: C-158

Labels: PROVED exact mutation-boundary guard and network-free contract coverage; MEASURED 56/56 local deployer tests plus terminal hosted checks and exact-head Codex review; NOT CLAIMED Killinchu enablement until its separate immutable-pin caller change merges.

Rollback: Before merge, close this pull request. After merge, revert through a protected signed pull request. The guard remains opt-in and defaults false, so existing callers are unchanged.

Risk: C — shared reusable deployment mutation-boundary control. This pull request enables no caller and changes no ruleset, secret, App installation, or branch protection.

## Outcome

Adds an opt-in fail-closed guard to the canonical reusable Hugging Face deployer. When enabled, the deployer rejects non-default-branch and stale source SHAs immediately before its first remote mutation.

## Contract

- optional require-default-branch-tip input defaults false, preserving all existing pinned callers;
- reads the caller repository default branch with the job token;
- requires the caller ref to be that branch and the exact resolved checkout SHA to equal its current tip;
- runs immediately before HfApi.create_commit, not in a separately scheduled preflight job.

## Verification

- 56/56 deployer contract tests passed;
- exact-tip, non-default, stale-tip, disabled-guard, separate source-SHA, and URL-encoding regressions passed;
- Ruff passed;
- reusable workflow YAML parsed;
- diff check passed;
- exact signed+DCO head `53321b4762e100dae11b050b6fff6d28a72958d1`;
- both earlier Codex findings resolved with zero open review threads;
- exact-head Codex review found no major issues;
- all hosted code, security, signature, DCO, staging, and required FORGE-9 checks are terminal green.

This PR does not enable the guard for existing callers; Killinchu will opt in through a separately reviewed immutable pin update.