### PR TITLE
build(hf): hash-lock reusable publisher dependencies

### DIFF
--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -576,14 +576,21 @@ class TestReusableWorkflowContract(unittest.TestCase):
 
     def test_shared_deployer_checkout_is_exact_reusable_revision(self):
         # The reusable workflow must checkout ITS OWN reviewed revision --
-        # github.job_workflow_sha is the documented context for that; the
-        # job.workflow_* forms do not exist and resolve empty.
-        self.assertIn("repository: szl-holdings/.github", self.workflow)
-        self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
-        self.assertNotIn("${{ job.workflow_repository }}", self.workflow)
-        self.assertNotIn("${{ job.workflow_sha }}", self.workflow)
+        # the called-workflow identity is supplied by the documented job
+        # context and the checked-out commit must be asserted byte-for-byte.
+        self.assertNotIn("github.job_workflow_sha", self.workflow)
+        self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
+        self.assertIn("ref: ${{ job.workflow_sha }}", self.workflow)
+        self.assertIn("EXPECTED_TOOLS_SHA: ${{ job.workflow_sha }}", self.workflow)
+        self.assertIn(
+            'ACTUAL_TOOLS_SHA="$(git -C tools rev-parse --verify HEAD)"',
+            self.workflow,
+        )
+        self.assertIn(
+            '[ "$ACTUAL_TOOLS_SHA" != "$EXPECTED_TOOLS_SHA" ]',
+            self.workflow,
+        )
         self.assertNotIn("ref: main", self.workflow)
