### PR TITLE
ci: scope workflow write permissions to jobs

### DIFF
--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -8,10 +8,7 @@ on:
       - completed
 
 permissions:
-  actions: read
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: forge9-attest-${{ github.event.workflow_run.head_sha }}
@@ -20,6 +17,11 @@ concurrency:
 jobs:
   attest:
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Mint the independent App token

--- a/.github/workflows/hf-kernel-card-publish-v2.yml
+++ b/.github/workflows/hf-kernel-card-publish-v2.yml
@@ -16,8 +16,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  actions: write
 
 concurrency:
   group: hf-kernel-card-publish-v2-${{ github.event_name }}-${{ github.ref }}
@@ -26,6 +24,10 @@ concurrency:
 jobs:
   publish:
     name: Publish, read back, and selfcheck exact kernel revisions
+    permissions:
+      actions: write
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Satisfies

Satisfies: C-109 / C-91

## Section reference

Organization workflow least-privilege security findings.

## Root cause

Two workflows granted write-capable permissions at the workflow level. OpenSSF Scorecard therefore reported high-severity TokenPermissionsID findings even though each workflow has only one job.

This change keeps the workflow default read-only and grants the same required capabilities only to the job that performs attestation/merge orchestration or publication/reporting. Triggers, secrets, commands, and release behavior are unchanged.

## Labels

Labels: No evidence-label changes; security hardening only.

## Rollback

Rollback: Revert commit 560a66236f8fda34b9bd7678c398554f0a12d437.

## Risk class

Risk: D — organization governance workflow permission-scope change.

Solo-Operator-Authorization: confirmed

## Tests executed

| Test | Command | Result | Evidence |
| --- | --- | --- | --- |
| Workflow lint | actionlint on both changed workflow files | PASS | No diagnostics |
| Permission contract | PyYAML structural assertions | PASS | Top-level read-only and exact job grants verified |
| Patch hygiene | git diff --check | PASS | No whitespace errors |

## Evidence checklist

- [ ] gate/ground-truth green
- [ ] gate/labels green; no silent evidence promotion
- [ ] gate/schema green
- [ ] gate/adversarial green
- [ ] gate/verify-all green with declared expected failures
- [ ] gate/provenance green; attestation verifies
- [ ] gate/a11y-perf green at desktop and mobile widths
- [ ] gate/lean green; sorry count did not increase
- [x] Screenshots not applicable; no UI changes
- [x] KNOWN_LIMITATIONS.md not applicable; no downgrade or blocker introduced
- [x] Commits include a DCO Signed-off-by trailer
- [x] No force-push, destructive rebase, or safeguard reduction

## Known limitations introduced

None. Full-repository actionlint v1.7.7 still reports pre-existing expression-schema diagnostics in unrelated reusable workflows; both changed workflows pass targeted lint.

## Doctrine

- [ ] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no vendor or secret changes