### PR TITLE
fix(governance): retry ready release drafts

### DIFF
--- a/.github/scripts/forge9_source_run.py
+++ b/.github/scripts/forge9_source_run.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Bind privileged FORGE-9 consumers to one exact workflow-run PR subject."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class SourceRunIdentityError(ValueError):
+    """Raised when a workflow run cannot be bound to one exact PR subject."""
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SourceRunIdentityError(f"{label} must be an object")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise SourceRunIdentityError(f"{label} must be an array")
+    return value
+
+
+def _integer(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise SourceRunIdentityError(f"{label} must be a positive integer")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise SourceRunIdentityError(f"{label} must be a non-empty string")
+    return value
+
+
+def _sha(value: Any, label: str) -> str:
+    text = _string(value, label)
+    if not SHA_PATTERN.fullmatch(text):
+        raise SourceRunIdentityError(f"{label} must be an exact 40-character SHA")
+    return text
+
+
+def _repo_id(value: Any, label: str) -> int:
+    return _integer(_mapping(value, label).get("id"), f"{label}.id")
+
+
+def _base_is_allowed(ref: str, exact: Iterable[str], prefixes: Iterable[str]) -> bool:
+    return ref in set(exact) or any(ref.startswith(prefix) for prefix in prefixes)
+
+
+def bind_source_run(
+    run: dict[str, Any],
+    *,
+    expected_run_id: int,
+    expected_repository: str,
+    expected_head_sha: str,
+    allowed_bases: Iterable[str],
+    allowed_base_prefixes: Iterable[str] = (),
+) -> dict[str, Any]:
+    """Return the sole exact PR association for a pull_request workflow run."""
+
+    run = _mapping(run, "workflow run")
+    expected_run_id = _integer(expected_run_id, "expected run id")
+    expected_repository = _string(expected_repository, "expected repository")
+    expected_head_sha = _sha(expected_head_sha, "expected head SHA")
+
+    if _integer(run.get("id"), "workflow run.id") != expected_run_id:
+        raise SourceRunIdentityError("workflow run id does not match SOURCE_GATE_RUN_ID")
+    if run.get("event") != "pull_request":
+        raise SourceRunIdentityError("workflow run event is not pull_request")
+    if _sha(run.get("head_sha"), "workflow run.head_sha") != expected_head_sha:
+        raise SourceRunIdentityError("workflow run head SHA does not match the event")
+
+    repository = _mapping(run.get("repository"), "workflow run.repository")
+    repository_id = _integer(repository.get("id"), "workflow run.repository.id")
+    if repository.get("full_name") != expected_repository:
+        raise SourceRunIdentityError("workflow run repository identity does not match")
+
+    head_repository = _mapping(
+        run.get("head_repository"), "workflow run.head_repository"
+    )
+    if _integer(head_repository.get("id"), "workflow run.head_repository.id") != (
+        repository_id
+    ) or head_repository.get("full_name") != expected_repository:
+        raise SourceRunIdentityError("workflow run came from a different head repository")
+
+    associations = _list(run.get("pull_requests"), "workflow run.pull_requests")
+    if len(associations) != 1:
+        raise SourceRunIdentityError(
+            "workflow run must identify exactly one pull request association"
+        )
+    association = _mapping(associations[0], "workflow run.pull_requests[0]")
+    association_id = _integer(association.get("id"), "source pull request.id")
+    number = _integer(association.get("number"), "source pull request.number")
+
+    head = _mapping(association.get("head"), "source pull request.head")
+    head_repo_id = _repo_id(head.get("repo"), "source pull request.head.repo")
+    head_sha = _sha(head.get("sha"), "source pull request.head.sha")
+    head_ref = _string(head.get("ref"), "source pull request.head.ref")
+    if head_repo_id != repository_id or head_sha != expected_head_sha:
+        raise SourceRunIdentityError(
+            "source pull request head repository or SHA does not match the run"
+        )
+
+    base = _mapping(association.get("base"), "source pull request.base")
+    base_repo_id = _repo_id(base.get("repo"), "source pull request.base.repo")
+    base_ref = _string(base.get("ref"), "source pull request.base.ref")
+    base_sha = _sha(base.get("sha"), "source pull request.base.sha")
+    if base_repo_id != repository_id:
+        raise SourceRunIdentityError("source pull request base repository does not match")
+    if not _base_is_allowed(base_ref, allowed_bases, allowed_base_prefixes):
+        raise SourceRunIdentityError(f"source pull request base {base_ref!r} is not allowed")
+
+    return {
+        "schema": "szl.forge9-source-run-binding/v1",
+        "source_gate_run_id": expected_run_id,
+        "event": "pull_request",
+        "repository_id": repository_id,
+        "repository_full_name": expected_repository,
+        "pull_request_id": association_id,
+        "pull_request_number": number,
+        "head_repository_id": head_repo_id,
+        "head_ref": head_ref,
+        "head_sha": head_sha,
+        "base_repository_id": base_repo_id,
+        "base_ref": base_ref,
+        "base_sha": base_sha,
+    }
+
+
+def verify_pull_request(binding: dict[str, Any], pull_request: dict[str, Any]) -> None:
+    """Require a current REST PR document to match an immutable run binding."""
+
+    binding = _mapping(binding, "source-run binding")
+    pull_request = _mapping(pull_request, "pull request")
+    repository = _string(
+        binding.get("repository_full_name"), "source-run binding.repository_full_name"
+    )
+    repository_id = _integer(
+        binding.get("repository_id"), "source-run binding.repository_id"
+    )
+
+    if _integer(pull_request.get("id"), "pull request.id") != _integer(
+        binding.get("pull_request_id"), "source-run binding.pull_request_id"
+    ):
+        raise SourceRunIdentityError("current pull request id does not match the run")
+    if _integer(pull_request.get("number"), "pull request.number") != _integer(
+        binding.get("pull_request_number"), "source-run binding.pull_request_number"
+    ):
+        raise SourceRunIdentityError("current pull request number does not match the run")
+    if pull_request.get("state") != "open":
+        raise SourceRunIdentityError("current pull request is not open")
+    if not isinstance(pull_request.get("draft"), bool):
+        raise SourceRunIdentityError("current pull request draft state is invalid")
+
+    head = _mapping(pull_request.get("head"), "pull request.head")
+    head_repo = _mapping(head.get("repo"), "pull request.head.repo")
+    if (
+        _integer(head_repo.get("id"), "pull request.head.repo.id") != repository_id
+        or head_repo.get("full_name") != repository
+        or _sha(head.get("sha"), "pull request.head.sha") != binding.get("head_sha")
+        or _string(head.get("ref"), "pull request.head.ref") != binding.get("head_ref")
+    ):
+        raise SourceRunIdentityError("current pull request head identity does not match")
+
+    base = _mapping(pull_request.get("base"), "pull request.base")
+    base_repo = _mapping(base.get("repo"), "pull request.base.repo")
+    if (
+        _integer(base_repo.get("id"), "pull request.base.repo.id") != repository_id
+        or base_repo.get("full_name") != repository
+        or _string(base.get("ref"), "pull request.base.ref") != binding.get("base_ref")
+        or _sha(base.get("sha"), "pull request.base.sha") != binding.get("base_sha")
+    ):
+        raise SourceRunIdentityError("current pull request base identity does not match")
+
+
+def _workflow_runs(payload: Any) -> list[dict[str, Any]]:
+    pages = payload if isinstance(payload, list) else [payload]
+    runs: list[dict[str, Any]] = []
+    for page_number, page in enumerate(pages, start=1):
+        page = _mapping(page, f"workflow-runs page {page_number}")
+        for run in _list(page.get("workflow_runs"), "workflow_runs"):
+            runs.append(_mapping(run, "workflow run"))
+    return runs
+
+
+def latest_matching_run_id(payload: Any, binding: dict[str, Any]) -> int:
+    """Return the newest gate run with the exact same PR association."""
+
+    binding = _mapping(binding, "source-run binding")
+    expected = {
+        key: binding.get(key)
+        for key in (
+            "repository_id",
+            "repository_full_name",
+            "pull_request_id",
+            "pull_request_number",
+            "head_repository_id",
+            "head_ref",
+            "head_sha",
+            "base_repository_id",
+            "base_ref",
+            "base_sha",
+        )
+    }
+    candidates: list[int] = []
+    for run in _workflow_runs(payload):
+        run_id = run.get("id")
+        if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id <= 0:
+            continue
+        try:
+            candidate = bind_source_run(
+                run,
+                expected_run_id=run_id,
+                expected_repository=_string(
+                    binding.get("repository_full_name"),
+                    "source-run binding.repository_full_name",
+                ),
+                expected_head_sha=_sha(
+                    binding.get("head_sha"), "source-run binding.head_sha"
+                ),
+                allowed_bases=(_string(binding.get("base_ref"), "binding.base_ref"),),
+            )
+        except SourceRunIdentityError:
+            continue
+        if all(candidate.get(key) == value for key, value in expected.items()):
+            candidates.append(run_id)
+    if not candidates:
+        raise SourceRunIdentityError(
+            "no workflow run has the exact bound pull request association"
+        )
+    return max(candidates)
+
+
+def _read_json(path: str) -> Any:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _write_json(path: str, value: Any) -> None:
+    Path(path).write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    bind = commands.add_parser("bind")
+    bind.add_argument("--run-file", required=True)
+    bind.add_argument("--expected-run-id", required=True, type=int)
+    bind.add_argument("--expected-repository", required=True)
+    bind.add_argument("--expected-head-sha", required=True)
+    bind.add_argument("--allowed-base", action="append", default=[])
+    bind.add_argument("--allowed-base-prefix", action="append", default=[])
+    bind.add_argument("--output", required=True)
+
+    verify = commands.add_parser("verify-pr")
+    verify.add_argument("--binding-file", required=True)
+    verify.add_argument("--pull-request-file", required=True)
+
+    latest = commands.add_parser("latest")
+    latest.add_argument("--runs-file", required=True)
+    latest.add_argument("--binding-file", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "bind":
+            binding = bind_source_run(
+                _read_json(args.run_file),
+                expected_run_id=args.expected_run_id,
+                expected_repository=args.expected_repository,
+                expected_head_sha=args.expected_head_sha,
+                allowed_bases=args.allowed_base,
+                allowed_base_prefixes=args.allowed_base_prefix,
+            )
+            _write_json(args.output, binding)
+            return 0
+        if args.command == "verify-pr":
+            verify_pull_request(
+                _read_json(args.binding_file), _read_json(args.pull_request_file)
+            )
+            return 0
+        if args.command == "latest":
+            print(
+                latest_matching_run_id(
+                    _read_json(args.runs_file), _read_json(args.binding_file)
+                )
+            )
+            return 0
+    except (OSError, json.JSONDecodeError, SourceRunIdentityError) as exc:
+        print(f"source-run identity error: {exc}", file=sys.stderr)
+        return 1
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -44,13 +44,17 @@ def run_verifier() -> None:
 
 
 def run_queue_controller_contract() -> None:
-    completed = subprocess.run(
-        [sys.executable, ".github/scripts/test_merge_queue_enqueue.py"],
-        cwd=ROOT,
-        check=False,
-    )
-    if completed.returncode:
-        fail("the trusted merge-queue controller contract failed")
+    for relative in (
+        ".github/scripts/test_forge9_source_run.py",
+        ".github/scripts/test_merge_queue_enqueue.py",
+    ):
+        completed = subprocess.run(
+            [sys.executable, relative],
+            cwd=ROOT,
+            check=False,
+        )
+        if completed.returncode:
+            fail(f"the trusted controller contract failed: {relative}")
 
 
 def ground_truth() -> None:
@@ -162,7 +166,9 @@ def verify_all() -> None:
     run_verifier()
     run_queue_controller_contract()
     for relative in (
+        ".github/scripts/forge9_source_run.py",
         ".github/scripts/run_forge9_gate.py",
+        ".github/scripts/test_forge9_source_run.py",
         ".github/scripts/test_merge_queue_enqueue.py",
         ".github/scripts/verify_forge9_governance.py",
         ".governance/forge9_gate_runner.py",

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -43,6 +43,16 @@ def run_verifier() -> None:
         fail("the complete governance invariant verifier failed")
 
 
+def run_queue_controller_contract() -> None:
+    completed = subprocess.run(
+        [sys.executable, ".github/scripts/test_merge_queue_enqueue.py"],
+        cwd=ROOT,
+        check=False,
+    )
+    if completed.returncode:
+        fail("the trusted merge-queue controller contract failed")
+
+
 def ground_truth() -> None:
     ruleset = load_json(".governance/ruleset-main.json")
     if ruleset.get("name") != "forge9-main":
@@ -150,8 +160,10 @@ def adversarial() -> None:
 
 def verify_all() -> None:
     run_verifier()
+    run_queue_controller_contract()
     for relative in (
         ".github/scripts/run_forge9_gate.py",
+        ".github/scripts/test_merge_queue_enqueue.py",
         ".github/scripts/verify_forge9_governance.py",
         ".governance/forge9_gate_runner.py",
     ):
@@ -179,11 +191,12 @@ def provenance() -> None:
         ".github/workflows/gates.yml",
         ".github/workflows/attest-and-approve.yml",
         ".github/workflows/forge9-staging.yml",
+        ".github/workflows/merge-queue-enqueue.yml",
     ):
         for number, line in enumerate(
             (ROOT / relative).read_text(encoding="utf-8").splitlines(), start=1
         ):
-            if "uses:" in line and not PINNED_ACTION.match(line):
+            if re.match(r"^\s*(?:-\s+)?uses:", line) and not PINNED_ACTION.match(line):
                 fail(f"{relative}:{number} contains an unpinned action")
 
 

--- a/.github/scripts/test_forge9_source_run.py
+++ b/.github/scripts/test_forge9_source_run.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Adversarial tests for exact FORGE-9 workflow-run PR identity binding."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from forge9_source_run import (
+    SourceRunIdentityError,
+    bind_source_run,
+    latest_matching_run_id,
+    verify_pull_request,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY = "szl-holdings/.github"
+REPOSITORY_ID = 1200488980
+HEAD_SHA = "3" * 40
+BASE_SHA = "a" * 40
+
+
+def association(*, number: int = 381, head_repo_id: int = REPOSITORY_ID) -> dict:
+    return {
+        "id": 4185826009 + number,
+        "number": number,
+        "head": {
+            "ref": f"agent/pr-{number}",
+            "sha": HEAD_SHA,
+            "repo": {
+                "id": head_repo_id,
+                "name": ".github" if head_repo_id == REPOSITORY_ID else "fork",
+                "url": "https://api.github.test/head",
+            },
+        },
+        "base": {
+            "ref": "main",
+            "sha": BASE_SHA,
+            "repo": {
+                "id": REPOSITORY_ID,
+                "name": ".github",
+                "url": "https://api.github.test/base",
+            },
+        },
+    }
+
+
+def workflow_run(*, run_id: int = 100, associations: list[dict] | None = None) -> dict:
+    return {
+        "id": run_id,
+        "event": "pull_request",
+        "head_sha": HEAD_SHA,
+        "repository": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+        "head_repository": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+        "pull_requests": [association()] if associations is None else associations,
+    }
+
+
+def current_pull_request(source: dict | None = None) -> dict:
+    source = association() if source is None else source
+    return {
+        "id": source["id"],
+        "number": source["number"],
+        "state": "open",
+        "draft": False,
+        "head": {
+            **source["head"],
+            "repo": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+        },
+        "base": {
+            **source["base"],
+            "repo": {"id": REPOSITORY_ID, "full_name": REPOSITORY},
+        },
+    }
+
+
+class SourceRunBindingTests(unittest.TestCase):
+    profiles = {
+        "attestor": {"allowed_bases": ("main",), "allowed_base_prefixes": ("release/",)},
+        "queue": {"allowed_bases": ("main",), "allowed_base_prefixes": ()},
+    }
+
+    def bind(self, run: dict, profile: str = "attestor") -> dict:
+        return bind_source_run(
+            run,
+            expected_run_id=100,
+            expected_repository=REPOSITORY,
+            expected_head_sha=HEAD_SHA,
+            **self.profiles[profile],
+        )
+
+    def test_valid_same_repository_association_binds_for_both_consumers(self) -> None:
+        for profile in self.profiles:
+            with self.subTest(profile=profile):
+                binding = self.bind(workflow_run(), profile)
+                self.assertEqual(binding["pull_request_number"], 381)
+                self.assertEqual(binding["head_repository_id"], REPOSITORY_ID)
+                verify_pull_request(binding, current_pull_request())
+
+    def test_empty_and_multiple_associations_fail_closed_for_both(self) -> None:
+        invalid = ([], [association(), association(number=382)])
+        for profile in self.profiles:
+            for associations in invalid:
+                with self.subTest(profile=profile, count=len(associations)):
+                    with self.assertRaises(SourceRunIdentityError):
+                        self.bind(workflow_run(associations=associations), profile)
+
+    def test_run_id_event_and_head_sha_mismatches_fail_closed(self) -> None:
+        mutations = {
+            "id": 101,
+            "event": "push",
+            "head_sha": "4" * 40,
+        }
+        for profile in self.profiles:
+            for field, value in mutations.items():
+                run = workflow_run()
+                run[field] = value
+                with self.subTest(profile=profile, field=field):
+                    with self.assertRaises(SourceRunIdentityError):
+                        self.bind(run, profile)
+
+    def test_fork_source_with_shared_public_sha_cannot_select_same_repo_pr(self) -> None:
+        fork_association = association(number=999, head_repo_id=999999)
+        for profile in self.profiles:
+            run = workflow_run(associations=[fork_association])
+            run["head_repository"] = {
+                "id": 999999,
+                "full_name": "outsider/fork",
+            }
+            with self.subTest(profile=profile):
+                with self.assertRaises(SourceRunIdentityError):
+                    self.bind(run, profile)
+
+    def test_other_source_pr_number_never_remaps_to_same_sha_candidate(self) -> None:
+        source = association(number=999)
+        for profile in self.profiles:
+            with self.subTest(profile=profile):
+                binding = self.bind(workflow_run(associations=[source]), profile)
+                self.assertEqual(binding["pull_request_number"], 999)
+                with self.assertRaises(SourceRunIdentityError):
+                    verify_pull_request(binding, current_pull_request(association(number=381)))
+
+    def test_base_repository_ref_and_sha_mismatches_fail_closed(self) -> None:
+        for profile in self.profiles:
+            for field, value in (
+                ("repo", {"id": 999999, "name": "other", "url": "x"}),
+                ("sha", "b" * 40),
+            ):
+                source = association()
+                source["base"][field] = value
+                if field == "sha":
+                    binding = self.bind(workflow_run(associations=[source]), profile)
+                    pr = current_pull_request()
+                    with self.subTest(profile=profile, field=field):
+                        with self.assertRaises(SourceRunIdentityError):
+                            verify_pull_request(binding, pr)
+                else:
+                    with self.subTest(profile=profile, field=field):
+                        with self.assertRaises(SourceRunIdentityError):
+                            self.bind(workflow_run(associations=[source]), profile)
+
+        release = association()
+        release["base"]["ref"] = "release/2026.08"
+        self.bind(workflow_run(associations=[release]), "attestor")
+        with self.assertRaises(SourceRunIdentityError):
+            self.bind(workflow_run(associations=[release]), "queue")
+
+    def test_current_pr_number_head_and_base_mismatches_fail_closed(self) -> None:
+        binding = self.bind(workflow_run())
+        mutations = (
+            ("number", 999),
+            ("head.sha", "5" * 40),
+            ("head.repo", {"id": 999999, "full_name": "outsider/fork"}),
+            ("base.ref", "release/other"),
+            ("base.sha", "b" * 40),
+            ("base.repo", {"id": 999999, "full_name": "outsider/base"}),
+        )
+        for dotted, value in mutations:
+            pr = current_pull_request()
+            target = pr
+            parts = dotted.split(".")
+            for part in parts[:-1]:
+                target = target[part]
+            target[parts[-1]] = value
+            with self.subTest(field=dotted):
+                with self.assertRaises(SourceRunIdentityError):
+                    verify_pull_request(binding, pr)
+
+    def test_latest_generation_filters_by_exact_pr_association(self) -> None:
+        binding = self.bind(workflow_run())
+        valid_newer = workflow_run(run_id=103)
+        foreign_newer = workflow_run(
+            run_id=104,
+            associations=[association(number=999, head_repo_id=999999)],
+        )
+        foreign_newer["head_repository"] = {
+            "id": 999999,
+            "full_name": "outsider/fork",
+        }
+        other_pr = workflow_run(run_id=105, associations=[association(number=999)])
+        payload = {"workflow_runs": [workflow_run(), valid_newer, foreign_newer, other_pr]}
+        self.assertEqual(latest_matching_run_id(payload, binding), 103)
+
+    def test_latest_generation_fails_when_no_exact_association_remains(self) -> None:
+        binding = self.bind(workflow_run())
+        payload = {"workflow_runs": [workflow_run(associations=[])]}
+        with self.assertRaises(SourceRunIdentityError):
+            latest_matching_run_id(payload, binding)
+
+
+class WorkflowSourceBindingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.attestor = (
+            ROOT / ".github/workflows/attest-and-approve.yml"
+        ).read_text(encoding="utf-8")
+        cls.queue = (
+            ROOT / ".github/workflows/merge-queue-enqueue.yml"
+        ).read_text(encoding="utf-8")
+
+    def test_both_consumers_use_exact_run_binding_and_current_pr_verification(self) -> None:
+        for name, source in (("attestor", self.attestor), ("queue", self.queue)):
+            with self.subTest(controller=name):
+                self.assertIn("actions/runs/$SOURCE_GATE_RUN_ID", source)
+                self.assertIn("forge9_source_run.py bind", source)
+                self.assertIn("forge9_source_run.py verify-pr", source)
+                self.assertIn("forge9_source_run.py latest", source)
+                self.assertNotRegex(source, r"commits/\$(?:HEAD_SHA|EXPECTED_HEAD)/pulls")
+
+    def test_queue_accepts_only_main_while_attestor_preserves_release(self) -> None:
+        self.assertIn("--allowed-base-prefix release/", self.attestor)
+        self.assertNotIn("--allowed-base-prefix release/", self.queue)
+        self.assertIn("--allowed-base main", self.attestor)
+        self.assertIn("--allowed-base main", self.queue)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_merge_queue_enqueue.py
+++ b/.github/scripts/test_merge_queue_enqueue.py
@@ -57,6 +57,11 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
         required = (
             "SOURCE_GATE_RUN_ID",
             "LATEST_GATE_RUN_ID",
+            "actions/runs/$SOURCE_GATE_RUN_ID",
+            "forge9_source_run.py bind",
+            "forge9_source_run.py verify-pr",
+            "forge9_source_run.py latest",
+            "source-run-binding.json",
             "PR body sha256:",
             "Gate run:",
             "CURRENT_BODY_SHA256",
@@ -86,6 +91,7 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
         )
         for marker in required:
             self.assertIn(marker, self.source, marker)
+        self.assertNotIn("commits/$EXPECTED_HEAD/pulls", self.source)
 
     def test_draft_deferral_is_complete_and_fail_closed(self) -> None:
         guard = re.compile(
@@ -99,7 +105,8 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
 
     def test_is_same_repository_only_and_does_not_expose_token(self) -> None:
         required = (
-            '.head.repo.full_name == $repository',
+            '--expected-repository "$REPOSITORY"',
+            "--allowed-base main",
             "trusted_default_branch_controller",
             "direct_merge_attempted",
             "bypass_used",

--- a/.github/scripts/test_merge_queue_enqueue.py
+++ b/.github/scripts/test_merge_queue_enqueue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -14,8 +15,31 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.source = WORKFLOW.read_text(encoding="utf-8")
 
+    def test_runs_only_from_trusted_default_branch_gate_completion(self) -> None:
+        required = (
+            "workflow_run:",
+            "FORGE-9 gates",
+            "github.event.workflow_run.conclusion == 'success'",
+            "github.event.workflow_run.event == 'pull_request'",
+            "ref: ${{ github.event.repository.default_branch }}",
+            "Checkout trusted controller source",
+        )
+        for marker in required:
+            self.assertIn(marker, self.source, marker)
+        self.assertNotRegex(self.source, re.compile(r"^\s+pull_request:\s*$", re.M))
+        self.assertNotIn("github.event.pull_request.head.sha", self.source)
+
+    def test_write_token_never_reaches_checkout_or_contract_test(self) -> None:
+        secret = "GH_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}"
+        self.assertEqual(self.source.count(secret), 1)
+        secret_offset = self.source.index(secret)
+        self.assertGreater(secret_offset, self.source.index("Checkout trusted controller source"))
+        self.assertGreater(secret_offset, self.source.index("Verify the enqueue-only source contract"))
+        self.assertNotIn(secret, self.source.split("steps:", 1)[0])
+
     def test_uses_only_the_queue_mutation(self) -> None:
         self.assertIn("enqueuePullRequest", self.source)
+        self.assertIn("dequeuePullRequest", self.source)
         self.assertIn("expectedHeadOid", self.source)
         forbidden = (
             "mergePullRequest",
@@ -29,10 +53,25 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
         for marker in forbidden:
             self.assertNotIn(marker, self.source, marker)
 
-    def test_requires_exact_head_attestation_and_app_approval(self) -> None:
+    def test_requires_exact_generation_head_body_and_app_provenance(self) -> None:
         required = (
+            "SOURCE_GATE_RUN_ID",
+            "LATEST_GATE_RUN_ID",
+            "PR body sha256:",
+            "Gate run:",
+            "CURRENT_BODY_SHA256",
+            "GRAPH_BODY_SHA256",
+            "CURRENT_BASE_REF",
+            "CURRENT_BASE_SHA",
+            "baseRefName",
+            "ref(qualifiedName:$base){target{oid}}",
+            ".data.repository.ref.target.oid",
+            "Base: $CURRENT_BASE_REF@$CURRENT_BASE_SHA",
+            "--paginate --slurp",
             "attestation/qillqaq",
             "qillqaq-attestor[bot]",
+            '.creator.type == "Bot"',
+            '.user.type == "Bot"',
             "commit_id == $head",
             "CURRENT_HEAD",
             "EXPECTED_HEAD",
@@ -41,14 +80,27 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
             "GRAPH_STATE",
             "CURRENT_STATE",
             "'OPEN'",
+            "queue-postcheck.json",
+            "queue-after-dequeue.json",
+            "queue absence verified",
         )
         for marker in required:
             self.assertIn(marker, self.source, marker)
 
+    def test_draft_deferral_is_complete_and_fail_closed(self) -> None:
+        guard = re.compile(
+            r'if \[ "\$CURRENT_DRAFT" = \'true\' \]; then\s+'
+            r'echo "Gate run .* queue request deferred"\s+'
+            r'exit 0\s+fi\s+'
+            r'\[ "\$CURRENT_DRAFT" = \'false\' \]',
+            re.S,
+        )
+        self.assertRegex(self.source, guard)
+
     def test_is_same_repository_only_and_does_not_expose_token(self) -> None:
         required = (
-            "github.event.pull_request.head.repo.full_name == github.repository",
-            "secrets.SZL_GITHUB_TOKEN",
+            '.head.repo.full_name == $repository',
+            "trusted_default_branch_controller",
             "direct_merge_attempted",
             "bypass_used",
             "token_value_recorded",
@@ -57,7 +109,7 @@ class MergeQueueEnqueueContractTests(unittest.TestCase):
             self.assertIn(marker, self.source, marker)
         self.assertNotIn("set -x", self.source)
         self.assertNotIn("echo $GH_TOKEN", self.source)
-        self.assertNotIn("echo \"$GH_TOKEN\"", self.source)
+        self.assertNotIn('echo "$GH_TOKEN"', self.source)
 
     def test_receipt_is_retained_and_never_claims_a_merge(self) -> None:
         self.assertIn("retention-days: 90", self.source)

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -59,7 +59,7 @@ FORBIDDEN_EXECUTABLE_PATTERNS = {
 }
 
 ATTESTOR_SELF_EDIT_GUARD = (
-    r"^(\.github/workflows/(attest-and-approve|gates|forge9-staging)"
+    r"^(\.github/workflows/(attest-and-approve|gates|forge9-staging|merge-queue-enqueue)"
     r"\.ya?ml|\.governance/)"
 )
 GOVERNED_BASE_FILTER = (
@@ -206,6 +206,9 @@ def verify_gate_contract() -> None:
     gate_template = (ROOT / ".github/workflows/gates.yml").read_text(
         encoding="utf-8"
     )
+    ready_trigger = "types: [opened, synchronize, reopened, ready_for_review, edited]"
+    if ready_trigger not in gate_template:
+        fail("the gate workflow must rerun when a draft PR becomes ready or its body is edited")
     for gate in GATES:
         if gate not in gate_template:
             fail(f"gate template is missing {gate}")
@@ -217,7 +220,7 @@ def verify_gate_contract() -> None:
         ROOT / ".github/workflows/attest-and-approve.yml"
     ).read_text(encoding="utf-8")
     if ATTESTOR_SELF_EDIT_GUARD not in attestor_template:
-        fail("attestor must refuse edits to both gate and attestor workflows")
+        fail("attestor must refuse edits to every governance and queue controller")
     guard = re.compile(ATTESTOR_SELF_EDIT_GUARD)
     guarded_paths = (
         ".github/workflows/attest-and-approve.yml",
@@ -226,6 +229,8 @@ def verify_gate_contract() -> None:
         ".github/workflows/gates.yaml",
         ".github/workflows/forge9-staging.yml",
         ".github/workflows/forge9-staging.yaml",
+        ".github/workflows/merge-queue-enqueue.yml",
+        ".github/workflows/merge-queue-enqueue.yaml",
         ".governance/gates.json",
     )
     for path in guarded_paths:
@@ -254,21 +259,75 @@ def verify_gate_contract() -> None:
         "client-id: ${{ vars.QILLQAQ_CLIENT_ID }}",
         'SOURCE_EVENT: ${{ github.event.workflow_run.event }}',
         'if [ "$SOURCE_EVENT" = "merge_group" ]; then',
-        '[[ "$HEAD_BRANCH" == gh-readonly-queue/main/* ]]',
+        '[[ "$HEAD_BRANCH" =~ ^gh-readonly-queue/main/pr-',
+        '.head.repo.full_name == $repository',
         "subject_kind: $subject_kind",
     ):
         if marker not in attestor_template:
             fail(f"attestor status publication is missing {marker!r}")
     if "app-id:" in attestor_template:
         fail("the attestor must use the supported GitHub App client-id input")
-    if attestor_template.count(
-        "if: steps.subject.outputs.kind == 'pull_request'"
-    ) != 2:
-        fail("only PR-head attestations may approve or request a queue entry")
+    guarded_pr_condition = (
+        "if: steps.subject.outputs.kind == 'pull_request' && "
+        "steps.subject.outputs.draft == 'false'"
+    )
+    if attestor_template.count(guarded_pr_condition) != 3:
+        fail("PR revalidation, App approval, and queue request must all reject drafts")
     if 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash' not in (
         attestor_template
     ):
         fail("the attestor must use GitHub's supported merge-queue CLI path")
+    for marker in (
+        'BODY_SHA256="$(jq -c \'.body // ""\'',
+        "pull_request_body_sha256",
+        "pull_request_base_ref",
+        "pull_request_base_sha",
+        "pull_request_head_sha",
+        "source_gate_run_id",
+        'LATEST_GATE_RUN_ID=',
+        '-f commit_id="$HEAD_SHA"',
+        "PR body sha256: $PR_BODY_SHA256",
+        "Base: $PR_BASE_REF@$PR_BASE_SHA",
+        "Gate run: $SOURCE_GATE_RUN_ID",
+        "--paginate --slurp",
+    ):
+        if marker not in attestor_template:
+            fail(f"the attestor freshness binding is missing {marker!r}")
+    draft_query = 'DRAFT=$(jq -r .draft "$RUNNER_TEMP/pr-before-queue.json")'
+    draft_guard = 'if [ "$DRAFT" = "true" ]; then'
+    draft_false_guard = '[ "$DRAFT" = "false" ]'
+    draft_deferral = (
+        "Attestation complete; protected merge request deferred while PR $PR is draft"
+    )
+    queue_request = 'gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash'
+    for marker in (draft_query, draft_guard, draft_false_guard, draft_deferral):
+        if marker not in attestor_template:
+            fail(f"the attestor draft guard is missing {marker!r}")
+    draft_block = re.compile(
+        re.escape(draft_query)
+        + r"\s+"
+        + re.escape(draft_guard)
+        + r"\s+"
+        + re.escape(
+            'echo "Attestation complete; protected merge request deferred while PR $PR is draft"'
+        )
+        + r"\s+exit 0\s+fi\s+"
+        + re.escape(draft_false_guard),
+        re.MULTILINE,
+    )
+    if not draft_block.search(attestor_template):
+        fail("the attestor draft guard must terminate successfully before queueing")
+    if attestor_template.index(draft_guard) > attestor_template.index(queue_request):
+        fail("the attestor must reject draft queue requests before invoking gh pr merge")
+
+    limitations = (GOVERNANCE / "KNOWN_LIMITATIONS.md").read_text(encoding="utf-8")
+    for marker in (
+        "enqueuePullRequest",
+        "non-atomic read-to-mutation interval remains",
+        "immutable commit",
+    ):
+        if marker not in limitations:
+            fail(f"mutable PR authority limitation is missing {marker!r}")
 
     release = load_json(GOVERNANCE / "ruleset-release.json")
     if not isinstance(release, dict):

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -62,10 +62,7 @@ ATTESTOR_SELF_EDIT_GUARD = (
     r"^(\.github/workflows/(attest-and-approve|gates|forge9-staging|merge-queue-enqueue)"
     r"\.ya?ml|\.governance/)"
 )
-GOVERNED_BASE_FILTER = (
-    '.base.ref == "main"\n'
-    '                  or (.base.ref | startswith("release/"))'
-)
+GOVERNED_BASE_FILTER = "--allowed-base-prefix release/"
 
 
 def fail(message: str) -> None:
@@ -260,13 +257,42 @@ def verify_gate_contract() -> None:
         'SOURCE_EVENT: ${{ github.event.workflow_run.event }}',
         'if [ "$SOURCE_EVENT" = "merge_group" ]; then',
         '[[ "$HEAD_BRANCH" =~ ^gh-readonly-queue/main/pr-',
-        '.head.repo.full_name == $repository',
+        "actions/runs/$SOURCE_GATE_RUN_ID",
+        "forge9_source_run.py bind",
+        "forge9_source_run.py verify-pr",
+        "forge9_source_run.py latest",
         "subject_kind: $subject_kind",
     ):
         if marker not in attestor_template:
             fail(f"attestor status publication is missing {marker!r}")
     if "app-id:" in attestor_template:
         fail("the attestor must use the supported GitHub App client-id input")
+    queue_template = (
+        ROOT / ".github/workflows/merge-queue-enqueue.yml"
+    ).read_text(encoding="utf-8")
+    for label, template in (
+        ("attestor", attestor_template),
+        ("queue controller", queue_template),
+    ):
+        for marker in (
+            "actions/runs/$SOURCE_GATE_RUN_ID",
+            "forge9_source_run.py bind",
+            "forge9_source_run.py verify-pr",
+            "forge9_source_run.py latest",
+            "source-run-binding.json",
+        ):
+            if marker not in template:
+                fail(f"{label} source-run identity binding is missing {marker!r}")
+        if re.search(r"commits/\$(?:HEAD_SHA|EXPECTED_HEAD)/pulls", template):
+            fail(f"{label} must not infer its privileged PR from a commit SHA")
+    if "--allowed-base-prefix release/" in queue_template:
+        fail("the main queue controller must not accept release/* associations")
+    for relative in (
+        ".github/scripts/forge9_source_run.py",
+        ".github/scripts/test_forge9_source_run.py",
+    ):
+        source = (ROOT / relative).read_text(encoding="utf-8")
+        compile(source, relative, "exec")
     guarded_pr_condition = (
         "if: steps.subject.outputs.kind == 'pull_request' && "
         "steps.subject.outputs.draft == 'false'"

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -33,6 +33,13 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
+      - name: Checkout trusted source-run resolver
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          fetch-depth: 1
+
       - name: Resolve the attestation subject
         id: subject
         env:
@@ -40,6 +47,7 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           SOURCE_EVENT: ${{ github.event.workflow_run.event }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -72,35 +80,30 @@ jobs:
           [ "$SOURCE_EVENT" = "pull_request" ] \
             || { echo "::error::unsupported source event: $SOURCE_EVENT"; exit 1; }
 
-          gh api \
-            -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" \
-            > "$RUNNER_TEMP/pulls.json"
-          mapfile -t PRS < <(
-            jq -r --arg sha "$HEAD_SHA" --arg repository "$REPOSITORY" \
-              '.[] | select(
-                .state == "open"
-                and .head.sha == $sha
-                and .head.repo.full_name == $repository
-                and (
-                  .base.ref == "main"
-                  or (.base.ref | startswith("release/"))
-                )
-              ) | .number' \
-              "$RUNNER_TEMP/pulls.json"
-          )
-          if [ "${#PRS[@]}" -ne 1 ]; then
-            echo "::error::expected exactly one open main or release/* PR for $HEAD_SHA; found ${#PRS[@]}"
-            exit 1
-          fi
-          PR="${PRS[0]}"
+          gh api "repos/$REPOSITORY/actions/runs/$SOURCE_GATE_RUN_ID" \
+            > "$RUNNER_TEMP/source-gate-run.json"
+          python .github/scripts/forge9_source_run.py bind \
+            --run-file "$RUNNER_TEMP/source-gate-run.json" \
+            --expected-run-id "$SOURCE_GATE_RUN_ID" \
+            --expected-repository "$REPOSITORY" \
+            --expected-head-sha "$HEAD_SHA" \
+            --allowed-base main \
+            --allowed-base-prefix release/ \
+            --output "$RUNNER_TEMP/source-run-binding.json"
+          PR="$(jq -r .pull_request_number "$RUNNER_TEMP/source-run-binding.json")"
           gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr.json"
+          python .github/scripts/forge9_source_run.py verify-pr \
+            --binding-file "$RUNNER_TEMP/source-run-binding.json" \
+            --pull-request-file "$RUNNER_TEMP/pr.json"
           PR_DRAFT="$(jq -r .draft "$RUNNER_TEMP/pr.json")"
           [[ "$PR_DRAFT" == "true" || "$PR_DRAFT" == "false" ]] \
             || { echo "::error::pull request draft state is invalid"; exit 1; }
           BODY_SHA256="$(jq -c '.body // ""' "$RUNNER_TEMP/pr.json" | sha256sum | cut -d' ' -f1)"
-          BASE_REF="$(jq -r .base.ref "$RUNNER_TEMP/pr.json")"
-          BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$BASE_REF" --jq .object.sha)"
+          BASE_REF="$(jq -r .base_ref "$RUNNER_TEMP/source-run-binding.json")"
+          BASE_SHA="$(jq -r .base_sha "$RUNNER_TEMP/source-run-binding.json")"
+          CURRENT_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$BASE_REF" --jq .object.sha)"
+          [ "$CURRENT_BASE_SHA" = "$BASE_SHA" ] \
+            || { echo "::error::source gate run base moved from $BASE_SHA to $CURRENT_BASE_SHA"; exit 1; }
           echo "kind=pull_request" >> "$GITHUB_OUTPUT"
           echo "number=$PR" >> "$GITHUB_OUTPUT"
           echo "node_id=$(jq -r .node_id "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
@@ -108,7 +111,7 @@ jobs:
           echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
           echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
-          echo "pr_head_sha=$(jq -r .head.sha "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=$(jq -r .head_sha "$RUNNER_TEMP/source-run-binding.json")" >> "$GITHUB_OUTPUT"
 
       - name: Verify gates and preconditions P1-P7
         if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
@@ -294,13 +297,19 @@ jobs:
         run: |
           set -euo pipefail
           gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr-before-app-mutation.json"
+          python .github/scripts/forge9_source_run.py verify-pr \
+            --binding-file "$RUNNER_TEMP/source-run-binding.json" \
+            --pull-request-file "$RUNNER_TEMP/pr-before-app-mutation.json"
           CURRENT_HEAD="$(jq -r .head.sha "$RUNNER_TEMP/pr-before-app-mutation.json")"
           CURRENT_BASE_REF="$(jq -r .base.ref "$RUNNER_TEMP/pr-before-app-mutation.json")"
           CURRENT_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)"
           CURRENT_DRAFT="$(jq -r .draft "$RUNNER_TEMP/pr-before-app-mutation.json")"
           CURRENT_BODY_SHA256="$(jq -c '.body // ""' "$RUNNER_TEMP/pr-before-app-mutation.json" | sha256sum | cut -d' ' -f1)"
-          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
-            --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD_SHA\")] | max_by(.id) | .id // 0")"
+          gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            > "$RUNNER_TEMP/gate-runs-before-app.json"
+          LATEST_GATE_RUN_ID="$(python .github/scripts/forge9_source_run.py latest \
+            --runs-file "$RUNNER_TEMP/gate-runs-before-app.json" \
+            --binding-file "$RUNNER_TEMP/source-run-binding.json")"
           [ "$CURRENT_HEAD" = "$HEAD_SHA" ] \
             || { echo "::error::pull request head moved before App mutation"; exit 1; }
           [ "$CURRENT_DRAFT" = "false" ] \
@@ -381,6 +390,9 @@ jobs:
         run: |
           set -euo pipefail
           gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr-before-queue.json"
+          python .github/scripts/forge9_source_run.py verify-pr \
+            --binding-file "$RUNNER_TEMP/source-run-binding.json" \
+            --pull-request-file "$RUNNER_TEMP/pr-before-queue.json"
           DRAFT=$(jq -r .draft "$RUNNER_TEMP/pr-before-queue.json")
           if [ "$DRAFT" = "true" ]; then
             echo "Attestation complete; protected merge request deferred while PR $PR is draft"
@@ -392,8 +404,11 @@ jobs:
           CURRENT_BASE_REF=$(jq -r .base.ref "$RUNNER_TEMP/pr-before-queue.json")
           CURRENT_BASE_SHA=$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)
           CURRENT_BODY_SHA256=$(jq -c '.body // ""' "$RUNNER_TEMP/pr-before-queue.json" | sha256sum | cut -d' ' -f1)
-          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
-            --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD_SHA\")] | max_by(.id) | .id // 0")"
+          gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            > "$RUNNER_TEMP/gate-runs-before-queue.json"
+          LATEST_GATE_RUN_ID="$(python .github/scripts/forge9_source_run.py latest \
+            --runs-file "$RUNNER_TEMP/gate-runs-before-queue.json" \
+            --binding-file "$RUNNER_TEMP/source-run-binding.json")"
           [ "$CURRENT_HEAD" = "$HEAD_SHA" ] \
             || { echo "::error::pull request head moved before queue request"; exit 1; }
           [ "$CURRENT_BODY_SHA256" = "$PR_BODY_SHA256" ] \

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -44,11 +44,29 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$SOURCE_EVENT" = "merge_group" ]; then
-            [[ "$HEAD_BRANCH" == gh-readonly-queue/main/* ]] \
+            [[ "$HEAD_BRANCH" =~ ^gh-readonly-queue/main/pr-([0-9]+)-([0-9a-f]{40})$ ]] \
               || { echo "::error::unexpected merge-group branch: $HEAD_BRANCH"; exit 1; }
+            PR="${BASH_REMATCH[1]}"
+            QUEUED_BASE_SHA="${BASH_REMATCH[2]}"
+            gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr.json"
+            [ "$(jq -r .head.repo.full_name "$RUNNER_TEMP/pr.json")" = "$REPOSITORY" ] \
+              || { echo "::error::merge-group PR is not from this repository"; exit 1; }
+            [ "$(jq -r .base.ref "$RUNNER_TEMP/pr.json")" = "main" ] \
+              || { echo "::error::merge-group PR does not target main"; exit 1; }
+            PR_DRAFT="$(jq -r .draft "$RUNNER_TEMP/pr.json")"
+            [[ "$PR_DRAFT" == "true" || "$PR_DRAFT" == "false" ]] \
+              || { echo "::error::merge-group PR draft state is invalid"; exit 1; }
+            [ "$PR_DRAFT" = "false" ] \
+              || { echo "::error::merge-group PR unexpectedly returned to draft"; exit 1; }
+            BODY_SHA256="$(jq -c '.body // ""' "$RUNNER_TEMP/pr.json" | sha256sum | cut -d' ' -f1)"
             echo "kind=merge_group" >> "$GITHUB_OUTPUT"
-            echo "number=" >> "$GITHUB_OUTPUT"
-            echo "node_id=" >> "$GITHUB_OUTPUT"
+            echo "number=$PR" >> "$GITHUB_OUTPUT"
+            echo "node_id=$(jq -r .node_id "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
+            echo "draft=$PR_DRAFT" >> "$GITHUB_OUTPUT"
+            echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
+            echo "base_ref=main" >> "$GITHUB_OUTPUT"
+            echo "base_sha=$QUEUED_BASE_SHA" >> "$GITHUB_OUTPUT"
+            echo "pr_head_sha=$(jq -r .head.sha "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           [ "$SOURCE_EVENT" = "pull_request" ] \
@@ -59,10 +77,11 @@ jobs:
             "repos/$REPOSITORY/commits/$HEAD_SHA/pulls?per_page=100" \
             > "$RUNNER_TEMP/pulls.json"
           mapfile -t PRS < <(
-            jq -r --arg sha "$HEAD_SHA" \
+            jq -r --arg sha "$HEAD_SHA" --arg repository "$REPOSITORY" \
               '.[] | select(
                 .state == "open"
                 and .head.sha == $sha
+                and .head.repo.full_name == $repository
                 and (
                   .base.ref == "main"
                   or (.base.ref | startswith("release/"))
@@ -76,11 +95,23 @@ jobs:
           fi
           PR="${PRS[0]}"
           gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr.json"
+          PR_DRAFT="$(jq -r .draft "$RUNNER_TEMP/pr.json")"
+          [[ "$PR_DRAFT" == "true" || "$PR_DRAFT" == "false" ]] \
+            || { echo "::error::pull request draft state is invalid"; exit 1; }
+          BODY_SHA256="$(jq -c '.body // ""' "$RUNNER_TEMP/pr.json" | sha256sum | cut -d' ' -f1)"
+          BASE_REF="$(jq -r .base.ref "$RUNNER_TEMP/pr.json")"
+          BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$BASE_REF" --jq .object.sha)"
           echo "kind=pull_request" >> "$GITHUB_OUTPUT"
           echo "number=$PR" >> "$GITHUB_OUTPUT"
           echo "node_id=$(jq -r .node_id "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
+          echo "draft=$PR_DRAFT" >> "$GITHUB_OUTPUT"
+          echo "body_sha256=$BODY_SHA256" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=$(jq -r .head.sha "$RUNNER_TEMP/pr.json")" >> "$GITHUB_OUTPUT"
 
       - name: Verify gates and preconditions P1-P7
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -89,7 +120,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "$SUBJECT_KIND" = "pull_request" ]; then
+          if [ -n "$PR" ]; then
           BODY=$(jq -r '.body // ""' "$RUNNER_TEMP/pr.json")
 
           grep -Eq 'Satisfies:[[:space:]]*(AT-[0-9]+|C-[0-9]+)' <<<"$BODY" \
@@ -103,7 +134,7 @@ jobs:
 
           gh api "repos/$REPOSITORY/pulls/$PR/files?per_page=100" --paginate \
             --jq '.[].filename' > "$RUNNER_TEMP/files.txt"
-          if grep -Eq '^(\.github/workflows/(attest-and-approve|gates|forge9-staging)\.ya?ml|\.governance/)' \
+          if grep -Eq '^(\.github/workflows/(attest-and-approve|gates|forge9-staging|merge-queue-enqueue)\.ya?ml|\.governance/)' \
               "$RUNNER_TEMP/files.txt"; then
             grep -Eq 'Solo-Operator-Authorization:[[:space:]]*confirmed' <<<"$BODY" \
               || { echo "::error::P5 governance change lacks solo-operator authorization"; exit 1; }
@@ -158,8 +189,15 @@ jobs:
             || { echo "::error::P7 default GITHUB_TOKEN can approve reviews"; exit 1; }
 
       - name: Build and sign the merge BAP
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_BODY_SHA256: ${{ steps.subject.outputs.body_sha256 }}
+          PR_BASE_REF: ${{ steps.subject.outputs.base_ref }}
+          PR_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
+          PR_HEAD_SHA: ${{ steps.subject.outputs.pr_head_sha }}
+          SOURCE_GATE_EVENT: ${{ github.event.workflow_run.event }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
           SUBJECT_KIND: ${{ steps.subject.outputs.kind }}
           PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
@@ -172,6 +210,12 @@ jobs:
             --arg subject_kind "$SUBJECT_KIND" \
             --arg pull_request "$PR" \
             --arg head_sha "$HEAD_SHA" \
+            --arg pull_request_body_sha256 "$PR_BODY_SHA256" \
+            --arg pull_request_base_ref "$PR_BASE_REF" \
+            --arg pull_request_base_sha "$PR_BASE_SHA" \
+            --arg pull_request_head_sha "$PR_HEAD_SHA" \
+            --arg source_gate_event "$SOURCE_GATE_EVENT" \
+            --arg source_gate_run_id "$SOURCE_GATE_RUN_ID" \
             --arg principal "spiffe://a11oy.net/ns/ci/sa/qillqaq-attestor" \
             --arg policy_id "merge-gate-v1" \
             --arg run_id "$RUN_ID" \
@@ -188,6 +232,23 @@ jobs:
                 end
               ),
               head_sha: $head_sha,
+              pull_request_body_sha256: (
+                if $pull_request != ""
+                then $pull_request_body_sha256
+                else null
+                end
+              ),
+              pull_request_base_ref: (
+                if $pull_request != "" then $pull_request_base_ref else null end
+              ),
+              pull_request_base_sha: (
+                if $pull_request != "" then $pull_request_base_sha else null end
+              ),
+              pull_request_head_sha: (
+                if $pull_request != "" then $pull_request_head_sha else null end
+              ),
+              source_gate_event: $source_gate_event,
+              source_gate_run_id: ($source_gate_run_id | tonumber),
               principal: $principal,
               policy_id: $policy_id,
               workflow_run_id: $run_id,
@@ -201,12 +262,15 @@ jobs:
             }' > merge-receipt.json
 
       - name: Install Cosign
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the merge BAP with Actions OIDC
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         run: cosign sign-blob --yes --bundle merge-receipt.bundle merge-receipt.json
 
       - name: Upload the signed merge BAP
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: merge-receipt-${{ github.event.workflow_run.head_sha }}
@@ -216,36 +280,83 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
+      - name: Revalidate current PR generation before App mutations
+        if: steps.subject.outputs.kind == 'pull_request' && steps.subject.outputs.draft == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR: ${{ steps.subject.outputs.number }}
+          PR_BASE_REF: ${{ steps.subject.outputs.base_ref }}
+          PR_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
+          PR_BODY_SHA256: ${{ steps.subject.outputs.body_sha256 }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr-before-app-mutation.json"
+          CURRENT_HEAD="$(jq -r .head.sha "$RUNNER_TEMP/pr-before-app-mutation.json")"
+          CURRENT_BASE_REF="$(jq -r .base.ref "$RUNNER_TEMP/pr-before-app-mutation.json")"
+          CURRENT_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)"
+          CURRENT_DRAFT="$(jq -r .draft "$RUNNER_TEMP/pr-before-app-mutation.json")"
+          CURRENT_BODY_SHA256="$(jq -c '.body // ""' "$RUNNER_TEMP/pr-before-app-mutation.json" | sha256sum | cut -d' ' -f1)"
+          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD_SHA\")] | max_by(.id) | .id // 0")"
+          [ "$CURRENT_HEAD" = "$HEAD_SHA" ] \
+            || { echo "::error::pull request head moved before App mutation"; exit 1; }
+          [ "$CURRENT_DRAFT" = "false" ] \
+            || { echo "::error::pull request returned to draft before App mutation"; exit 1; }
+          [ "$CURRENT_BODY_SHA256" = "$PR_BODY_SHA256" ] \
+            || { echo "::error::pull request body changed before App mutation"; exit 1; }
+          [ "$CURRENT_BASE_REF" = "$PR_BASE_REF" ] && [ "$CURRENT_BASE_SHA" = "$PR_BASE_SHA" ] \
+            || { echo "::error::pull request base changed before App mutation"; exit 1; }
+          [ "$LATEST_GATE_RUN_ID" = "$SOURCE_GATE_RUN_ID" ] \
+            || { echo "::error::a newer gate generation exists for this head"; exit 1; }
+
       - name: Approve as the App and verify the review identity
-        if: steps.subject.outputs.kind == 'pull_request'
+        if: steps.subject.outputs.kind == 'pull_request' && steps.subject.outputs.draft == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR: ${{ steps.subject.outputs.number }}
           REPOSITORY: ${{ github.repository }}
+          PR_BASE_REF: ${{ steps.subject.outputs.base_ref }}
+          PR_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
+          PR_BODY_SHA256: ${{ steps.subject.outputs.body_sha256 }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
           DIGEST=$(sha256sum merge-receipt.json | cut -d' ' -f1)
           gh api -X POST "repos/$REPOSITORY/pulls/$PR/reviews" \
             -f event=APPROVE \
-            -f body="ATTESTED. All Section 18 gates green. Merge BAP sha256: $DIGEST"
-          COUNT=$(gh api "repos/$REPOSITORY/pulls/$PR/reviews?per_page=100" --paginate \
-            --jq "[.[] | select(.user.login == \"qillqaq-attestor[bot]\" and .state == \"APPROVED\" and .commit_id == \"$HEAD_SHA\")] | length")
+            -f commit_id="$HEAD_SHA" \
+            -f body="ATTESTED. All Section 18 gates green. Merge BAP sha256: $DIGEST. PR body sha256: $PR_BODY_SHA256. Base: $PR_BASE_REF@$PR_BASE_SHA. Gate run: $SOURCE_GATE_RUN_ID"
+          gh api "repos/$REPOSITORY/pulls/$PR/reviews?per_page=100" --paginate --slurp \
+            > "$RUNNER_TEMP/review-pages.json"
+          COUNT=$(jq --arg head "$HEAD_SHA" --arg body_digest "PR body sha256: $PR_BODY_SHA256" --arg base "Base: $PR_BASE_REF@$PR_BASE_SHA" --arg gate_run "Gate run: $SOURCE_GATE_RUN_ID" '[.[][] | select(
+            .user.login == "qillqaq-attestor[bot]"
+            and .state == "APPROVED"
+            and .commit_id == $head
+            and ((.body // "") | contains($body_digest))
+            and ((.body // "") | contains($base))
+            and ((.body // "") | contains($gate_run))
+          )] | length' "$RUNNER_TEMP/review-pages.json")
           [ "$COUNT" -ge 1 ] \
             || { echo "::error::App approval was not recorded for the exact head SHA"; exit 1; }
 
       - name: Publish required App attestation status
+        if: steps.subject.outputs.kind == 'merge_group' || steps.subject.outputs.draft == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           SUBJECT_KIND: ${{ steps.subject.outputs.kind }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ "$SUBJECT_KIND" = "pull_request" ]; then
-            DESCRIPTION="Signed BAP and exact-head App review verified"
+            DESCRIPTION="Signed BAP and App review for gate run $SOURCE_GATE_RUN_ID"
           else
-            DESCRIPTION="Signed BAP verified for merge-group gates"
+            DESCRIPTION="Signed BAP for merge-group gate run $SOURCE_GATE_RUN_ID"
           fi
           gh api \
             --method POST \
@@ -257,12 +368,45 @@ jobs:
           echo "Published attestation/qillqaq for $HEAD_SHA"
 
       - name: Request protected merge after attestation
-        if: steps.subject.outputs.kind == 'pull_request'
+        if: steps.subject.outputs.kind == 'pull_request' && steps.subject.outputs.draft == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR: ${{ steps.subject.outputs.number }}
+          PR_BASE_REF: ${{ steps.subject.outputs.base_ref }}
+          PR_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
+          PR_BODY_SHA256: ${{ steps.subject.outputs.body_sha256 }}
           REPOSITORY: ${{ github.repository }}
+          SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
+          gh api "repos/$REPOSITORY/pulls/$PR" > "$RUNNER_TEMP/pr-before-queue.json"
+          DRAFT=$(jq -r .draft "$RUNNER_TEMP/pr-before-queue.json")
+          if [ "$DRAFT" = "true" ]; then
+            echo "Attestation complete; protected merge request deferred while PR $PR is draft"
+            exit 0
+          fi
+          [ "$DRAFT" = "false" ] \
+            || { echo "::error::pull request draft state is invalid"; exit 1; }
+          CURRENT_HEAD=$(jq -r .head.sha "$RUNNER_TEMP/pr-before-queue.json")
+          CURRENT_BASE_REF=$(jq -r .base.ref "$RUNNER_TEMP/pr-before-queue.json")
+          CURRENT_BASE_SHA=$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)
+          CURRENT_BODY_SHA256=$(jq -c '.body // ""' "$RUNNER_TEMP/pr-before-queue.json" | sha256sum | cut -d' ' -f1)
+          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$HEAD_SHA\")] | max_by(.id) | .id // 0")"
+          [ "$CURRENT_HEAD" = "$HEAD_SHA" ] \
+            || { echo "::error::pull request head moved before queue request"; exit 1; }
+          [ "$CURRENT_BODY_SHA256" = "$PR_BODY_SHA256" ] \
+            || { echo "::error::pull request body changed after attestation"; exit 1; }
+          [ "$CURRENT_BASE_REF" = "$PR_BASE_REF" ] && [ "$CURRENT_BASE_SHA" = "$PR_BASE_SHA" ] \
+            || { echo "::error::pull request base changed after attestation"; exit 1; }
+          [ "$LATEST_GATE_RUN_ID" = "$SOURCE_GATE_RUN_ID" ] \
+            || { echo "::error::a newer gate generation exists before queue request"; exit 1; }
+          if [ "$PR_BASE_REF" = "main" ]; then
+            echo "Attestation complete; trusted default-branch controller owns the main queue request"
+            exit 0
+          fi
+          [[ "$PR_BASE_REF" == release/* ]] \
+            || { echo "::error::unsupported protected base $PR_BASE_REF"; exit 1; }
           gh pr merge "$PR" --repo "$REPOSITORY" --auto --squash
           echo "Requested the protected merge path for PR $PR"

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -2,6 +2,7 @@ name: FORGE-9 gates
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   merge_group:
 
 permissions:

--- a/.github/workflows/merge-queue-enqueue.yml
+++ b/.github/workflows/merge-queue-enqueue.yml
@@ -51,6 +51,7 @@ jobs:
           mkdir -p reports/merge-queue-enqueue
           printf '%s\n' '{"schema":"szl.merge-queue-enqueue-contract/v1","stage":"source-contract","result":"STARTED"}' \
             > reports/merge-queue-enqueue/contract.json
+          python .github/scripts/test_forge9_source_run.py
           python .github/scripts/test_merge_queue_enqueue.py
           git diff --check
 
@@ -68,29 +69,24 @@ jobs:
           NAME="${REPOSITORY#*/}"
           mkdir -p reports/merge-queue-enqueue
 
-          gh api -H "Accept: application/vnd.github+json" \
-            "repos/$REPOSITORY/commits/$EXPECTED_HEAD/pulls?per_page=100" \
-            > reports/merge-queue-enqueue/candidate-pulls.json
-          mapfile -t PRS < <(
-            jq -r --arg sha "$EXPECTED_HEAD" --arg repository "$REPOSITORY" '.[] | select(
-              .state == "open"
-              and .head.sha == $sha
-              and .head.repo.full_name == $repository
-              and .base.ref == "main"
-            ) | .number' reports/merge-queue-enqueue/candidate-pulls.json
-          )
-          if [ "${#PRS[@]}" -eq 0 ]; then
-            echo "No open same-repository main PR matches gate run $SOURCE_GATE_RUN_ID; nothing to enqueue"
-            exit 0
-          fi
-          [ "${#PRS[@]}" -eq 1 ] \
-            || { echo "::error::expected one eligible PR for $EXPECTED_HEAD; found ${#PRS[@]}"; exit 1; }
-          PR="${PRS[0]}"
+          gh api "repos/$REPOSITORY/actions/runs/$SOURCE_GATE_RUN_ID" \
+            > reports/merge-queue-enqueue/source-gate-run.json
+          python .github/scripts/forge9_source_run.py bind \
+            --run-file reports/merge-queue-enqueue/source-gate-run.json \
+            --expected-run-id "$SOURCE_GATE_RUN_ID" \
+            --expected-repository "$REPOSITORY" \
+            --expected-head-sha "$EXPECTED_HEAD" \
+            --allowed-base main \
+            --output reports/merge-queue-enqueue/source-run-binding.json
+          PR="$(jq -r .pull_request_number reports/merge-queue-enqueue/source-run-binding.json)"
 
           attested=0
           for attempt in $(seq 1 120); do
             gh api "repos/$REPOSITORY/pulls/$PR" \
               > reports/merge-queue-enqueue/pull-request.json