-        self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
 
     def test_shell_consumes_inputs_through_environment(self):
         for unsafe in (

--- a/.github/scripts/test_hf_publisher_lock.py
+++ b/.github/scripts/test_hf_publisher_lock.py
@@ -7,12 +7,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "reusable-hf-deploy.yml"
 TESTS_WORKFLOW = ROOT / ".github" / "workflows" / "tests.yml"
+WITNESS_WORKFLOW = ROOT / ".github" / "workflows" / "reusable-hf-deploy-source-witness.yml"
 LOCK = ROOT / "requirements" / "hf-publisher.lock"
 
 
 def main() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     tests_workflow = TESTS_WORKFLOW.read_text(encoding="utf-8")
+    witness_workflow = WITNESS_WORKFLOW.read_text(encoding="utf-8")
     lock = LOCK.read_text(encoding="utf-8")
 
     for source in (workflow, tests_workflow):
@@ -53,11 +55,12 @@ def main() -> None:
     secret = workflow.index("Require governed publisher")
     assert create < install < secret
 
-    assert "github.job_workflow_sha" not in tests_workflow
-    assert "name: Reusable publisher exact-source witness" in tests_workflow
-    assert "uses: ./.github/workflows/reusable-hf-deploy.yml" in tests_workflow
-    assert "contract-only: true" in tests_workflow
-    assert "HF_TOKEN: ${{ github.token }}" in tests_workflow
+    assert "github.job_workflow_sha" not in witness_workflow
+    assert "name: Reusable publisher exact-source witness" in witness_workflow
+    assert "  push:" in witness_workflow
+    assert "uses: ./.github/workflows/reusable-hf-deploy.yml" in witness_workflow
+    assert "contract-only: true" in witness_workflow
+    assert "HF_TOKEN: ${{ github.token }}" in witness_workflow
 
     assert "HF publisher clean Linux install and runtime proof" in tests_workflow
     assert "python3 -m pip install --dry-run" not in tests_workflow

--- a/.github/scripts/test_hf_publisher_lock.py
+++ b/.github/scripts/test_hf_publisher_lock.py
@@ -26,6 +26,13 @@ def main() -> None:
         assert "--ignore-installed" in source
 
     assert "Create fresh publisher virtual environment" in workflow
+    assert "github.job_workflow_sha" not in workflow
+    assert "repository: ${{ job.workflow_repository }}" in workflow
+    assert "ref: ${{ job.workflow_sha }}" in workflow
+    assert "EXPECTED_TOOLS_SHA: ${{ job.workflow_sha }}" in workflow
+    assert 'ACTUAL_TOOLS_SHA="$(git -C tools rev-parse --verify HEAD)"' in workflow
+    assert '[[ ! "$EXPECTED_TOOLS_SHA" =~ ^[0-9a-f]{40}$ ]]' in workflow
+    assert '[ "$ACTUAL_TOOLS_SHA" != "$EXPECTED_TOOLS_SHA" ]' in workflow
     assert '"$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P -m pip install' in workflow
     assert "tools/requirements/hf-publisher.lock" in workflow
     assert '"huggingface_hub==1.19.0"' not in workflow
@@ -45,6 +52,12 @@ def main() -> None:
     install = workflow.index("Install hash-locked deployment client closure")
     secret = workflow.index("Require governed publisher")
     assert create < install < secret
+
+    assert "github.job_workflow_sha" not in tests_workflow
+    assert "name: Reusable publisher exact-source witness" in tests_workflow
+    assert "uses: ./.github/workflows/reusable-hf-deploy.yml" in tests_workflow
+    assert "contract-only: true" in tests_workflow
+    assert "HF_TOKEN: ${{ github.token }}" in tests_workflow
 
     assert "HF publisher clean Linux install and runtime proof" in tests_workflow
     assert "python3 -m pip install --dry-run" not in tests_workflow

--- a/.github/scripts/test_hf_publisher_lock.py
+++ b/.github/scripts/test_hf_publisher_lock.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "reusable-hf-deploy.yml"
+LOCK = ROOT / "requirements" / "hf-publisher.lock"
+
+
+def main() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    lock = LOCK.read_text(encoding="utf-8")
+
+    assert 'python-version: "3.12.10"' in workflow
+    assert "--require-hashes" in workflow
+    assert "--only-binary=:all:" in workflow
+    assert "tools/requirements/hf-publisher.lock" in workflow
+    assert '"huggingface_hub==1.19.0"' not in workflow
+    assert '"requests==2.32.5"' not in workflow
+    assert "--only-binary=:all:" in lock
+
+    entries = re.findall(
+        r"(?m)^([a-z0-9][a-z0-9-]*)==([^\s\\]+)\s+\\\n"
+        r"\s+--hash=sha256:([0-9a-f]{64})$",
+        lock,
+    )
+    names = [name for name, _, _ in entries]
+    assert len(entries) == 26, f"expected 26 locked wheels, found {len(entries)}"
+    assert len(names) == len(set(names)), "duplicate package in publisher lock"
+    assert {"huggingface-hub", "requests", "hf-xet", "certifi"} <= set(names)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_hf_publisher_lock.py
+++ b/.github/scripts/test_hf_publisher_lock.py
@@ -6,19 +6,68 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "reusable-hf-deploy.yml"
+TESTS_WORKFLOW = ROOT / ".github" / "workflows" / "tests.yml"
 LOCK = ROOT / "requirements" / "hf-publisher.lock"
 
 
 def main() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    tests_workflow = TESTS_WORKFLOW.read_text(encoding="utf-8")
     lock = LOCK.read_text(encoding="utf-8")
 
-    assert 'python-version: "3.12.10"' in workflow
-    assert "--require-hashes" in workflow
-    assert "--only-binary=:all:" in workflow
+    for source in (workflow, tests_workflow):
+        assert 'python-version: "3.12.10"' in source
+        assert 'VENV="$RUNNER_TEMP/hf-publisher-venv"' in source
+        assert 'if [ -e "$VENV" ]; then' in source
+        assert 'python3 -m venv "$VENV"' in source
+        assert '"$VENV/bin/python" -I -P -c' in source
+        assert "--require-hashes" in source
+        assert "--only-binary=:all:" in source
+        assert "--ignore-installed" in source
+
+    assert "Create fresh publisher virtual environment" in workflow
+    assert '"$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P -m pip install' in workflow
     assert "tools/requirements/hf-publisher.lock" in workflow
     assert '"huggingface_hub==1.19.0"' not in workflow
     assert '"requests==2.32.5"' not in workflow
+    assert "python3 tools/.github/scripts/hf_" not in workflow
+    for script in (
+        "hf_deploy_from_dockerfile.py",
+        "hf_space_source_binding.py",
+    ):
+        invocation = (
+            '"$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P '
+            f"tools/.github/scripts/{script}"
+        )
+        assert invocation in workflow
+
+    create = workflow.index("Create fresh publisher virtual environment")
+    install = workflow.index("Install hash-locked deployment client closure")
+    secret = workflow.index("Require governed publisher")
+    assert create < install < secret
+
+    assert "HF publisher clean Linux install and runtime proof" in tests_workflow
+    assert "python3 -m pip install --dry-run" not in tests_workflow
+    assert '"$VENV/bin/python" -I -P -m pip install' in tests_workflow
+    for module in (
+        "certifi",
+        "charset_normalizer",
+        "hf_xet",
+        "httpcore",
+        "httpx",
+        "huggingface_hub",
+        "requests",
+        "urllib3",
+        "yaml",
+    ):
+        assert module in tests_workflow
+    assert 'version("huggingface-hub") == "1.19.0"' in tests_workflow
+    assert 'version("requests") == "2.32.5"' in tests_workflow
+    assert '"$VENV/bin/python" -I -P -m py_compile' in tests_workflow
+    assert '"$VENV/bin/python" -I -P .github/scripts/hf_deploy_from_dockerfile.py --help' in tests_workflow
+    assert '"$VENV/bin/python" -I -P .github/scripts/hf_space_source_binding.py --help' in tests_workflow
+    assert '"$VENV/bin/python" -I -P .github/scripts/test_hf_deploy_from_dockerfile.py' in tests_workflow
+    assert '"$VENV/bin/python" -I -P .github/scripts/test_hf_space_source_binding.py' in tests_workflow
     assert "--only-binary=:all:" in lock
 
     entries = re.findall(

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -229,10 +229,20 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         self.assertIn("requirements/hf-publisher.lock", self.workflow)
         self.assertIn("--require-hashes", self.workflow)
         self.assertIn("--only-binary=:all:", self.workflow)
+        self.assertIn("--ignore-installed", self.workflow)
         self.assertNotIn('"huggingface_hub==1.19.0"', self.workflow)
         self.assertNotIn('"requests==2.32.5"', self.workflow)
         self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
         self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
+        self.assertIn(
+            '"$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P '
+            "tools/.github/scripts/hf_space_source_binding.py",
+            self.workflow,
+        )
+        self.assertNotIn(
+            "python3 tools/.github/scripts/hf_space_source_binding.py",
+            self.workflow,
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -189,9 +189,11 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         path = os.path.join(HERE, "..", "workflows", "reusable-hf-deploy.yml")
         with open(path, encoding="utf-8") as fh:
             cls.workflow = fh.read()
-        tests_path = os.path.join(HERE, "..", "workflows", "tests.yml")
-        with open(tests_path, encoding="utf-8") as fh:
-            cls.tests_workflow = fh.read()
+        witness_path = os.path.join(
+            HERE, "..", "workflows", "reusable-hf-deploy-source-witness.yml"
+        )
+        with open(witness_path, encoding="utf-8") as fh:
+            cls.witness_workflow = fh.read()
 
     def test_source_binding_inputs_are_optional_but_paired(self):
         self.assertIn("source-revision-variable:", self.workflow)
@@ -273,9 +275,9 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         self.assertEqual(contract.count("uses:"), 1)
         self.assertIn("repository: ${{ job.workflow_repository }}", contract)
         self.assertIn("ref: ${{ job.workflow_sha }}", contract)
-        self.assertIn("EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", contract)
+        self.assertIn("EXPECTED_EVENT_SHA: ${{ github.sha }}", contract)
         self.assertIn(
-            '[ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_PR_HEAD_SHA" ]',
+            '[ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_EVENT_SHA" ]',
             contract,
         )
         for forbidden in (
@@ -289,17 +291,19 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
             self.assertNotIn(forbidden, contract)
 
     def test_tests_workflow_calls_actual_reusable_contract(self):
-        self.assertNotIn("github.job_workflow_sha", self.tests_workflow)
+        self.assertNotIn("github.job_workflow_sha", self.witness_workflow)
         self.assertIn(
             "name: Reusable publisher exact-source witness",
-            self.tests_workflow,
+            self.witness_workflow,
         )
+        self.assertIn("  push:", self.witness_workflow)
         self.assertIn(
             "uses: ./.github/workflows/reusable-hf-deploy.yml",
-            self.tests_workflow,
+            self.witness_workflow,
         )
-        self.assertIn("contract-only: true", self.tests_workflow)
-        self.assertIn("HF_TOKEN: ${{ github.token }}", self.tests_workflow)
+        self.assertIn("contract-only: true", self.witness_workflow)
+        self.assertIn("HF_TOKEN: ${{ github.token }}", self.witness_workflow)
+        self.assertIn("permissions:\n  contents: read", self.witness_workflow)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -225,9 +225,12 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         ):
             self.assertNotIn(unsafe, self.workflow)
 
-    def test_workflow_uses_exact_supported_clients_and_immutable_tool_revision(self):
-        self.assertIn('"huggingface_hub==1.19.0"', self.workflow)
-        self.assertIn('"requests==2.32.5"', self.workflow)
+    def test_workflow_uses_hash_locked_clients_and_immutable_tool_revision(self):
+        self.assertIn("requirements/hf-publisher.lock", self.workflow)
+        self.assertIn("--require-hashes", self.workflow)
+        self.assertIn("--only-binary=:all:", self.workflow)
+        self.assertNotIn('"huggingface_hub==1.19.0"', self.workflow)
+        self.assertNotIn('"requests==2.32.5"', self.workflow)
         self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
         self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
 

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -189,6 +189,9 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         path = os.path.join(HERE, "..", "workflows", "reusable-hf-deploy.yml")
         with open(path, encoding="utf-8") as fh:
             cls.workflow = fh.read()
+        tests_path = os.path.join(HERE, "..", "workflows", "tests.yml")
+        with open(tests_path, encoding="utf-8") as fh:
+            cls.tests_workflow = fh.read()
 
     def test_source_binding_inputs_are_optional_but_paired(self):
         self.assertIn("source-revision-variable:", self.workflow)
@@ -232,8 +235,22 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
         self.assertIn("--ignore-installed", self.workflow)
         self.assertNotIn('"huggingface_hub==1.19.0"', self.workflow)
         self.assertNotIn('"requests==2.32.5"', self.workflow)
-        self.assertIn("ref: ${{ github.job_workflow_sha }}", self.workflow)
-        self.assertNotIn("repository: szl-holdings/.github\n          ref: main", self.workflow)
+        self.assertNotIn("github.job_workflow_sha", self.workflow)
+        self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
+        self.assertIn("ref: ${{ job.workflow_sha }}", self.workflow)
+        self.assertIn("EXPECTED_TOOLS_SHA: ${{ job.workflow_sha }}", self.workflow)
+        self.assertIn(
+            'ACTUAL_TOOLS_SHA="$(git -C tools rev-parse --verify HEAD)"',
+            self.workflow,
+        )
+        self.assertIn(
+            '[[ ! "$EXPECTED_TOOLS_SHA" =~ ^[0-9a-f]{40}$ ]]',
+            self.workflow,
+        )
+        self.assertIn(
+            '[ "$ACTUAL_TOOLS_SHA" != "$EXPECTED_TOOLS_SHA" ]',
+            self.workflow,
+        )
         self.assertIn(
             '"$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P '
             "tools/.github/scripts/hf_space_source_binding.py",
@@ -243,6 +260,46 @@ class ReusableWorkflowSourceBindingTests(unittest.TestCase):
             "python3 tools/.github/scripts/hf_space_source_binding.py",
             self.workflow,
         )
+
+    def test_contract_only_witness_is_exact_read_only_and_non_secret(self):
+        deploy_start = self.workflow.index("  hf-deploy:")
+        contract_start = self.workflow.index("  exact-source-contract:")
+        deploy = self.workflow[deploy_start:contract_start]
+        contract = self.workflow[contract_start:]
+
+        self.assertIn("if: ${{ inputs.contract-only == false }}", deploy)
+        self.assertIn("if: ${{ inputs.contract-only == true }}", contract)
+        self.assertIn("permissions:\n      contents: read", contract)
+        self.assertEqual(contract.count("uses:"), 1)
+        self.assertIn("repository: ${{ job.workflow_repository }}", contract)
+        self.assertIn("ref: ${{ job.workflow_sha }}", contract)
+        self.assertIn("EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", contract)
+        self.assertIn(
+            '[ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_PR_HEAD_SHA" ]',
+            contract,
+        )
+        for forbidden in (
+            "HF_TOKEN",
+            "pip install",
+            "hf_deploy_from_dockerfile.py",
+            "hf_space_source_binding.py",
+            "curl ",
+            "gh api",
+        ):
+            self.assertNotIn(forbidden, contract)
+
+    def test_tests_workflow_calls_actual_reusable_contract(self):
+        self.assertNotIn("github.job_workflow_sha", self.tests_workflow)
+        self.assertIn(
+            "name: Reusable publisher exact-source witness",
+            self.tests_workflow,
+        )
+        self.assertIn(
+            "uses: ./.github/workflows/reusable-hf-deploy.yml",
+            self.tests_workflow,
+        )
+        self.assertIn("contract-only: true", self.tests_workflow)
+        self.assertIn("HF_TOKEN: ${{ github.token }}", self.tests_workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/reusable-hf-deploy-source-witness.yml
+++ b/.github/workflows/reusable-hf-deploy-source-witness.yml
@@ -1,0 +1,18 @@
+name: Reusable publisher exact-source witness
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  reusable-publisher-exact-source-witness:
+    name: Reusable publisher exact-source witness
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-hf-deploy.yml
+    with:
+      contract-only: true
+    secrets:
+      HF_TOKEN: ${{ github.token }}

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -63,6 +63,11 @@ on:
         required: false
         type: boolean
         default: false
+      contract-only:
+        description: "Run only the non-secret exact-source workflow_call witness; never publish."
+        required: false
+        type: boolean
+        default: false
     secrets:
       HF_TOKEN:
         description: "HF write token with organization write access to the target Space."
@@ -74,6 +79,7 @@ permissions:
 jobs:
   hf-deploy:
     name: Deploy derived COPY set, bind source, and attest live state
+    if: ${{ inputs.contract-only == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
@@ -96,11 +102,35 @@ jobs:
       - name: Checkout exact reusable-workflow revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: szl-holdings/.github
-          ref: ${{ github.job_workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: tools
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Assert exact reusable-workflow tools revision
+        shell: bash
+        env:
+          WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          EXPECTED_TOOLS_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_TOOLS_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::job.workflow_sha is not an exact 40-character commit SHA: $EXPECTED_TOOLS_SHA"
+            exit 2
+          fi
+          ACTUAL_TOOLS_SHA="$(git -C tools rev-parse --verify HEAD)"
+          if [[ ! "$ACTUAL_TOOLS_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Checked-out tools HEAD is not an exact 40-character commit SHA: $ACTUAL_TOOLS_SHA"
+            exit 2
+          fi
+          if [ "$ACTUAL_TOOLS_SHA" != "$EXPECTED_TOOLS_SHA" ]; then
+            echo "::error::Reusable-workflow tools mismatch: expected $EXPECTED_TOOLS_SHA, found $ACTUAL_TOOLS_SHA"
+            exit 2
+          fi
+          printf 'job.workflow_repository=%s\n' "$WORKFLOW_REPOSITORY"
+          printf 'job.workflow_sha=%s\n' "$EXPECTED_TOOLS_SHA"
+          printf 'checked_out_tools_head=%s\n' "$ACTUAL_TOOLS_SHA"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -275,3 +305,55 @@ jobs:
             hf-source-binding-verify.json
           if-no-files-found: warn
           retention-days: 90
+
+  exact-source-contract:
+    name: Reusable publisher exact-source witness
+    if: ${{ inputs.contract-only == true }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout called reusable-workflow revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: tools
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Assert exact called-workflow source
+        shell: bash
+        env:
+          WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          EXPECTED_WORKFLOW_SHA: ${{ job.workflow_sha }}
+          EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$EXPECTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::job.workflow_sha is not an exact 40-character commit SHA: $EXPECTED_WORKFLOW_SHA"
+            exit 2
+          fi
+          ACTUAL_TOOLS_SHA="$(git -C tools rev-parse --verify HEAD)"
+          if [[ ! "$ACTUAL_TOOLS_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Checked-out tools HEAD is not an exact 40-character commit SHA: $ACTUAL_TOOLS_SHA"
+            exit 2
+          fi
+          if [ "$ACTUAL_TOOLS_SHA" != "$EXPECTED_WORKFLOW_SHA" ]; then
+            echo "::error::Called-workflow source mismatch: expected $EXPECTED_WORKFLOW_SHA, found $ACTUAL_TOOLS_SHA"
+            exit 2
+          fi
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if [[ ! "$EXPECTED_PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::pull_request head is not an exact 40-character commit SHA: $EXPECTED_PR_HEAD_SHA"
+              exit 2
+            fi
+            if [ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_PR_HEAD_SHA" ]; then
+              echo "::error::Called workflow is not the exact pull-request head: workflow $EXPECTED_WORKFLOW_SHA, PR $EXPECTED_PR_HEAD_SHA"
+              exit 2
+            fi
+          fi
+          printf 'job.workflow_repository=%s\n' "$WORKFLOW_REPOSITORY"
+          printf 'job.workflow_sha=%s\n' "$EXPECTED_WORKFLOW_SHA"
+          printf 'checked_out_tools_head=%s\n' "$ACTUAL_TOOLS_SHA"

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -328,7 +328,7 @@ jobs:
         env:
           WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
           EXPECTED_WORKFLOW_SHA: ${{ job.workflow_sha }}
-          EXPECTED_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXPECTED_EVENT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [[ ! "$EXPECTED_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -344,16 +344,15 @@ jobs:
             echo "::error::Called-workflow source mismatch: expected $EXPECTED_WORKFLOW_SHA, found $ACTUAL_TOOLS_SHA"
             exit 2
           fi
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            if [[ ! "$EXPECTED_PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "::error::pull_request head is not an exact 40-character commit SHA: $EXPECTED_PR_HEAD_SHA"
-              exit 2
-            fi
-            if [ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_PR_HEAD_SHA" ]; then
-              echo "::error::Called workflow is not the exact pull-request head: workflow $EXPECTED_WORKFLOW_SHA, PR $EXPECTED_PR_HEAD_SHA"
-              exit 2
-            fi
+          if [[ ! "$EXPECTED_EVENT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::github.sha is not an exact 40-character commit SHA: $EXPECTED_EVENT_SHA"
+            exit 2
+          fi
+          if [ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_EVENT_SHA" ]; then
+            echo "::error::Called workflow is not the exact event head: workflow $EXPECTED_WORKFLOW_SHA, event $EXPECTED_EVENT_SHA"
+            exit 2
           fi
           printf 'job.workflow_repository=%s\n' "$WORKFLOW_REPOSITORY"
           printf 'job.workflow_sha=%s\n' "$EXPECTED_WORKFLOW_SHA"
+          printf 'github.sha=%s\n' "$EXPECTED_EVENT_SHA"
           printf 'checked_out_tools_head=%s\n' "$ACTUAL_TOOLS_SHA"

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -107,11 +107,28 @@ jobs:
         with:
           python-version: "3.12.10"
 
+      - name: Create fresh publisher virtual environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/hf-publisher-venv"
+          if [ -e "$VENV" ]; then
+            echo '::error::Refusing preexisting publisher virtual environment.'
+            exit 2
+          fi
+          python3 -m venv "$VENV"
+          ACTUAL_VERSION="$("$VENV/bin/python" -I -P -c 'import platform; print(platform.python_version())')"
+          if [ "$ACTUAL_VERSION" != "3.12.10" ]; then
+            echo "::error::Expected publisher Python 3.12.10, found $ACTUAL_VERSION."
+            exit 2
+          fi
+
       - name: Install hash-locked deployment client closure
+        shell: bash
         run: >-
-          python -m pip install --disable-pip-version-check
-          --require-hashes --only-binary=:all:
-          -r tools/requirements/hf-publisher.lock
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P -m pip install
+          --disable-pip-version-check --require-hashes --only-binary=:all:
+          --ignore-installed -r tools/requirements/hf-publisher.lock
 
       - name: Resolve target and exact checked-out source
         id: hf
@@ -173,7 +190,7 @@ jobs:
           if [ "$REQUIRE_DEFAULT_BRANCH_TIP" = "true" ]; then
             TIP_GUARD_ARGS+=(--require-default-branch-tip)
           fi
-          python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root caller \
             --github-repo "$GH_REPO" \
             --hf-repo "$HF_REPO" \
@@ -196,7 +213,7 @@ jobs:
           SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}
         run: |
           set -euo pipefail
-          python3 tools/.github/scripts/hf_space_source_binding.py \
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_space_source_binding.py \
             --mode bind \
             --repo-id "$HF_REPO" \
             --variable "$SOURCE_REVISION_VARIABLE" \
@@ -211,7 +228,7 @@ jobs:
           HF_REPO: ${{ steps.hf.outputs.hf_repo }}
         run: |
           set -euo pipefail
-          python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --restart-space \
             --manifest hf-deploy-manifest.json \
             --hf-repo "$HF_REPO"
@@ -223,7 +240,7 @@ jobs:
           WAIT_RUNNING: ${{ inputs.wait-running }}
         run: |
           set -euo pipefail
-          python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --attest \
             --manifest hf-deploy-manifest.json \
             --hf-repo "$HF_REPO" \
@@ -239,7 +256,7 @@ jobs:
           SOURCE_REVISION_PROBE_PATH: ${{ inputs.source-revision-probe-path }}
         run: |
           set -euo pipefail
-          python3 tools/.github/scripts/hf_space_source_binding.py \
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_space_source_binding.py \
             --mode verify \
             --repo-id "$HF_REPO" \
             --variable "$SOURCE_REVISION_VARIABLE" \

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -105,13 +105,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.12.10"
 
-      - name: Install exact supported deployment clients
+      - name: Install hash-locked deployment client closure
         run: >-
           python -m pip install --disable-pip-version-check
-          "huggingface_hub==1.19.0"
-          "requests==2.32.5"
+          --require-hashes --only-binary=:all:
+          -r tools/requirements/hf-publisher.lock
 
       - name: Resolve target and exact checked-out source
         id: hf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,17 +11,6 @@ permissions:
   contents: read
 
 jobs:
-  reusable-publisher-exact-source-witness:
-    name: Reusable publisher exact-source witness
-    if: github.event_name == 'pull_request'
-    permissions:
-      contents: read
-    uses: ./.github/workflows/reusable-hf-deploy.yml
-    with:
-      contract-only: true
-    secrets:
-      HF_TOKEN: ${{ github.token }}
-
   test:
     name: Run tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,17 @@ permissions:
   contents: read
 
 jobs:
+  reusable-publisher-exact-source-witness:
+    name: Reusable publisher exact-source witness
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-hf-deploy.yml
+    with:
+      contract-only: true
+    secrets:
+      HF_TOKEN: ${{ github.token }}
+
   test:
     name: Run tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,6 +225,12 @@ jobs:
       - name: HF publisher immutable dependency closure self-test
         run: python3 .github/scripts/test_hf_publisher_lock.py
 
+      - name: HF publisher Linux wheel closure resolver proof
+        run: >-
+          python3 -m pip install --dry-run --disable-pip-version-check
+          --require-hashes --only-binary=:all:
+          -r requirements/hf-publisher.lock
+
       # Pins the canonical static-Space publication path used by the Hugging
       # Face organization front door. The tests are network-free and lock safe
       # path handling, immutable source identity, and generated deployment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.12.10"
 
       # A full 40-character ref is not enough for a reusable workflow: the
       # target file can be absent at that exact commit (the a11oy/docs-site
@@ -225,11 +225,32 @@ jobs:
       - name: HF publisher immutable dependency closure self-test
         run: python3 .github/scripts/test_hf_publisher_lock.py
 
-      - name: HF publisher Linux wheel closure resolver proof
-        run: >-
-          python3 -m pip install --dry-run --disable-pip-version-check
-          --require-hashes --only-binary=:all:
-          -r requirements/hf-publisher.lock
+      - name: HF publisher clean Linux install and runtime proof
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/hf-publisher-venv"
+          if [ -e "$VENV" ]; then
+            echo '::error::Refusing preexisting publisher virtual environment.'
+            exit 2
+          fi
+          python3 -m venv "$VENV"
+          ACTUAL_VERSION="$("$VENV/bin/python" -I -P -c 'import platform; print(platform.python_version())')"
+          if [ "$ACTUAL_VERSION" != "3.12.10" ]; then
+            echo "::error::Expected publisher Python 3.12.10, found $ACTUAL_VERSION."
+            exit 2
+          fi
+          "$VENV/bin/python" -I -P -m pip install \
+            --disable-pip-version-check --require-hashes --only-binary=:all: \
+            --ignore-installed -r requirements/hf-publisher.lock
+          "$VENV/bin/python" -I -P -c 'from importlib.metadata import version; import certifi, charset_normalizer, hf_xet, httpcore, httpx, huggingface_hub, requests, urllib3, yaml; assert version("huggingface-hub") == "1.19.0"; assert version("requests") == "2.32.5"'
+          "$VENV/bin/python" -I -P -m py_compile \
+            .github/scripts/hf_deploy_from_dockerfile.py \
+            .github/scripts/hf_space_source_binding.py
+          "$VENV/bin/python" -I -P .github/scripts/hf_deploy_from_dockerfile.py --help >/dev/null
+          "$VENV/bin/python" -I -P .github/scripts/hf_space_source_binding.py --help >/dev/null
+          "$VENV/bin/python" -I -P .github/scripts/test_hf_deploy_from_dockerfile.py
+          "$VENV/bin/python" -I -P .github/scripts/test_hf_space_source_binding.py
 
       # Pins the canonical static-Space publication path used by the Hugging
       # Face organization front door. The tests are network-free and lock safe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,6 +222,9 @@ jobs:
       - name: HF deploy-from-Dockerfile derivation self-test
         run: python3 .github/scripts/test_hf_deploy_from_dockerfile.py
 
+      - name: HF publisher immutable dependency closure self-test
+        run: python3 .github/scripts/test_hf_publisher_lock.py
+
       # Pins the canonical static-Space publication path used by the Hugging
       # Face organization front door. The tests are network-free and lock safe
       # path handling, immutable source identity, and generated deployment

--- a/requirements/hf-publisher.lock
+++ b/requirements/hf-publisher.lock
@@ -1,0 +1,56 @@
+# Linux CPython 3.12 wheel closure for the reusable Hugging Face publisher.
+# Resolved for manylinux_2_17_x86_64; every accepted artifact is explicit.
+--only-binary=:all:
+
+annotated-doc==0.0.5 \
+    --hash=sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101
+anyio==4.14.2 \
+    --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+charset-normalizer==3.4.9 \
+    --hash=sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd
+click==8.4.2 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
+colorama==0.4.6 \
+    --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+filelock==3.32.2 \
+    --hash=sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82
+fsspec==2026.7.0 \
+    --hash=sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279
+h11==0.16.0 \
+    --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+hf-xet==1.6.0 \
+    --hash=sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f
+httpcore==1.0.9 \
+    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55
+httpx==0.28.1 \
+    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+huggingface-hub==1.19.0 \
+    --hash=sha256:1dc72e1f6b4d6df6b30eb72e57d00514ef453d660f04af2b87f0e67267f31ee0
+idna==3.18 \
+    --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+markdown-it-py==4.2.0 \
+    --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+packaging==26.3 \
+    --hash=sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c
+pygments==2.20.0 \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+pyyaml==6.0.3 \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+requests==2.32.5 \
+    --hash=sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
+rich==15.0.0 \
+    --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+shellingham==1.5.4 \
+    --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
+tqdm==4.70.0 \
+    --hash=sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+typer==0.25.1 \
+    --hash=sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897


### PR DESCRIPTION
Adds a complete hash-locked Linux CPython 3.12 wheel closure for the canonical reusable Hugging Face publisher.

Security boundary:
- exact Python 3.12.10 runtime
- 26 exact wheel versions and SHA-256 hashes
- --require-hashes and --only-binary=:all:
- no fallback direct installs
- network-free contract test wired into repository CI

This is a supply-chain hardening PR only. It does not publish, deploy, restart, or claim a live Hugging Face runtime. Caller pinning remains gated on the external DCO root-of-trust successor.