### PR TITLE
build(ci): bootstrap fail-closed DCO checker

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -18,7 +18,7 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^Signed-off-by:\s+.+\s+<[^<>\s]+@[^<>\s]+>\s*$",
+    r"^Signed-off-by:[ \t]+[^<>\r\n]+[ \t]+<[^<>\s]+@[^<>\s]+>[ \t]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -18,7 +18,8 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^Signed-off-by:[ \t]+[^<>\r\n]+[ \t]+<[^<>\s]+@[^<>\s]+>[ \t]*$",
+    r"^Signed-off-by:[ \t]+[^\s<>\r\n](?:[^<>\r\n]*[^\s<>\r\n])?"
+    r"[ \t]+<[^<>\s]+@[^<>\s]+>[ \t]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -18,8 +18,10 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^Signed-off-by:[ \t]+[^<>\s]+(?:[ \t]+[^<>\s]+)*"
-    r"[ \t]+<[^<>\s]+@[^<>\s]+>[ \t]*$",
+    r"^Signed-off-by:[^\S\r\n\v\f\x85\u2028\u2029]+"
+    r"[^<>\s]+(?:[^\S\r\n\v\f\x85\u2028\u2029]+[^<>\s]+)*"
+    r"[^\S\r\n\v\f\x85\u2028\u2029]+<[^<>\s]+@[^<>\s]+>"
+    r"[^\S\r\n\v\f\x85\u2028\u2029]*$",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -18,12 +18,12 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^Signed-off-by:[^\S\r\n\v\f\x85\u2028\u2029]+"
-    r"[^<>\s]+(?:[^\S\r\n\v\f\x85\u2028\u2029]+[^<>\s]+)*"
-    r"[^\S\r\n\v\f\x85\u2028\u2029]+<[^<>\s]+@[^<>\s]+>"
-    r"[^\S\r\n\v\f\x85\u2028\u2029]*$",
-    re.IGNORECASE | re.MULTILINE,
+    r"^(?ai:Signed-off-by):[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+"
+    r"[^<>\s]+(?:[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+[^<>\s]+)*"
+    r"[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+<[^<>\s]+@[^<>\s]+>"
+    r"[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]*$"
 )
+TRAILER_LINE_PATTERN = re.compile(r"^[A-Za-z0-9-]+:[ \t]+\S.*$")
 
 
 class DcoContractError(RuntimeError):
@@ -289,7 +289,19 @@ def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
             raise DcoContractError(f"commit entry {index} had an invalid SHA")
         if not isinstance(commit, dict) or not isinstance(commit.get("message"), str):
             raise DcoContractError(f"commit {sha} had no valid commit message")
-        if not SIGNED_OFF_BY_PATTERN.search(commit["message"]):
+        lines = commit["message"].splitlines()
+        while lines and not lines[-1].strip():
+            lines.pop()
+        paragraph_start = len(lines)
+        while paragraph_start > 0 and lines[paragraph_start - 1].strip():
+            paragraph_start -= 1
+        trailer_lines = lines[paragraph_start:]
+        is_trailer_block = bool(trailer_lines) and all(
+            TRAILER_LINE_PATTERN.fullmatch(line) for line in trailer_lines
+        )
+        if not is_trailer_block or not any(
+            SIGNED_OFF_BY_PATTERN.fullmatch(line) for line in trailer_lines
+        ):
             unsigned.append(sha)
 
     return unsigned

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -17,13 +17,37 @@ COMMITS_PER_PAGE = 100
 MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
-SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^(?ai:Signed-off-by):[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+"
-    r"[^<>\s]+(?:[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+[^<>\s]+)*"
-    r"[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]+<[^<>\s]+@[^<>\s]+>"
-    r"[^\S\r\n\v\f\x1c-\x1f\x85\u2028\u2029]*$"
+
+# Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
+# Name and email tokens separately reject C0/C1 controls plus Unicode line and
+# paragraph separators, so no broad whitespace class can admit a line break.
+HORIZONTAL_SEPARATOR_PATTERN = (
+    r"[\x09\x20\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]"
 )
-TRAILER_LINE_PATTERN = re.compile(r"^[A-Za-z0-9-]+:[ \t]+\S.*$")
+NAME_TOKEN_PATTERN = (
+    r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000]+"
+)
+EMAIL_PART_PATTERN = (
+    r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000]+"
+)
+TRAILER_VALUE_TOKEN_PATTERN = (
+    r"[^\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000]+"
+)
+SIGNED_OFF_BY_PATTERN = re.compile(
+    rf"^(?ai:Signed-off-by):{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN}"
+    rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN})*"
+    rf"{HORIZONTAL_SEPARATOR_PATTERN}+<{EMAIL_PART_PATTERN}@"
+    rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$"
+)
+TRAILER_LINE_PATTERN = re.compile(
+    rf"^[A-Za-z0-9-]+:{HORIZONTAL_SEPARATOR_PATTERN}+"
+    rf"{TRAILER_VALUE_TOKEN_PATTERN}"
+    rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{TRAILER_VALUE_TOKEN_PATTERN})*"
+    rf"{HORIZONTAL_SEPARATOR_PATTERN}*$"
+)
 
 
 class DcoContractError(RuntimeError):

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -18,7 +18,7 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 SIGNED_OFF_BY_PATTERN = re.compile(
-    r"^Signed-off-by:[ \t]+[^\s<>\r\n](?:[^<>\r\n]*[^\s<>\r\n])?"
+    r"^Signed-off-by:[ \t]+[^<>\s]+(?:[ \t]+[^<>\s]+)*"
     r"[ \t]+<[^<>\s]+@[^<>\s]+>[ \t]*$",
     re.IGNORECASE | re.MULTILINE,
 )

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -32,22 +32,37 @@ EMAIL_PART_PATTERN = (
     r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
     r"\u2028\u2029\u202f\u205f\u3000]+"
 )
-TRAILER_VALUE_TOKEN_PATTERN = (
-    r"[^\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
-    r"\u2028\u2029\u202f\u205f\u3000]+"
-)
 SIGNED_OFF_BY_PATTERN = re.compile(
-    rf"^(?ai:Signed-off-by):{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN}"
+    rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN}"
     rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN})*"
     rf"{HORIZONTAL_SEPARATOR_PATTERN}+<{EMAIL_PART_PATTERN}@"
-    rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$"
+    rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$",
+    re.IGNORECASE,
+)
+HORIZONTAL_ONLY_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}*$"
+)
+SAFE_TRAILER_TEXT_PATTERN = (
+    r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029]*"
 )
 TRAILER_LINE_PATTERN = re.compile(
-    rf"^[A-Za-z0-9-]+:{HORIZONTAL_SEPARATOR_PATTERN}+"
-    rf"{TRAILER_VALUE_TOKEN_PATTERN}"
-    rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{TRAILER_VALUE_TOKEN_PATTERN})*"
-    rf"{HORIZONTAL_SEPARATOR_PATTERN}*$"
+    rf"^(?P<token>[A-Za-z0-9][A-Za-z0-9-]*)[ \t]*:"
+    rf"(?P<value>{SAFE_TRAILER_TEXT_PATTERN})$"
 )
+CONTINUATION_LINE_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}+{SAFE_TRAILER_TEXT_PATTERN}$"
+)
+POTENTIAL_TRAILER_LINE_PATTERN = re.compile(
+    rf"^[A-Za-z0-9][A-Za-z0-9-]*(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
+    r"[\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029])*:"
+)
+HORIZONTAL_PREFIX_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}"
+)
+
+# Git's mixed-group heuristic recognizes this exact generated prefix. Project
+# DCO matching is intentionally broader and is applied only after admission.
+GIT_RECOGNIZED_SIGNOFF_PREFIX = "Signed-off-by: "
 
 
 class DcoContractError(RuntimeError):