+            python .github/scripts/forge9_source_run.py verify-pr \
+              --binding-file reports/merge-queue-enqueue/source-run-binding.json \
+              --pull-request-file reports/merge-queue-enqueue/pull-request.json
             CURRENT_HEAD="$(jq -r .head.sha reports/merge-queue-enqueue/pull-request.json)"
             CURRENT_BASE_REF="$(jq -r .base.ref reports/merge-queue-enqueue/pull-request.json)"
             CURRENT_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)"
@@ -102,6 +98,8 @@ jobs:
               || { echo "::error::pull request head moved from $EXPECTED_HEAD to $CURRENT_HEAD"; exit 1; }
             [ "$CURRENT_STATE" = 'OPEN' ] \
               || { echo "::error::pull request state is $CURRENT_STATE, not OPEN"; exit 1; }
+            [ "$CURRENT_BASE_SHA" = "$(jq -r .base_sha reports/merge-queue-enqueue/source-run-binding.json)" ] \
+              || { echo "::error::source gate run base moved before attestation"; exit 1; }
             if [ "$CURRENT_DRAFT" = 'true' ]; then
               echo "Gate run $SOURCE_GATE_RUN_ID is for draft PR $PR; queue request deferred"
               exit 0
@@ -109,8 +107,11 @@ jobs:
             [ "$CURRENT_DRAFT" = 'false' ] \
               || { echo "::error::pull request draft state is invalid"; exit 1; }
 
