### PR TITLE
fix: validate Hugging Face Space metadata

### DIFF
--- a/.github/scripts/public_front_door_check.py
+++ b/.github/scripts/public_front_door_check.py
@@ -23,6 +23,21 @@ BANNED_COPY = {
     "trust ceiling 0.97",
     "all models operational",
 }
+HUB_CARD_EMOJI = "🛡️"
+
+
+def front_matter_value(document: str, key: str) -> str | None:
+    """Return an unquoted scalar from the leading YAML front matter only."""
+    lines = document.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return None
+        name, separator, value = line.partition(":")
+        if separator and name.strip() == key:
+            return value.strip()
+    return None
 
 
 class SurfaceParser(HTMLParser):
@@ -69,6 +84,13 @@ def main() -> int:
         require(url in hub_card, f"Hugging Face card missing canonical link: {url}", failures)
     require("./assets/estate-command-system.svg" in profile, "profile does not use canonical hero", failures)
     require("deployment.json" in hub_card, "Hub card does not expose served source binding", failures)
+    card_emoji = front_matter_value(hub_card, "emoji")
+    require(card_emoji is not None, "Hub card front matter is missing emoji", failures)
+    require(
+        card_emoji == HUB_CARD_EMOJI,
+        f"Hub card emoji must be the approved Extended Pictographic value {HUB_CARD_EMOJI}",
+        failures,
+    )
 
     combined = f"{profile}\n{hub_card}\n{html}".lower()
     for phrase in BANNED_COPY:
@@ -98,7 +120,7 @@ def main() -> int:
     report = {
         "schema": "szl.public-front-door-check/v1",
         "state": "PASS" if not failures else "FAIL",
-        "checks": 15 + len(REQUIRED_LINKS) * 2 + len(BANNED_COPY),
+        "checks": 16 + len(REQUIRED_LINKS) * 2 + len(BANNED_COPY),
         "failures": failures,
     }
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/.github/scripts/test_public_front_door_check.py
+++ b/.github/scripts/test_public_front_door_check.py
@@ -1,0 +1,25 @@
+import unittest
+
+import public_front_door_check as check
+
+
+class FrontMatterTests(unittest.TestCase):
+    def test_reads_emoji_from_leading_front_matter(self):
+        document = "---\nsdk: static\nemoji: 🛡️\n---\n# Card\n"
+        self.assertEqual(check.front_matter_value(document, "emoji"), "🛡️")
+
+    def test_ignores_emoji_line_in_card_body(self):
+        document = "---\nsdk: static\n---\n# Card\nemoji: 🛡️\n"
+        self.assertIsNone(check.front_matter_value(document, "emoji"))
+
+    def test_rejects_non_leading_front_matter(self):
+        document = "# Card\n---\nemoji: 🛡️\n---\n"
+        self.assertIsNone(check.front_matter_value(document, "emoji"))
+
+    def test_approved_value_is_exact(self):
+        self.assertEqual(check.HUB_CARD_EMOJI, "🛡️")
+        self.assertNotEqual(check.HUB_CARD_EMOJI, "𠀀")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,3 +236,9 @@ jobs:
       # navigation, accessibility, and honesty contract.
       - name: Public front-door contract
         run: python3 .github/scripts/public_front_door_check.py
+
+      - name: Public front-door parser self-test
+        run: >-
+          python3 -m unittest discover
+          -s .github/scripts
+          -p test_public_front_door_check.py

--- a/huggingface/org-card/README.md
+++ b/huggingface/org-card/README.md
@@ -1,6 +1,6 @@
 ---
 title: SZL Holdings — Governed Decision Infrastructure
-emoji: ◈
+emoji: 🛡️
 colorFrom: gray
 colorTo: yellow
 sdk: static


### PR DESCRIPTION
## Contract metadata

Satisfies: C-158

Labels: PROVED Hugging Face metadata preflight and network-free regression contracts; MEASURED failed deployment run `30709829547`; NOT CLAIMED live publication until the successor merge returns an exact served deployment manifest.

Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a signed pull request, which restores the prior metadata and its fail-closed publication error.

Risk: B - two-line public metadata correction plus a network-free preflight guard. No secret, model, dataset, runtime, App, ruleset, branch protection, or authorization change.

## Diagnosis

Protected main deployment run [`30709829547`](https://github.com/szl-holdings/.github/actions/runs/30709829547) failed before any Hub write because Hugging Face rejected `emoji: ◈`; the value does not match the required `Extended_Pictographic` metadata contract.

## Fix

- replace the non-pictographic diamond with a valid shield emoji
- fail the local public-front-door contract if future Space metadata lacks a pictographic emoji code point
- increment the reported contract count from 27 to 28

## Validation

- `python .github/scripts/test_hf_static_space_deploy.py` - 6 passed
- `python .github/scripts/public_front_door_check.py` - 28 checks, PASS
- Python compilation passed
- `git diff --check` passed
- commit `5a975ba5eec602a002e943f48b1bf3217364d027` is cryptographically signed and locally verified

## Boundary

This PR repairs the deployment preflight. Operational status remains unclaimed until the merged successor publishes and the same-host `deployment.json` exactly matches that protected revision and publication attempt.
