### PR TITLE
fix(ci): classify terminal Nemo attempt without masking successors

### DIFF
--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -30,6 +30,9 @@ from ci_health_digest_http import (
 RED = {"failure", "startup_failure", "timed_out", "action_required"}
 SOURCE_WORKFLOW_PREFIX = ".github/workflows/"
 DYNAMIC_WORKFLOW_PREFIX = "dynamic/"
+TERMINAL_NEMO_RUN_ID = 30641766033
+TERMINAL_NEMO_RUN_NUMBER = 10
+TERMINAL_NEMO_RUN_ATTEMPT = 1
 POLICY = [
     (
         "lambda-bounty",
@@ -112,6 +115,8 @@ class RedRun:
     workflow: str
     provenance: str
     conclusion: str
+    run_id: int | None
+    run_attempt: int | None
     run_number: int | None
     event: str | None
     url: str | None
@@ -123,16 +128,21 @@ def classify(
     *,
     event: str | None = None,
     run_number: int | None = None,
+    run_id: int | None = None,
+    run_attempt: int | None = None,
 ) -> tuple[str, str]:
     if (
         repository == "a11oy"
         and workflow == "Nemo v3 isolated owner GPU dispatch"
         and event == "repository_dispatch"
-        and run_number == 10
+        and run_number == TERMINAL_NEMO_RUN_NUMBER
+        and run_id == TERMINAL_NEMO_RUN_ID
+        and run_attempt == TERMINAL_NEMO_RUN_ATTEMPT
     ):
         return (
             "INTENTIONAL",
-            "Run #10 is the immutable zero-effect Attempt 15 prefetch rejection. "
+            "Workflow run 30641766033 attempt 1 (run #10) is the immutable "
+            "zero-effect Attempt 15 prefetch rejection. "
             "Protected bridge evidence at 53b6e206 quarantines Attempts 15 and 16; "
             "NEVER_RESEND and no future successor.",
         )
@@ -397,6 +407,12 @@ def _red_run(
         ),
         provenance=provenance,
         conclusion=conclusion,
+        run_id=int(run["id"]) if run.get("id") is not None else None,
+        run_attempt=(
+            int(run["run_attempt"])
+            if run.get("run_attempt") is not None
+            else None
+        ),
         run_number=(
             int(run["run_number"])
             if run.get("run_number") is not None
@@ -547,6 +563,8 @@ def build_body(
                 red.workflow,
                 event=red.event,
                 run_number=red.run_number,
+                run_id=red.run_id,
+                run_attempt=red.run_attempt,
             )
             buckets[disposition].append((red, note))
             total += 1

--- a/.github/scripts/ci_health_digest_sweep.py
+++ b/.github/scripts/ci_health_digest_sweep.py
@@ -117,7 +117,25 @@ class RedRun:
     url: str | None
 
 
-def classify(repository: str, workflow: str) -> tuple[str, str]:
+def classify(
+    repository: str,
+    workflow: str,
+    *,
+    event: str | None = None,
+    run_number: int | None = None,
+) -> tuple[str, str]:
+    if (
+        repository == "a11oy"
+        and workflow == "Nemo v3 isolated owner GPU dispatch"
+        and event == "repository_dispatch"
+        and run_number == 10
+    ):
+        return (
+            "INTENTIONAL",
+            "Run #10 is the immutable zero-effect Attempt 15 prefetch rejection. "
+            "Protected bridge evidence at 53b6e206 quarantines Attempts 15 and 16; "
+            "NEVER_RESEND and no future successor.",
+        )
     for repository_match, substring, verdict in POLICY:
         if (
             not repository_match or repository_match == repository
@@ -524,7 +542,12 @@ def build_body(
     total = 0
     for repository in sorted(reds):
         for red in reds[repository]:
-            disposition, note = classify(repository, red.workflow)
+            disposition, note = classify(
+                repository,
+                red.workflow,
+                event=red.event,
+                run_number=red.run_number,
+            )
             buckets[disposition].append((red, note))
             total += 1
 

--- a/.github/scripts/test_ci_health_digest_default_branch.py
+++ b/.github/scripts/test_ci_health_digest_default_branch.py
@@ -253,14 +253,60 @@ class ClassificationPolicyTests(unittest.TestCase):
                 "Nemo v3 isolated owner GPU dispatch",
                 event="repository_dispatch",
                 run_number=10,
+                run_id=30641766033,
+                run_attempt=1,
             ),
             (
                 "INTENTIONAL",
-                "Run #10 is the immutable zero-effect Attempt 15 prefetch rejection. "
+                "Workflow run 30641766033 attempt 1 (run #10) is the immutable "
+                "zero-effect Attempt 15 prefetch rejection. "
                 "Protected bridge evidence at 53b6e206 quarantines Attempts 15 and 16; "
                 "NEVER_RESEND and no future successor.",
             ),
         )
+
+    def test_rerun_of_terminal_nemo_run_remains_actionable(self):
+        self.assertEqual(
+            sweep.classify(
+                "a11oy",
+                "Nemo v3 isolated owner GPU dispatch",
+                event="repository_dispatch",
+                run_number=10,
+                run_id=30641766033,
+                run_attempt=2,
+            ),
+            ("ACTIONABLE", ""),
+        )
+
+    def test_terminal_coordinates_with_wrong_run_id_remain_actionable(self):
+        self.assertEqual(
+            sweep.classify(
+                "a11oy",
+                "Nemo v3 isolated owner GPU dispatch",
+                event="repository_dispatch",
+                run_number=10,
+                run_id=30641766034,
+                run_attempt=1,
+            ),
+            ("ACTIONABLE", ""),
+        )
+
+    def test_red_run_captures_immutable_run_identity(self):
+        red = sweep._red_run(
+            repository="a11oy",
+            workflow={"id": 1, "name": "Nemo v3 isolated owner GPU dispatch"},
+            provenance="protected_default_branch",
+            run={
+                "conclusion": "failure",
+                "id": 30641766033,
+                "run_attempt": 1,
+                "run_number": 10,
+                "event": "repository_dispatch",
+            },
+        )
+        self.assertIsNotNone(red)
+        self.assertEqual(red.run_id, 30641766033)
+        self.assertEqual(red.run_attempt, 1)
 
     def test_future_nemo_owner_dispatch_failure_remains_actionable(self):
         self.assertEqual(
@@ -269,6 +315,8 @@ class ClassificationPolicyTests(unittest.TestCase):
                 "Nemo v3 isolated owner GPU dispatch",
                 event="repository_dispatch",
                 run_number=11,
+                run_id=30641766033,
+                run_attempt=1,
             ),
             ("ACTIONABLE", ""),
         )
@@ -280,6 +328,8 @@ class ClassificationPolicyTests(unittest.TestCase):
                 "Nemo v3 isolated owner GPU dispatch",
                 event="push",
                 run_number=10,
+                run_id=30641766033,
+                run_attempt=1,
             ),
             ("ACTIONABLE", ""),
         )

--- a/.github/scripts/test_ci_health_digest_default_branch.py
+++ b/.github/scripts/test_ci_health_digest_default_branch.py
@@ -245,5 +245,45 @@ class WorkflowProvenanceTests(unittest.TestCase):
         self.assertEqual(coverage["excluded_non_default_workflows"], 2)
 
 
+class ClassificationPolicyTests(unittest.TestCase):
+    def test_terminal_nemo_attempt_15_run_is_intentional(self):
+        self.assertEqual(
+            sweep.classify(
+                "a11oy",
+                "Nemo v3 isolated owner GPU dispatch",
+                event="repository_dispatch",
+                run_number=10,
+            ),
+            (
+                "INTENTIONAL",
+                "Run #10 is the immutable zero-effect Attempt 15 prefetch rejection. "
+                "Protected bridge evidence at 53b6e206 quarantines Attempts 15 and 16; "
+                "NEVER_RESEND and no future successor.",
+            ),
+        )
+
+    def test_future_nemo_owner_dispatch_failure_remains_actionable(self):
+        self.assertEqual(
+            sweep.classify(
+                "a11oy",
+                "Nemo v3 isolated owner GPU dispatch",
+                event="repository_dispatch",
+                run_number=11,
+            ),
+            ("ACTIONABLE", ""),
+        )
+
+    def test_non_dispatch_nemo_run_remains_actionable(self):
+        self.assertEqual(
+            sweep.classify(
+                "a11oy",
+                "Nemo v3 isolated owner GPU dispatch",
+                event="push",
+                run_number=10,
+            ),
+            ("ACTIONABLE", ""),
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Contract metadata

Satisfies: C-158

Labels: PROVED exact immutable-run classification boundary and network-free regression coverage; MEASURED protected exact-head checks and independent Codex review; NOT CLAIMED any Nemo retry, GPU execution, or future-successor authorization.

Rollback: Before merge, close this pull request. After merge, revert the eventual protected squash commit through a signed pull request; the digest will then return the terminal run to ACTIONABLE.

Risk: C - organization-wide CI health classification policy. This changes no workflow, secret, App installation, ruleset, branch protection, or execution authorization.

## Diagnosis

A11oy owner-dispatch run #10 is still surfaced as actionable even though it is the immutable, zero-effect Attempt 15 prefetch rejection. Protected `szl-gpu-bridge` main `53b6e206366127f321b98942210e22feb0c56dce` preserves Attempt 15 evidence, terminally quarantines Attempt 16, refuses signing it, and grants no future successor.

Re-running either attempt would violate the protected no-resend contract.

## Change

- classify only repository `a11oy`
- require the exact workflow name and `repository_dispatch` event
- require run number `10`
- require immutable workflow-run ID `30641766033`
- require original run attempt `1`
- keep every rerun attempt, run-ID drift, future run number, and other event actionable
- add network-free tests for the positive and fail-closed negative boundaries

## Evidence

- Failed zero-effect run: https://github.com/szl-holdings/a11oy/actions/runs/30641766033
- Current protected status: https://github.com/szl-holdings/szl-gpu-bridge/actions/runs/30707840507
- Exact Attempt 16 status job: https://github.com/szl-holdings/szl-gpu-bridge/actions/runs/30707840507/job/91389921741

## Testing

Not run locally. Protected PR checks are the merge gate.