-            LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
-              --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+            gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+              > reports/merge-queue-enqueue/gate-runs.json
+            LATEST_GATE_RUN_ID="$(python .github/scripts/forge9_source_run.py latest \
+              --runs-file reports/merge-queue-enqueue/gate-runs.json \
+              --binding-file reports/merge-queue-enqueue/source-run-binding.json)"
             if [ "$LATEST_GATE_RUN_ID" != "$SOURCE_GATE_RUN_ID" ]; then
               echo "Gate run $SOURCE_GATE_RUN_ID is stale; newer generation $LATEST_GATE_RUN_ID owns this head"
               exit 0
@@ -149,14 +150,20 @@ jobs:
 
           gh api "repos/$REPOSITORY/pulls/$PR" \
             > reports/merge-queue-enqueue/pull-request-before-enqueue.json
+          python .github/scripts/forge9_source_run.py verify-pr \
+            --binding-file reports/merge-queue-enqueue/source-run-binding.json \
+            --pull-request-file reports/merge-queue-enqueue/pull-request-before-enqueue.json
           FINAL_HEAD="$(jq -r .head.sha reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
           FINAL_BASE_REF="$(jq -r .base.ref reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
           FINAL_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$FINAL_BASE_REF" --jq .object.sha)"
           FINAL_STATE="$(jq -r '.state | ascii_upcase' reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
           FINAL_DRAFT="$(jq -r .draft reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
           FINAL_BODY_SHA256="$(jq -c '.body // ""' reports/merge-queue-enqueue/pull-request-before-enqueue.json | sha256sum | cut -d' ' -f1)"