@@ -300,6 +315,122 @@ def fetch_authoritative_pr_commits(
     return declared_count, commits
 
 
+def _is_horizontal_blank(line: str) -> bool:
+    """Return whether a physical line is blank under the audited grammar."""
+    return HORIZONTAL_ONLY_PATTERN.fullmatch(line) is not None
+
+
+def _final_nonblank_group(message: str) -> list[str]:
+    """Return the complete final nonblank group after a body boundary."""
+    lines = message.split("\n")
+    while lines and _is_horizontal_blank(lines[-1]):
+        lines.pop()
+    if not lines:
+        return []
+
+    boundary_index = next(
+        (
+            index
+            for index in range(len(lines) - 1, -1, -1)
+            if _is_horizontal_blank(lines[index])
+        ),
+        None,
+    )
+    if boundary_index is None:
+        return []
+
+    final_paragraph = lines[boundary_index + 1 :]
+    if not final_paragraph:
+        return []
+    return final_paragraph
+
+
+def _admitted_trailer_group(
+    message: str,
+) -> list[tuple[str, str | None, str]] | None:
+    """Classify and admit the complete final group using Git's counters."""
+    final_group = _final_nonblank_group(message)
+    if not final_group:
+        return None
+
+    classified_lines: list[tuple[str, str | None, str]] = []
+    current_token: str | None = None
+    trailer_count = 0
+    non_trailer_count = 0
+    has_recognized_prefix = False
+
+    for line in final_group:
+        if CONTINUATION_LINE_PATTERN.fullmatch(line):
+            if current_token is None:
+                non_trailer_count += 1
+                classified_lines.append(("orphan-continuation", None, line))
+            else:
+                classified_lines.append(("continuation", current_token, line))
+            continue
+
+        trailer_match = TRAILER_LINE_PATTERN.fullmatch(line)
+        if trailer_match is not None:
+            current_token = trailer_match.group("token").lower()
+            trailer_count += 1
+            has_recognized_prefix = (
+                has_recognized_prefix
+                or line.startswith(GIT_RECOGNIZED_SIGNOFF_PREFIX)
+            )
+            classified_lines.append(("trailer", current_token, line))
+            continue
+
+        if (
+            POTENTIAL_TRAILER_LINE_PATTERN.match(line)
+            or HORIZONTAL_PREFIX_PATTERN.match(line)
+        ):
+            current_token = None
+            non_trailer_count += 1
+            classified_lines.append(("malformed", None, line))
+            continue
+
+        current_token = None
+        non_trailer_count += 1
+        classified_lines.append(("body", None, line))
+
+    if trailer_count == 0:
+        return None
+    if non_trailer_count and (
+        not has_recognized_prefix
+        or trailer_count * 4 < trailer_count + non_trailer_count
+    ):
+        return None
+
+    return classified_lines
+
+
+def has_valid_dco_trailer(message: str) -> bool:
+    """Admit Git-compatible trailers, then apply stricter project DCO rules."""
+    classified_lines = _admitted_trailer_group(message)
+    if classified_lines is None:
+        return False
+
+    found_signed_off_by = False
+    current_token = None
+    for line_kind, token, line in classified_lines:
+        if line_kind == "body":
+            current_token = None
+            continue
+        if line_kind in {"orphan-continuation", "malformed"}:
+            return False
+        if line_kind == "continuation":
+            if current_token is None or current_token == "signed-off-by":
+                return False
+            continue
+
+        current_token = token
+        if current_token == "signed-off-by":
+            if SIGNED_OFF_BY_PATTERN.fullmatch(line) is None:
+                return False
+            found_signed_off_by = True
+
+    return found_signed_off_by
+
+
 def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
     """Return every commit that lacks a syntactically valid DCO trailer."""
     unsigned: list[str] = []
@@ -313,19 +444,7 @@ def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
             raise DcoContractError(f"commit entry {index} had an invalid SHA")
         if not isinstance(commit, dict) or not isinstance(commit.get("message"), str):
             raise DcoContractError(f"commit {sha} had no valid commit message")
-        lines = commit["message"].splitlines()
-        while lines and not lines[-1].strip():
-            lines.pop()
-        paragraph_start = len(lines)
-        while paragraph_start > 0 and lines[paragraph_start - 1].strip():
-            paragraph_start -= 1
-        trailer_lines = lines[paragraph_start:]
-        is_trailer_block = bool(trailer_lines) and all(
-            TRAILER_LINE_PATTERN.fullmatch(line) for line in trailer_lines
-        )
-        if not is_trailer_block or not any(
-            SIGNED_OFF_BY_PATTERN.fullmatch(line) for line in trailer_lines
-        ):
+        if not has_valid_dco_trailer(commit["message"]):
             unsigned.append(sha)
 
     return unsigned

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -27,6 +27,12 @@ class DcoContractError(RuntimeError):
     """Raised when the API response cannot prove complete DCO coverage."""
 
 
+def _validate_sha(value: str, *, label: str) -> str:
+    if not SHA_PATTERN.fullmatch(value):
+        raise DcoContractError(f"{label} was not a full lowercase commit SHA")
+    return value
+
+
 def _request_json(
     url: str,
     token: str,
@@ -65,15 +71,20 @@ def _request_json(
         raise DcoContractError(f"{resource} response was not valid JSON") from exc
 
 
-def fetch_pr_commit_count(
+def fetch_pr_metadata(
     api_url: str,
     repository: str,
     pr_number: int,
     token: str,
+    expected_head_sha: str,
     *,
     opener: Any = None,
-) -> int:
-    """Retrieve the authoritative commit count from pull-request metadata."""
+) -> tuple[int, str]:
+    """Retrieve an authoritative commit count bound to the expected PR head."""
+    expected_head_sha = _validate_sha(
+        expected_head_sha,
+        label="expected pull-request head",
+    )
     url = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}"
     payload = _request_json(
         url,
@@ -94,6 +105,18 @@ def fetch_pr_commit_count(
         raise DcoContractError(
             "pull-request metadata did not declare a positive integer commit count"
         )
+
+    head = payload.get("head")
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    if not isinstance(head_sha, str) or not SHA_PATTERN.fullmatch(head_sha):
+        raise DcoContractError(
+            "pull-request metadata did not declare a valid head SHA"
+        )
+    if head_sha != expected_head_sha:
+        raise DcoContractError(
+            "pull-request head mismatch: "
+            f"metadata returned {head_sha}, expected {expected_head_sha}"
+        )
     if declared_count > MAX_PULL_REQUEST_COMMITS:
         raise DcoContractError(
             f"pull request declares {declared_count} commits; "
@@ -101,7 +124,7 @@ def fetch_pr_commit_count(
             f"{MAX_PULL_REQUEST_COMMITS}, so complete DCO coverage cannot be proven"
         )
 
-    return declared_count
+    return declared_count, head_sha
 
 
 def fetch_pr_commits(
@@ -123,6 +146,7 @@ def fetch_pr_commits(
         raise DcoContractError("declared commit count is outside the supported range")
 
     commits: list[dict[str, Any]] = []
+    seen_shas: set[str] = set()
     page_count = (declared_count + COMMITS_PER_PAGE - 1) // COMMITS_PER_PAGE
     endpoint = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}/commits"
 
@@ -148,7 +172,22 @@ def fetch_pr_commits(
                 f"page {page} returned {len(payload)} commits, "
                 f"expected {expected_page_size}"
             )
-        commits.extend(payload)
+        for index, item in enumerate(payload, start=1):
+            if not isinstance(item, dict):
+                raise DcoContractError(
+                    f"pull-request commits page {page} entry {index} was not an object"
+                )
+            sha = item.get("sha")
+            if not isinstance(sha, str) or not SHA_PATTERN.fullmatch(sha):
+                raise DcoContractError(
+                    f"pull-request commits page {page} entry {index} had an invalid SHA"
+                )
+            if sha in seen_shas:
+                raise DcoContractError(
+                    f"pull-request commits response contained duplicate SHA {sha}"
+                )
+            seen_shas.add(sha)
+            commits.append(item)
 
     boundary_page = page_count + 1
     boundary_payload = _request_json(
@@ -181,15 +220,21 @@ def fetch_authoritative_pr_commits(
     repository: str,
     pr_number: int,
     token: str,
+    expected_head_sha: str,
     *,
     opener: Any = None,
 ) -> tuple[int, list[dict[str, Any]]]:
-    """Bind complete paginated retrieval to the metadata-declared commit count."""
-    declared_count = fetch_pr_commit_count(
+    """Bind complete pagination to stable metadata and the exact event head."""
+    expected_head_sha = _validate_sha(
+        expected_head_sha,
+        label="expected pull-request head",
+    )
+    declared_count, initial_head_sha = fetch_pr_metadata(
         api_url,
         repository,
         pr_number,
         token,
+        expected_head_sha,
         opener=opener,
     )
     commits = fetch_pr_commits(
@@ -200,10 +245,30 @@ def fetch_authoritative_pr_commits(
         declared_count,
         opener=opener,
     )
+    final_count, final_head_sha = fetch_pr_metadata(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        expected_head_sha,
+        opener=opener,
+    )
+    if final_count != declared_count or final_head_sha != initial_head_sha:
+        raise DcoContractError(
+            "pull-request metadata drifted during commit retrieval: "
+            f"initial head/count {initial_head_sha}/{declared_count}, "
+            f"final head/count {final_head_sha}/{final_count}"
+        )
     if len(commits) != declared_count:
         raise DcoContractError(
             "pull-request commit count mismatch after retrieval: "
             f"retrieved {len(commits)}, metadata declared {declared_count}"
+        )
+    retrieved_head_sha = commits[-1]["sha"]
+    if retrieved_head_sha != expected_head_sha:
+        raise DcoContractError(
+            "pull-request retrieved head mismatch: "
+            f"final commit was {retrieved_head_sha}, expected {expected_head_sha}"
         )
     return declared_count, commits
 
@@ -240,6 +305,7 @@ def main() -> int:
         repository = _required_environment("GITHUB_REPOSITORY")
         token = _required_environment("GITHUB_TOKEN")
         pr_number_text = _required_environment("PR_NUMBER")
+        expected_head_sha = _required_environment("EXPECTED_HEAD_SHA")
         try:
             pr_number = int(pr_number_text)
         except ValueError as exc:
@@ -252,6 +318,7 @@ def main() -> int:
             repository,
             pr_number,
             token,
+            expected_head_sha,
         )
         unsigned = unsigned_commit_shas(commits)
         if unsigned:

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fail-closed DCO validation for every commit returned by the PR API."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class DcoContractError(RuntimeError):
+    """The authoritative PR commit set could not be validated safely."""
+
+
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_SIGNOFF_RE = re.compile(
+    r"^Signed-off-by:\s+.+\s+<[^<>\s]+@[^<>\s]+>\s*$",
+    re.MULTILINE,
+)
+
+
+def _required_environment(env):
+    api_url = str(env.get("GITHUB_API_URL") or "").rstrip("/")
+    repository = str(env.get("GITHUB_REPOSITORY") or "")
+    token = str(env.get("GITHUB_TOKEN") or "")
+    pr_number = str(env.get("PR_NUMBER") or "")
+
+    parsed = urllib.parse.urlsplit(api_url)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
+        raise DcoContractError("GITHUB_API_URL must be an absolute HTTPS origin")
+    if not _REPOSITORY_RE.fullmatch(repository):
+        raise DcoContractError("GITHUB_REPOSITORY must be exactly <owner>/<repo>")
+    if not token:
+        raise DcoContractError("GITHUB_TOKEN is required")
+    if not pr_number.isdigit() or int(pr_number) < 1:
+        raise DcoContractError("PR_NUMBER must be a positive integer")
+    return api_url, repository, int(pr_number), token
+
+
+def fetch_pr_commits(api_url, repository, pr_number, token, *, opener=None):
+    """Return every authoritative PR commit or fail closed."""
+    if opener is None:
+        opener = urllib.request.urlopen
+
+    encoded_repo = urllib.parse.quote(repository, safe="/")
+    commits = []
+    for page in range(1, 101):
+        url = (
+            f"{api_url}/repos/{encoded_repo}/pulls/{pr_number}/commits"
+            f"?per_page=100&page={page}"
+        )
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "szl-dco-check/1.0",
+            },
+        )
+        try:
+            with opener(request, timeout=30) as response:
+                status = getattr(response, "status", 200)
+                raw = response.read()
+        except (OSError, TimeoutError, urllib.error.URLError) as exc:
+            raise DcoContractError(
+                f"PR commit API retrieval failed on page {page}: {type(exc).__name__}"
+            ) from exc
+
+        if status != 200:
+            raise DcoContractError(
+                f"PR commit API returned HTTP {status} on page {page}"
+            )
+        try:
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise DcoContractError(
+                f"PR commit API returned invalid JSON on page {page}"
+            ) from exc
+        if not isinstance(payload, list):
+            raise DcoContractError(
+                f"PR commit API returned a non-list payload on page {page}"
+            )
+        if not payload:
+            if page == 1:
+                raise DcoContractError("PR commit API returned an empty commit list")
+            break
+
+        commits.extend(payload)
+        if len(payload) < 100:
+            break
+    else:
+        raise DcoContractError("PR commit API exceeded the bounded pagination limit")
+
+    if not commits:
+        raise DcoContractError("PR commit API returned an empty commit list")
+    return commits
+
+
+def commits_missing_signoff(commits):
+    """Return commit SHAs without a valid Signed-off-by trailer."""
+    if not isinstance(commits, list) or not commits:
+        raise DcoContractError("DCO validation requires a non-empty commit list")
+
+    missing = []
+    for index, item in enumerate(commits, start=1):
+        if not isinstance(item, dict):
+            raise DcoContractError(f"commit {index} is not an object")
+        sha = str(item.get("sha") or "").lower()
+        commit = item.get("commit")
+        message = commit.get("message") if isinstance(commit, dict) else None
+        if not _SHA_RE.fullmatch(sha):
+            raise DcoContractError(f"commit {index} has no exact SHA")
+        if not isinstance(message, str) or not message:
+            raise DcoContractError(f"commit {sha} has no commit message")
+        if not _SIGNOFF_RE.search(message):
+            missing.append(sha)
+    return missing
+
+
+def main(env=None, *, opener=None):
+    env = os.environ if env is None else env
+    try:
+        api_url, repository, pr_number, token = _required_environment(env)
+        commits = fetch_pr_commits(
+            api_url,
+            repository,
+            pr_number,
+            token,
+            opener=opener,
+        )
+        missing = commits_missing_signoff(commits)
+    except DcoContractError as exc:
+        print(f"::error title=DCO contract::{exc}")
+        return 2
+
+    if missing:
+        for sha in missing:
+            print(f"::error title=DCO sign-off missing::{sha}")
+        print(
+            f"FAIL: {len(missing)} of {len(commits)} PR commits "
+            "lack a valid Signed-off-by trailer."
+        )
+        return 1
+
+    print(f"OK: all {len(commits)} PR commits carry Signed-off-by trailers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail-closed DCO validation for every commit returned by the PR API."""
+"""Fail-closed DCO validation for every commit in a pull request."""
 
 from __future__ import annotations
 
@@ -7,150 +7,268 @@ import json
 import os
 import re
 import sys
-import urllib.error
-import urllib.parse
-import urllib.request
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 
-class DcoContractError(RuntimeError):
-    """The authoritative PR commit set could not be validated safely."""
-
-
-_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-_SIGNOFF_RE = re.compile(
+API_VERSION = "2022-11-28"
+COMMITS_PER_PAGE = 100
+MAX_PULL_REQUEST_COMMITS = 250
+REQUEST_TIMEOUT_SECONDS = 30
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SIGNED_OFF_BY_PATTERN = re.compile(
     r"^Signed-off-by:\s+.+\s+<[^<>\s]+@[^<>\s]+>\s*$",
-    re.MULTILINE,
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
-def _required_environment(env):
-    api_url = str(env.get("GITHUB_API_URL") or "").rstrip("/")
-    repository = str(env.get("GITHUB_REPOSITORY") or "")
-    token = str(env.get("GITHUB_TOKEN") or "")
-    pr_number = str(env.get("PR_NUMBER") or "")
-
-    parsed = urllib.parse.urlsplit(api_url)
-    if parsed.scheme != "https" or not parsed.netloc or parsed.query or parsed.fragment:
-        raise DcoContractError("GITHUB_API_URL must be an absolute HTTPS origin")
-    if not _REPOSITORY_RE.fullmatch(repository):
-        raise DcoContractError("GITHUB_REPOSITORY must be exactly <owner>/<repo>")
-    if not token:
-        raise DcoContractError("GITHUB_TOKEN is required")
-    if not pr_number.isdigit() or int(pr_number) < 1:
-        raise DcoContractError("PR_NUMBER must be a positive integer")
-    return api_url, repository, int(pr_number), token
+class DcoContractError(RuntimeError):
+    """Raised when the API response cannot prove complete DCO coverage."""
 
 
-def fetch_pr_commits(api_url, repository, pr_number, token, *, opener=None):
-    """Return every authoritative PR commit or fail closed."""
-    if opener is None:
-        opener = urllib.request.urlopen
+def _request_json(
+    url: str,
+    token: str,
+    *,
+    resource: str,
+    opener: Any = None,
+) -> Any:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    open_request = opener or urlopen
 
-    encoded_repo = urllib.parse.quote(repository, safe="/")
-    commits = []
-    for page in range(1, 101):
-        url = (
-            f"{api_url}/repos/{encoded_repo}/pulls/{pr_number}/commits"
-            f"?per_page=100&page={page}"
+    try:
+        with open_request(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+            if status != 200:
+                raise DcoContractError(
+                    f"{resource} retrieval failed with HTTP status {status}"
+                )
+            body = response.read()
+    except DcoContractError:
+        raise
+    except (OSError, TimeoutError, URLError) as exc:
+        raise DcoContractError(f"{resource} retrieval failed: {exc}") from exc
+
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DcoContractError(f"{resource} response was not valid JSON") from exc
+
+
+def fetch_pr_commit_count(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    *,
+    opener: Any = None,
+) -> int:
+    """Retrieve the authoritative commit count from pull-request metadata."""
+    url = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}"
+    payload = _request_json(
+        url,
+        token,
+        resource="pull-request metadata",
+        opener=opener,
+    )
+
+    if not isinstance(payload, dict):
+        raise DcoContractError("pull-request metadata response was not an object")
+
+    declared_count = payload.get("commits")
+    if (
+        isinstance(declared_count, bool)
+        or not isinstance(declared_count, int)
+        or declared_count <= 0
+    ):
+        raise DcoContractError(
+            "pull-request metadata did not declare a positive integer commit count"
         )
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {token}",
-                "X-GitHub-Api-Version": "2022-11-28",
-                "User-Agent": "szl-dco-check/1.0",
-            },
+    if declared_count > MAX_PULL_REQUEST_COMMITS:
+        raise DcoContractError(
+            f"pull request declares {declared_count} commits; "
+            f"the pull-request commits endpoint is capped at "
+            f"{MAX_PULL_REQUEST_COMMITS}, so complete DCO coverage cannot be proven"
         )
-        try:
-            with opener(request, timeout=30) as response:
-                status = getattr(response, "status", 200)
-                raw = response.read()
-        except (OSError, TimeoutError, urllib.error.URLError) as exc:
-            raise DcoContractError(
-                f"PR commit API retrieval failed on page {page}: {type(exc).__name__}"
-            ) from exc
 
-        if status != 200:
-            raise DcoContractError(
-                f"PR commit API returned HTTP {status} on page {page}"
-            )
-        try:
-            payload = json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise DcoContractError(
-                f"PR commit API returned invalid JSON on page {page}"
-            ) from exc
+    return declared_count
+
+
+def fetch_pr_commits(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    declared_count: int,
+    *,
+    opener: Any = None,
+) -> list[dict[str, Any]]:
+    """Retrieve exactly the declared commits and prove the page boundary is empty."""
+    if (
+        isinstance(declared_count, bool)
+        or not isinstance(declared_count, int)
+        or declared_count <= 0
+        or declared_count > MAX_PULL_REQUEST_COMMITS
+    ):
+        raise DcoContractError("declared commit count is outside the supported range")
+
+    commits: list[dict[str, Any]] = []
+    page_count = (declared_count + COMMITS_PER_PAGE - 1) // COMMITS_PER_PAGE
+    endpoint = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}/commits"
+
+    for page in range(1, page_count + 1):
+        payload = _request_json(
+            f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={page}",
+            token,
+            resource=f"pull-request commits page {page}",
+            opener=opener,
+        )
         if not isinstance(payload, list):
             raise DcoContractError(
-                f"PR commit API returned a non-list payload on page {page}"
+                f"pull-request commits page {page} response was not a list"
             )
-        if not payload:
-            if page == 1:
-                raise DcoContractError("PR commit API returned an empty commit list")
-            break
 
+        expected_page_size = min(
+            COMMITS_PER_PAGE,
+            declared_count - len(commits),
+        )
+        if len(payload) != expected_page_size:
+            raise DcoContractError(
+                "pull-request commit count mismatch: "
+                f"page {page} returned {len(payload)} commits, "
+                f"expected {expected_page_size}"
+            )
         commits.extend(payload)
-        if len(payload) < 100:
-            break
-    else:
-        raise DcoContractError("PR commit API exceeded the bounded pagination limit")
 
-    if not commits:
-        raise DcoContractError("PR commit API returned an empty commit list")
+    boundary_page = page_count + 1
+    boundary_payload = _request_json(
+        f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={boundary_page}",
+        token,
+        resource=f"pull-request commits boundary page {boundary_page}",
+        opener=opener,
+    )
+    if not isinstance(boundary_payload, list):
+        raise DcoContractError(
+            f"pull-request commits boundary page {boundary_page} response was not a list"
+        )
+    if boundary_payload:
+        raise DcoContractError(
+            "pull-request commit count mismatch: "
+            f"boundary page {boundary_page} unexpectedly returned "
+            f"{len(boundary_payload)} commits"
+        )
+    if len(commits) != declared_count:
+        raise DcoContractError(
+            "pull-request commit count mismatch: "
+            f"retrieved {len(commits)}, metadata declared {declared_count}"
+        )
+
     return commits
 
 
-def commits_missing_signoff(commits):
-    """Return commit SHAs without a valid Signed-off-by trailer."""
-    if not isinstance(commits, list) or not commits:
-        raise DcoContractError("DCO validation requires a non-empty commit list")
+def fetch_authoritative_pr_commits(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    *,
+    opener: Any = None,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Bind complete paginated retrieval to the metadata-declared commit count."""
+    declared_count = fetch_pr_commit_count(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        opener=opener,
+    )
+    commits = fetch_pr_commits(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        declared_count,
+        opener=opener,
+    )
+    if len(commits) != declared_count:
+        raise DcoContractError(
+            "pull-request commit count mismatch after retrieval: "
+            f"retrieved {len(commits)}, metadata declared {declared_count}"
+        )
+    return declared_count, commits
 
-    missing = []
+
+def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
+    """Return every commit that lacks a syntactically valid DCO trailer."""
+    unsigned: list[str] = []
+
     for index, item in enumerate(commits, start=1):
         if not isinstance(item, dict):
-            raise DcoContractError(f"commit {index} is not an object")
-        sha = str(item.get("sha") or "").lower()
+            raise DcoContractError(f"commit entry {index} was not an object")
+        sha = item.get("sha")
         commit = item.get("commit")
-        message = commit.get("message") if isinstance(commit, dict) else None
-        if not _SHA_RE.fullmatch(sha):
-            raise DcoContractError(f"commit {index} has no exact SHA")
-        if not isinstance(message, str) or not message:
-            raise DcoContractError(f"commit {sha} has no commit message")
-        if not _SIGNOFF_RE.search(message):
-            missing.append(sha)
-    return missing
+        if not isinstance(sha, str) or not SHA_PATTERN.fullmatch(sha):
+            raise DcoContractError(f"commit entry {index} had an invalid SHA")
+        if not isinstance(commit, dict) or not isinstance(commit.get("message"), str):
+            raise DcoContractError(f"commit {sha} had no valid commit message")
+        if not SIGNED_OFF_BY_PATTERN.search(commit["message"]):
+            unsigned.append(sha)
+
+    return unsigned
 
 
-def main(env=None, *, opener=None):
-    env = os.environ if env is None else env
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise DcoContractError(f"required environment variable {name} is empty")
+    return value
+
+
+def main() -> int:
     try:
-        api_url, repository, pr_number, token = _required_environment(env)
-        commits = fetch_pr_commits(
+        api_url = _required_environment("GITHUB_API_URL")
+        repository = _required_environment("GITHUB_REPOSITORY")
+        token = _required_environment("GITHUB_TOKEN")
+        pr_number_text = _required_environment("PR_NUMBER")
+        try:
+            pr_number = int(pr_number_text)
+        except ValueError as exc:
+            raise DcoContractError("PR_NUMBER must be an integer") from exc
+        if pr_number <= 0:
+            raise DcoContractError("PR_NUMBER must be positive")
+
+        declared_count, commits = fetch_authoritative_pr_commits(
             api_url,
             repository,
             pr_number,
             token,
-            opener=opener,
         )
-        missing = commits_missing_signoff(commits)
+        unsigned = unsigned_commit_shas(commits)
+        if unsigned:
+            print(
+                "DCO check failed: commits without a Signed-off-by trailer:",
+                file=sys.stderr,
+            )
+            for sha in unsigned:
+                print(f"  {sha}", file=sys.stderr)
+            return 1
+
+        print(f"DCO check passed for all {declared_count} pull-request commits")
+        return 0
     except DcoContractError as exc:
-        print(f"::error title=DCO contract::{exc}")
-        return 2
-
-    if missing:
-        for sha in missing:
-            print(f"::error title=DCO sign-off missing::{sha}")
-        print(
-            f"FAIL: {len(missing)} of {len(commits)} PR commits "
-            "lack a valid Signed-off-by trailer."
-        )
+        print(f"DCO check failed closed: {exc}", file=sys.stderr)
         return 1
-
-    print(f"OK: all {len(commits)} PR commits carry Signed-off-by trailers.")
-    return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -163,6 +163,26 @@ class DcoCheckTests(unittest.TestCase):
             [commit["sha"] for commit in malformed],
         )
 
+    def test_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
+        separators = ("\v", "\f", "\x85", "\u2028", "\u2029")
+        malformed = [
+            _commit(
+                index,
+                f"fix: vertical name\n\nSigned-off-by: A{separator}B <test@example.com>",
+            )
+            for index, separator in enumerate(separators, start=9)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_one_character_signer_name_is_accepted(self) -> None:
+        commit = _commit(14, "fix: short signer\n\nSigned-off-by: X <x@example.com>")
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
+
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
         expected_head, responses = _stable_responses(commits)

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -152,6 +152,17 @@ class DcoCheckTests(unittest.TestCase):
             [commit["sha"] for commit in malformed],
         )
 
+    def test_whitespace_only_signer_names_are_rejected(self) -> None:
+        malformed = [
+            _commit(7, "fix: blank name\n\nSigned-off-by:   <test@example.com>"),
+            _commit(8, "fix: tab name\n\nSigned-off-by:\t\t<test@example.com>"),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
         expected_head, responses = _stable_responses(commits)

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import unittest
 from pathlib import Path
 from urllib.error import URLError
@@ -17,21 +18,14 @@ PR_NUMBER = 399
 TOKEN = "test-token"
 
 
-def _commit(index: int, message: str) -> dict[str, object]:
-    return {
-        "sha": f"{index:040x}",
-        "commit": {"message": message},
-    }
+def _commit(index: int, message: str | None = None) -> dict[str, object]:
+    if message is None:
+        message = f"fix: commit {index}\n\nSigned-off-by: Test User <test@example.com>"
+    return {"sha": f"{index:040x}", "commit": {"message": message}}
 
 
 def _signed_commits(count: int, *, start: int = 1) -> list[dict[str, object]]:
-    return [
-        _commit(
-            index,
-            f"fix: commit {index}\n\nSigned-off-by: Test User <test@example.com>",
-        )
-        for index in range(start, start + count)
-    ]
+    return [_commit(index) for index in range(start, start + count)]
 
 
 def _commit_pages(commits: list[dict[str, object]]) -> list[list[dict[str, object]]]:
@@ -41,15 +35,32 @@ def _commit_pages(commits: list[dict[str, object]]) -> list[list[dict[str, objec
     ]
 
 
+def _head_sha(commits: list[dict[str, object]]) -> str:
+    sha = commits[-1]["sha"]
+    if not isinstance(sha, str):
+        raise AssertionError("fixture SHA was not a string")
+    return sha
+
+
+def _metadata(count: int, head_sha: str) -> dict[str, object]:
+    return {"commits": count, "head": {"sha": head_sha}}
+
+
+def _stable_responses(
+    commits: list[dict[str, object]],
+) -> tuple[str, list[object]]:
+    count = len(commits)
+    head_sha = _head_sha(commits)
+    metadata = _metadata(count, head_sha)
+    return head_sha, [metadata, *_commit_pages(commits), [], metadata]
+
+
 UNSIGNED_EMPTY_COMMIT = _commit(1, "chore: intentionally empty commit")
 UNSIGNED_MERGE_COMMIT = _commit(
     2,
     "Merge substantive policy update\n\nThis commit changes governed behavior.",
 )
-SIGNED_MULTI_COMMIT_PR = [
-    _commit(3, "feat: first\n\nSigned-off-by: Test User <test@example.com>"),
-    _commit(4, "fix: second\n\nSigned-off-by: Other User <other@example.com>"),
-]
+SIGNED_MULTI_COMMIT_PR = [_commit(3), _commit(4)]
 
 
 class _Response:
@@ -85,49 +96,34 @@ class _SequenceOpener:
         return _Response(response)
 
 
-def _authoritative_responses(count: int) -> list[object]:
-    commits = _signed_commits(count)
-    return [{"commits": count}, *_commit_pages(commits), []]
-
-
 class DcoCheckTests(unittest.TestCase):
     def test_metadata_api_retrieval_failure_fails_closed(self) -> None:
+        expected_head = _head_sha(_signed_commits(1))
         opener = _SequenceOpener(URLError("metadata unavailable"))
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
     def test_commits_api_retrieval_failure_fails_closed(self) -> None:
+        expected_head = _head_sha(_signed_commits(1))
         opener = _SequenceOpener(
-            {"commits": 1},
-            URLError("commits unavailable"),
+            _metadata(1, expected_head), URLError("commits unavailable")
         )
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
     def test_unexpectedly_empty_commit_list_fails_closed(self) -> None:
-        opener = _SequenceOpener({"commits": 1}, [])
+        expected_head = _head_sha(_signed_commits(1))
+        opener = _SequenceOpener(_metadata(1, expected_head), [])
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
     def test_unsigned_empty_commit_is_rejected(self) -> None:
@@ -145,90 +141,175 @@ class DcoCheckTests(unittest.TestCase):
     def test_fully_signed_multi_commit_pr_passes(self) -> None:
         self.assertEqual(dco_check.unsigned_commit_shas(SIGNED_MULTI_COMMIT_PR), [])
 
-    def test_249_commits_are_retrieved_completely(self) -> None:
-        opener = _SequenceOpener(*_authoritative_responses(249))
+    def test_valid_stable_pagination_passes(self) -> None:
+        commits = _signed_commits(3)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
 
-        declared, commits = dco_check.fetch_authoritative_pr_commits(
-            API_URL,
-            REPOSITORY,
-            PR_NUMBER,
-            TOKEN,
-            opener=opener,
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+        )
+
+        self.assertEqual(declared, 3)
+        self.assertEqual(retrieved, commits)
+        self.assertEqual(len(opener.urls), 4)
+
+    def test_249_commits_are_retrieved_completely(self) -> None:
+        commits = _signed_commits(249)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
+
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
         )
 
         self.assertEqual(declared, 249)
-        self.assertEqual(len(commits), 249)
-        self.assertTrue(opener.urls[-1].endswith("per_page=100&page=4"))
+        self.assertEqual(len(retrieved), 249)
+        self.assertTrue(opener.urls[-2].endswith("per_page=100&page=4"))
 
     def test_exactly_250_commits_are_retrieved_completely(self) -> None:
-        opener = _SequenceOpener(*_authoritative_responses(250))
+        commits = _signed_commits(250)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
 
-        declared, commits = dco_check.fetch_authoritative_pr_commits(
-            API_URL,
-            REPOSITORY,
-            PR_NUMBER,
-            TOKEN,
-            opener=opener,
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
         )
 
         self.assertEqual(declared, 250)
-        self.assertEqual(len(commits), 250)
-        self.assertTrue(opener.urls[-1].endswith("per_page=100&page=4"))
+        self.assertEqual(len(retrieved), 250)
+        self.assertTrue(opener.urls[-2].endswith("per_page=100&page=4"))
 
     def test_251_commits_are_rejected_before_commit_pagination(self) -> None:
-        opener = _SequenceOpener({"commits": 251})
+        expected_head = _head_sha(_signed_commits(251))
+        opener = _SequenceOpener(_metadata(251, expected_head))
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "capped at 250"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
         self.assertEqual(len(opener.urls), 1)
 
     def test_declared_and_retrieved_short_count_mismatch_is_rejected(self) -> None:
         commits = _signed_commits(248)
+        expected_head = _head_sha(_signed_commits(249))
         opener = _SequenceOpener(
-            {"commits": 249},
-            *_commit_pages(commits),
+            _metadata(249, expected_head), *_commit_pages(commits)
         )
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
     def test_nonempty_boundary_page_count_mismatch_is_rejected(self) -> None:
         commits = _signed_commits(249)
+        expected_head = _head_sha(commits)
         opener = _SequenceOpener(
-            {"commits": 249},
-            *_commit_pages(commits),
-            [_signed_commits(1, start=250)[0]],
+            _metadata(249, expected_head), *_commit_pages(commits), [_commit(250)]
         )
 
         with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
             dco_check.fetch_authoritative_pr_commits(
-                API_URL,
-                REPOSITORY,
-                PR_NUMBER,
-                TOKEN,
-                opener=opener,
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
-    def test_workflow_contains_no_message_prefix_or_file_count_bypass(self) -> None:
+    def test_duplicate_entries_within_page_are_rejected(self) -> None:
+        first = _commit(1)
+        expected_head = _head_sha(_signed_commits(2))
+        opener = _SequenceOpener(_metadata(2, expected_head), [first, first])
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "duplicate SHA"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_duplicate_sha_across_pages_is_rejected(self) -> None:
+        first_page = _signed_commits(100)
+        expected_head = _head_sha(_signed_commits(101))
+        opener = _SequenceOpener(
+            _metadata(101, expected_head), first_page, [first_page[0]]
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "duplicate SHA"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_initial_metadata_head_mismatch_is_rejected(self) -> None:
+        expected_head = _head_sha(_signed_commits(2))
+        replacement_head = _head_sha(_signed_commits(3))
+        opener = _SequenceOpener(_metadata(2, replacement_head))
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_same_count_head_replacement_during_pagination_is_rejected(self) -> None:
+        commits = _signed_commits(2)
+        expected_head = _head_sha(commits)
+        replacement_head = _head_sha(_signed_commits(3))
+        opener = _SequenceOpener(
+            _metadata(2, expected_head),
+            commits,
+            [],
+            _metadata(2, replacement_head),
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_metadata_count_drift_after_pagination_is_rejected(self) -> None:
+        commits = _signed_commits(2)
+        expected_head = _head_sha(commits)
+        opener = _SequenceOpener(
+            _metadata(2, expected_head), commits, [], _metadata(3, expected_head)
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "metadata drifted"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_final_retrieved_sha_must_equal_expected_head(self) -> None:
+        expected_head = _head_sha(_signed_commits(2))
+        replacement_commits = [_commit(1), _commit(3)]
+        stable_metadata = _metadata(2, expected_head)
+        opener = _SequenceOpener(
+            stable_metadata, replacement_commits, [], stable_metadata
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieved head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_workflow_binds_head_and_has_no_historical_bypass(self) -> None:
         workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
         workflow = workflow_path.read_text(encoding="utf-8")
 
-        self.assertNotIn("head_commit.message", workflow)
-        self.assertNotIn("changed_files", workflow)
-        self.assertIn("dco_check.py", workflow)
+        self.assertIn(
+            "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", workflow
+        )
+        self.assertRegex(
+            workflow,
+            r"(?m)^\s*python3\s+\.github/scripts/dco_check\.py\s*$",
+        )
+        forbidden_patterns = (
+            r"(?i)\bfile_count\b",
+            r"(?i)\bchanged_files\b",
+            r"(?i)\bgit\s+show\b",
+            r"(?im)\bgrep\b[^\n]*\^Merge",
+            r"(?is)(?:file_count|changed_files).{0,200}(?:-eq|==)\s*0"
+            r".{0,200}(?:exit\s+0|success|pass)",
+            r"head_commit\.message",
+        )
+        for pattern in forbidden_patterns:
+            self.assertIsNone(re.search(pattern, workflow), pattern)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -1,119 +1,234 @@
 #!/usr/bin/env python3
-"""Network-free regression fixtures for the fail-closed DCO policy."""
+"""Focused regression tests for the fail-closed DCO checker."""
 
 from __future__ import annotations
 
-import importlib.util
 import json
-import os
-import urllib.error
 import unittest
+from pathlib import Path
+from urllib.error import URLError
+
+import dco_check
 
 
-_HERE = os.path.dirname(os.path.abspath(__file__))
-_MODULE_PATH = os.path.join(_HERE, "dco_check.py")
-_spec = importlib.util.spec_from_file_location("dco_check", _MODULE_PATH)
-assert _spec and _spec.loader
-dco = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(dco)
+API_URL = "https://api.github.test"
+REPOSITORY = "szl-holdings/example"
+PR_NUMBER = 399
+TOKEN = "test-token"
 
 
-def _commit(char, message, *, files=None):
+def _commit(index: int, message: str) -> dict[str, object]:
     return {
-        "sha": char * 40,
+        "sha": f"{index:040x}",
         "commit": {"message": message},
-        "files": [] if files is None else files,
     }
 
 
-UNSIGNED_EMPTY_COMMIT = _commit("a", "chore(ci): retrigger checks", files=[])
+def _signed_commits(count: int, *, start: int = 1) -> list[dict[str, object]]:
+    return [
+        _commit(
+            index,
+            f"fix: commit {index}\n\nSigned-off-by: Test User <test@example.com>",
+        )
+        for index in range(start, start + count)
+    ]
+
+
+def _commit_pages(commits: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+    return [
+        commits[index : index + dco_check.COMMITS_PER_PAGE]
+        for index in range(0, len(commits), dco_check.COMMITS_PER_PAGE)
+    ]
+
+
+UNSIGNED_EMPTY_COMMIT = _commit(1, "chore: intentionally empty commit")
 UNSIGNED_MERGE_COMMIT = _commit(
-    "b",
-    "Merge branch 'feature/dco-bypass'\n\nSubstantive unsigned merge.",
-    files=["governance/policy.yml"],
+    2,
+    "Merge substantive policy update\n\nThis commit changes governed behavior.",
 )
 SIGNED_MULTI_COMMIT_PR = [
-    _commit(
-        "c",
-        "fix(ci): fail closed\n\nSigned-off-by: Example One <one@example.com>",
-    ),
-    _commit(
-        "d",
-        "test(ci): add fixtures\n\nSigned-off-by: Example Two <two@example.com>",
-    ),
+    _commit(3, "feat: first\n\nSigned-off-by: Test User <test@example.com>"),
+    _commit(4, "fix: second\n\nSigned-off-by: Other User <other@example.com>"),
 ]
 
 
 class _Response:
-    status = 200
-
-    def __init__(self, payload):
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.status = status
         self._body = json.dumps(payload).encode("utf-8")
 
-    def __enter__(self):
+    def __enter__(self) -> "_Response":
         return self
 
-    def __exit__(self, exc_type, exc, traceback):
-        return False
+    def __exit__(self, *args: object) -> None:
+        return None
 
-    def read(self):
+    def read(self) -> bytes:
         return self._body
 
 
-class DcoPolicyTests(unittest.TestCase):
-    def test_api_retrieval_failure_fails_closed(self):
-        def unavailable(_request, timeout):
-            self.assertEqual(timeout, 30)
-            raise urllib.error.URLError("offline")
+class _SequenceOpener:
+    def __init__(self, *responses: object) -> None:
+        self._responses = list(responses)
+        self.urls: list[str] = []
 
-        with self.assertRaisesRegex(dco.DcoContractError, "retrieval failed"):
-            dco.fetch_pr_commits(
-                "https://api.github.com",
-                "szl-holdings/.github",
-                395,
-                "governed-token",
-                opener=unavailable,
+    def __call__(self, request: object, timeout: int) -> _Response:
+        del timeout
+        self.urls.append(request.full_url)  # type: ignore[attr-defined]
+        if not self._responses:
+            raise AssertionError("unexpected API request")
+        response = self._responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        if isinstance(response, _Response):
+            return response
+        return _Response(response)
+
+
+def _authoritative_responses(count: int) -> list[object]:
+    commits = _signed_commits(count)
+    return [{"commits": count}, *_commit_pages(commits), []]
+
+
+class DcoCheckTests(unittest.TestCase):
+    def test_metadata_api_retrieval_failure_fails_closed(self) -> None:
+        opener = _SequenceOpener(URLError("metadata unavailable"))
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
             )
 
-    def test_unexpectedly_empty_api_list_fails_closed(self):
-        with self.assertRaisesRegex(dco.DcoContractError, "empty commit list"):
-            dco.fetch_pr_commits(
-                "https://api.github.com",
-                "szl-holdings/.github",
-                395,
-                "governed-token",
-                opener=lambda _request, timeout: _Response([]),
+    def test_commits_api_retrieval_failure_fails_closed(self) -> None:
+        opener = _SequenceOpener(
+            {"commits": 1},
+            URLError("commits unavailable"),
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
             )
 
-    def test_unsigned_empty_commit_is_rejected(self):
+    def test_unexpectedly_empty_commit_list_fails_closed(self) -> None:
+        opener = _SequenceOpener({"commits": 1}, [])
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
+            )
+
+    def test_unsigned_empty_commit_is_rejected(self) -> None:
         self.assertEqual(
-            dco.commits_missing_signoff([UNSIGNED_EMPTY_COMMIT]),
-            ["a" * 40],
+            dco_check.unsigned_commit_shas([UNSIGNED_EMPTY_COMMIT]),
+            [UNSIGNED_EMPTY_COMMIT["sha"]],
         )
 
-    def test_unsigned_substantive_merge_prefixed_commit_is_rejected(self):
+    def test_unsigned_substantive_merge_prefixed_commit_is_rejected(self) -> None:
         self.assertEqual(
-            dco.commits_missing_signoff([UNSIGNED_MERGE_COMMIT]),
-            ["b" * 40],
+            dco_check.unsigned_commit_shas([UNSIGNED_MERGE_COMMIT]),
+            [UNSIGNED_MERGE_COMMIT["sha"]],
         )
 
-    def test_fully_signed_multi_commit_pr_passes(self):
-        self.assertEqual(dco.commits_missing_signoff(SIGNED_MULTI_COMMIT_PR), [])
+    def test_fully_signed_multi_commit_pr_passes(self) -> None:
+        self.assertEqual(dco_check.unsigned_commit_shas(SIGNED_MULTI_COMMIT_PR), [])
 
-    def test_workflow_has_no_message_or_zero_file_bypass(self):
-        workflow_path = os.path.join(_HERE, "..", "workflows", "dco.yml")
-        with open(workflow_path, encoding="utf-8") as handle:
-            workflow = handle.read()
+    def test_249_commits_are_retrieved_completely(self) -> None:
+        opener = _SequenceOpener(*_authoritative_responses(249))
 
-        self.assertIn("python3 .github/scripts/dco_check.py", workflow)
-        self.assertIn("python3 .github/scripts/test_dco_check.py", workflow)
-        for forbidden in (
-            'grep -q "^Merge "',
-            "file_count=",
-            "assuming OK",
-            "|| echo",
-        ):
-            self.assertNotIn(forbidden, workflow)
+        declared, commits = dco_check.fetch_authoritative_pr_commits(
+            API_URL,
+            REPOSITORY,
+            PR_NUMBER,
+            TOKEN,
+            opener=opener,
+        )
+
+        self.assertEqual(declared, 249)
+        self.assertEqual(len(commits), 249)
+        self.assertTrue(opener.urls[-1].endswith("per_page=100&page=4"))
+
+    def test_exactly_250_commits_are_retrieved_completely(self) -> None:
+        opener = _SequenceOpener(*_authoritative_responses(250))
+
+        declared, commits = dco_check.fetch_authoritative_pr_commits(
+            API_URL,
+            REPOSITORY,
+            PR_NUMBER,
+            TOKEN,
+            opener=opener,
+        )
+
+        self.assertEqual(declared, 250)
+        self.assertEqual(len(commits), 250)
+        self.assertTrue(opener.urls[-1].endswith("per_page=100&page=4"))
+
+    def test_251_commits_are_rejected_before_commit_pagination(self) -> None:
+        opener = _SequenceOpener({"commits": 251})
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "capped at 250"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
+            )
+
+        self.assertEqual(len(opener.urls), 1)
+
+    def test_declared_and_retrieved_short_count_mismatch_is_rejected(self) -> None:
+        commits = _signed_commits(248)
+        opener = _SequenceOpener(
+            {"commits": 249},
+            *_commit_pages(commits),
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
+            )
+
+    def test_nonempty_boundary_page_count_mismatch_is_rejected(self) -> None:
+        commits = _signed_commits(249)
+        opener = _SequenceOpener(
+            {"commits": 249},
+            *_commit_pages(commits),
+            [_signed_commits(1, start=250)[0]],
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                opener=opener,
+            )
+
+    def test_workflow_contains_no_message_prefix_or_file_count_bypass(self) -> None:
+        workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertNotIn("head_commit.message", workflow)
+        self.assertNotIn("changed_files", workflow)
+        self.assertIn("dco_check.py", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -165,6 +165,8 @@ class DcoCheckTests(unittest.TestCase):
 
     def test_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
         separators = (
+            "\r",
+            "\n",
             "\v",
             "\f",
             "\x1c",
@@ -188,22 +190,58 @@ class DcoCheckTests(unittest.TestCase):
             [commit["sha"] for commit in malformed],
         )
 
+    def test_other_control_characters_in_signer_names_are_rejected(self) -> None:
+        controls = ("\x00", "\x01", "\x1c", "\x1f", "\x7f", "\x80", "\x9f")
+        malformed = [
+            _commit(
+                index,
+                f"fix: control name\n\nSigned-off-by: A{control}B <test@example.com>",
+            )
+            for index, control in enumerate(controls, start=20)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
     def test_one_character_signer_name_is_accepted(self) -> None:
         commit = _commit(14, "fix: short signer\n\nSigned-off-by: X <x@example.com>")
 
         self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
 
-    def test_horizontal_unicode_spaces_in_signer_names_are_accepted(self) -> None:
-        separators = ("\u00a0", "\u2003")
-        commits = [
+    def test_audited_horizontal_separators_are_accepted(self) -> None:
+        separators = (
+            "\t",
+            "\x20",
+            "\u00a0",
+            "\u1680",
+            "\u2000",
+            "\u2001",
+            "\u2002",
+            "\u2003",
+            "\u2004",
+            "\u2005",
+            "\u2006",
+            "\u2007",
+            "\u2008",
+            "\u2009",
+            "\u200a",
+            "\u202f",
+            "\u205f",
+            "\u3000",
+        )
+        signed = [
             _commit(
                 index,
-                f"fix: unicode name\n\nSigned-off-by: A{separator}B <test@example.com>",
+                "fix: horizontal signer\n\n"
+                f"Signed-off-by:{separator}A{separator}B{separator}"
+                f"<test@example.com>{separator}",
             )
-            for index, separator in enumerate(separators, start=15)
+            for index, separator in enumerate(separators, start=30)
         ]
 
-        self.assertEqual(dco_check.unsigned_commit_shas(commits), [])
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
 
     def test_unicode_lookalike_header_is_rejected(self) -> None:
         commit = _commit(
@@ -368,6 +406,30 @@ class DcoCheckTests(unittest.TestCase):
             dco_check.fetch_authoritative_pr_commits(
                 API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
+
+    def test_workflow_binds_head_and_has_no_historical_bypass(self) -> None:
+        workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", workflow
+        )
+        self.assertIn("python3 .github/scripts/test_dco_check.py", workflow)
+        self.assertRegex(
+            workflow,
+            r"(?m)^\s*python3\s+\.github/scripts/dco_check\.py\s*$",
+        )
+        forbidden_patterns = (
+            r"(?i)\bfile_count\b",
+            r"(?i)\bchanged_files\b",
+            r"(?i)\bgit\s+show\b",
+            r"(?im)\bgrep\b[^\n]*\^Merge",
+            r"(?is)(?:file_count|changed_files).{0,200}(?:-eq|==)\s*0"
+            r".{0,200}(?:exit\s+0|success|pass)",
+            r"head_commit\.message",
+        )
+        for pattern in forbidden_patterns:
+            self.assertIsNone(re.search(pattern, workflow), pattern)
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -141,6 +141,17 @@ class DcoCheckTests(unittest.TestCase):
     def test_fully_signed_multi_commit_pr_passes(self) -> None:
         self.assertEqual(dco_check.unsigned_commit_shas(SIGNED_MULTI_COMMIT_PR), [])
 
+    def test_multiline_sign_off_values_are_rejected(self) -> None:
+        malformed = [
+            _commit(5, "fix: split name\n\nSigned-off-by: Test User\n<test@example.com>"),
+            _commit(6, "fix: split trailer\n\nSigned-off-by:\nTest User <test@example.com>"),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
         expected_head, responses = _stable_responses(commits)

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Network-free regression fixtures for the fail-closed DCO policy."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import urllib.error
+import unittest
+
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_PATH = os.path.join(_HERE, "dco_check.py")
+_spec = importlib.util.spec_from_file_location("dco_check", _MODULE_PATH)
+assert _spec and _spec.loader
+dco = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dco)
+
+
+def _commit(char, message, *, files=None):
+    return {
+        "sha": char * 40,
+        "commit": {"message": message},
+        "files": [] if files is None else files,
+    }
+
+
+UNSIGNED_EMPTY_COMMIT = _commit("a", "chore(ci): retrigger checks", files=[])
+UNSIGNED_MERGE_COMMIT = _commit(
+    "b",
+    "Merge branch 'feature/dco-bypass'\n\nSubstantive unsigned merge.",
+    files=["governance/policy.yml"],
+)
+SIGNED_MULTI_COMMIT_PR = [
+    _commit(
+        "c",
+        "fix(ci): fail closed\n\nSigned-off-by: Example One <one@example.com>",
+    ),
+    _commit(
+        "d",
+        "test(ci): add fixtures\n\nSigned-off-by: Example Two <two@example.com>",
+    ),
+]
+
+
+class _Response:
+    status = 200
+
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self._body
+
+
+class DcoPolicyTests(unittest.TestCase):
+    def test_api_retrieval_failure_fails_closed(self):
+        def unavailable(_request, timeout):
+            self.assertEqual(timeout, 30)
+            raise urllib.error.URLError("offline")
+
+        with self.assertRaisesRegex(dco.DcoContractError, "retrieval failed"):
+            dco.fetch_pr_commits(
+                "https://api.github.com",
+                "szl-holdings/.github",
+                395,
+                "governed-token",
+                opener=unavailable,
+            )
+
+    def test_unexpectedly_empty_api_list_fails_closed(self):
+        with self.assertRaisesRegex(dco.DcoContractError, "empty commit list"):
+            dco.fetch_pr_commits(
+                "https://api.github.com",
+                "szl-holdings/.github",
+                395,
+                "governed-token",
+                opener=lambda _request, timeout: _Response([]),
+            )
+
+    def test_unsigned_empty_commit_is_rejected(self):
+        self.assertEqual(
+            dco.commits_missing_signoff([UNSIGNED_EMPTY_COMMIT]),
+            ["a" * 40],
+        )
+
+    def test_unsigned_substantive_merge_prefixed_commit_is_rejected(self):
+        self.assertEqual(
+            dco.commits_missing_signoff([UNSIGNED_MERGE_COMMIT]),
+            ["b" * 40],
+        )
+
+    def test_fully_signed_multi_commit_pr_passes(self):
+        self.assertEqual(dco.commits_missing_signoff(SIGNED_MULTI_COMMIT_PR), [])
+
+    def test_workflow_has_no_message_or_zero_file_bypass(self):
+        workflow_path = os.path.join(_HERE, "..", "workflows", "dco.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow = handle.read()
+
+        self.assertIn("python3 .github/scripts/dco_check.py", workflow)
+        self.assertIn("python3 .github/scripts/test_dco_check.py", workflow)
+        for forbidden in (
+            'grep -q "^Merge "',
+            "file_count=",
+            "assuming OK",
+            "|| echo",
+        ):
+            self.assertNotIn(forbidden, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -183,6 +183,18 @@ class DcoCheckTests(unittest.TestCase):
 
         self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
 
+    def test_horizontal_unicode_spaces_in_signer_names_are_accepted(self) -> None:
+        separators = ("\u00a0", "\u2003")
+        commits = [
+            _commit(
+                index,
+                f"fix: unicode name\n\nSigned-off-by: A{separator}B <test@example.com>",
+            )
+            for index, separator in enumerate(separators, start=15)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(commits), [])
+
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
         expected_head, responses = _stable_responses(commits)

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -164,7 +164,17 @@ class DcoCheckTests(unittest.TestCase):
         )
 
     def test_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
-        separators = ("\v", "\f", "\x85", "\u2028", "\u2029")
+        separators = (
+            "\v",
+            "\f",
+            "\x1c",
+            "\x1d",
+            "\x1e",
+            "\x1f",
+            "\x85",
+            "\u2028",
+            "\u2029",
+        )
         malformed = [
             _commit(
                 index,
@@ -194,6 +204,23 @@ class DcoCheckTests(unittest.TestCase):
         ]
 
         self.assertEqual(dco_check.unsigned_commit_shas(commits), [])
+
+    def test_unicode_lookalike_header_is_rejected(self) -> None:
+        commit = _commit(
+            17,
+            "fix: lookalike\n\nSıgned-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+    def test_body_signoff_outside_final_trailer_block_is_rejected(self) -> None:
+        commit = _commit(
+            18,
+            "fix: quoted signoff\n\nSigned-off-by: Test User <test@example.com>"
+            "\n\nOrdinary postscript text.",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
 
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
@@ -341,30 +368,6 @@ class DcoCheckTests(unittest.TestCase):
             dco_check.fetch_authoritative_pr_commits(
                 API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
-
-    def test_workflow_binds_head_and_has_no_historical_bypass(self) -> None:
-        workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
-        workflow = workflow_path.read_text(encoding="utf-8")
-
-        self.assertIn(
-            "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", workflow
-        )
-        self.assertRegex(
-            workflow,
-            r"(?m)^\s*python3\s+\.github/scripts/dco_check\.py\s*$",
-        )
-        forbidden_patterns = (
-            r"(?i)\bfile_count\b",
-            r"(?i)\bchanged_files\b",
-            r"(?i)\bgit\s+show\b",
-            r"(?im)\bgrep\b[^\n]*\^Merge",
-            r"(?is)(?:file_count|changed_files).{0,200}(?:-eq|==)\s*0"
-            r".{0,200}(?:exit\s+0|success|pass)",
-            r"head_commit\.message",
-        )
-        for pattern in forbidden_patterns:
-            self.assertIsNone(re.search(pattern, workflow), pattern)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 import unittest
 from pathlib import Path
 from urllib.error import URLError
 
-import dco_check
+import dco_check as dco_check
 
 
 API_URL = "https://api.github.test"
@@ -44,6 +46,41 @@ def _head_sha(commits: list[dict[str, object]]) -> str:
 
 def _metadata(count: int, head_sha: str) -> dict[str, object]:
     return {"commits": count, "head": {"sha": head_sha}}
+
+
+def _density_message(
+    body_line_count: int,
+    signoff_line: str = "Signed-off-by: Test User <test@example.com>",
+) -> str:
+    body = "\n".join(
+        f"ordinary body line {index}" for index in range(1, body_line_count + 1)
+    )
+    return (
+        "fix: density boundary\n\n"
+        f"{body}\n"
+        f"{signoff_line}"
+    )
+
+
+def _two_trailer_density_message(
+    body_line_count: int,
+    *,
+    include_orphan: bool = False,
+) -> str:
+    body = "\n".join(
+        f"ordinary body line {index}" for index in range(1, body_line_count + 1)
+    )
+    orphan = "\n orphan continuation" if include_orphan else ""
+    return (
+        "fix: continuation density\n\n"
+        f"{body}{orphan}\n"
+        "Reviewed-by: Reviewer <reviewer@example.com>\n"
+        " folded one\n"
+        "\tfolded two\n"
+        " folded three\n"
+        "\tfolded four\n"
+        "Signed-off-by: Test User <test@example.com>"
+    )
 
 
 def _stable_responses(
@@ -164,19 +201,7 @@ class DcoCheckTests(unittest.TestCase):
         )
 
     def test_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
-        separators = (
-            "\r",
-            "\n",
-            "\v",
-            "\f",
-            "\x1c",
-            "\x1d",
-            "\x1e",
-            "\x1f",
-            "\x85",
-            "\u2028",
-            "\u2029",
-        )
+        separators = ("\r", "\n", "\v", "\f", "\x85", "\u2028", "\u2029")
         malformed = [
             _commit(
                 index,
@@ -243,22 +268,376 @@ class DcoCheckTests(unittest.TestCase):
 
         self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
 
-    def test_unicode_lookalike_header_is_rejected(self) -> None:
-        commit = _commit(
-            17,
-            "fix: lookalike\n\nSıgned-off-by: Test User <test@example.com>",
-        )
+    def test_preceding_folded_non_dco_trailers_are_accepted(self) -> None:
+        signed = [
+            _commit(
+                50,
+                "fix: reviewed change\n\n"
+                "Reviewed-by: Reviewer <reviewer@example.com>\n"
+                " review context\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                51,
+                "fix: co-authored change\n\n"
+                "Co-authored-by: Contributor <contributor@example.com>\n"
+                " first continuation\n"
+                "\tsecond continuation\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
 
-        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
 
     def test_body_signoff_outside_final_trailer_block_is_rejected(self) -> None:
-        commit = _commit(
-            18,
-            "fix: quoted signoff\n\nSigned-off-by: Test User <test@example.com>"
-            "\n\nOrdinary postscript text.",
+        malformed = _commit(
+            52,
+            "fix: body signoff\n\n"
+            "Signed-off-by: Test User <test@example.com>\n\n"
+            "A final body paragraph is not a trailer block.",
         )
 
-        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_continuation_after_signed_off_by_is_rejected(self) -> None:
+        malformed = _commit(
+            53,
+            "fix: folded identity\n\n"
+            "Signed-off-by: Test User <test@example.com>\n"
+            " attacker-controlled identity extension",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_folded_signoff_name_or_email_is_rejected(self) -> None:
+        malformed = [
+            _commit(
+                54,
+                "fix: folded name\n\n"
+                "Signed-off-by: Test\n"
+                " User <test@example.com>",
+            ),
+            _commit(
+                55,
+                "fix: folded email\n\n"
+                "Signed-off-by: Test User <test@\n"
+                " example.com>",
+            ),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_orphan_continuation_in_trailer_region_is_rejected(self) -> None:
+        malformed = _commit(
+            56,
+            "fix: orphan continuation\n\n"
+            " continuation without a preceding trailer\n"
+            "Signed-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_trailer_block_body_boundaries_match_git_semantics(self) -> None:
+        accepted = [
+            _commit(
+                57,
+                "fix: final trailer suffix\n\n"
+                "Body text may precede the final structured suffix.\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                59,
+                "fix: admitted body after trailer\n\n"
+                "Signed-off-by: Test User <test@example.com>\n"
+                "Git admits this complete group at fifty percent density.",
+            ),
+        ]
+        rejected = [
+            _commit(
+                58,
+                "fix: missing boundary\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(accepted), [])
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(rejected),
+            [commit["sha"] for commit in rejected],
+        )
+
+    def test_git_density_admission_boundaries_are_deterministic(self) -> None:
+        density_20 = _commit(70, _density_message(4))
+        density_25 = _commit(71, _density_message(3))
+        density_50 = _commit(72, _density_message(1))
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([density_20]),
+            [density_20["sha"]],
+        )
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([density_25, density_50]),
+            [],
+        )
+
+    def test_git_density_admission_matches_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        fixtures = (
+            (4, False),
+            (3, True),
+            (1, True),
+        )
+        for body_line_count, expected in fixtures:
+            with self.subTest(body_line_count=body_line_count):
+                message = _density_message(body_line_count)
+                parsed = subprocess.run(
+                    [git, "interpret-trailers", "--parse"],
+                    input=message,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                    timeout=5,
+                ).stdout
+                git_accepts = any(
+                    line.lower().startswith("signed-off-by:")
+                    for line in parsed.splitlines()
+                )
+                policy_accepts = not dco_check.unsigned_commit_shas(
+                    [_commit(73, message)]
+                )
+
+                self.assertEqual(git_accepts, expected)
+                self.assertEqual(policy_accepts, git_accepts)
+
+    def test_mixed_group_recognition_requires_exact_git_prefix(self) -> None:
+        variants = {
+            "canonical": (
+                "Signed-off-by: Test User <test@example.com>",
+                (False, True, True),
+                (False, True, True),
+            ),
+            "tab": (
+                "Signed-off-by:\tTest User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "nbsp": (
+                "Signed-off-by:\u00a0Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "lowercase": (
+                "signed-off-by: Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "uppercase": (
+                "SIGNED-OFF-BY: Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "malformed": (
+                "Signed-off-by: malformed",
+                (False, True, True),
+                (False, False, False),
+            ),
+        }
+        body_counts = (4, 3, 1)
+
+        for name, (line, admission_results, policy_results) in variants.items():
+            for body_count, admitted, accepted in zip(
+                body_counts,
+                admission_results,
+                policy_results,
+                strict=True,
+            ):
+                with self.subTest(name=name, body_count=body_count):
+                    message = _density_message(body_count, line)
+                    self.assertEqual(
+                        dco_check._admitted_trailer_group(message) is not None,
+                        admitted,
+                    )
+                    policy_accepts = not dco_check.unsigned_commit_shas(
+                        [_commit(80, message)]
+                    )
+                    self.assertEqual(policy_accepts, accepted)
+
+    def test_mixed_group_prefix_admission_matches_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        variants = (
+            "Signed-off-by: Test User <test@example.com>",
+            "Signed-off-by:\tTest User <test@example.com>",
+            "Signed-off-by:\u00a0Test User <test@example.com>",
+            "signed-off-by: Test User <test@example.com>",
+            "SIGNED-OFF-BY: Test User <test@example.com>",
+            "Signed-off-by: malformed",
+        )
+        for line in variants:
+            for body_count in (4, 3, 1):
+                with self.subTest(line=line, body_count=body_count):
+                    message = _density_message(body_count, line)
+                    parsed = subprocess.run(
+                        [git, "interpret-trailers", "--parse"],
+                        input=message,
+                        text=True,
+                        capture_output=True,
+                        check=True,
+                        timeout=5,
+                    ).stdout
+                    git_admits = bool(parsed.strip())
+                    policy_admits = (
+                        dco_check._admitted_trailer_group(message) is not None
+                    )
+
+                    self.assertEqual(policy_admits, git_admits)
+
+    def test_project_signoff_variants_pass_in_all_trailer_groups(self) -> None:
+        signoff_lines = (
+            "Signed-off-by:\tTest User <test@example.com>",
+            "Signed-off-by:\u00a0Test User <test@example.com>",
+            "signed-off-by: Test User <test@example.com>",
+            "SIGNED-OFF-BY: Test User <test@example.com>",
+        )
+        signed = [
+            _commit(
+                index,
+                "fix: fully structured trailer group\n\n"
+                "Reviewed-by: Reviewer <reviewer@example.com>\n"
+                f"{line}",
+            )
+            for index, line in enumerate(signoff_lines, start=81)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_density_counters_ignore_attached_continuations(self) -> None:
+        admitted_at_25 = _two_trailer_density_message(6)
+        rejected_below_25 = _two_trailer_density_message(7)
+        rejected_with_orphan = _two_trailer_density_message(
+            6,
+            include_orphan=True,
+        )
+
+        self.assertIsNotNone(
+            dco_check._admitted_trailer_group(admitted_at_25)
+        )
+        self.assertIsNone(
+            dco_check._admitted_trailer_group(rejected_below_25)
+        )
+        self.assertIsNone(
+            dco_check._admitted_trailer_group(rejected_with_orphan)
+        )
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(
+                [
+                    _commit(90, admitted_at_25),
+                    _commit(91, rejected_below_25),
+                    _commit(92, rejected_with_orphan),
+                ]
+            ),
+            [f"{91:040x}", f"{92:040x}"],
+        )
+
+    def test_density_counters_match_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        fixtures = (
+            _two_trailer_density_message(6),
+            _two_trailer_density_message(7),
+            _two_trailer_density_message(6, include_orphan=True),
+        )
+        for message in fixtures:
+            with self.subTest(message=message):
+                parsed = subprocess.run(
+                    [git, "interpret-trailers", "--parse"],
+                    input=message,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                    timeout=5,
+                ).stdout
+                git_admits = bool(parsed.strip())
+                policy_admits = (
+                    dco_check._admitted_trailer_group(message) is not None
+                )
+
+                self.assertEqual(policy_admits, git_admits)
+
+    def test_complete_group_does_not_discard_malformed_material(self) -> None:
+        malformed = [
+            _commit(
+                74,
+                "fix: malformed generic trailer\n\n"
+                "Reviewed-by: Reviewer\x1cName <reviewer@example.com>\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                75,
+                "fix: malformed key spacing\n\n"
+                "Reviewed-by\x1c: Reviewer <reviewer@example.com>\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_generic_key_to_colon_spacing_and_folds_are_accepted(self) -> None:
+        signed = [
+            _commit(
+                76,
+                "fix: spaced trailer before DCO\n\n"
+                "Reviewed-by \t : Reviewer <reviewer@example.com>\n"
+                " first folded value\n"
+                "\tsecond folded value\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                77,
+                "fix: spaced trailer after DCO\n\n"
+                "Signed-off-by: Test User <test@example.com>\n"
+                "Reviewed-by\t: Reviewer <reviewer@example.com>\n"
+                " folded value belonging to Reviewed-by",
+            ),
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_trailing_blank_line_variants_are_accepted(self) -> None:
+        endings = ("", "\n", "\n\n", "\n \t\n")
+        signed = [
+            _commit(
+                index,
+                "fix: trailing blanks\n\n"
+                "Signed-off-by: Test User <test@example.com>"
+                f"{ending}",
+            )
+            for index, ending in enumerate(endings, start=60)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
 
     def test_valid_stable_pagination_passes(self) -> None:
         commits = _signed_commits(3)
@@ -430,6 +809,54 @@ class DcoCheckTests(unittest.TestCase):
         )
         for pattern in forbidden_patterns:
             self.assertIsNone(re.search(pattern, workflow), pattern)
+
+
+    def test_unicode_lookalike_header_is_rejected(self) -> None:
+        commit = _commit(
+            17,
+            "fix: lookalike\n\nSıgned-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+
+    def test_target_body_signoff_outside_final_trailer_block_is_rejected(self) -> None:
+        commit = _commit(
+            18,
+            "fix: quoted signoff\n\nSigned-off-by: Test User <test@example.com>"
+            "\n\nOrdinary postscript text.",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+
+    def test_target_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
+        separators = (
+            "\r",
+            "\n",
+            "\v",
+            "\f",
+            "\x1c",
+            "\x1d",
+            "\x1e",
+            "\x1f",
+            "\x85",
+            "\u2028",
+            "\u2029",
+        )
+        malformed = [
+            _commit(
+                index,
+                f"fix: vertical name\n\nSigned-off-by: A{separator}B <test@example.com>",
+            )
+            for index, separator in enumerate(separators, start=9)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -23,45 +23,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - name: Self-test the fail-closed DCO policy
+        run: |
+          set -euo pipefail
+          python3 -m py_compile \
+            .github/scripts/dco_check.py \
+            .github/scripts/test_dco_check.py
+          python3 .github/scripts/test_dco_check.py
       - name: Check DCO on PR commits
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Checking Signed-off-by on PR commits..."
-          # Get commits in this PR
-          COMMITS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --jq '.[].sha' 2>/dev/null || echo "")
-          if [ -z "$COMMITS" ]; then
-            echo "No commits found — assuming OK"
-            exit 0
-          fi
-
-          FAIL=0
-          for sha in $COMMITS; do
-            body=$(git log -1 --format="%B" "$sha" 2>/dev/null || echo "")
-
-            # Merge-queue / merge commit artifacts may be synthetic and message-only.
-            if echo "$body" | grep -q "^Merge "; then
-              echo "  SKIP: $sha — merge commit artifact"
-              continue
-            fi
-
-            # Workflow maintenance/no-op commits do not carry signed intent and must
-            # not block policy gates.
-            file_count=$(git show --name-only --pretty=format: "$sha" | awk 'NF > 0' | wc -l | tr -d ' ')
-            if [ "$file_count" -eq 0 ]; then
-              echo "  SKIP: $sha — tooling/no-op commit artifact"
-              continue
-            fi
-
-            if echo "$body" | grep -q "^Signed-off-by:"; then
-              echo "  OK: $sha"
-            else
-              echo "  MISSING: $sha — no Signed-off-by"
-              FAIL=1
-            fi
-          done
-          exit $FAIL
+          set -euo pipefail
+          python3 .github/scripts/dco_check.py
       - name: DCO status (push/workflow_dispatch)
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -23,24 +23,45 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Self-test the fail-closed DCO policy
-        run: |
-          set -euo pipefail
-          python3 -m py_compile \
-            .github/scripts/dco_check.py \
-            .github/scripts/test_dco_check.py
-          python3 .github/scripts/test_dco_check.py
       - name: Check DCO on PR commits
         if: github.event_name == 'pull_request'
         env:
-          GITHUB_API_URL: ${{ github.api_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          python3 .github/scripts/dco_check.py
+          echo "Checking Signed-off-by on PR commits..."
+          # Get commits in this PR
+          COMMITS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --jq '.[].sha' 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found — assuming OK"
+            exit 0
+          fi
+
+          FAIL=0
+          for sha in $COMMITS; do
+            body=$(git log -1 --format="%B" "$sha" 2>/dev/null || echo "")
+
+            # Merge-queue / merge commit artifacts may be synthetic and message-only.
+            if echo "$body" | grep -q "^Merge "; then
+              echo "  SKIP: $sha — merge commit artifact"
+              continue
+            fi
+
+            # Workflow maintenance/no-op commits do not carry signed intent and must
+            # not block policy gates.
+            file_count=$(git show --name-only --pretty=format: "$sha" | awk 'NF > 0' | wc -l | tr -d ' ')
+            if [ "$file_count" -eq 0 ]; then
+              echo "  SKIP: $sha — tooling/no-op commit artifact"
+              continue
+            fi
+
+            if echo "$body" | grep -q "^Signed-off-by:"; then
+              echo "  OK: $sha"
+            else
+              echo "  MISSING: $sha — no Signed-off-by"
+              FAIL=1
+            fi
+          done
+          exit $FAIL
       - name: DCO status (push/workflow_dispatch)
         if: github.event_name != 'pull_request'
         run: |

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,7 @@ name: DCO
 
 # Verifies Developer Certificate of Origin sign-off.
 # On push to main: passes (squash merges via admin are signed).
-# On PR: verifies Signed-off-by trailers on commits.
+# On PR: verifies Signed-off-by trailers on every commit at the exact event head.
 
 on:
   push:
@@ -23,47 +23,26 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - name: Self-test the fail-closed DCO policy
+        run: |
+          set -euo pipefail
+          python3 -m py_compile \
+            .github/scripts/dco_check.py \
+            .github/scripts/test_dco_check.py
+          python3 .github/scripts/test_dco_check.py
       - name: Check DCO on PR commits
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          echo "Checking Signed-off-by on PR commits..."
-          # Get commits in this PR
-          COMMITS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --jq '.[].sha' 2>/dev/null || echo "")
-          if [ -z "$COMMITS" ]; then
-            echo "No commits found — assuming OK"
-            exit 0
-          fi
-
-          FAIL=0
-          for sha in $COMMITS; do
-            body=$(git log -1 --format="%B" "$sha" 2>/dev/null || echo "")
-
-            # Merge-queue / merge commit artifacts may be synthetic and message-only.
-            if echo "$body" | grep -q "^Merge "; then
-              echo "  SKIP: $sha — merge commit artifact"
-              continue
-            fi
-
-            # Workflow maintenance/no-op commits do not carry signed intent and must
-            # not block policy gates.
-            file_count=$(git show --name-only --pretty=format: "$sha" | awk 'NF > 0' | wc -l | tr -d ' ')
-            if [ "$file_count" -eq 0 ]; then
-              echo "  SKIP: $sha — tooling/no-op commit artifact"
-              continue
-            fi
-
-            if echo "$body" | grep -q "^Signed-off-by:"; then
-              echo "  OK: $sha"
-            else
-              echo "  MISSING: $sha — no Signed-off-by"
-              FAIL=1
-            fi
-          done
-          exit $FAIL
+          set -euo pipefail
+          python3 .github/scripts/dco_check.py
       - name: DCO status (push/workflow_dispatch)
         if: github.event_name != 'pull_request'
         run: |
-          echo "Push to main — commits signed via PR DCO gate or admin squash merge."
+          echo "Push to main - commits signed via PR DCO gate or admin squash merge."
           echo "DCO OK"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,7 @@ name: DCO
 
 # Verifies Developer Certificate of Origin sign-off.
 # On push to main: passes (squash merges via admin are signed).
-# On PR: verifies Signed-off-by trailers on every commit at the exact event head.
+# On PR: verifies Signed-off-by trailers on commits.
 
 on:
   push:
@@ -23,26 +23,47 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Self-test the fail-closed DCO policy
-        run: |
-          set -euo pipefail
-          python3 -m py_compile \
-            .github/scripts/dco_check.py \
-            .github/scripts/test_dco_check.py
-          python3 .github/scripts/test_dco_check.py
       - name: Check DCO on PR commits
         if: github.event_name == 'pull_request'
         env:
-          GITHUB_API_URL: ${{ github.api_url }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          python3 .github/scripts/dco_check.py
+          echo "Checking Signed-off-by on PR commits..."
+          # Get commits in this PR
+          COMMITS=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" --jq '.[].sha' 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found — assuming OK"
+            exit 0
+          fi
+
+          FAIL=0
+          for sha in $COMMITS; do
+            body=$(git log -1 --format="%B" "$sha" 2>/dev/null || echo "")
+
+            # Merge-queue / merge commit artifacts may be synthetic and message-only.
+            if echo "$body" | grep -q "^Merge "; then
+              echo "  SKIP: $sha — merge commit artifact"
+              continue
+            fi
+
+            # Workflow maintenance/no-op commits do not carry signed intent and must
+            # not block policy gates.
+            file_count=$(git show --name-only --pretty=format: "$sha" | awk 'NF > 0' | wc -l | tr -d ' ')
+            if [ "$file_count" -eq 0 ]; then
+              echo "  SKIP: $sha — tooling/no-op commit artifact"
+              continue
+            fi
+
+            if echo "$body" | grep -q "^Signed-off-by:"; then
+              echo "  OK: $sha"
+            else
+              echo "  MISSING: $sha — no Signed-off-by"
+              FAIL=1
+            fi
+          done
+          exit $FAIL
       - name: DCO status (push/workflow_dispatch)
         if: github.event_name != 'pull_request'
         run: |
-          echo "Push to main - commits signed via PR DCO gate or admin squash merge."
+          echo "Push to main — commits signed via PR DCO gate or admin squash merge."
           echo "DCO OK"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -37,6 +37,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           python3 .github/scripts/dco_check.py


### PR DESCRIPTION
## Summary

- add a fail-closed DCO checker that binds API pagination, commit count, and the exact PR head
- require a syntactically valid Signed-off-by entry in the final trailer block of every candidate commit
- reject empty responses, multiline or body-level pseudo-trailers, Unicode lookalike headers, blank names, and vertical control separators
- add focused regression coverage for all retrieval, pagination, head-stability, and trailer boundaries

## Protected bootstrap boundary

This PR adds only `.github/scripts/dco_check.py` and its regression suite. It intentionally leaves `.github/workflows/dco.yml` and branch rules byte-identical to protected main, because the checker cannot be executed as a protected-base dependency until it exists on protected main.

The draft activation successor is #400. After this bootstrap merges normally, #400 must reconcile to the new main and execute the checker from the protected default-branch context. No candidate-controlled fallback is authorized.

## Evidence policy

- exact head: `85ada0da4bfb0be776e59657062767ee6948593b`
- commit: GitHub signature verified and DCO signed off
- merge requires terminal hosted checks, resolved exact-head review, and a policy-compatible normal merge
- no deployment or enforcement activation is claimed by this bootstrap PR