### PR TITLE
fix(hf): restore org-card publication authority and CI coverage

### DIFF
--- a/.github/scripts/test_hf_static_space_deploy.py
+++ b/.github/scripts/test_hf_static_space_deploy.py
@@ -153,6 +153,19 @@ class StaticSpaceDeployTests(unittest.TestCase):
             contract, "a" * 40, self.authority_env()
         )
 
+    def test_publish_workflow_exports_exact_authority_environment(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        workflow = (
+            repo_root / ".github" / "workflows" / "hf-org-card-deploy.yml"
+        ).read_text(encoding="utf-8")
+        for required in (
+            "environment: production",
+            "GITHUB_TOKEN: ${{ github.token }}",
+            "SZL_PUBLICATION_ENVIRONMENT: production",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, workflow)
+
     def test_publish_authority_rejects_branch_dispatch_and_rerun(self):
         contract, _ = deploy.load_contract(self.root, self.manifest)
         for name, value in {

--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -11,6 +11,7 @@ on:
       - ".github/scripts/hf_static_space_deploy.py"
       - ".github/scripts/hf_org_card_embed_check.py"
       - ".github/scripts/public_front_door_check.py"
+      - ".github/scripts/test_hf_org_card_embed_check.py"
       - ".github/scripts/test_hf_static_space_deploy.py"
       - ".github/scripts/test_public_front_door_check.py"
       - ".github/workflows/hf-org-card-deploy.yml"
@@ -57,6 +58,12 @@ jobs:
           -s .github/scripts
           -p test_public_front_door_check.py
 
+      - name: Test org-card embed contract
+        run: >-
+          python -m unittest discover
+          -s .github/scripts
+          -p test_hf_org_card_embed_check.py
+
       - name: Run org-card embed hardening check
         run: python .github/scripts/hf_org_card_embed_check.py
 
@@ -69,6 +76,8 @@ jobs:
       - name: Publish and verify exact source
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SZL_PUBLICATION_ENVIRONMENT: production
         run: >-
           python .github/scripts/hf_static_space_deploy.py
           --repo-root .

--- a/.github/workflows/hf-org-card-embed-check.yml
+++ b/.github/workflows/hf-org-card-embed-check.yml
@@ -1,6 +1,18 @@
 name: Validate Hugging Face org card embed hardening
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "huggingface/org-card/**"
+      - "huggingface/org-card.manifest.json"
+      - "profile/assets/**"
+      - "profile/assets/evidence-lattice-v2.webp"
+      - ".github/scripts/hf_org_card_embed_check.py"
+      - ".github/scripts/public_front_door_check.py"
+      - ".github/scripts/test_hf_org_card_embed_check.py"
+      - ".github/scripts/test_public_front_door_check.py"
+      - ".github/workflows/hf-org-card-embed-check.yml"
   push:
     branches: [main]
     paths:
@@ -10,8 +22,10 @@ on:
       - "profile/assets/evidence-lattice-v2.webp"
       - ".github/scripts/hf_org_card_embed_check.py"
       - ".github/scripts/public_front_door_check.py"
+      - ".github/scripts/test_hf_org_card_embed_check.py"
       - ".github/scripts/test_public_front_door_check.py"
-      - ".github/scripts/hf-org-card-embed-check.yml"
+      - ".github/workflows/hf-org-card-embed-check.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -46,6 +60,12 @@ jobs:
           python -m unittest discover
           -s .github/scripts
           -p test_public_front_door_check.py
+
+      - name: Run org-card embed contract tests
+        run: >-
+          python -m unittest discover
+          -s .github/scripts
+          -p test_hf_org_card_embed_check.py
 
       - name: Verify org-card embed hardening
         run: python .github/scripts/hf_org_card_embed_check.py


### PR DESCRIPTION
## Summary

- export the exact protected-main publication environment required by the fail-closed Hugging Face org-card deployer
- pass the workflow-scoped GitHub token through the publish step
- run the dedicated org-card embed contract suite in both pull-request validation and deployment
- restore pull-request and manual-dispatch coverage for the embed workflow
- correct the embed-workflow path filter
- add a regression that locks the production authority exports

## Root cause

The source card on GitHub was newer than the live Hugging Face Space. The publish workflow declared the production environment but did not export `SZL_PUBLICATION_ENVIRONMENT=production` or `GITHUB_TOKEN` to the deployment process, so the fail-closed publisher rejected the job. The embed workflow also invoked only the public-front-door tests and contained an incorrect workflow path trigger.

## Evidence

Executed against the patched current-main snapshot:

- `test_hf_static_space_deploy.py`: 23 passed
- `test_hf_org_card_embed_check.py`: 8 passed
- `test_public_front_door_check.py`: 50 passed
- `hf_org_card_embed_check.py`: passed with zero failures
- `public_front_door_check.py`: passed, 87 checks, zero failures

Total focused unit coverage: 81 passed.

## Truth boundary

This pull request does not mutate Hugging Face. The live Space remains on the older card until this exact head satisfies protected checks, merges normally, the protected-main deployment succeeds, and live source/readback verification matches the merged revision.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>