-          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
-            --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+          gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            > reports/merge-queue-enqueue/gate-runs-before-enqueue.json
+          LATEST_GATE_RUN_ID="$(python .github/scripts/forge9_source_run.py latest \
+            --runs-file reports/merge-queue-enqueue/gate-runs-before-enqueue.json \
+            --binding-file reports/merge-queue-enqueue/source-run-binding.json)"
           [ "$FINAL_HEAD" = "$EXPECTED_HEAD" ] \
             || { echo "::error::pull request head moved before enqueue"; exit 1; }
           [ "$FINAL_STATE" = 'OPEN' ] \
@@ -241,8 +248,11 @@ jobs:
           POST_STATE="$(jq -r .data.repository.pullRequest.state reports/merge-queue-enqueue/queue-postcheck.json)"
           POST_BODY_SHA256="$(jq -c '.data.repository.pullRequest.body // ""' reports/merge-queue-enqueue/queue-postcheck.json | sha256sum | cut -d' ' -f1)"
           QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-postcheck.json)"
-          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
-            --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+          gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            > reports/merge-queue-enqueue/gate-runs-postcheck.json
+          LATEST_GATE_RUN_ID="$(python .github/scripts/forge9_source_run.py latest \
+            --runs-file reports/merge-queue-enqueue/gate-runs-postcheck.json \
+            --binding-file reports/merge-queue-enqueue/source-run-binding.json)"
           if [ "$POST_HEAD" != "$EXPECTED_HEAD" ] \
               || [ "$POST_BASE_REF" != "$CURRENT_BASE_REF" ] \
               || [ "$POST_BASE_SHA" != "$CURRENT_BASE_SHA" ] \

