### PR TITLE
fix(notifications): move full inbox to Done

### DIFF
--- a/.github/scripts/clear_personal_notifications.py
+++ b/.github/scripts/clear_personal_notifications.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""Clear the authenticated GitHub user's unread notification inbox.
+"""Move every authenticated GitHub notification inbox thread to Done.
 
 The script records counts only. It never logs notification subjects, repository
-names, URLs, or token material. Bulk clearing is followed by an exact unread
-inventory and an individual-thread fallback so the final count must be zero.
+names, URLs, thread identifiers, or token material. The GitHub notification API
+requires a classic personal access token with ``notifications`` or ``repo``
+scope; GitHub App and fine-grained tokens are intentionally unsupported by that
+API.
+
+Inbox clearance is stronger than marking notifications read: every thread still
+returned by ``GET /notifications?all=true`` is deleted through the documented
+"Mark a thread as done" endpoint. The final readback must show both zero inbox
+threads and zero unread threads.
 """
 from __future__ import annotations
 
@@ -20,9 +27,10 @@ from typing import Any
 
 API = "https://api.github.com"
 API_VERSION = "2022-11-28"
-PER_PAGE = 100
-MAX_PAGES = 100
-MAX_ATTEMPTS = 5
+PER_PAGE = 50
+MAX_PAGES = 200
+MAX_ROUNDS = 8
+SETTLE_SECONDS = 2
 
 
 class NotificationError(RuntimeError):
@@ -48,7 +56,7 @@ def request(
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {token}",
             "X-GitHub-Api-Version": API_VERSION,
-            "User-Agent": "szl-clear-personal-notifications/1.0",
+            "User-Agent": "szl-clear-personal-notifications/2.0",
             **({"Content-Type": "application/json"} if body is not None else {}),
         },
     )
@@ -76,12 +84,15 @@ def request(
         ) from exc
 
 
-def unread_thread_ids(token: str) -> list[str]:
+def notification_thread_ids(token: str, *, include_read: bool) -> list[str]:
+    """Return current inbox thread IDs without recording notification content."""
+
     ids: list[str] = []
