### PR TITLE
fix(hf): bind org-card accessible section labels

### DIFF
--- a/.github/scripts/hf_org_card_embed_check.py
+++ b/.github/scripts/hf_org_card_embed_check.py
@@ -59,6 +59,7 @@ class OrgCardParser(HTMLParser):
         self.main_count = 0
         self.class_tokens: set[str] = set()
         self.ids: list[str] = []
+        self.aria_labelledby: list[str] = []
         self.hrefs: list[str] = []
         self.images: list[dict[str, str]] = []
         self.styles: list[str] = []
@@ -94,6 +95,8 @@ class OrgCardParser(HTMLParser):
         self.class_tokens.update(classes)
         if values.get("id"):
             self.ids.append(values["id"])
+        if "aria-labelledby" in values:
+            self.aria_labelledby.append(values["aria-labelledby"])
         if values.get("style"):
             self.inline_style_count += 1
 
@@ -322,6 +325,21 @@ def validate_document(document: str) -> list[str]:
         failures.append(f"duplicate DOM ids: {duplicate_ids}")
     if bad_ids:
         failures.append(f"unscoped DOM ids: {bad_ids}")
+
+    if any(not value.split() for value in parser.aria_labelledby):
+        failures.append("aria-labelledby must contain at least one DOM id")
+    missing_label_ids = sorted(
+        {
+            target
+            for value in parser.aria_labelledby
+            for target in value.split()
+            if target not in parser.ids
+        }
+    )
+    if missing_label_ids:
+        failures.append(
+            f"aria-labelledby targets are missing: {missing_label_ids}"
+        )
 
     bad_hrefs = sorted(value for value in parser.hrefs if not _safe_href(value))
     if bad_hrefs:

--- a/.github/scripts/test_hf_org_card_embed_check.py
+++ b/.github/scripts/test_hf_org_card_embed_check.py
@@ -137,6 +137,16 @@ class EmbedContractTests(unittest.TestCase):
         failures = check.validate_document(document)
         self.assertTrue(any("navigation targets" in item for item in failures))
 
+    def test_rejects_missing_aria_label_target(self):
+        document = valid_document().replace(
+            '<main id="szl-hf-main">',
+            '<main id="szl-hf-main" aria-labelledby="szl-hf-missing-title">',
+        )
+        failures = check.validate_document(document)
+        self.assertTrue(
+            any("aria-labelledby targets are missing" in item for item in failures)
+        )
+
     def test_rejects_missing_embed_marker(self):
         document = valid_document().replace(
             ' data-szl-embed-safe="true"', ""

--- a/huggingface/org-card/index.html
+++ b/huggingface/org-card/index.html
@@ -290,7 +290,7 @@
            alt="" width="1800" height="776" fetchpriority="high" decoding="async">
     </div>
 
-    <section id="szl-hf-paths" aria-labelledby="paths-title">
+    <section id="szl-hf-paths" aria-labelledby="szl-hf-paths-title">
       <div class="szl-hf-shell">
         <div class="szl-hf-section-head">
           <div><div class="szl-hf-eyebrow">Choose a mission</div><h2 id="szl-hf-paths-title">One front door. Four focused paths.</h2></div>
@@ -325,7 +325,7 @@
       </div>
     </section>
 
-    <section id="szl-hf-system" aria-labelledby="system-title">
+    <section id="szl-hf-system" aria-labelledby="szl-hf-system-title">
       <div class="szl-hf-shell">
         <div class="szl-hf-section-head">
           <div><div class="szl-hf-eyebrow">One governed loop</div><h2 id="szl-hf-system-title">Six stages. One accountable path.</h2></div>
@@ -344,7 +344,7 @@
       </div>
     </section>
 
-    <section id="szl-hf-artifacts" aria-labelledby="artifacts-title">
+    <section id="szl-hf-artifacts" aria-labelledby="szl-hf-artifacts-title">
       <div class="szl-hf-shell">
         <div class="szl-hf-section-head">
           <div><div class="szl-hf-eyebrow">Hugging Face portfolio</div><h2 id="szl-hf-artifacts-title">Five artifact classes. No category shortcuts.</h2></div>
@@ -375,7 +375,7 @@
       </div>
     </section>
 
-    <section id="szl-hf-status" aria-labelledby="status-title">
+    <section id="szl-hf-status" aria-labelledby="szl-hf-status-title">
       <div class="szl-hf-shell">
         <div class="szl-hf-section-head">
           <div><div class="szl-hf-eyebrow">Current state</div><h2 id="szl-hf-status-title">Status is linked, not hardcoded.</h2></div>
@@ -405,7 +405,7 @@
       </div>
     </section>
 
-    <section class="szl-hf-closing" aria-labelledby="closing-title">
+    <section class="szl-hf-closing" aria-labelledby="szl-hf-closing-title">
       <div class="szl-hf-shell szl-hf-closing-panel">
         <div class="szl-hf-eyebrow">Build, evaluate, verify</div>
         <h2 id="szl-hf-closing-title">Move from model output to accountable action.</h2>


### PR DESCRIPTION
## Summary

- retarget all five org-card section `aria-labelledby` references to their actual namespaced heading IDs
- extend the fail-closed embed parser to validate every `aria-labelledby` IDREF
- add a regression proving missing accessible-name targets are rejected

## Root cause

The host-isolation rename prefixed the heading IDs but left the section IDREFs on their former unprefixed values. The existing checker validated navigation fragments but did not validate ARIA IDREF integrity.

## Validation

Executed on exact protected main `08068f42ba8b9ee062644bfa97c84cd60e61d017`:

- `test_hf_static_space_deploy.py`: 23 passed
- `test_public_front_door_check.py`: 50 passed
- `test_hf_org_card_embed_check.py`: 9 passed
- `hf_org_card_embed_check.py`: PASS, zero failures
- `public_front_door_check.py`: PASS, 87 checks, zero failures
- local HTTP preview: 200
- SSH signature verified locally; DCO sign-off present

## Release chain

This is the narrow accessibility successor after #393 and #396. It addresses the remaining actionable org-card review finding from closed #392 without replaying or rewriting superseded history.

## Truth boundary

No Hugging Face mutation is claimed by this PR. Live publication is complete only after this exact head passes protected checks, merges normally, the protected-main publish workflow succeeds, and the served deployment/readback matches the merged revision.