--- a/.github/workflows/merge-queue-enqueue.yml
+++ b/.github/workflows/merge-queue-enqueue.yml
@@ -1,43 +1,47 @@
 name: Protected Merge Queue Enqueue
 
+# workflow_run always loads this controller from the trusted default branch.
+# No pull-request-controlled file or command receives the write-capable token.
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review, edited]
+  workflow_run:
+    workflows:
+      - FORGE-9 gates
+    types:
+      - completed
 
 permissions:
+  actions: read
+  checks: read
   contents: read
   pull-requests: read
   statuses: read
-  checks: read
 
 concurrency:
-  group: merge-queue-enqueue-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  group: merge-queue-enqueue-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
   enqueue:
     name: Enqueue exact attested head without direct merge
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      GH_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
       REPOSITORY: ${{ github.repository }}
-      PR: ${{ github.event.pull_request.number }}
-      EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+      EXPECTED_HEAD: ${{ github.event.workflow_run.head_sha }}
+      SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
-      - name: Checkout the exact controller source
+      - name: Checkout trusted controller source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 1
 
@@ -50,9 +54,11 @@ jobs:
           python .github/scripts/test_merge_queue_enqueue.py
           git diff --check
 
-      - name: Wait for exact-head App attestation and enqueue
+      - name: Wait for this gate generation's App attestation and enqueue
         id: enqueue
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           [ -n "${GH_TOKEN:-}" ] \
@@ -62,32 +68,75 @@ jobs:
           NAME="${REPOSITORY#*/}"
           mkdir -p reports/merge-queue-enqueue
 