+    seen: set[str] = set()
     for page in range(1, MAX_PAGES + 1):
         query = urllib.parse.urlencode(
             {
-                "all": "false",
+                "all": "true" if include_read else "false",
                 "participating": "false",
                 "per_page": PER_PAGE,
                 "page": page,
@@ -93,37 +104,26 @@ def unread_thread_ids(token: str) -> list[str]:
         for item in payload:
             thread_id = str((item or {}).get("id") or "")
             if not thread_id:
-                raise NotificationError("GitHub returned a notification without a thread id")
-            ids.append(thread_id)
+                raise NotificationError(
+                    "GitHub returned a notification without a thread id"
+                )
+            if thread_id not in seen:
+                seen.add(thread_id)
+                ids.append(thread_id)
         if len(payload) < PER_PAGE:
             return ids
     raise NotificationError(
-        f"Unread inventory exceeded the fail-closed limit of {MAX_PAGES * PER_PAGE}"
+        f"Inbox inventory exceeded the fail-closed limit of "
+        f"{MAX_PAGES * PER_PAGE} threads"
     )
 
 
-def mark_all_read(token: str) -> int:
-    status, _ = request(
-        token,
-        "PUT",
-        "/notifications",
-        {"last_read_at": utc_now()},
-    )
-    if status not in {202, 205}:
-        raise NotificationError(f"Unexpected bulk-clear response status: {status}")
-    return status
-
-
-def mark_thread_read(token: str, thread_id: str) -> None:
-    status, _ = request(
-        token,
-        "PATCH",
-        f"/notifications/threads/{urllib.parse.quote(thread_id, safe='')}",
-        {"read": True},
-    )
-    if status not in {200, 205}:
+def mark_thread_done(token: str, thread_id: str) -> None:
+    encoded = urllib.parse.quote(thread_id, safe="")
+    status, _ = request(token, "DELETE", f"/notifications/threads/{encoded}")
+    if status != 204:
         raise NotificationError(
-            f"Unexpected thread-clear response status for {thread_id}: {status}"
+            f"Unexpected mark-done response status for one thread: {status}"
         )
 
 
@@ -133,47 +133,51 @@ def clear_inbox(token: str) -> dict[str, Any]:
     if not identity:
         raise NotificationError("Authenticated GitHub identity did not expose a login")
 
-    before_ids = unread_thread_ids(token)
-    bulk_attempts = 0
-    fallback_threads = 0
-    remaining = before_ids
+    before_inbox = notification_thread_ids(token, include_read=True)
+    before_unread = notification_thread_ids(token, include_read=False)
 
-    for attempt in range(1, MAX_ATTEMPTS + 1):
-        bulk_attempts = attempt
-        mark_all_read(token)
-        time.sleep(2)
-        remaining = unread_thread_ids(token)
+    cleared_ids: set[str] = set()
+    delete_attempts = 0
+    rounds = 0
+    remaining = before_inbox
+
+    for round_number in range(1, MAX_ROUNDS + 1):
+        rounds = round_number
         if not remaining:
             break
-
         for thread_id in remaining:
-            mark_thread_read(token, thread_id)
-            fallback_threads += 1
-        time.sleep(2)
-        remaining = unread_thread_ids(token)
-        if not remaining:
-            break
-
-    if remaining:
-        mark_all_read(token)
-        time.sleep(3)
-        remaining = unread_thread_ids(token)
+            mark_thread_done(token, thread_id)
+            delete_attempts += 1
+            cleared_ids.add(thread_id)
+        time.sleep(SETTLE_SECONDS)
+        remaining = notification_thread_ids(token, include_read=True)
 
     if remaining:
         raise NotificationError(
-            f"Unread inbox did not converge to zero; remaining_count={len(remaining)}"
+            f"Notification inbox did not converge to zero; "
+            f"remaining_count={len(remaining)}"
+        )
+
+    final_unread = notification_thread_ids(token, include_read=False)
+    if final_unread:
+        raise NotificationError(
+            f"Unread notifications remained after inbox clearance; "
+            f"remaining_count={len(final_unread)}"
         )
 
     return {
-        "schema": "szl.github-notification-clearance/v1",
+        "schema": "szl.github-notification-clearance/v2",
         "generated_at": utc_now(),
         "identity": identity,
-        "before_unread_count": len(before_ids),
+        "before_inbox_count": len(before_inbox),
+        "before_unread_count": len(before_unread),
+        "after_inbox_count": 0,
         "after_unread_count": 0,
-        "cleared_count": len(before_ids),
-        "bulk_attempts": bulk_attempts,
-        "individual_thread_fallbacks": fallback_threads,
+        "cleared_count": len(cleared_ids),
+        "clearance_rounds": rounds,
+        "delete_attempts": delete_attempts,
         "notification_content_recorded": False,
+        "thread_ids_recorded": False,
         "status": "CLEARED",
     }
 
@@ -198,10 +202,12 @@ def main() -> int:
         code = 0
     except Exception as exc:  # noqa: BLE001
         report = {
-            "schema": "szl.github-notification-clearance/v1",
+            "schema": "szl.github-notification-clearance/v2",
             "generated_at": utc_now(),
+            "after_inbox_count": None,
             "after_unread_count": None,
             "notification_content_recorded": False,
+            "thread_ids_recorded": False,
             "status": "FAILED",
             "errors": [f"{type(exc).__name__}: {exc}"],
         }

--- a/.github/scripts/test_clear_personal_notifications.py
+++ b/.github/scripts/test_clear_personal_notifications.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Network-free regressions for personal GitHub notification inbox clearance."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+import urllib.parse
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).with_name("clear_personal_notifications.py")
+SPEC = importlib.util.spec_from_file_location("clear_personal_notifications", MODULE_PATH)
+assert SPEC and SPEC.loader
+clearer = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = clearer
+SPEC.loader.exec_module(clearer)
+
+
+class FakeGitHub:
+    def __init__(self, count: int, *, inject_concurrent: bool = False) -> None:
+        self.threads = {
+            str(index): {"unread": index % 2 == 0, "done": False}
+            for index in range(1, count + 1)
+        }
+        self.inject_concurrent = inject_concurrent
+        self.injected = False
+        self.deleted: list[str] = []
+
+    def request(self, token, method, path, payload=None):
+        self.assert_token(token)
+        if method == "GET" and path == "/user":
+            return 200, {"login": "stephenlutar2-hash"}
+
+        if method == "GET" and path.startswith("/notifications?"):
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
+            include_read = query["all"][0] == "true"
+            page = int(query["page"][0])
+            per_page = int(query["per_page"][0])
+            active = [
+                thread_id
+                for thread_id, state in sorted(
+                    self.threads.items(), key=lambda pair: int(pair[0])
+                )
+                if not state["done"] and (include_read or state["unread"])
+            ]
+            start = (page - 1) * per_page
+            payload_out = [{"id": item} for item in active[start : start + per_page]]
+            return 200, payload_out
+
+        if method == "DELETE" and path.startswith("/notifications/threads/"):
+            thread_id = urllib.parse.unquote(path.rsplit("/", 1)[-1])
+            if thread_id not in self.threads:
+                raise AssertionError(f"unknown thread: {thread_id}")
+            self.threads[thread_id]["done"] = True
+            self.deleted.append(thread_id)
+            if self.inject_concurrent and not self.injected:
+                self.injected = True
+                self.threads["999"] = {"unread": True, "done": False}
+            return 204, None
+
+        raise AssertionError(f"unexpected request: {method} {path} {payload}")
+
+    @staticmethod
+    def assert_token(token):
+        if token != "classic-token":
+            raise AssertionError("wrong token")
+
+
+class NotificationClearanceTests(unittest.TestCase):
+    def test_inventory_includes_read_threads_and_paginates_at_api_maximum(self):
+        api = FakeGitHub(53)
+        with patch.object(clearer, "request", api.request):
+            ids = clearer.notification_thread_ids(
+                "classic-token", include_read=True
+            )
+            unread = clearer.notification_thread_ids(
+                "classic-token", include_read=False
+            )
+        self.assertEqual(len(ids), 53)
+        self.assertEqual(len(unread), 26)
+        self.assertEqual(clearer.PER_PAGE, 50)
+
+    def test_mark_thread_done_uses_documented_delete_endpoint(self):
+        api = FakeGitHub(1)
+        with patch.object(clearer, "request", api.request):
+            clearer.mark_thread_done("classic-token", "1")
+        self.assertEqual(api.deleted, ["1"])
+        self.assertTrue(api.threads["1"]["done"])
+
+    def test_clear_inbox_moves_read_and_unread_threads_to_done(self):
+        api = FakeGitHub(4)
+        with (
+            patch.object(clearer, "request", api.request),
+            patch.object(clearer.time, "sleep", return_value=None),
+        ):
+            report = clearer.clear_inbox("classic-token")
+        self.assertEqual(report["before_inbox_count"], 4)
+        self.assertEqual(report["before_unread_count"], 2)
+        self.assertEqual(report["after_inbox_count"], 0)
+        self.assertEqual(report["after_unread_count"], 0)
+        self.assertEqual(report["cleared_count"], 4)
+        self.assertEqual(report["status"], "CLEARED")
+        self.assertFalse(report["notification_content_recorded"])
+        self.assertFalse(report["thread_ids_recorded"])
+        self.assertTrue(all(state["done"] for state in api.threads.values()))
+
+    def test_clear_inbox_catches_notification_arriving_during_clearance(self):
+        api = FakeGitHub(2, inject_concurrent=True)
+        with (
+            patch.object(clearer, "request", api.request),
+            patch.object(clearer.time, "sleep", return_value=None),
+        ):
+            report = clearer.clear_inbox("classic-token")
+        self.assertEqual(report["before_inbox_count"], 2)
+        self.assertEqual(report["cleared_count"], 3)
+        self.assertGreaterEqual(report["clearance_rounds"], 2)
+        self.assertTrue(api.threads["999"]["done"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Moves every authenticated GitHub notification Inbox thread to **Done** so the Inbox count—not only the unread count—can reach exactly zero.

## Root cause

The prior control queried only `GET /notifications?all=false` and changed read state. Already-read threads therefore remained in Inbox, which is why the screenshot could show rows without blue unread dots while the Inbox badge still reported 336.

## Changes

- inventory the complete Inbox with `all=true`, including read threads;
- use GitHub's documented `DELETE /notifications/threads/{thread_id}` mark-Done endpoint;
- paginate at the documented 50-item maximum;
- run bounded repeated sweeps to catch notifications arriving during clearance;
- fail unless both `after_inbox_count == 0` and `after_unread_count == 0`;
- record counts only—never notification subjects, repositories, URLs, thread IDs, or token values;
- add network-free tests for pagination, read+unread removal, exact DELETE semantics, and a concurrent-arrival race.

## Signed successor lineage

PR #386 preserved the correct source but its contents-API commits were not cryptographically verified, so the merge queue correctly refused them. Staging PR #387 squash-normalized that exact two-file tree into GitHub-generated commit `79350c281c12a36f193ba4130a7d5e0d4c897cb7` without force-pushing or rewriting the predecessor branch. This successor contains that single DCO-trailered commit on exact protected main.

## Tests executed

| Test | Result | Evidence |
| --- | --- | --- |
| Python compilation | PASS | both changed Python files |
| Network-free notification regressions | PASS | 4 tests |
| Repository CI / FORGE-9 / security gates | PENDING | this exact head |
| Protected post-merge notification clearance | PENDING | existing workflow triggered by the owned script path |
| Count-only receipt and second post-receipt sweep | PENDING | existing protected workflow |

## Token and privacy boundary

The protected workflow consumes the existing classic notification token from Actions secrets. No token value is requested, printed, copied, committed, or persisted. GitHub App and fine-grained tokens are not substituted because GitHub's notifications endpoints do not support them.

## Contract metadata

Satisfies: C-160

Labels: PROVED complete-Inbox algorithm, documented mark-Done endpoint, bounded pagination, privacy-preserving reports, DCO successor lineage, and network-free race regressions; MEASURED exact-head hosted gates and protected post-merge count-only clearance; NOT CLAIMED zero until the authenticated workflow reports `after_inbox_count: 0` and `after_unread_count: 0`.

Rollback: Before merge, close this pull request. After merge, revert the protected merge commit through a signed+DCO pull request; doing so restores the known limitation where already-read notifications remain in Inbox.

Risk: B - authenticated personal notification triage through the existing protected secret path; no repository source outside the notification clearer, no branch protection, App, model, dataset, product runtime, or Hugging Face mutation.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>