### PR TITLE
fix(hf): reconcile collection truth

### DIFF
--- a/.github/scripts/hf_collection_truth_reconcile.py
+++ b/.github/scripts/hf_collection_truth_reconcile.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Reconcile two narrow, evidence-backed Hugging Face collection truths.
+
+The reconciler intentionally owns only two facts:
+
+* the public command-system domain is ``https://a-11-oy.com``; and
+* ``SZLHOLDINGS/szl-nemo`` is a recipe/scorer repository, not a trained SZL
+  weight artifact, so it must not be listed in ``Trained Models & Weights``.
+
+Dry-run is the default.  Publication is allowed only when ``--publish`` is
+supplied by the protected merged-main workflow.  The script does not create,
+rename, or delete a collection or repository and does not touch model files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ORG = "SZLHOLDINGS"
+START_TITLE = "Start Here — Alloy Estate"
+TRAINED_TITLE = "Trained Models & Weights"
+NEMO_REPO = "SZLHOLDINGS/szl-nemo"
+START_DESCRIPTION = (
+    "Public navigation only; each artifact card and live status is authoritative. "
+    "Λ remains Conjecture 1 (advisory). Canonical site: https://a-11-oy.com."
+)
+REQUIRED_TRAINED_WEIGHTS = frozenset(
+    {
+        "SZLHOLDINGS/SZL-Forge-1.5B-ReceiptAgent",
+        "SZLHOLDINGS/SZL-Khipu-1.5B",
+        "SZLHOLDINGS/SZL-Khipu-1.5B-GGUF",
+    }
+)
+
+
+class ReconcileError(RuntimeError):
+    """The live collection state is ambiguous or failed verification."""
+
+
+@dataclass(frozen=True)
+class Action:
+    target: str
+    operation: str
+    status: str
+    detail: str
+
+
+def _item_id(item: Any) -> str:
+    return str(getattr(item, "item_id", ""))
+
+
+def _item_object_id(item: Any) -> str:
+    value = getattr(item, "item_object_id", None)
+    if not value:
+        raise ReconcileError(f"collection item {_item_id(item)!r} has no object id")
+    return str(value)
+
+
+class CollectionTruthReconciler:
+    def __init__(self, api: Any, *, publish: bool) -> None:
+        self.api = api
+        self.publish = publish
+        self.actions: list[Action] = []
+
+    def _collections_by_title(self) -> dict[str, Any]:
+        wanted = {START_TITLE, TRAINED_TITLE}
+        found: dict[str, Any] = {}
+        for summary in self.api.list_collections(owner=ORG, limit=99):
+            title = str(getattr(summary, "title", ""))
+            if title not in wanted:
+                continue
+            if title in found:
+                raise ReconcileError(f"duplicate collection title: {title}")
+            found[title] = self.api.get_collection(summary.slug)
+        missing = sorted(wanted - found.keys())
+        if missing:
+            raise ReconcileError(f"required collections missing: {missing}")
+        return found
+
+    def _reconcile_start(self, collection: Any) -> None:
+        current = str(getattr(collection, "description", "") or "")
+        if current == START_DESCRIPTION:
+            self.actions.append(
+                Action(collection.slug, "update-description", "unchanged", START_DESCRIPTION)
+            )
+            return
+        status = "published" if self.publish else "dry-run"
+        self.actions.append(
+            Action(collection.slug, "update-description", status, START_DESCRIPTION)
+        )
+        if self.publish:
+            self.api.update_collection_metadata(
+                collection_slug=collection.slug,
+                description=START_DESCRIPTION,
+            )
+
+    def _reconcile_trained(self, collection: Any) -> None:
+        item_ids = {_item_id(item) for item in collection.items}
+        missing = sorted(REQUIRED_TRAINED_WEIGHTS - item_ids)
+        if missing:
+            raise ReconcileError(
+                "refusing removal because expected trained-weight anchors are missing: "
+                f"{missing}"
+            )
+        nemo = [item for item in collection.items if _item_id(item) == NEMO_REPO]
+        if len(nemo) > 1:
+            raise ReconcileError(f"duplicate {NEMO_REPO} entries in {collection.slug}")
+        if not nemo:
+            self.actions.append(
+                Action(collection.slug, "remove-recipe-from-trained", "unchanged", NEMO_REPO)
+            )
+            return
+        status = "published" if self.publish else "dry-run"
+        self.actions.append(
+            Action(collection.slug, "remove-recipe-from-trained", status, NEMO_REPO)
+        )
+        if self.publish:
+            self.api.delete_collection_item(
+                collection_slug=collection.slug,
+                item_object_id=_item_object_id(nemo[0]),
+            )
+
+    def _verify(self) -> dict[str, Any]:
+        collections = self._collections_by_title()
+        start = collections[START_TITLE]
+        trained = collections[TRAINED_TITLE]
+        errors: list[str] = []
+        if str(getattr(start, "description", "") or "") != START_DESCRIPTION:
+            errors.append("Start Here description does not match the canonical domain")
+        trained_ids = {_item_id(item) for item in trained.items}
+        if NEMO_REPO in trained_ids:
+            errors.append("recipe-only szl-nemo remains in Trained Models & Weights")
+        missing = sorted(REQUIRED_TRAINED_WEIGHTS - trained_ids)
+        if missing:
+            errors.append(f"trained-weight anchors missing after reconcile: {missing}")
+        return {
+            "start_collection": start.slug,
+            "trained_collection": trained.slug,
+            "start_description": str(getattr(start, "description", "") or ""),
+            "trained_items": sorted(trained_ids),
+            "errors": errors,
+        }
+
+    def run(self) -> dict[str, Any]:
+        collections = self._collections_by_title()
+        self._reconcile_start(collections[START_TITLE])
+        self._reconcile_trained(collections[TRAINED_TITLE])
+
+        verification: dict[str, Any]
+        if self.publish:
+            verification = self._verify()
+            if verification["errors"]:
+                raise ReconcileError("; ".join(verification["errors"]))
+        else:
+            verification = {
+                "status": "NOT_EVALUATED",
+                "reason": "dry-run performs no mutation; protected merged-main publishes and reads back",
+            }
+        return {
+            "schema": "szl.hf.collection-truth-reconcile.v1",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "organization": ORG,
+            "mode": "publish" if self.publish else "dry-run",
+            "actions": [asdict(action) for action in self.actions],
+            "verification": verification,
+            "boundaries": [
+                "No collection or repository is created, renamed, or deleted.",
+                "No model, dataset, Space, kernel, or weight file is modified.",
+                "Collection membership is not training, quality, or operational proof.",
+            ],
+        }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--publish", action="store_true")
+    parser.add_argument(
+        "--report", default="reports/hf-collection-truth-reconcile-latest.json"
+    )
+    args = parser.parse_args()
+
+    from huggingface_hub import HfApi
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        report = CollectionTruthReconciler(HfApi(), publish=args.publish).run()
+        exit_code = 0
+    except Exception as exc:
+        report = {
+            "schema": "szl.hf.collection-truth-reconcile.v1",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "organization": ORG,
+            "mode": "publish" if args.publish else "dry-run",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+        exit_code = 2
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/hf_collection_truth_reconcile.py
+++ b/.github/scripts/hf_collection_truth_reconcile.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,6 +38,16 @@ REQUIRED_TRAINED_WEIGHTS = frozenset(
         "SZLHOLDINGS/SZL-Khipu-1.5B-GGUF",
     }
 )