+          gh api -H "Accept: application/vnd.github+json" \
+            "repos/$REPOSITORY/commits/$EXPECTED_HEAD/pulls?per_page=100" \
+            > reports/merge-queue-enqueue/candidate-pulls.json
+          mapfile -t PRS < <(
+            jq -r --arg sha "$EXPECTED_HEAD" --arg repository "$REPOSITORY" '.[] | select(
+              .state == "open"
+              and .head.sha == $sha
+              and .head.repo.full_name == $repository
+              and .base.ref == "main"
+            ) | .number' reports/merge-queue-enqueue/candidate-pulls.json
+          )
+          if [ "${#PRS[@]}" -eq 0 ]; then
+            echo "No open same-repository main PR matches gate run $SOURCE_GATE_RUN_ID; nothing to enqueue"
+            exit 0
+          fi
+          [ "${#PRS[@]}" -eq 1 ] \
+            || { echo "::error::expected one eligible PR for $EXPECTED_HEAD; found ${#PRS[@]}"; exit 1; }
+          PR="${PRS[0]}"
+
           attested=0
           for attempt in $(seq 1 120); do
             gh api "repos/$REPOSITORY/pulls/$PR" \
               > reports/merge-queue-enqueue/pull-request.json
             CURRENT_HEAD="$(jq -r .head.sha reports/merge-queue-enqueue/pull-request.json)"
