### PR TITLE
feat: establish public experience foundation

### DIFF
--- a/docs/PUBLIC_EXPERIENCE_STANDARD.md
+++ b/docs/PUBLIC_EXPERIENCE_STANDARD.md
@@ -1,0 +1,233 @@
+<!-- markdownlint-disable MD013 -->
+
+# SZL public experience standard
+
+Status: **ADOPTED AS A ROLLOUT CONTRACT**. Individual surfaces remain
+unchanged until their own protected pull requests pass verification.
+
+This standard makes the SZL estate legible as one company while preserving
+the technical and evidentiary boundaries of each product. It governs public
+websites, GitHub repositories, Hugging Face artifacts, documentation, demos,
+and investor-facing materials.
+
+## Audience order
+
+Every public surface must serve one primary audience and provide direct exits
+for the other two.
+
+1. **Investor or buyer:** What category is this, who needs it, what outcome
+   does it create, and what evidence supports the claim?
+2. **Builder or integrator:** How can I run, evaluate, integrate, and debug it?
+3. **Verifier or reviewer:** Where are the exact source, policy, evaluation,
+   receipt, security, and limitation records?
+
+Do not make all three audiences read the same long page in the same order.
+
+## Surface responsibilities
+
+| Surface | Primary job | Must not become |
+| --- | --- | --- |
+| `a-11-oy.com` | Product narrative, use cases, demonstrations, conversion | A raw evidence dump or repository index |
+| `a11oy.net` | Independent proof registry and receipt verification | A duplicate marketing homepage |
+| Killinchu | Operator-focused demonstration and mission workflow | An ungrouped collection of technology tabs |
+| GitHub organization | Company thesis, product map, diligence, developer routing | A full Space directory or live status dashboard |
+| GitHub repository | Project outcome, maturity, quickstart, architecture, limits | Generic company boilerplate before the project |
+| Hugging Face organization | Curated model, dataset, and Space portfolio | An unordered artifact feed |
+| Model or dataset card | Reproducible artifact contract and limitations | Marketing copy without metadata or evaluation |
+| Documentation site | Task-oriented learning and complete reference | A product homepage duplicate |
+
+## Shared navigation
+
+Product websites should use at most seven stable top-level destinations:
+
+1. Product
+2. Solutions
+3. Developers
+4. Evidence
+5. Research
+6. Company
+7. Get started
+
+Use task-specific secondary navigation. Every deep page must expose its active
+section, a route home, and a route to documentation or evidence. The canonical
+labels must stay consistent across domains.
+
+## Visual system
+
+The KANCHAY system is the single source of visual language.
+
+### Token authority
+
+The versioned
+[`szl-brand` color tokens](https://github.com/szl-holdings/szl-brand/blob/cebb154c6445b1eefc5024f5d988bb701bbdded2/kit/tokens/COLOR_TOKENS.json)
+and
+[`szl-design-system.css`](https://github.com/szl-holdings/szl-brand/blob/cebb154c6445b1eefc5024f5d988bb701bbdded2/kit/tokens/szl-design-system.css)
+are the canonical token authority. Consumers import the JSON, CSS, SCSS, or
+Tailwind representation from `szl-brand`; this document defines usage and does
+not duplicate color values.
+
+Color is never the only carrier of state. Every state includes a visible text
+label and, where appropriate, a timestamp and source.
+
+### Typography and layout
+
+- Use one sans-serif family for interface and prose and one monospace family
+  for evidence, code, identifiers, and metrics.
+- Keep body text between 60 and 78 characters per line.
+- Use an 8-pixel spacing base and a restrained type scale.
+- Prefer one strong visual or product capture over decorative card walls.
+- Reserve motion for state change or spatial explanation; honor reduced motion.
+- Avoid fake terminal decoration, ornamental grids, and glowing effects when
+  they do not explain a product behavior.
+
+## Narrative sequence
+
+An investor-facing product page should follow this order:
+
+1. Category, audience, outcome, and primary action in the first viewport.
+2. Product in context: a real interface, workflow, or verified demonstration.
+3. The problem and the economic or operational consequence.
+4. Three to five capabilities expressed as outcomes.
+5. Evidence with source, scope, and date.
+6. Architecture and differentiation.
+7. Security, limitations, and operational status.
+8. Developer path and integration options.
+9. Company, contact, and final action.
+
+Metrics without a current source, timestamp, unit, and scope do not ship.
+Customer logos, certifications, authorizations, and performance claims require
+their own evidence.
+
+## Evidence vocabulary
+
+| Label | Contract |
+| --- | --- |
+| **PROVED** | Machine-checked statement with exact theorem or artifact scope |
+| **MEASURED** | Direct observation with disclosed instrument, time, and context |
+| **REPORTED** | Identified upstream statement, not independently measured here |
+| **MODELED** | Simulation, projection, or analytical derivation |
+| **CONJECTURE** | Formal hypothesis that remains unproved |
+| **ROADMAP** | Planned capability with no operational claim |
+
+Operational status is separate from evidence class. Use **OPERATIONAL**,
+**PARTIAL**, **DEGRADED**, **UNAVAILABLE**, or **HISTORICAL**. Never use green
+styling for conjectures, roadmap items, partial capability, or unavailable
+evidence.
+
+Lambda is an advisory score. A separately named policy gate is the enforcing
+control. Public copy must not call Lambda both advisory and an enforcement gate.
+
+## Repository front door
+
+Every active repository README must include, in this order:
+
+1. Project name and one-sentence user outcome.
+2. Maturity/status with a linked source.
+3. Product, docs, demo, or evidence actions when applicable.
+4. Problem and capabilities.
+5. A tested quickstart that takes less than ten minutes.
+6. Architecture and trust boundaries.
+7. Configuration without secret values.
+8. Native verification commands.
+9. Limits and non-goals.
+10. Security, contribution, support, changelog, and actual license.
+
+Badges are supporting metadata, not the hero. Do not use a green status badge
+unless the linked source establishes that exact state.
+
+## Hugging Face portfolio
+
+### Organization card
+
+The organization card must state the company thesis, link the product and
+evidence surfaces, explain the artifact taxonomy, and feature only canonical
+release families. It must route users to support and security reporting.
+
+Use four explicit artifact classes:
+
+- **trained weights** with training, evaluation, and lineage evidence;
+- **datasets** with provenance, schema, privacy, and validation evidence;
+- **governed kernels and tools** with source and executable-test evidence, but
+  no implied model-training receipt;
+- **Spaces** with source, immutable dependencies, runtime behavior, and
+  demonstration limits.
+
+### Collections
+
+Collections represent a release family or a complete workflow:
+
+- one canonical model family per collection;
+- related adapters, quantizations, datasets, evaluations, and demos;
+- explicit ordering from primary artifact to derived artifacts;
+- a short scope and maturity statement;
+- no duplicate or unexplained entries.
+
+### Models
+
+Model cards require valid metadata, immutable revision guidance, intended and
+excluded uses, architecture, training and data lineage, preprocessing,
+evaluation protocol and results, safety and bias limits, hardware needs,
+reproducible usage, license, citation, support, and changelog.
+
+### Datasets
+
+Dataset cards additionally require schema, splits, sizes, provenance and
+consent, PII handling, validation, known gaps, and update policy. Synthetic,
+public, licensed, and derived data must remain distinguishable.
+
+### Spaces
+
+Every Space states its source repository, pinned model and dataset revisions,
+runtime status behavior, data retention or privacy behavior, limitations, and
+a reproducible local path. A visible demo is not evidence of production
+readiness.
+
+Use the templates in [`templates/`](../templates/README.md) as the adoption
+baseline.
+
+## Accessibility and performance gate
+
+Critical user flows target WCAG 2.2 AA. Verification includes keyboard-only
+navigation, visible focus, semantic landmarks, heading order, labels, contrast,
+200 percent zoom, mobile reflow, reduced motion, and useful error messages.
+
+For public websites, measure both mobile and desktop at the 75th percentile:
+
+- Largest Contentful Paint at or below 2.5 seconds;
+- Interaction to Next Paint at or below 200 milliseconds;
+- Cumulative Layout Shift at or below 0.1.
+
+Do not trade accessibility, truth labels, or core product usability for a
+perfect synthetic performance score.
+
+## Protected rollout gate
+
+Each surface upgrades independently through normal protection:
+
+1. Refresh the exact default-branch base and active ownership locks.
+2. Inventory routes, entry points, content sources, deployment owners, and
+   generated evidence.
+3. Make the smallest coherent surface change.
+4. Run native lint, type, test, build, link, metadata, and accessibility checks.
+5. Exercise the primary investor, builder, and verifier journeys end to end.
+6. Confirm no unresolved review findings and no source drift.
+7. Merge normally; do not bypass, self-approve, or weaken a gate.
+8. Verify the deployed immutable revision before calling the surface upgraded.
+
+An approved standard is not evidence that all surfaces have adopted it. Track
+adoption by repository and immutable revision, and label unmodified surfaces
+as pending.
+
+## Rollout order
+
+1. Organization profile, templates, and brand tokens.
+2. Company homepage and documentation navigation.
+3. Flagship product and proof registry.
+4. Killinchu information architecture and operator flows.
+5. Canonical GitHub repositories by product family.
+6. Hugging Face organization card and release-family collections.
+7. Model, dataset, and Space cards, prioritized by active usage.
+8. Long-tail repositories and historical surface cleanup.
+
+This order creates a dependable source of truth before multiplying changes
+across the estate.

--- a/profile/README.md
+++ b/profile/README.md
@@ -58,7 +58,7 @@ Most AI systems stop at an answer. SZL adds a control and evidence layer:
 | --- | --- |
 | What can I see working? | [a11oy](https://a-11-oy.com) and the [killinchu demonstration](https://szlholdings-killinchu.hf.space/elite) |
 | How is the system assembled? | [Platform](https://github.com/szl-holdings/platform) and [a11oy architecture](https://github.com/szl-holdings/a11oy/blob/main/docs/architecture.md) |
-| What can be independently checked? | [Proof registry](https://a11oy.net), [receipt specification](https://github.com/szl-holdings/governed-receipt-spec), and [public trust portal](https://github.com/szl-holdings/szl-trust) |
+| What can be independently checked? | [Proof registry](https://a11oy.net), [receipt specification](https://github.com/szl-holdings/governed-receipt-spec), and [maintained trust documentation](https://github.com/szl-holdings/docs-site/tree/main/docs/trust) |
 | What is formally established? | [Lean sources](https://github.com/szl-holdings/lutar-lean) and the [formula ledger](https://github.com/szl-holdings/szl-formula-ledger) |
 | Where are the models and data? | [SZLHOLDINGS on Hugging Face](https://huggingface.co/SZLHOLDINGS) and the [receipt lake](https://huggingface.co/datasets/SZLHOLDINGS/szl-lake) |
 
@@ -98,7 +98,7 @@ The shared contract is documented in the
 | **Products** | [a11oy](https://github.com/szl-holdings/a11oy) · [killinchu](https://github.com/szl-holdings/killinchu) |
 | **Applications and demonstrations** | [SDA](https://github.com/szl-holdings/sda) · [David Leads](https://github.com/szl-holdings/david-leads) · [IMMUNE](https://github.com/szl-holdings/immune) |
 | **Runtime** | [platform](https://github.com/szl-holdings/platform) · [szl-substrate](https://github.com/szl-holdings/szl-substrate) · [Ouroboros](https://github.com/szl-holdings/ouroboros) · [router](https://github.com/szl-holdings/szl-router) |
-| **Evidence** | [receipt spec](https://github.com/szl-holdings/governed-receipt-spec) · [receipt library](https://github.com/szl-holdings/szl-receipt) · [trust portal](https://github.com/szl-holdings/szl-trust) · [evidence doctrine](https://github.com/szl-holdings/evidence-doctrine) |
+| **Evidence** | [receipt spec](https://github.com/szl-holdings/governed-receipt-spec) · [receipt library](https://github.com/szl-holdings/szl-receipt) · [trust documentation](https://github.com/szl-holdings/docs-site/tree/main/docs/trust) · [evidence doctrine](https://github.com/szl-holdings/evidence-doctrine) |
 | **Formal methods** | [lutar-lean](https://github.com/szl-holdings/lutar-lean) · [formula ledger](https://github.com/szl-holdings/szl-formula-ledger) · [Lambda gate](https://github.com/szl-holdings/szl-lambda-gate) |
 | **Models and compute** | [Forge](https://github.com/szl-holdings/szl-forge) · [kernels](https://github.com/szl-holdings/szl-kernels) · [energy attestation](https://github.com/szl-holdings/szl-energy-attest) |
 | **Research and examples** | [papers](https://github.com/szl-holdings/szl-papers) · [cookbook](https://github.com/szl-holdings/szl-cookbook) · [documentation source](https://github.com/szl-holdings/docs-site) |

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,107 +1,155 @@
+<!-- markdownlint-disable MD013 MD033 MD041 -->
 <!--
-  SZL Holdings — organization profile README (szl-holdings/.github -> profile/README.md)
-  Minimal funnel front door · 2026-06-30 · Honesty doctrine v11 LOCKED.
-  Pattern: anthropic.com (company front door) is separate from console.anthropic.com (product).
-  This card FUNNELS into the flagship a-11-oy.com — it does NOT duplicate console content.
-  Canonical (source of truth: lutar-lean@main):
-    Locked-proven = EXACTLY 8 {F1,F4,F7,F11,F12,F18,F19,F22}.
-    Λ-uniqueness = Conjecture 1 (unconditional machine-checked FALSE; conditional Theorem U proven, axiom-free).
-    SLSA = L1 honest · L2 build-attested · L3 roadmap. No FedRAMP/ATO/CMMC without "roadmap".
-  KANCHAY palette only (void #080c14 · proof #3af4c8 · lattice #5b8dee · gold #d7b96b). No purple. Canonical domain is a-11-oy.com (with hyphens); the pre-sunset domain must never appear on any surface.
+  SZL Holdings organization profile.
+  Investor path first; builder and verification paths remain one click away.
+  Canonical claims: exactly 8 locked-proven formulas; Lambda uniqueness is
+  Conjecture 1; SLSA L1 honest, L2 build-attested, L3 roadmap.
 -->
 
 <div align="center">
 
-# SZL Holdings
+<img src="./assets/png/szl-holdings-logo.png" alt="SZL Holdings — governed, attributed, executable" width="760" />
 
-### Governed AI you can prove — every decision comes with a signed, verifiable receipt.
+# Governed AI that leaves evidence
 
-**a11oy** is the enterprise / regulated-AI platform (the code spine); **killinchu** is the defense & maritime front-end built on it. One doctrine, one receipt bus, two buyers.
+SZL Holdings builds decision infrastructure for high-consequence AI. The
+system can evaluate policy, execute an allowed action, and return a portable
+receipt that another party can verify.
 
-[![locked-proven](https://img.shields.io/badge/locked--proven-8%20formulas-3af4c8?style=flat-square)](https://github.com/szl-holdings/lutar-lean)
-[![Lean 4](https://img.shields.io/badge/Lean%204-machine--checked-5b8dee?style=flat-square)](https://github.com/szl-holdings/lutar-lean)
-[![Λ](https://img.shields.io/badge/%CE%9B-Conjecture%201%20(never%20green)-7e8aa3?style=flat-square)](https://github.com/szl-holdings/lutar-lean)
-[![SLSA](https://img.shields.io/badge/SLSA-L1%20honest%20%C2%B7%20L2%20attested%20%C2%B7%20L3%20roadmap-d7b96b?style=flat-square)](https://slsa.dev/spec/v1.0/levels)
-[![DOI](https://img.shields.io/badge/concept%20DOI-10.5281%2Fzenodo.19944926-3af4c8?style=flat-square)](https://doi.org/10.5281/zenodo.19944926)
-
-<br/>
-
-## [Enter a11oy →](https://a-11-oy.com)
-
-### ◇ [Explore the Holographic Estate →](https://a-11-oy.com/holographic)
-
-[**◆ Estate hub — every Space, live →**](https://szlholdings-szl-estate-live.static.hf.space) · [**Verify a receipt →**](https://a-11-oy.com/verify) · [**Read the docs →**](https://szl-holdings.github.io/docs-site/) · [**docs-site repo →**](https://github.com/szl-holdings/docs-site)
+[**See the platform**](https://a-11-oy.com) ·
+[**Start building**](https://holdings.a-11-oy.com/docs-site/) ·
+[**Verify evidence**](https://a11oy.net) ·
+[**Explore models and data**](https://huggingface.co/SZLHOLDINGS)
 
 </div>
 
 ---
 
-## Start here: product, proof, and source
+## One substrate, two product lines
 
-This is the shortest diligence path through the public estate. Runtime
-availability, model quality, formal proof, and supply-chain evidence are
-separate claims; inspect each at its owning source.
+| Product | For | Outcome | Explore |
+| --- | --- | --- | --- |
+| **a11oy** | Enterprises and regulated teams | Governed inference and agentic execution with inspectable decision receipts | [Product](https://a-11-oy.com) · [Source](https://github.com/szl-holdings/a11oy) · [Proof registry](https://a11oy.net) |
+| **killinchu** | Defense and maritime operators | A counter-UAS and maritime command demonstration built on the same governance substrate | [Live demo](https://szlholdings-killinchu.hf.space/elite) · [Source](https://github.com/szl-holdings/killinchu) |
 
-| Inspect | Authoritative public surface | What it establishes |
-|---|---|---|
-| **Product** | [a-11-oy.com](https://a-11-oy.com) · [a11oy source](https://github.com/szl-holdings/a11oy) | Governed runtime, public interfaces, route contracts, and implementation |
-| **System architecture** | [platform](https://github.com/szl-holdings/platform) · [architecture](https://github.com/szl-holdings/a11oy/blob/main/docs/architecture.md) | Monorepo integration boundaries and the a11oy execution spine |
-| **Defense demonstration** | [killinchu](https://github.com/szl-holdings/killinchu) · [live demo](https://szlholdings-killinchu.hf.space/elite) | Counter-UAS and maritime demonstration surfaces; simulated effectors remain labeled |
-| **Formal evidence** | [lutar-lean](https://github.com/szl-holdings/lutar-lean) | Lean/mathlib sources for exactly eight locked-proven formulas and the explicit conjecture boundary |
-| **Receipt contract** | [governed-receipt-spec](https://github.com/szl-holdings/governed-receipt-spec) · [verify](https://a-11-oy.com/verify) | Portable receipt schema plus an independent verification entry point |
-| **Models and data** | [SZLHOLDINGS on Hugging Face](https://huggingface.co/SZLHOLDINGS) · [szl-lake](https://huggingface.co/datasets/SZLHOLDINGS/szl-lake) | Published artifacts, cards, licenses, datasets, and model-specific evaluation boundaries |
+The product experience and the evidence experience are intentionally
+separate. Product surfaces explain what the system does. Proof surfaces let
+reviewers inspect what actually happened.
 
-For technical review, begin with the
-[architecture](https://github.com/szl-holdings/a11oy/blob/main/docs/architecture.md),
-[security policy](https://github.com/szl-holdings/.github/blob/main/SECURITY.md),
-and [contribution contract](https://github.com/szl-holdings/.github/blob/main/CONTRIBUTING.md).
-Claims without a reproducible artifact or current receipt remain unverified.
+## The operating thesis
 
-Repository lifecycle is explicit: 12 public archives are frozen records, not
-deleted work. Use the
-[estate lifecycle map](https://github.com/szl-holdings/.github/blob/main/docs/ESTATE_LIFECYCLE.md)
-to find each canonical active successor and its retention rationale.
+```text
+request -> policy gate -> bounded execution -> decision receipt -> independent verification
+```
 
----
+Most AI systems stop at an answer. SZL adds a control and evidence layer:
 
-## Spaces
+1. **Attribute the request.** Bind an actor, intent, policy, and source
+   revision.
+2. **Gate the decision.** Refuse when authority or evidence is insufficient.
+3. **Execute within a bound.** Preserve explicit permissions, limits, and
+   failure states.
+4. **Return evidence.** Emit a receipt that can be retained, replayed, and
+   verified outside the product UI.
 
-| Space | What it is | Open |
-|---|---|---|
-| **◆ estate hub** — one flag | The single index of the whole estate: **every** Space read from the **live** Hugging Face API at page load, each card's title & description passed through **verbatim** (REPORTED), per-Space runtime status fetched live (RUNNING = running *now*), honest **UNAVAILABLE** on any failure. New Spaces appear automatically. 0 runtime CDN. | **[open →](https://szlholdings-szl-estate-live.static.hf.space)** |
-| **a11oy** — flagship | Governed-AI Command Center: ask-and-act behind deny-by-default gates, a live decision feed, and a signed receipt for every action. | **[a-11-oy.com](https://a-11-oy.com)** |
-| **Holographic Estate** — 3D showcase | The frontier tier as one live holographic lattice — 70+ live surfaces (frontier organs, energy, counter-UAS, governance, PINN, anatomy) in navigable 3D, the exact live count self-verifiable at [`/api/a11oy/v1/frontier/surfaces`](https://a-11-oy.com/api/a11oy/v1/frontier/surfaces). 0 runtime CDN; WebGL2 with optional WebGPU; every value carries its honesty label. | **[a-11-oy.com/holographic](https://a-11-oy.com/holographic)** |
-| **the Brain** | Governed graph, retrieval, memory-freshness, and lineage showcase. The [live capability contract](https://a-11-oy.com/api/a11oy/v1/brain/capabilities) is authoritative: the service is currently **PARTIALLY OPERATIONAL** and ready for showcase, not autonomous or training claims. Read-only requests mint nothing; durable signed per-read/write receipts are not claimed. | [a-11-oy.com/brain](https://a-11-oy.com/brain) |
-| **killinchu** | Counter-UAS & maritime command *demonstration* — multi-sensor fusion with signed engagement receipts (effector link is a labeled simulation). | [demo →](https://szlholdings-killinchu.hf.space/elite) |
-| **anatomy** | Living anatomy map — the locked-8 ladder and the four honesty tiers, visualized. | [view →](https://szlholdings-anatomy.hf.space) |
-| **david-leads** | Sovereign insurance intelligence — audit-defensible lead intelligence from public data only. | [view →](https://szlholdings-david-leads.hf.space) |
-| **energy-attest-holo** | Honest energy-attestation surface: attests the sovereign mesh's live NVML meters and shows **RED / UNAVAILABLE** when none are live (the honest current state), with GB grid carbon intensity as REPORTED context. 0 runtime CDN. | [view →](https://szlholdings-energy-attest-holo.static.hf.space) |
-| **governed-norm-holo** | Inspectable rendering of the a11oy WILLAY refusal classifiers — every governed-refusal rule discloses its category, what it fires on, its rationale and its lineage. The live list is fetched keyless from a11oy `/willay/classifiers` (REPORTED; honest UNAVAILABLE if the gate is unreachable). Trust ceiling 0.97; 0 runtime CDN. | [view →](https://szlholdings-governed-norm-holo.static.hf.space) |
-| **lambda-gate-holo** | The Λ governance-trust gate as a holographic explainer: Λ = **Conjecture 1** (never a theorem, never green), status read live from the machine-checked szl-formula-ledger — unconditional uniqueness is machine-checked FALSE, only a conditional Theorem U is proven. Trust ceiling 0.97; 0 runtime CDN. | [view →](https://szlholdings-lambda-gate-holo.static.hf.space) |
-| **receipt-chain-live** | The Khipu receipt lake's sha3-256 hash chain re-verified **in your browser** — fetches the live lake keyless and recomputes every link locally (verification = MEASURED-in-your-browser; lake values REPORTED; honest UNAVAILABLE if the lake is unreachable). | [view →](https://szlholdings-receipt-chain-live.static.hf.space) |
-| **szl-provctl-live** | Provenance-DAG verify hologram for the szl-provctl kernel — in-browser hash verification over the kernel's real provenance sample (labeled as a sample, not live telemetry). | [view →](https://szlholdings-szl-provctl-live.static.hf.space) |
-| **szl-kernels-live** | The governed-kernel suite hub — every kernel hologram in one surface, LIVE/ROADMAP status fetched from the HF Spaces API at page load (REPORTED: a roadmap item only shows LIVE when its Space is actually running). | [view →](https://szlholdings-szl-kernels-live.static.hf.space) |
-| **szl-govsign-live** | The szl-govsign kernel's DSSE / in-toto signing story — real kernel source fetched live + keyless (REPORTED verbatim), PAE cross-checked against the DSSE spec vector and ECDSA P-256 sign/verify run in your browser via WebCrypto (MEASURED; demo keypair explicitly labeled NOT a production key). | [view →](https://szlholdings-szl-govsign-live.static.hf.space) |
-| **szl-blocked-live** | honest-BLOCKED as a first-class state — the szl-blocked deny-by-default lattice (HARD_DENY > advisory-Λ-tighten > HARD_ALLOW) felt interactively (labeled DEMO), kernel source passed through verbatim, EU AI Act Annex IV DRAFT-skeleton doctrine passed through exactly (NOT legal advice). | [view →](https://szlholdings-szl-blocked-live.static.hf.space) |
+## Diligence in five links
 
----
+| Question | Canonical source |
+| --- | --- |
+| What can I see working? | [a11oy](https://a-11-oy.com) and the [killinchu demonstration](https://szlholdings-killinchu.hf.space/elite) |
+| How is the system assembled? | [Platform](https://github.com/szl-holdings/platform) and [a11oy architecture](https://github.com/szl-holdings/a11oy/blob/main/docs/architecture.md) |
+| What can be independently checked? | [Proof registry](https://a11oy.net), [receipt specification](https://github.com/szl-holdings/governed-receipt-spec), and [public trust portal](https://github.com/szl-holdings/szl-trust) |
+| What is formally established? | [Lean sources](https://github.com/szl-holdings/lutar-lean) and the [formula ledger](https://github.com/szl-holdings/szl-formula-ledger) |
+| Where are the models and data? | [SZLHOLDINGS on Hugging Face](https://huggingface.co/SZLHOLDINGS) and the [receipt lake](https://huggingface.co/datasets/SZLHOLDINGS/szl-lake) |
 
-## Live evidence
+At canonical Lean revision
+[`675d62b`](https://github.com/szl-holdings/lutar-lean/blob/675d62bd6f035047283fd3798440edad049635c2/README.md#tier-1--locked-proven-sorry-free-count-machine-enforced),
+observed 2026-08-01, the corpus machine-enforces exactly eight locked-proven
+formulas. Lambda uniqueness remains **Conjecture 1**, not a theorem. Runtime
+availability, model quality, formal proof, and supply-chain assurance are
+different claims and are evaluated at their owning sources.
 
-Not claims — receipts. Three independent surfaces over the same signed evidence:
+## Build with SZL
 
-| Surface | What it is | Open |
-|---|---|---|
-| **Quant signals wall** | Every signal & backtest as a DSSE-signed receipt, re-verified server-side against a pinned key on every request — plus the engine's **autonomous ~6-hourly paper ledger** (hash-chain-sealed; the wall MEASURES what the ledger recorded, promises nothing). ADVISORY / PAPER-ONLY: verification proves integrity + origin, never accuracy or profitability. | [a-11-oy.com/signals](https://a-11-oy.com/signals) |
-| **szl-lake dataset** | The canonical receipt corpus (khipu chains · quant family · papers · trajectories · SBOMs), mirrored GitHub ↔ Hugging Face with per-file sha256 manifests; the quant ledger is re-verified in CI against the pinned engine key before every mirror lands. | [🤗 szl-lake](https://huggingface.co/datasets/SZLHOLDINGS/szl-lake) |
-| **Autonomous ledger (raw)** | The append-only data branch written by the engine's scheduled CI — DSSE receipts + hash chain, independently walkable with the published verifier. GitHub cron is best-effort: gaps mean runs did not fire. | [szl-quant@ledger](https://github.com/szl-holdings/szl-quant/tree/ledger) |
+Choose the shortest path for the job:
+
+- **Integrate the platform:** begin in the
+  [documentation hub](https://holdings.a-11-oy.com/docs-site/).
+- **Verify or emit receipts:** use the
+  [governed receipt specification](https://github.com/szl-holdings/governed-receipt-spec)
+  and [shared receipt library](https://github.com/szl-holdings/szl-receipt).
+- **Add governed tools:** connect through
+  [Hatun MCP](https://github.com/szl-holdings/hatun-mcp).
+- **Run the shared substrate:** inspect
+  [szl-substrate](https://github.com/szl-holdings/szl-substrate) and the
+  [platform monorepo](https://github.com/szl-holdings/platform).
+- **Read the complete documentation:** open the
+  [documentation site](https://holdings.a-11-oy.com/docs-site/).
+
+Every repository should state its audience, maturity, five-minute path,
+architecture boundary, evidence level, security policy, and support route.
+The shared contract is documented in the
+[public experience standard](https://github.com/szl-holdings/.github/blob/main/docs/PUBLIC_EXPERIENCE_STANDARD.md).
+
+## Open-source map
+
+| Layer | Canonical repositories |
+| --- | --- |
+| **Products** | [a11oy](https://github.com/szl-holdings/a11oy) · [killinchu](https://github.com/szl-holdings/killinchu) |
+| **Applications and demonstrations** | [SDA](https://github.com/szl-holdings/sda) · [David Leads](https://github.com/szl-holdings/david-leads) · [IMMUNE](https://github.com/szl-holdings/immune) |
+| **Runtime** | [platform](https://github.com/szl-holdings/platform) · [szl-substrate](https://github.com/szl-holdings/szl-substrate) · [Ouroboros](https://github.com/szl-holdings/ouroboros) · [router](https://github.com/szl-holdings/szl-router) |
+| **Evidence** | [receipt spec](https://github.com/szl-holdings/governed-receipt-spec) · [receipt library](https://github.com/szl-holdings/szl-receipt) · [trust portal](https://github.com/szl-holdings/szl-trust) · [evidence doctrine](https://github.com/szl-holdings/evidence-doctrine) |
+| **Formal methods** | [lutar-lean](https://github.com/szl-holdings/lutar-lean) · [formula ledger](https://github.com/szl-holdings/szl-formula-ledger) · [Lambda gate](https://github.com/szl-holdings/szl-lambda-gate) |
+| **Models and compute** | [Forge](https://github.com/szl-holdings/szl-forge) · [kernels](https://github.com/szl-holdings/szl-kernels) · [energy attestation](https://github.com/szl-holdings/szl-energy-attest) |
+| **Research and examples** | [papers](https://github.com/szl-holdings/szl-papers) · [cookbook](https://github.com/szl-holdings/szl-cookbook) · [documentation source](https://github.com/szl-holdings/docs-site) |
+
+Archived repositories are preserved as historical evidence. Their active
+successors and retention rationale are listed in the
+[estate lifecycle map](https://github.com/szl-holdings/.github/blob/main/docs/ESTATE_LIFECYCLE.md).
+
+## Evidence and status language
+
+The same labels appear across product, code, documentation, and model cards.
+
+| Label | Meaning |
+| --- | --- |
+| **PROVED** | A precisely scoped statement is machine-checked by the named proof artifact. |
+| **MEASURED** | Directly observed with a disclosed instrument, time, and context. |
+| **REPORTED** | Supplied by an identified upstream source and not independently measured here. |
+| **MODELED** | Simulated, projected, or analytically derived; not a production observation. |
+| **CONJECTURE** | A formal hypothesis that remains unproved and is never rendered green. |
+| **ROADMAP** | Planned work; no operational claim is made. |
+
+Operational status is reported separately as **OPERATIONAL**, **PARTIAL**,
+**DEGRADED**, **UNAVAILABLE**, or **HISTORICAL**.
+
+Evidence integrity does not by itself prove model quality, safety, accuracy,
+profitability, compliance, or operational availability.
+
+## Trust and responsible use
+
+- Report vulnerabilities through the
+  [security policy](https://github.com/szl-holdings/.github/security/policy).
+- Review organization-wide expectations in
+  [TRUST.md](https://github.com/szl-holdings/.github/blob/main/TRUST.md) and
+  [PRIVACY.md](https://github.com/szl-holdings/.github/blob/main/PRIVACY.md).
+- Ask technical questions through the
+  [support policy](https://github.com/szl-holdings/.github/blob/main/SUPPORT.md).
+- Propose a change through the
+  [contribution guide](https://github.com/szl-holdings/.github/blob/main/CONTRIBUTING.md).
+
+No production authorization to operate, regulatory approval, or universal
+safety guarantee is claimed by this profile.
 
 ---
 
 <div align="center">
 
-**8 formulas locked-proven · Λ = Conjecture 1, never green · honest by design · public data only.**
+Governed · attributed · executable · independently verifiable
 
-<sub>[lutar-lean](https://github.com/szl-holdings/lutar-lean) · [🤗 SZLHOLDINGS](https://huggingface.co/SZLHOLDINGS) · concept DOI [10.5281/zenodo.19944926](https://doi.org/10.5281/zenodo.19944926) · No production ATO claimed · SLSA L1 honest / L2 attested / L3 roadmap · trust ceiling 0.97, never 100%</sub>
+[a-11-oy.com](https://a-11-oy.com) ·
+[a11oy.net](https://a11oy.net) ·
+[Documentation](https://holdings.a-11-oy.com/docs-site/) ·
+[Hugging Face](https://huggingface.co/SZLHOLDINGS)
 
 </div>

--- a/profile/README.md
+++ b/profile/README.md
@@ -101,7 +101,7 @@ The shared contract is documented in the
 | **Evidence** | [receipt spec](https://github.com/szl-holdings/governed-receipt-spec) · [receipt library](https://github.com/szl-holdings/szl-receipt) · [trust documentation](https://github.com/szl-holdings/docs-site/tree/main/docs/trust) · [evidence doctrine](https://github.com/szl-holdings/evidence-doctrine) |
 | **Formal methods** | [lutar-lean](https://github.com/szl-holdings/lutar-lean) · [formula ledger](https://github.com/szl-holdings/szl-formula-ledger) · [Lambda gate](https://github.com/szl-holdings/szl-lambda-gate) |
 | **Models and compute** | [Forge](https://github.com/szl-holdings/szl-forge) · [kernels](https://github.com/szl-holdings/szl-kernels) · [energy attestation](https://github.com/szl-holdings/szl-energy-attest) |
-| **Research and examples** | [papers](https://github.com/szl-holdings/szl-papers) · [cookbook](https://github.com/szl-holdings/szl-cookbook) · [documentation source](https://github.com/szl-holdings/docs-site) |
+| **Research and examples** | [papers](https://github.com/szl-holdings/szl-papers) · [maintained cookbook recipes](https://github.com/szl-holdings/docs-site/tree/main/docs/cookbook/recipes) · [documentation source](https://github.com/szl-holdings/docs-site) |
 
 Archived repositories are preserved as historical evidence. Their active
 successors and retention rationale are listed in the

--- a/templates/HUGGINGFACE_DATASET_CARD.md
+++ b/templates/HUGGINGFACE_DATASET_CARD.md
@@ -1,0 +1,114 @@
+---
+license: {{HF_LICENSE_ID}}
+language:
+  - {{LANGUAGE_CODE}}
+task_categories:
+  - {{TASK_CATEGORY}}
+pretty_name: {{DATASET_NAME}}
+thumbnail: {{ABSOLUTE_THUMBNAIL_URL}}
+size_categories:
+  - {{SIZE_CATEGORY}}
+tags:
+  - szl-holdings
+  - governed-ai
+---
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+# {{DATASET_NAME}}
+
+> {{ONE_SENTENCE_CONTENT_AND_PURPOSE}}
+
+**Release:** `{{IMMUTABLE_REVISION}}` · **Status:** {{STATUS_LABEL}} ·
+**License:** {{LICENSE_NAME}}
+
+## Dataset summary
+
+{{WHAT_THE_DATASET_CONTAINS_WHO_CREATED_IT_AND_WHAT_IT_SUPPORTS}}
+
+| Property | Value |
+| --- | --- |
+| Rows or artifacts | {{COUNT}} |
+| Splits | {{SPLITS}} |
+| Formats | {{FORMATS}} |
+| Languages | {{LANGUAGES}} |
+| Source revision | `{{SOURCE_REVISION}}` |
+| Manifest digest | `{{MANIFEST_DIGEST}}` |
+
+## Supported and excluded uses
+
+### Supported
+
+- {{INTENDED_USE_1}}
+- {{INTENDED_USE_2}}
+
+### Excluded
+
+- {{EXCLUDED_USE_1}}
+- {{EXCLUDED_USE_2}}
+
+## Load the data
+
+```python
+{{REPRODUCIBLE_LOAD_EXAMPLE}}
+```
+
+Pin the exact dataset revision in reproducible work.
+
+## Structure
+
+### Splits
+
+| Split | Records | Purpose |
+|---|---:|---|
+| `{{SPLIT_NAME}}` | {{RECORD_COUNT}} | {{SPLIT_PURPOSE}} |
+
+### Fields
+
+| Field | Type | Nullable | Description |
+|---|---|---:|---|
+| `{{FIELD_NAME}}` | `{{FIELD_TYPE}}` | {{YES_OR_NO}} | {{FIELD_DESCRIPTION}} |
+
+## Provenance and governance
+
+Document collection sources, dates, licenses, consent, attribution,
+preprocessing, filtering, deduplication, synthetic generation, and derivation.
+
+| Stage | Source | Revision or digest |
+| --- | --- | --- |
+| Raw input | {{RAW_SOURCE_LINK}} | `{{RAW_SOURCE_DIGEST}}` |
+| Transformation | {{PIPELINE_LINK}} | `{{PIPELINE_REVISION}}` |
+| Validation | {{VALIDATION_LINK}} | `{{VALIDATION_RECEIPT}}` |
+
+### Privacy and PII
+
+{{PII_REVIEW_REMOVAL_RETENTION_AND_CONTACT_PROCESS}}
+
+## Validation
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Schema | {{RESULT}} | {{EVIDENCE_LINK}} |
+| Integrity | {{RESULT}} | {{EVIDENCE_LINK}} |
+| Contamination or leakage | {{RESULT}} | {{EVIDENCE_LINK}} |
+
+## Known gaps and bias
+
+- {{GAP_1}}
+- {{GAP_2}}
+- {{BIAS_OR_REPRESENTATION_LIMIT}}
+
+## Update policy
+
+{{VERSIONING_CADENCE_COMPATIBILITY_AND_RETENTION_POLICY}}
+
+## Citation and support
+
+```bibtex
+{{BIBTEX_CITATION}}
+```
+
+- Source: {{SOURCE_REPOSITORY}}
+- Security or privacy: {{SECURITY_POLICY}}
+- Issues: {{ISSUE_TRACKER}}
+- Changelog: {{CHANGELOG}}

--- a/templates/HUGGINGFACE_MODEL_CARD.md
+++ b/templates/HUGGINGFACE_MODEL_CARD.md
@@ -1,0 +1,130 @@
+---
+license: {{HF_LICENSE_ID}}
+language:
+  - {{LANGUAGE_CODE}}
+library_name: {{LIBRARY_NAME}}
+pipeline_tag: {{PIPELINE_TAG}}
+thumbnail: {{ABSOLUTE_THUMBNAIL_URL}}
+tags:
+  - szl-holdings
+  - governed-ai
+base_model: {{BASE_MODEL_ID_OR_DELETE}}
+datasets:
+  - {{DATASET_ID_OR_DELETE}}
+model-index:
+  - name: {{MODEL_NAME}}
+    results:
+      - task:
+          type: {{PIPELINE_TAG}}
+          name: {{TASK_DISPLAY_NAME}}
+        dataset:
+          type: {{EVALUATION_DATASET_ID}}
+          name: {{EVALUATION_DATASET_NAME}}
+          split: {{EVALUATION_SPLIT}}
+        metrics:
+          - type: {{METRIC_ID}}
+            value: {{METRIC_VALUE}}
+            name: {{METRIC_DISPLAY_NAME}}
+---
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+# {{MODEL_NAME}}
+
+> {{ONE_SENTENCE_CAPABILITY_AND_PRIMARY_USER}}
+
+**Release:** `{{IMMUTABLE_REVISION}}` · **Status:** {{STATUS_LABEL}} ·
+**License:** {{LICENSE_NAME}}
+
+## Model summary
+
+{{WHAT_THE_MODEL_IS_AND_WHERE_IT_FITS_IN_THE_SZL_ESTATE}}
+
+| Property | Value |
+| --- | --- |
+| Architecture | {{ARCHITECTURE}} |
+| Parameters | {{PARAMETER_COUNT}} |
+| Context length | {{CONTEXT_LENGTH}} |
+| Precision | {{PRECISION}} |
+| Languages | {{LANGUAGES}} |
+| Source revision | `{{SOURCE_REVISION}}` |
+| Artifact digest | `{{ARTIFACT_DIGEST}}` |
+
+## Intended use
+
+### Supported
+
+- {{INTENDED_USE_1}}
+- {{INTENDED_USE_2}}
+
+### Excluded
+
+- {{EXCLUDED_USE_1}}
+- {{EXCLUDED_USE_2}}
+
+This model does not independently establish safety, compliance, factual
+accuracy, authorization, or fitness for a high-consequence decision.
+
+## Quickstart
+
+Install dependencies:
+
+```bash
+{{INSTALL_COMMAND}}
+```
+
+Run a minimal, deterministic example:
+
+```python
+{{REPRODUCIBLE_INFERENCE_EXAMPLE}}
+```
+
+Pin `revision="{{IMMUTABLE_REVISION}}"` in production or evaluation code.
+
+## Training and lineage
+
+| Stage | Source | Revision or digest |
+| --- | --- | --- |
+| Base model | {{BASE_MODEL_LINK}} | `{{BASE_MODEL_REVISION}}` |
+| Dataset | {{DATASET_LINK}} | `{{DATASET_REVISION}}` |
+| Training code | {{TRAINING_CODE_LINK}} | `{{TRAINING_CODE_REVISION}}` |
+| Receipt | {{TRAINING_RECEIPT_LINK}} | `{{RECEIPT_DIGEST}}` |
+
+Describe preprocessing, filtering, deduplication, sampling, prompt format,
+hyperparameters, random seeds, hardware, training duration, and known gaps.
+Mark unavailable lineage explicitly; do not infer it.
+
+## Evaluation
+
+| Evaluation | Result | Scope | Reproduce |
+|---|---:|---|---|
+| {{EVALUATION_NAME}} | {{RESULT_WITH_UNIT}} | {{DATASET_SPLIT_AND_LIMITS}} | {{EVALUATION_COMMAND_OR_LINK}} |
+
+State when and where each result was measured. Separate upstream-reported
+benchmarks from SZL measurements and from modeled results.
+
+## Safety, bias, and limitations
+
+- {{LIMITATION_1}}
+- {{LIMITATION_2}}
+- {{BIAS_OR_COVERAGE_GAP}}
+- {{REQUIRED_HUMAN_OR_POLICY_CONTROL}}
+
+## Hardware and deployment
+
+| Mode | Minimum tested hardware | Notes |
+|---|---|---|
+| {{MODE_1}} | {{HARDWARE_1}} | {{NOTES_1}} |
+
+## Citation
+
+```bibtex
+{{BIBTEX_CITATION}}
+```
+
+## Support and changes
+
+- Source: {{SOURCE_REPOSITORY}}
+- Security: {{SECURITY_POLICY}}
+- Issues: {{ISSUE_TRACKER}}
+- Changelog: {{CHANGELOG}}

--- a/templates/HUGGINGFACE_SPACE_CARD.md
+++ b/templates/HUGGINGFACE_SPACE_CARD.md
@@ -1,0 +1,90 @@
+---
+title: {{SPACE_TITLE}}
+short_description: {{SHORT_DESCRIPTION}}
+emoji: {{EMOJI}}
+colorFrom: {{COLOR_FROM}}
+colorTo: {{COLOR_TO}}
+sdk: {{SDK}}
+sdk_version: {{GRADIO_VERSION_OR_DELETE}}
+app_file: {{GRADIO_OR_STATIC_APP_FILE_OR_DELETE}}
+app_port: {{DOCKER_APP_PORT_OR_DELETE}}
+base_path: {{NON_STATIC_BASE_PATH_OR_DELETE}}
+pinned: false
+license: {{HF_LICENSE_ID}}
+thumbnail: {{ABSOLUTE_THUMBNAIL_URL}}
+models:
+  - {{MODEL_ID_OR_DELETE}}
+datasets:
+  - {{DATASET_ID_OR_DELETE}}
+tags:
+  - szl-holdings
+  - governed-ai
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# {{SPACE_TITLE}}
+
+> {{ONE_SENTENCE_DEMONSTRATION_AND_AUDIENCE}}
+
+**Runtime status:** {{STATUS_BEHAVIOR_OR_STATUS_ENDPOINT}} ·
+**Source:** {{SOURCE_REPOSITORY}} at `{{SOURCE_REVISION}}`
+
+Before publication, delete metadata fields that do not apply. `sdk_version` is
+Gradio-only; Docker Spaces use `app_port`; static Spaces use `app_file` and may
+add `app_build_command`.
+
+## What this demonstrates
+
+{{TWO_TO_FOUR_SENTENCES_DESCRIBING_THE_REAL_USER_FLOW}}
+
+This Space demonstrates {{EXPLICIT_SCOPE}}. It does not claim
+{{EXPLICIT_NON_CLAIM}}.
+
+## Try the primary flow
+
+1. {{STEP_1}}
+2. {{STEP_2}}
+3. {{STEP_3}}
+
+Expected result: {{EXPECTED_RESULT_AND_EVIDENCE}}
+
+## Immutable dependencies
+
+| Dependency | Repository | Revision |
+| --- | --- | --- |
+| Model | {{MODEL_ID_OR_NONE}} | `{{MODEL_REVISION_OR_NONE}}` |
+| Dataset | {{DATASET_ID_OR_NONE}} | `{{DATASET_REVISION_OR_NONE}}` |
+| Application | {{SOURCE_REPOSITORY}} | `{{SOURCE_REVISION}}` |
+
+## Runtime and evidence behavior
+
+- Health or status source: {{STATUS_ENDPOINT_OR_METHOD}}
+- Evidence label: {{PROVED_MEASURED_REPORTED_MODELED_CONJECTURE_ROADMAP}}
+- Receipt behavior: {{WHAT_MINTS_A_RECEIPT_AND_WHAT_DOES_NOT}}
+- Failure behavior: {{HOW_UNAVAILABLE_OR_DEGRADED_IS_DISPLAYED}}
+
+## Privacy and data handling
+
+{{INPUT_LOGGING_RETENTION_TELEMETRY_THIRD_PARTIES_AND_DELETION_BEHAVIOR}}
+
+Do not enter secrets, regulated data, or personal information unless this
+section explicitly documents an approved handling contract.
+
+## Run locally
+
+```bash
+{{CLONE_INSTALL_AND_RUN_COMMANDS}}
+```
+
+## Limits
+
+- {{LIMIT_1}}
+- {{LIMIT_2}}
+- {{OPERATIONAL_OR_SAFETY_BOUNDARY}}
+
+## Support
+
+- Documentation: {{DOCS_LINK}}
+- Source and issues: {{SOURCE_REPOSITORY}}
+- Security: {{SECURITY_POLICY}}

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,24 +1,38 @@
-# Templates
+# Public surface templates
 
-  Shared templates for every repository in the [SZL Holdings](https://github.com/szl-holdings) organization. New repositories should bootstrap from these to maintain a consistent presentation across the org.
+These templates make every SZL repository and Hugging Face artifact easy to
+evaluate for investors, operators, researchers, and developers. They define a
+common information architecture without forcing unrelated projects into the
+same technical stack.
 
-  | Template | Purpose |
-  |---|---|
-  | [`README.md`](./README.md) | Default repository README structure (placeholders in `{{ }}`) |
-  | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Contribution policy for source-available proprietary repos |
-  | [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) | Contributor Covenant 2.1, with SZL contact channel |
-  | [`SECURITY.md`](./SECURITY.md) | Vulnerability reporting policy, CVSS triage SLAs |
+| Template | Use it for |
+| --- | --- |
+| [`REPO_README.md`](./REPO_README.md) | Public or internal GitHub repository front doors |
+| [`HUGGINGFACE_MODEL_CARD.md`](./HUGGINGFACE_MODEL_CARD.md) | Model repositories on Hugging Face |
+| [`HUGGINGFACE_DATASET_CARD.md`](./HUGGINGFACE_DATASET_CARD.md) | Dataset repositories on Hugging Face |
+| [`HUGGINGFACE_SPACE_CARD.md`](./HUGGINGFACE_SPACE_CARD.md) | Space README and runtime contract |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Repository contribution policy |
+| [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) | Community participation rules |
+| [`SECURITY.md`](./SECURITY.md) | Vulnerability reporting and response |
 
-  ## How to use
+## Adoption contract
 
-  1. Copy the template into a new repository.
-  2. Replace every `{{PLACEHOLDER}}` token with the repo-specific value.
-  3. Confirm the CI badge URL matches the repository's actual workflow file name (`ci.yml` by default).
-  4. Open a PR and tag a maintainer for review.
+1. Copy the relevant template into the target repository.
+2. Replace every `{{PLACEHOLDER}}`; unresolved placeholders fail review.
+3. Delete sections that genuinely do not apply. Do not invent metrics,
+   customers, evaluations, security controls, or operational state.
+4. Link every status or performance claim to its owning evidence.
+5. Run the target repository's native checks and validate every copied command.
+6. Publish through a protected pull request with normal review.
 
-  The audit history of org-wide template rollouts lives in the platform repo at `docs/audits/github-org.md`.
+The complete hierarchy, vocabulary, accessibility target, and rollout gate are
+defined in
+[`PUBLIC_EXPERIENCE_STANDARD.md`](../docs/PUBLIC_EXPERIENCE_STANDARD.md).
 
-  ---
+Hugging Face `{{HF_LICENSE_ID}}` values use the Hub's lower-case repository
+card identifiers, such as `apache-2.0` or `cc-by-4.0`, not display-case SPDX
+spelling. Confirm every value in the
+[Hugging Face license registry](https://huggingface.co/docs/hub/en/repositories-licenses).
 
-  (c) 2024–2026 SZL Holdings, LLC.
-  
+These templates are starting points. The target repository remains the source
+of truth for its license, maturity, support model, and runtime behavior.

--- a/templates/REPO_README.md
+++ b/templates/REPO_README.md
@@ -1,47 +1,131 @@
-# {{REPO_DISPLAY_NAME}}
+<!-- markdownlint-disable MD013 -->
 
-  > {{TAGLINE}}
+# {{PROJECT_NAME}}
 
-  [![CI](https://github.com/szl-holdings/{{REPO}}/actions/workflows/ci.yml/badge.svg)](https://github.com/szl-holdings/{{REPO}}/actions/workflows/ci.yml)
-  [![License](https://img.shields.io/badge/license-Proprietary-red?style=flat-square)](./LICENSE)
+> {{ONE_SENTENCE_OUTCOME_FOR_THE_PRIMARY_USER}}
 
-  {{REPO_DISPLAY_NAME}} is part of the [SZL Holdings](https://github.com/szl-holdings) platform — governed AI decision infrastructure for regulated enterprises.
+[![Status](https://img.shields.io/badge/status-{{STATUS_LABEL}}-{{STATUS_COLOR}})]({{STATUS_EVIDENCE_URL}})
+[![CI]({{CI_BADGE_URL}})]({{CI_WORKFLOW_URL}})
+[![License](https://img.shields.io/badge/license-{{LICENSE_ID}}-5b8dee)](./LICENSE)
 
-  ## What it does
+{{PROJECT_NAME}} is {{WHAT_IT_IS}} for {{PRIMARY_AUDIENCE}}. It helps them
+{{USER_OUTCOME}} without {{IMPORTANT_BOUNDARY_OR_RISK}}.
 
-  {{ONE_PARAGRAPH_DESCRIPTION}}
+[**Try it**]({{DEMO_OR_QUICKSTART_URL}}) ·
+[**Read the docs**]({{DOCS_URL}}) ·
+[**Review evidence**]({{EVIDENCE_URL}})
 
-  ## Capabilities
+## Why it exists
 
-  - {{CAPABILITY_1}}
-  - {{CAPABILITY_2}}
-  - {{CAPABILITY_3}}
+{{PROBLEM_CONTEXT_IN_TWO_TO_FOUR_SENTENCES}}
 
-  ## Status
+## What it does
 
-  **{{STATUS}}** — This is a product module within the [SZL Holdings platform monorepo](https://github.com/szl-holdings/szl-holdings-platform).
+- **{{CAPABILITY_1}}:** {{CAPABILITY_1_OUTCOME}}
+- **{{CAPABILITY_2}}:** {{CAPABILITY_2_OUTCOME}}
+- **{{CAPABILITY_3}}:** {{CAPABILITY_3_OUTCOME}}
 
-  ## Tech stack
+## Maturity and evidence
 
-  TypeScript · React · Vite · Express · PostgreSQL · Drizzle ORM
+| Dimension | State | Evidence |
+| --- | --- | --- |
+| Product | {{PRODUCT_STATE}} | {{PRODUCT_EVIDENCE}} |
+| Runtime | {{RUNTIME_STATE}} | {{RUNTIME_EVIDENCE}} |
+| Security | {{SECURITY_STATE}} | {{SECURITY_EVIDENCE}} |
+| Evaluation | {{EVALUATION_STATE}} | {{EVALUATION_EVIDENCE}} |
 
-  ## Documentation
+Evidence class uses **PROVED**, **MEASURED**, **REPORTED**, **MODELED**,
+**CONJECTURE**, or **ROADMAP**. Operational status separately uses
+**OPERATIONAL**, **PARTIAL**, **DEGRADED**, **UNAVAILABLE**, or **HISTORICAL**.
+Evidence integrity does not independently establish model quality, safety, or
+compliance.
 
-  - [License](./LICENSE) — proprietary, source-available
-  - [Security policy](./SECURITY.md) — how to report vulnerabilities
-  - [Contributing](./CONTRIBUTING.md) — how to engage with this project
-  - [Code of Conduct](./CODE_OF_CONDUCT.md)
+## Quickstart
 
-  ## Related repositories
+### Prerequisites
 
-  - [`szl-holdings-platform`](https://github.com/szl-holdings/szl-holdings-platform) — TypeScript monorepo, all domain packs
-  - [`a11oy`](https://github.com/szl-holdings/a11oy) — governed agentic execution fabric
-  - [`ouroboros`](https://github.com/szl-holdings/ouroboros) — bounded-loop runtime (Lutar Invariant)
-  - [`ouroboros-thesis`](https://github.com/szl-holdings/ouroboros-thesis) — research papers with Zenodo DOIs
+- {{PREREQUISITE_1}}
+- {{PREREQUISITE_2}}
 
-  ---
+```{{SHELL_LANGUAGE}}
+{{INSTALL_COMMAND}}
+{{RUN_COMMAND}}
+```
 
-  **[SZL Holdings](https://szlholdings.com)** · [Platform Repository](https://github.com/szl-holdings/szl-holdings-platform) · [stephen@szlholdings.com](mailto:stephen@szlholdings.com)
+Expected result:
 
-  (c) 2024–2026 SZL Holdings, LLC. All rights reserved.
-  
+```text
+{{EXPECTED_OUTPUT}}
+```
+
+Next, follow {{FIRST_REAL_TASK_LINK}}. The quickstart must be executable from a
+clean environment and should take less than ten minutes.
+
+## Architecture
+
+```text
+{{INPUT}} -> {{GATE_OR_CORE}} -> {{OUTPUT}} -> {{EVIDENCE}}
+```
+
+| Boundary | Responsibility |
+| --- | --- |
+| `{{COMPONENT_1}}` | {{COMPONENT_1_RESPONSIBILITY}} |
+| `{{COMPONENT_2}}` | {{COMPONENT_2_RESPONSIBILITY}} |
+| `{{COMPONENT_3}}` | {{COMPONENT_3_RESPONSIBILITY}} |
+
+See {{ARCHITECTURE_LINK}} for trust boundaries, persistence, failure modes,
+and deployment topology.
+
+## Configuration
+
+| Setting | Required | Default | Description |
+| --- | ---: | --- | --- |
+| `{{SETTING_1}}` | {{YES_OR_NO}} | `{{DEFAULT_1}}` | {{SETTING_1_DESCRIPTION}} |
+| `{{SETTING_2}}` | {{YES_OR_NO}} | `{{DEFAULT_2}}` | {{SETTING_2_DESCRIPTION}} |
+
+Never place credentials in examples, issue bodies, logs, or committed files.
+
+## Verification
+
+```{{SHELL_LANGUAGE}}
+{{TEST_COMMAND}}
+{{LINT_COMMAND}}
+{{TYPECHECK_OR_BUILD_COMMAND}}
+```
+
+Document the expected checks, supported versions, and known environment
+constraints. Link release artifacts to their immutable source revision.
+
+## Limits and non-goals
+
+- {{LIMIT_1}}
+- {{LIMIT_2}}
+- {{EXPLICIT_NON_GOAL}}
+
+## Documentation
+
+- [Architecture]({{ARCHITECTURE_LINK}})
+- [API or CLI reference]({{REFERENCE_LINK}})
+- [Examples]({{EXAMPLES_LINK}})
+- [Changelog]({{CHANGELOG_LINK}})
+- [Security policy](https://github.com/szl-holdings/.github/security/policy)
+- [Contributing](https://github.com/szl-holdings/.github/blob/main/CONTRIBUTING.md)
+- [Support](https://github.com/szl-holdings/.github/blob/main/SUPPORT.md)
+
+## Related projects
+
+| Project | Relationship |
+| --- | --- |
+| [{{RELATED_PROJECT_1}}]({{RELATED_PROJECT_1_URL}}) | {{RELATIONSHIP_1}} |
+| [{{RELATED_PROJECT_2}}]({{RELATED_PROJECT_2_URL}}) | {{RELATIONSHIP_2}} |
+
+## License
+
+{{LICENSE_SENTENCE_MATCHING_THE_ACTUAL_LICENSE_FILE}}
+
+---
+
+[SZL Holdings](https://github.com/szl-holdings) ·
+[a11oy](https://a-11-oy.com) ·
+[Documentation](https://holdings.a-11-oy.com/docs-site/) ·
+[Hugging Face](https://huggingface.co/SZLHOLDINGS)


### PR DESCRIPTION
## Outcome
Creates a concise organization front door and a reusable public-experience contract for investors, builders, and verifiers.

## What changed
- rewrites the organization profile around product, diligence, builder, and evidence paths
- separates products, applications, runtime, evidence, formal methods, models/compute, and research
- makes proof, measurement, modeled state, conjecture, roadmap, and runtime status non-interchangeable
- adds one repository README template and Hugging Face model, dataset, and Space card templates
- binds the locked-proven count to an immutable Lean revision instead of a floating metric
- imports brand authority from `szl-brand` rather than defining another token system

## Validation
- Markdown lint: zero findings on all seven changed files
- `git diff --check`: clean
- model and dataset card metadata: parsed and validated after placeholder substitution
- Gradio, Docker, and static Space metadata variants: parsed
- public navigation targets inspected; local new-file links mapped to this exact tree
- independent review findings addressed before commit
- exact head is SSH-signed and includes a DCO sign-off

## Boundaries
This PR does not mutate Hugging Face assets, live sites, A11oy/Bridge/GPU execution state, rulesets, repository visibility, archives, DNS, or secrets. Volatile estate counts are not hardcoded.