+
+
+def _hub_token_from_environment(environ: Any) -> str | None:
+    """Select the approved Hub credential without relying on implicit aliases."""
+
+    return (
+        environ.get("HF_ORG_TOKEN")
+        or environ.get("HF_ORG_TOKEN1")
+        or environ.get("HF_TOKEN")
+    )
 
 
 class ReconcileError(RuntimeError):
@@ -190,7 +201,14 @@ def main() -> int:
     report_path = Path(args.report)
     report_path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        report = CollectionTruthReconciler(HfApi(), publish=args.publish).run()
+        token = _hub_token_from_environment(os.environ)
+        if args.publish and not token:
+            raise ReconcileError(
+                "publish mode requires HF_ORG_TOKEN, HF_ORG_TOKEN1, or HF_TOKEN"
+            )
+        report = CollectionTruthReconciler(
+            HfApi(token=token), publish=args.publish
+        ).run()
         exit_code = 0
     except Exception as exc:
         report = {

--- a/.github/scripts/test_hf_collection_truth_reconcile.py
+++ b/.github/scripts/test_hf_collection_truth_reconcile.py
@@ -116,6 +116,35 @@ class ReconcileTests(unittest.TestCase):
         self.assertNotIn("delete_collection(", source)
         self.assertNotIn("upload_file(", source)
 
+    def test_hub_token_selection_uses_approved_fallback_order(self) -> None:
+        self.assertEqual(
+            module._hub_token_from_environment(
+                {
+                    "HF_ORG_TOKEN": "org-primary",
+                    "HF_ORG_TOKEN1": "org-secondary",
+                    "HF_TOKEN": "generic",
+                }
+            ),
+            "org-primary",
+        )
+        self.assertEqual(
+            module._hub_token_from_environment(
+                {"HF_ORG_TOKEN1": "org-secondary", "HF_TOKEN": "generic"}
+            ),
+            "org-secondary",
+        )
+        self.assertEqual(
+            module._hub_token_from_environment({"HF_TOKEN": "generic"}),
+            "generic",
+        )
+        self.assertIsNone(module._hub_token_from_environment({}))
+
+    def test_manual_publish_is_pinned_to_main(self) -> None:
+        workflow = (
+            HERE.parent / "workflows" / "hf-collection-truth-reconcile.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('[ "$GITHUB_REF" = "refs/heads/main" ]', workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_hf_collection_truth_reconcile.py
+++ b/.github/scripts/test_hf_collection_truth_reconcile.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+import unittest
+
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "hf_collection_truth_reconcile", HERE / "hf_collection_truth_reconcile.py"
+)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+
+def item(item_id: str, object_id: str) -> SimpleNamespace:
+    return SimpleNamespace(item_id=item_id, item_object_id=object_id)
+
+
+class FakeApi:
+    def __init__(self, *, duplicate_start: bool = False, missing_anchor: bool = False) -> None:
+        anchors = sorted(module.REQUIRED_TRAINED_WEIGHTS)
+        if missing_anchor:
+            anchors.pop()
+        self.start = SimpleNamespace(
+            title=module.START_TITLE,
+            slug="SZLHOLDINGS/start-here",
+            description="Canonical site: a11oy.com.",
+            items=[],
+        )
+        self.trained = SimpleNamespace(
+            title=module.TRAINED_TITLE,
+            slug="SZLHOLDINGS/trained-models",
+            description="weights only",
+            items=[item(repo_id, f"anchor-{index}") for index, repo_id in enumerate(anchors)]
+            + [item(module.NEMO_REPO, "nemo-object")],
+        )
+        self.duplicate_start = duplicate_start
+        self.updated: list[tuple[str, str]] = []
+        self.deleted: list[tuple[str, str]] = []
+
+    def list_collections(self, *, owner: str, limit: int):
+        assert owner == module.ORG
+        assert limit == 99
+        result = [self.start, self.trained]
+        if self.duplicate_start:
+            result.append(
+                SimpleNamespace(title=module.START_TITLE, slug="SZLHOLDINGS/start-here-copy")
+            )
+        return result
+
+    def get_collection(self, slug: str):
+        if slug == self.start.slug:
+            return self.start
+        if slug == self.trained.slug:
+            return self.trained
+        raise AssertionError(f"unexpected slug: {slug}")
+
+    def update_collection_metadata(self, *, collection_slug: str, description: str):
+        assert collection_slug == self.start.slug
+        self.updated.append((collection_slug, description))
+        self.start.description = description
+
+    def delete_collection_item(self, *, collection_slug: str, item_object_id: str):
+        assert collection_slug == self.trained.slug
+        self.deleted.append((collection_slug, item_object_id))
+        self.trained.items = [
+            candidate
+            for candidate in self.trained.items
+            if candidate.item_object_id != item_object_id
+        ]
+
+
+class ReconcileTests(unittest.TestCase):
+    def test_dry_run_is_zero_effect(self) -> None:
+        api = FakeApi()
+        report = module.CollectionTruthReconciler(api, publish=False).run()
+        self.assertEqual(report["mode"], "dry-run")
+        self.assertEqual(report["verification"]["status"], "NOT_EVALUATED")
+        self.assertEqual(api.updated, [])
+        self.assertEqual(api.deleted, [])
+        self.assertIn("a11oy.com", api.start.description)
+
+    def test_publish_repairs_domain_and_recipe_membership_then_reads_back(self) -> None:
+        api = FakeApi()
+        report = module.CollectionTruthReconciler(api, publish=True).run()
+        self.assertEqual(report["verification"]["errors"], [])
+        self.assertEqual(api.start.description, module.START_DESCRIPTION)
+        self.assertNotIn(module.NEMO_REPO, report["verification"]["trained_items"])
+        self.assertEqual(api.deleted, [(api.trained.slug, "nemo-object")])
+        self.assertEqual(len(api.updated), 1)
+
+    def test_duplicate_collection_title_fails_closed(self) -> None:
+        with self.assertRaisesRegex(module.ReconcileError, "duplicate collection title"):
+            module.CollectionTruthReconciler(
+                FakeApi(duplicate_start=True), publish=True
+            ).run()
+
+    def test_missing_trained_weight_anchor_refuses_removal(self) -> None:
+        api = FakeApi(missing_anchor=True)
+        with self.assertRaisesRegex(module.ReconcileError, "anchors are missing"):
+            module.CollectionTruthReconciler(api, publish=True).run()
+        self.assertEqual(api.deleted, [])
+
+    def test_contract_is_narrow(self) -> None:
+        source = (HERE / "hf_collection_truth_reconcile.py").read_text(encoding="utf-8")
+        self.assertIn("https://a-11-oy.com", source)
+        self.assertIn(module.NEMO_REPO, source)
+        self.assertNotIn("create_collection(", source)
+        self.assertNotIn("delete_collection(", source)
+        self.assertNotIn("upload_file(", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-collection-truth-reconcile.yml
+++ b/.github/workflows/hf-collection-truth-reconcile.yml
@@ -68,7 +68,7 @@ jobs:
           publish=false
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
             publish=true
-          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" = "true" ]; then
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF" = "refs/heads/main" ] && [ "${{ inputs.publish }}" = "true" ]; then
             publish=true
           fi
           echo "publish=$publish" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/hf-collection-truth-reconcile.yml
+++ b/.github/workflows/hf-collection-truth-reconcile.yml
@@ -1,0 +1,100 @@
+name: HF Collection Truth Reconcile
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_collection_truth_reconcile.py
+      - .github/scripts/test_hf_collection_truth_reconcile.py
+      - .github/workflows/hf-collection-truth-reconcile.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_collection_truth_reconcile.py
+      - .github/scripts/test_hf_collection_truth_reconcile.py
+      - .github/workflows/hf-collection-truth-reconcile.yml
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the two exact collection truth repairs
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-collection-truth-reconcile-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile and verify exact collection truth
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+    steps:
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned Hub client range
+        run: python -m pip install --disable-pip-version-check "huggingface_hub>=1.3,<2"
+
+      - name: Test fail-closed reconciler
+        run: |
+          python -m py_compile \
+            .github/scripts/hf_collection_truth_reconcile.py \
+            .github/scripts/test_hf_collection_truth_reconcile.py
+          python .github/scripts/test_hf_collection_truth_reconcile.py
+          git diff --check
+
+      - name: Select zero-effect or protected publication mode
+        id: mode
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            publish=true
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "${{ inputs.publish }}" = "true" ]; then
+            publish=true
+          fi
+          echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          if [ "$publish" = true ] && [ -z "${HF_ORG_TOKEN:-${HF_TOKEN:-}}" ]; then
+            echo "::error::No approved Hugging Face organization write credential is configured."
+            exit 2
+          fi
+
+      - name: Dry-run against live collections
+        if: steps.mode.outputs.publish != 'true'
+        run: >-
+          python .github/scripts/hf_collection_truth_reconcile.py
+          --report reports/hf-collection-truth-reconcile-latest.json
+
+      - name: Publish from protected merged main and read back
+        if: steps.mode.outputs.publish == 'true'
+        run: >-
+          python .github/scripts/hf_collection_truth_reconcile.py
+          --publish
+          --report reports/hf-collection-truth-reconcile-latest.json
+
+      - name: Upload immutable workflow evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        with:
+          name: hf-collection-truth-${{ github.run_id }}
+          path: reports/hf-collection-truth-reconcile-latest.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/hf-collection-truth-reconcile.yml
+++ b/.github/workflows/hf-collection-truth-reconcile.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload immutable workflow evidence
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hf-collection-truth-${{ github.run_id }}
           path: reports/hf-collection-truth-reconcile-latest.json


### PR DESCRIPTION
## Contract metadata

Satisfies: C-159

Labels: PROVEN fail-closed reconciler regressions; MEASURED public Hub dry-run against the two exact live drifts; NOT CLAIMED publication until protected merged-main workflow mutation and readback succeed.

Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a signed pull request; the workflow then stops owning future reconciliations without rewriting historical Hub state.

Risk: B - two metadata-only collection repairs. No repository, model, dataset, Space, kernel, weight, visibility, hardware, secret, A11oy source, governance rule, or branch protection is changed.

## Diagnosis

The live `Start Here — Alloy Estate` description names `a11oy.com`, while the canonical command-system domain is `https://a-11-oy.com`. The live `Trained Models & Weights` collection also includes `SZLHOLDINGS/szl-nemo`, whose own card says it is a recipe plus conformance scorer and explicitly not an SZL fine-tune.

The former clone-capable estate publisher that originally wrote these collections was intentionally removed. No current narrow, protected publisher owns these two truths.

## Fix

- add a fail-closed, dry-run-by-default collection reconciler
- update only the `Start Here` description to the canonical hyphenated domain
- remove only the recipe-only `szl-nemo` item from the trained-weight collection
- refuse removal if any of the three expected trained-weight anchors is missing
- publish only from protected merged main (or an explicit protected manual dispatch)
- read both collections back after publication and fail if either truth remains wrong

## Validation

- `python .github/scripts/test_hf_collection_truth_reconcile.py` - 5 passed
- Python compilation passed
- workflow YAML parsed successfully
- `git diff --check` passed
- live zero-effect dry-run identified exactly two pending actions
- commits `89b6eb3ac3b815fff3598f5de7e67246a70113d3` and `bcc9e34a533bb27e4b86235615254ca85a2a6309` are cryptographically signed and locally verified

## Boundary

Collection membership is navigation metadata, not training, model quality, runtime, or operational proof. The three separate `SOURCE_UNBOUND` kernel-model repositories remain unpromoted: no complete byte-matching GitHub artifact source was found, so this PR does not attach cosmetic provenance.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>