+            CURRENT_BASE_REF="$(jq -r .base.ref reports/merge-queue-enqueue/pull-request.json)"
+            CURRENT_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$CURRENT_BASE_REF" --jq .object.sha)"
             CURRENT_STATE="$(jq -r '.state | ascii_upcase' reports/merge-queue-enqueue/pull-request.json)"
             CURRENT_DRAFT="$(jq -r .draft reports/merge-queue-enqueue/pull-request.json)"
+            CURRENT_BODY_SHA256="$(jq -c '.body // ""' reports/merge-queue-enqueue/pull-request.json | sha256sum | cut -d' ' -f1)"
 
             [ "$CURRENT_HEAD" = "$EXPECTED_HEAD" ] \
               || { echo "::error::pull request head moved from $EXPECTED_HEAD to $CURRENT_HEAD"; exit 1; }
             [ "$CURRENT_STATE" = 'OPEN' ] \
               || { echo "::error::pull request state is $CURRENT_STATE, not OPEN"; exit 1; }
+            if [ "$CURRENT_DRAFT" = 'true' ]; then
+              echo "Gate run $SOURCE_GATE_RUN_ID is for draft PR $PR; queue request deferred"
+              exit 0
+            fi
             [ "$CURRENT_DRAFT" = 'false' ] \
-              || { echo "::error::pull request returned to draft"; exit 1; }
+              || { echo "::error::pull request draft state is invalid"; exit 1; }
 
-            gh api "repos/$REPOSITORY/commits/$EXPECTED_HEAD/status" \
-              > reports/merge-queue-enqueue/commit-status.json
-            STATUS_COUNT="$(jq '[.statuses[] | select(.context == "attestation/qillqaq" and .state == "success")] | length' reports/merge-queue-enqueue/commit-status.json)"
+            LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+              --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+            if [ "$LATEST_GATE_RUN_ID" != "$SOURCE_GATE_RUN_ID" ]; then
+              echo "Gate run $SOURCE_GATE_RUN_ID is stale; newer generation $LATEST_GATE_RUN_ID owns this head"
+              exit 0
+            fi
 
-            gh api "repos/$REPOSITORY/pulls/$PR/reviews?per_page=100" \
-              > reports/merge-queue-enqueue/reviews.json
-            APPROVAL_COUNT="$(jq --arg head "$EXPECTED_HEAD" '[.[] | select(
-              (.user.login == "qillqaq-attestor[bot]" or .user.login == "qillqaq-attestor")
+            gh api "repos/$REPOSITORY/commits/$EXPECTED_HEAD/statuses?per_page=100" --paginate --slurp \
+              > reports/merge-queue-enqueue/commit-status-pages.json
+            STATUS_COUNT="$(jq --arg description "Signed BAP and App review for gate run $SOURCE_GATE_RUN_ID" '[.[][] | select(
+              .context == "attestation/qillqaq"
+              and .state == "success"
+              and .description == $description
+              and (.creator.login == "qillqaq-attestor[bot]" or .creator.login == "qillqaq-attestor")
+              and .creator.type == "Bot"
+            )] | length' reports/merge-queue-enqueue/commit-status-pages.json)"
+
+            gh api "repos/$REPOSITORY/pulls/$PR/reviews?per_page=100" --paginate --slurp \
+              > reports/merge-queue-enqueue/review-pages.json
+            APPROVAL_COUNT="$(jq --arg head "$EXPECTED_HEAD" --arg body_digest "PR body sha256: $CURRENT_BODY_SHA256" --arg base "Base: $CURRENT_BASE_REF@$CURRENT_BASE_SHA" --arg gate_run "Gate run: $SOURCE_GATE_RUN_ID" '[.[][] | select(
+              .user.login == "qillqaq-attestor[bot]"
+              and .user.type == "Bot"
               and .state == "APPROVED"
               and .commit_id == $head
-            )] | length' reports/merge-queue-enqueue/reviews.json)"
+              and ((.body // "") | contains($body_digest))
+              and ((.body // "") | contains($base))
+              and ((.body // "") | contains($gate_run))
+            )] | length' reports/merge-queue-enqueue/review-pages.json)"
 
             if [ "$STATUS_COUNT" -ge 1 ] && [ "$APPROVAL_COUNT" -ge 1 ]; then
               attested=1
@@ -96,19 +145,46 @@ jobs:
             sleep 10
           done
           [ "$attested" -eq 1 ] \
-            || { echo "::error::exact-head qillqaq attestation did not arrive"; exit 1; }
+            || { echo "::error::current-generation qillqaq attestation did not arrive"; exit 1; }
+
+          gh api "repos/$REPOSITORY/pulls/$PR" \
+            > reports/merge-queue-enqueue/pull-request-before-enqueue.json
+          FINAL_HEAD="$(jq -r .head.sha reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
+          FINAL_BASE_REF="$(jq -r .base.ref reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
+          FINAL_BASE_SHA="$(gh api "repos/$REPOSITORY/git/ref/heads/$FINAL_BASE_REF" --jq .object.sha)"
+          FINAL_STATE="$(jq -r '.state | ascii_upcase' reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
+          FINAL_DRAFT="$(jq -r .draft reports/merge-queue-enqueue/pull-request-before-enqueue.json)"
+          FINAL_BODY_SHA256="$(jq -c '.body // ""' reports/merge-queue-enqueue/pull-request-before-enqueue.json | sha256sum | cut -d' ' -f1)"
+          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+          [ "$FINAL_HEAD" = "$EXPECTED_HEAD" ] \
+            || { echo "::error::pull request head moved before enqueue"; exit 1; }
+          [ "$FINAL_STATE" = 'OPEN' ] \
+            || { echo "::error::pull request state changed before enqueue"; exit 1; }
+          [ "$FINAL_DRAFT" = 'false' ] \
+            || { echo "::error::pull request returned to draft before enqueue"; exit 1; }
+          [ "$FINAL_BODY_SHA256" = "$CURRENT_BODY_SHA256" ] \
+            || { echo "::error::pull request body changed after attestation"; exit 1; }
+          [ "$FINAL_BASE_REF" = "$CURRENT_BASE_REF" ] && [ "$FINAL_BASE_SHA" = "$CURRENT_BASE_SHA" ] \
+            || { echo "::error::pull request base changed after attestation"; exit 1; }
+          [ "$LATEST_GATE_RUN_ID" = "$SOURCE_GATE_RUN_ID" ] \
+            || { echo "::error::a newer gate generation exists before enqueue"; exit 1; }
 
           gh api graphql \
-            -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id headRefOid isDraft state mergeQueueEntry{id}}}}' \
+            -f query='query($owner:String!,$name:String!,$number:Int!,$base:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$base){target{oid}} pullRequest(number:$number){id headRefOid baseRefName isDraft state body mergeQueueEntry{id}}}}' \
             -F owner="$OWNER" \
             -F name="$NAME" \
             -F number="$PR" \
+            -f base="refs/heads/$CURRENT_BASE_REF" \
             > reports/merge-queue-enqueue/queue-before.json
 
           PULL_REQUEST_ID="$(jq -r .data.repository.pullRequest.id reports/merge-queue-enqueue/queue-before.json)"
           GRAPH_HEAD="$(jq -r .data.repository.pullRequest.headRefOid reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_BASE_REF="$(jq -r .data.repository.pullRequest.baseRefName reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_BASE_SHA="$(jq -r .data.repository.ref.target.oid reports/merge-queue-enqueue/queue-before.json)"
           GRAPH_DRAFT="$(jq -r .data.repository.pullRequest.isDraft reports/merge-queue-enqueue/queue-before.json)"
           GRAPH_STATE="$(jq -r .data.repository.pullRequest.state reports/merge-queue-enqueue/queue-before.json)"
+          GRAPH_BODY_SHA256="$(jq -c '.data.repository.pullRequest.body // ""' reports/merge-queue-enqueue/queue-before.json | sha256sum | cut -d' ' -f1)"
           QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-before.json)"
 
           [ "$GRAPH_HEAD" = "$EXPECTED_HEAD" ] \
@@ -117,6 +193,10 @@ jobs:
             || { echo "::error::GraphQL reports draft state"; exit 1; }
           [ "$GRAPH_STATE" = 'OPEN' ] \
             || { echo "::error::GraphQL state is $GRAPH_STATE, not OPEN"; exit 1; }
+          [ "$GRAPH_BODY_SHA256" = "$CURRENT_BODY_SHA256" ] \
+            || { echo "::error::GraphQL body changed before enqueue"; exit 1; }
+          [ "$GRAPH_BASE_REF" = "$CURRENT_BASE_REF" ] && [ "$GRAPH_BASE_SHA" = "$CURRENT_BASE_SHA" ] \
+            || { echo "::error::GraphQL base changed before enqueue"; exit 1; }
 
           if [ -n "$QUEUE_ENTRY" ]; then
             RESULT='ALREADY_QUEUED'
@@ -147,11 +227,65 @@ jobs:
             RESULT='ENQUEUED'
           fi
 
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$number:Int!,$base:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$base){target{oid}} pullRequest(number:$number){headRefOid baseRefName isDraft state body mergeQueueEntry{id}}}}' \
+            -F owner="$OWNER" \
+            -F name="$NAME" \
+            -F number="$PR" \
+            -f base="refs/heads/$CURRENT_BASE_REF" \
+            > reports/merge-queue-enqueue/queue-postcheck.json
+          POST_HEAD="$(jq -r .data.repository.pullRequest.headRefOid reports/merge-queue-enqueue/queue-postcheck.json)"
+          POST_BASE_REF="$(jq -r .data.repository.pullRequest.baseRefName reports/merge-queue-enqueue/queue-postcheck.json)"
+          POST_BASE_SHA="$(jq -r .data.repository.ref.target.oid reports/merge-queue-enqueue/queue-postcheck.json)"
+          POST_DRAFT="$(jq -r .data.repository.pullRequest.isDraft reports/merge-queue-enqueue/queue-postcheck.json)"
+          POST_STATE="$(jq -r .data.repository.pullRequest.state reports/merge-queue-enqueue/queue-postcheck.json)"
+          POST_BODY_SHA256="$(jq -c '.data.repository.pullRequest.body // ""' reports/merge-queue-enqueue/queue-postcheck.json | sha256sum | cut -d' ' -f1)"
+          QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-postcheck.json)"
+          LATEST_GATE_RUN_ID="$(gh api "repos/$REPOSITORY/actions/workflows/gates.yml/runs?event=pull_request&per_page=100" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_HEAD\")] | max_by(.id) | .id // 0")"
+          if [ "$POST_HEAD" != "$EXPECTED_HEAD" ] \
+              || [ "$POST_BASE_REF" != "$CURRENT_BASE_REF" ] \
+              || [ "$POST_BASE_SHA" != "$CURRENT_BASE_SHA" ] \
+              || [ "$POST_DRAFT" != 'false' ] \
+              || [ "$POST_STATE" != 'OPEN' ] \
+              || [ "$POST_BODY_SHA256" != "$CURRENT_BODY_SHA256" ] \
+              || [ "$LATEST_GATE_RUN_ID" != "$SOURCE_GATE_RUN_ID" ] \
+              || [ -z "$QUEUE_ENTRY" ]; then
+            if [ -n "$QUEUE_ENTRY" ]; then
+              set +e
+              gh api graphql \
+                -f query='mutation($id:ID!){dequeuePullRequest(input:{id:$id}){clientMutationId}}' \
+                -F id="$PULL_REQUEST_ID" \
+                > reports/merge-queue-enqueue/dequeue-result.json \
+                2> reports/merge-queue-enqueue/dequeue-error.txt
+              dequeue_code=$?
+              set -e
+              gh api graphql \
+                -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){mergeQueueEntry{id}}}}' \
+                -F owner="$OWNER" \
+                -F name="$NAME" \
+                -F number="$PR" \
+                > reports/merge-queue-enqueue/queue-after-dequeue.json
+              REMAINING_QUEUE_ENTRY="$(jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' reports/merge-queue-enqueue/queue-after-dequeue.json)"
+              if [ -n "$REMAINING_QUEUE_ENTRY" ]; then
+                echo "::error::authority changed and queue-entry removal could not be verified (mutation exit $dequeue_code)"
+                cat reports/merge-queue-enqueue/dequeue-error.txt
+                exit 1
+              fi
+            fi
+            echo "::error::pull request authority changed during enqueue; queue absence verified"
+            exit 1
+          fi
+
           jq -n \
             --arg schema 'szl.merge-queue-enqueue/v1' \
             --arg repository "$REPOSITORY" \
             --argjson pull_request "$PR" \
             --arg head_sha "$EXPECTED_HEAD" \
+            --arg source_gate_run_id "$SOURCE_GATE_RUN_ID" \
+            --arg pull_request_base_ref "$CURRENT_BASE_REF" \
+            --arg pull_request_base_sha "$CURRENT_BASE_SHA" \
+            --arg pull_request_body_sha256 "$CURRENT_BODY_SHA256" \
             --arg result "$RESULT" \
             --arg queue_entry_id "$QUEUE_ENTRY" \
             '{
@@ -159,9 +293,16 @@ jobs:
               repository: $repository,
               pull_request: $pull_request,
               head_sha: $head_sha,
+              source_gate_run_id: ($source_gate_run_id | tonumber),
+              pull_request_base_ref: $pull_request_base_ref,
+              pull_request_base_sha: $pull_request_base_sha,
+              pull_request_body_sha256: $pull_request_body_sha256,
               result: $result,
               queue_entry_id: $queue_entry_id,
+              trusted_default_branch_controller: true,
               exact_head_attestation_verified: true,
+              exact_body_attestation_verified: true,
+              exact_gate_generation_verified: true,
               exact_head_app_approval_verified: true,
               direct_merge_attempted: false,
               bypass_used: false,

--- a/.governance/KNOWN_LIMITATIONS.md
+++ b/.governance/KNOWN_LIMITATIONS.md
@@ -31,7 +31,9 @@
   `pilots/2026-07-26-merge-group-delivery-blocker.md`.
 - GitHub rejected `enqueuePullRequest` for the App installation token despite
   its live merge-queue grant. The App retains attestation and approval duties;
-  the ephemeral repository token requests the protected queue after attestation.
+  the governed token requests the protected main queue only from a
+  trusted-default-branch `workflow_run` controller. The ephemeral repository
+  token remains limited to non-queued `release/*` auto-merge requests.
 - GitHub also rejected queue entry when `required_deployments` was active even
   with a successful exact-head `staging` deployment. Staging is therefore
   enforced by the `deploy/staging` required check pinned to GitHub Actions; the
@@ -39,6 +41,14 @@
 - Required statuses also apply to the synthesized merge-group commit. The
   attestor therefore signs and publishes a second BAP for that SHA; App review
   and the queue request remain PR-head-only operations.
+- GitHub's `enqueuePullRequest` mutation can atomically bind the expected head
+  SHA, but not the mutable PR body or base SHA. The controller binds the body
+  digest, base ref/SHA, and gate-run generation into the App evidence; checks
+  them immediately before and after enqueue; and dequeues a changed subject.
+  `ready_for_review` and `edited` also create fresh gate generations. A final
+  non-atomic read-to-mutation interval remains. Eliminating it requires moving
+  authorization into the immutable commit or a separately hosted App service
+  that can invalidate queue entries on every PR metadata event.
 - Commit metadata rules evaluate the full squash message, including the PR
   body. The rulesets enforce the conventional first line and allow the
   remaining body so GitHub's queue-generated commit can pass.

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -63,10 +63,13 @@ The App needs `Administration: read` to inspect repository Actions policy and
 rulesets. It keeps `Contents: read` and does not receive merge or queue
 authority. GitHub rejected the GraphQL enqueue mutation for the installation
 token even with the merge-queue permission. After the App signs the BAP and
-records its approval, the repository-scoped ephemeral `GITHUB_TOKEN` uses
-GitHub's supported `gh pr merge` path to request the protected queue. That token
-cannot approve reviews and cannot bypass the ruleset. `id-token: write` is a
-workflow permission, not a GitHub App permission.
+records its approval, a `workflow_run` controller loaded only from the trusted
+default branch uses the governed `SZL_GITHUB_TOKEN` for the exact
+`enqueuePullRequest` mutation. Pull-request-controlled code never receives that
+token. The repository-scoped ephemeral `GITHUB_TOKEN` requests only the
+non-queued `release/*` auto-merge path; it cannot approve reviews or bypass the
+ruleset. `id-token: write` is a workflow permission, not a GitHub App
+permission.
 
 The attestor uses a repository Actions variable for the public App client ID
 and a repository Actions secret for the private key. It does not enter the

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -16,8 +16,12 @@ therefore does not claim independent human review.
   requires it and pins it to App ID `4395545`; the default-branch queue records
   it as evidence. The App repeats gate verification, BAP signing, and status
   publication for the synthesized merge-group commit.
-- The ephemeral repository token requests the protected merge queue only after
-  the App attestation succeeds; it cannot approve or bypass the ruleset.
+- A trusted-default-branch `workflow_run` controller requests the protected
+  main queue only after exact gate-generation, body, base, App-status, and App-
+  review evidence matches. Its governed token is never exposed to PR code.
+- The ephemeral repository token requests only the non-queued `release/*`
+  auto-merge path after App attestation; it cannot approve or bypass the
+  ruleset.
 - The App has read-only Contents access and cannot alter repository code.
 - Ruleset bypass actors remain empty.
 
@@ -37,8 +41,8 @@ protected auto-merge path.
 
 ## Governance changes
 
-A pull request that edits the gate workflow, attestor workflow, or
-`.governance/` must include both:
+A pull request that edits the gate, attestor, merge-queue controller, staging
+workflow, or `.governance/` must include both:
 
 ```text
 Solo-Operator-Authorization: confirmed


### PR DESCRIPTION
## Outcome

- Ports the corrected #376 draft-queue guard onto exact protected `main`, then closes the two reviewed P1 source-identity gaps with one signed forward fix.
- Draft pull requests create no App approval, attestation status, main-queue request, or `release/*` auto-merge request.
- `FORGE-9 gates` reruns on `ready_for_review` and `edited`, so a `release/*` draft receives a fresh exact-generation attestation before the existing protected auto-merge path can act.
- Both privileged `workflow_run` consumers now fetch the exact `SOURCE_GATE_RUN_ID` and fail closed unless its sole `pull_requests[]` association matches the selected PR number, numeric PR identity, same head repository identity/ref/SHA, and base repository identity/ref/SHA.
- Freshness selection is association-bound; neither controller infers a privileged target from `commits/$SHA/pulls` or from a head SHA alone.
- The write-capable main-queue token remains confined to trusted default-branch controller code, with exact run, PR, head, base, body, App identity, and gate-generation checks before and after enqueue.

## Root cause

The original gate workflow omitted `ready_for_review`, so a draft `release/*` PR could defer successfully without a policy-compatible event to retrigger its attestor after becoming ready.

The reviewed successor also treated `workflow_run.head_sha` as PR identity. A fork or another PR can reuse the same public commit, allowing a commit-to-pulls lookup and SHA-only freshness query to remap a successful run onto a different same-repository PR. The fix binds all privileged decisions to the source run's exact GitHub association and revalidates that binding at every mutation boundary.

## Exact provenance

- Base: `abd795d7ed0c4088ad026152ab15923e781fd3e9`
- Head: `e7b2372a5a627b6943ac426f48bd5802ec15e7bc`
- Commit chain: `abd795d7... -> 3450f809... -> e7b2372a...`
- Final tree: `137ee2ff2eaf1a7be35e1a7b6ac280393d44f1ab`
- Two forward commits; both have GitHub-valid SSH signatures and DCO `Signed-off-by` trailers.
- Scope from base: 11 files, +1120/-82.
- First successor tree `c2bad8f7...` exactly equaled corrected #376 head `590a0e88...`; the second commit contains only the reviewed source-run identity fix and its regression coverage.
- #376 and `agent/forge9-draft-attestation-guard` were not pushed, rewritten, closed, approved, or merged by this successor.

## Validation

- All eight FORGE-9 gates passed locally.
- Governance invariant verifier passed.
- Exact source-run identity regressions passed: 11/11, including valid, empty, multiple, run/event/head mismatch, shared-SHA fork, other-PR collision, base mismatch, live-PR mismatch, and exact-association freshness cases for both controllers.
- Trusted merge-queue controller regressions passed: 7/7.
- Live GitHub payload integration passed against gate run `30722546541` and PR #381; the resolver bound exactly #381, this repository, exact head/base, and returned the exact latest run.
- Deployment contract regressions passed: 62/62.
- Reconciliation/readiness regressions passed: 39/39.
- Ruff and `py_compile` passed on all 5 Python files changed by this PR.
- All 3 changed workflows parsed as YAML and passed checksum-verified Actionlint v1.7.12.
- `git diff --check` passed.
- Hosted checks for the final exact head and this final evidence-body generation remain required; the review-thread replies will record their terminal result.

## Governance

Satisfies: AT-22
Labels: governance, security, merge-queue
Rollback: revert the eventual protected merge commit; do not reactivate commit-SHA PR inference or a PR-controlled queue-token path.
Risk: D — changes privileged attestation and merge-queue control flow.
Solo-Operator-Authorization: confirmed

## Mutation boundary

No merge, approval, protection change, Hugging Face dispatch, deployment, queue request, or reconciliation write was performed. The PR remains draft.