### PR TITLE
feat(release): bind immutable source revision files

### DIFF
--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -106,6 +106,10 @@ def materialize_source_revision_file(repo_root, requested_path, source_sha):
             "lowercase 40-character SHA"
         )
     rel = normalize_repo_path(requested_path, label="source revision file")
+    if rel.split("/", 1)[0].casefold() == ".git":
+        raise DeployContractError(
+            "source revision file must not be inside Git metadata"
+        )
     if rel == "Dockerfile":
         raise DeployContractError(
             "source revision file collides with reserved Hugging Face "
@@ -169,11 +173,13 @@ def sha256(data: bytes) -> str:
 # --------------------------------------------------------------------------- #
 # Dockerfile COPY parsing (shared logic with hf_module_drift_check.py)
 # --------------------------------------------------------------------------- #
-def parse_copy_sources(dockerfile_text):
+def parse_copy_sources(dockerfile_text, *, eligible_sources=None):
     """Return COPY/ADD *source* tokens. Joins line-continuations, handles the
     JSON-array form, drops --flag options, and SKIPS `--from=` build-stage
     copies. A whole-context source is rejected because it cannot be represented
-    as a curated, independently attestable deploy set."""
+    as a curated, independently attestable deploy set. When requested,
+    eligible_sources receives only sources from instructions without
+    `--exclude`, which are safe to use as source-revision coverage."""
     logical = []
     buf = ""
     for raw in dockerfile_text.splitlines():
@@ -191,6 +197,7 @@ def parse_copy_sources(dockerfile_text):
         logical.append(buf)
 
     sources = []
+    revision_eligible = []
     for line in logical:
         m = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
         if not m:
@@ -210,14 +217,18 @@ def parse_copy_sources(dockerfile_text):
                     f"invalid JSON-form Dockerfile instruction: {line.strip()}"
                 )
             sources.extend(arr[:-1])
+            revision_eligible.extend(arr[:-1])
             continue
         toks = rest.split()
         skip = False
+        has_exclude = False
         clean = []
         for t in toks:
             if t.startswith("--"):
                 if t.lower().startswith("--from"):
                     skip = True
+                if t.lower().startswith("--exclude"):
+                    has_exclude = True
                 continue
             clean.append(t)
         if skip:
@@ -238,22 +249,30 @@ def parse_copy_sources(dockerfile_text):
                     "the deployer requires an explicit curated source set"
                 )
         sources.extend(srcs)
+        if not has_exclude:
+            revision_eligible.extend(srcs)
 
-    out, seen = [], set()
-    for s in sources:
-        s = s.strip()
-        # Strip a literal leading "./" only -- NOT arbitrary leading "."/"/"
-        # chars, or a dotdir source like ".compliance/x" collapses to "compliance/x".
-        while s.startswith("./"):
-            s = s[2:]
-        if s in ("", "."):
-            raise DeployContractError(
-                "bare `COPY . <dest>` / `ADD . <dest>` is forbidden: "
-                "the deployer requires an explicit curated source set"
-            )
-        if s and s not in seen:
-            seen.add(s)
-            out.append(s)
+    def normalized_unique(raw_sources):
+        out, seen = [], set()
+        for source in raw_sources:
+            source = source.strip()
+            # Strip a literal leading "./" only -- NOT arbitrary leading "."/"/"
+            # chars, or a dotdir source like ".compliance/x" collapses.
+            while source.startswith("./"):
+                source = source[2:]
+            if source in ("", "."):
+                raise DeployContractError(
+                    "bare `COPY . <dest>` / `ADD . <dest>` is forbidden: "
+                    "the deployer requires an explicit curated source set"
+                )
+            if source and source not in seen:
+                seen.add(source)
+                out.append(source)
+        return out
+
+    out = normalized_unique(sources)
+    if eligible_sources is not None:
+        eligible_sources.extend(normalized_unique(revision_eligible))
     return out
 
 
@@ -550,24 +569,56 @@ def probe_smoke_routes(hf_repo, smoke_paths, retries=6, delay=5):
 # derive: Dockerfile -> deploy manifest (no network, no push)
 # --------------------------------------------------------------------------- #
 def derive(args):
+    readme_path = normalize_repo_path(
+        args.readme_path,
+        label="README source path",
+    )
+    requested_revision = getattr(args, "source_revision_file", "")
+    if requested_revision:
+        revision_candidate = normalize_repo_path(
+            requested_revision,
+            label="source revision file",
+        )
+        if (
+            args.include_readme
+            and revision_candidate.casefold() == readme_path.casefold()
+        ):
+            raise DeployContractError(
+                "source revision file collides with the included README target"
+            )
+        manifest_out = str(getattr(args, "manifest_out", "") or "")
+        if manifest_out:
+            root = os.path.realpath(args.repo_root)
+            revision_full = os.path.realpath(
+                os.path.join(root, *revision_candidate.split("/"))
+            )
+            manifest_full = os.path.realpath(os.path.abspath(manifest_out))
+            if os.path.normcase(revision_full) == os.path.normcase(manifest_full):
+                raise DeployContractError(
+                    "source revision file collides with the manifest output"
+                )
     revision_rel = materialize_source_revision_file(
         args.repo_root,
-        getattr(args, "source_revision_file", ""),
+        requested_revision,
         getattr(args, "source_sha", ""),
     )
     dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
     with open(df_path, "rb") as fh:
         dockerfile_text = fh.read().decode("utf-8", "replace")
-    sources = parse_copy_sources(dockerfile_text)
+    eligible_sources = []
+    sources = parse_copy_sources(
+        dockerfile_text,
+        eligible_sources=eligible_sources,
+    )
     tree = local_tree(args.repo_root)
     targets, unresolved = expand_sources(sources, tree)
+    eligible_targets, _ = expand_sources(eligible_sources, tree)
 
     # include-readme is authoritative. A README may already be in the derived
     # set because the Dockerfile explicitly COPYs it; remove that exact path
     # when the caller owns the Space card separately. Normalize the CLI path to
     # the forward-slash form used by local_tree/expand_sources, without filtering
     # unrelated nested README files.
-    readme_path = normalize_repo_path(args.readme_path, label="README source path")
     if not args.include_readme:
         targets.pop(readme_path, None)
 
@@ -576,9 +627,10 @@ def derive(args):
             "Dockerfile COPY/ADD sources were not found in the checkout: "
             + ", ".join(sorted(unresolved))
         )
-    if revision_rel and revision_rel not in targets:
+    if revision_rel and revision_rel not in eligible_targets:
         raise DeployContractError(
             "source revision file is not covered by a Dockerfile COPY/ADD "
+            "instruction without --exclude: "
             f"source: {revision_rel!r}"
         )
 

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -148,6 +148,132 @@ def materialize_source_revision_file(repo_root, requested_path, source_sha):
     return rel
 
 
+def _dockerignore_pattern_regex(pattern):
+    """Compile Docker patternmatcher wildcards for slash-delimited repo paths."""
+    pieces = ["^"]
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "*":
+            if index + 1 < len(pattern) and pattern[index + 1] == "*":
+                index += 2
+                if index < len(pattern) and pattern[index] == "/":
+                    index += 1
+                    pieces.append("(?:.*/)?")
+                else:
+                    pieces.append(".*")
+                continue
+            pieces.append("[^/]*")
+        elif char == "?":
+            pieces.append("[^/]")
+        elif char == "[":
+            end = index + 1
+            if end < len(pattern) and pattern[end] in ("!", "^"):
+                end += 1
+            if end < len(pattern) and pattern[end] == "]":
+                end += 1
+            while end < len(pattern) and pattern[end] != "]":
+                end += 1
+            if end >= len(pattern):
+                raise DeployContractError(
+                    f"invalid Docker ignore pattern: {pattern!r}"
+                )
+            content = pattern[index + 1 : end]
+            if "/" in content:
+                raise DeployContractError(
+                    f"invalid Docker ignore character class: {pattern!r}"
+                )
+            if content.startswith("!"):
+                content = "^" + content[1:]
+            elif content.startswith("^"):
+                content = "\\" + content
+            pieces.append("[" + content + "]")
+            index = end
+        elif char == "\\":
+            index += 1
+            if index >= len(pattern):
+                raise DeployContractError(
+                    f"invalid trailing escape in Docker ignore pattern: {pattern!r}"
+                )
+            pieces.append(re.escape(pattern[index]))
+        else:
+            pieces.append(re.escape(char))
+        index += 1
+    pieces.append("$")
+    try:
+        return re.compile("".join(pieces))
+    except re.error as exc:
+        raise DeployContractError(
+            f"invalid Docker ignore pattern: {pattern!r}"
+        ) from exc
+
+
+def _dockerignore_patterns(ignore_path):
+    """Load normalized patternmatcher rules from one effective ignore file."""
+    with open(ignore_path, "rb") as fh:
+        data = fh.read(262145)
+    if len(data) > 262144:
+        raise DeployContractError("Docker ignore file exceeds 256 KiB")
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise DeployContractError("Docker ignore file is not valid UTF-8") from exc
+
+    patterns = []
+    for raw_line in text.splitlines():
+        if raw_line.startswith("#"):
+            continue
+        pattern = raw_line.strip()
+        if not pattern:
+            continue
+        negated = pattern.startswith("!")
+        if negated:
+            pattern = pattern[1:].strip()
+            if not pattern:
+                raise DeployContractError(
+                    "Docker ignore file contains an empty negation"
+                )
+        pattern = posixpath.normpath(pattern).strip("/")
+        if pattern in ("", "."):
+            continue
+        patterns.append((negated, _dockerignore_pattern_regex(pattern)))
+    return patterns
+
+
+def _effective_dockerignore(repo_root, dockerfile_rel):
+    """Resolve Dockerfile-specific precedence over the root ignore file."""
+    candidates = (dockerfile_rel + ".dockerignore", ".dockerignore")
+    root = os.path.realpath(repo_root)
+    for rel in candidates:
+        requested = os.path.join(root, *rel.split("/"))
+        if not os.path.lexists(requested):
+            continue
+        normalized, full = source_file(repo_root, rel)
+        return normalized, full
+    return None, None
+
+
+def source_revision_is_dockerignored(repo_root, dockerfile_rel, revision_rel):
+    """Return the effective ignore file when Docker removes the revision path."""
+    ignore_rel, ignore_path = _effective_dockerignore(repo_root, dockerfile_rel)
+    if ignore_path is None:
+        return None
+
+    path = normalize_repo_path(revision_rel, label="source revision file")
+    parents = path.split("/")[:-1]
+    candidates = [path] + [
+        "/".join(parents[: index + 1])
+        for index in range(len(parents))
+    ]
+    matched = False
+    for negated, pattern in _dockerignore_patterns(ignore_path):
+        if negated != matched:
+            continue
+        if any(pattern.fullmatch(candidate) for candidate in candidates):
+            matched = not negated
+    return ignore_rel if matched else None
+
+
 def read_source_bytes(repo_root, target_path, meta):
     """Read the GitHub source mapped to an HF target path."""
     source_path = meta.get("source_path") or target_path
@@ -597,12 +723,23 @@ def derive(args):
                 raise DeployContractError(
                     "source revision file collides with the manifest output"
                 )
+    dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
+    if requested_revision:
+        ignored_by = source_revision_is_dockerignored(
+            args.repo_root,
+            dockerfile_rel,
+            revision_candidate,
+        )
+        if ignored_by:
+            raise DeployContractError(
+                "source revision file is excluded from the Docker build "
+                f"context by {ignored_by!r}: {revision_candidate!r}"
+            )
     revision_rel = materialize_source_revision_file(
         args.repo_root,
         requested_revision,
         getattr(args, "source_sha", ""),
     )
-    dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
     with open(df_path, "rb") as fh:
         dockerfile_text = fh.read().decode("utf-8", "replace")
     eligible_sources = []

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -265,21 +265,13 @@ def source_revision_is_dockerignored(repo_root, dockerfile_rel, revision_rel):
         "/".join(parents[: index + 1])
         for index in range(len(parents))
     ]
-    candidates = [path] + [
-        "/".join(parents[: index + 1])
-        for index in range(len(parents))
-    ]
-    matched = False
+    candidates = [path] + parent_candidates
+    ignored = {candidate: False for candidate in candidates}
     for negated, pattern in _dockerignore_patterns(ignore_path):
-        if negated != matched:
-            continue
-        if not negated and any(
-            pattern.fullmatch(parent) for parent in parent_candidates
-        ):
-            return ignore_rel
-        if any(pattern.fullmatch(candidate) for candidate in candidates):
-            matched = not negated
-    return ignore_rel if matched else None
+        for candidate in candidates:
+            if pattern.fullmatch(candidate):
+                ignored[candidate] = not negated
+    return ignore_rel if any(ignored.values()) else None
 
 
 def read_source_bytes(repo_root, target_path, meta):

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -95,6 +95,41 @@ def source_file(repo_root, source_path):
     return rel, full
 
 
+def materialize_source_revision_file(repo_root, requested_path, source_sha):
+    """Write an exact source SHA to a new, repository-contained payload file."""
+    if not requested_path:
+        return None
+    source_sha = str(source_sha or "")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise DeployContractError(
+            "--source-revision-file requires --source-sha to be an exact "
+            "lowercase 40-character SHA"
+        )
+    rel = normalize_repo_path(requested_path, label="source revision file")
+    root = os.path.realpath(repo_root)
+    full = os.path.realpath(os.path.join(root, *rel.split("/")))
+    try:
+        contained = os.path.commonpath((root, full)) == root
+    except ValueError:
+        contained = False
+    if not contained:
+        raise DeployContractError(
+            f"source revision file escapes the repository root: {rel!r}"
+        )
+    if os.path.lexists(full):
+        raise DeployContractError(
+            f"source revision file must not already exist: {rel!r}"
+        )
+    parent = os.path.dirname(full)
+    if not os.path.isdir(parent):
+        raise DeployContractError(
+            f"source revision file parent is not a directory: {rel!r}"
+        )
+    with open(full, "x", encoding="ascii", newline="\n") as fh:
+        fh.write(source_sha + "\n")
+    return rel
+
+
 def read_source_bytes(repo_root, target_path, meta):
     """Read the GitHub source mapped to an HF target path."""
     source_path = meta.get("source_path") or target_path
@@ -501,6 +536,11 @@ def probe_smoke_routes(hf_repo, smoke_paths, retries=6, delay=5):
 # derive: Dockerfile -> deploy manifest (no network, no push)
 # --------------------------------------------------------------------------- #
 def derive(args):
+    revision_rel = materialize_source_revision_file(
+        args.repo_root,
+        getattr(args, "source_revision_file", ""),
+        getattr(args, "source_sha", ""),
+    )
     dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
     with open(df_path, "rb") as fh:
         dockerfile_text = fh.read().decode("utf-8", "replace")
@@ -522,6 +562,11 @@ def derive(args):
             "Dockerfile COPY/ADD sources were not found in the checkout: "
             + ", ".join(sorted(unresolved))
         )
+    if revision_rel and revision_rel not in targets:
+        raise DeployContractError(
+            "source revision file is not covered by a Dockerfile COPY/ADD "
+            f"source: {revision_rel!r}"
+        )
 
     files = {}
     for rel, src in sorted(targets.items()):
@@ -533,6 +578,8 @@ def derive(args):
             "copy_source": src,
             "source_path": rel,
         }
+        if rel == revision_rel:
+            files[rel]["generated_from_source_sha"] = True
 
     readme_rel = None
     if args.include_readme:
@@ -578,6 +625,7 @@ def derive(args):
         "unresolved_sources": unresolved,
         "readme": readme_rel,
         "smoke_paths": smoke_paths,
+        "source_revision_file": revision_rel,
         "files": files,
     }
     return manifest, files
@@ -837,6 +885,14 @@ def main(argv=None):
         help="exact checked-out source SHA used by mutation-boundary guards",
     )
     ap.add_argument("--dockerfile-path", default="Dockerfile")
+    ap.add_argument(
+        "--source-revision-file",
+        default="",
+        help=(
+            "write --source-sha to this new repository-contained path before "
+            "derivation; the Dockerfile must COPY the generated file"
+        ),
+    )
     ap.add_argument("--readme-path", default="README.md")
     ap.add_argument("--include-readme", default="true")
     ap.add_argument(

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -150,7 +150,7 @@ def materialize_source_revision_file(repo_root, requested_path, source_sha):
 
 def _dockerignore_pattern_regex(pattern):
     """Compile Docker patternmatcher wildcards for slash-delimited repo paths."""
-    pieces = ["^"]
+    pieces = ["^(?:.*/)?" if "/" not in pattern else "^"]
     index = 0
     while index < len(pattern):
         char = pattern[index]
@@ -741,6 +741,7 @@ def derive(args):
         dockerfile_text,
         eligible_sources=eligible_sources,
     )
+    smoke_paths = normalize_smoke_paths(getattr(args, "smoke_paths", None))
 
     revision_rel = None
     revision_content = None
@@ -873,8 +874,6 @@ def derive(args):
             raise DeployContractError(
                 "source revision materialization changed the validated target"
             )
-
-    smoke_paths = normalize_smoke_paths(getattr(args, "smoke_paths", None))
 
     manifest = {
         "schema": 2,

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -117,6 +117,14 @@ def materialize_source_revision_file(repo_root, requested_path, source_sha):
         raise DeployContractError(
             f"source revision file must not already exist: {rel!r}"
         )
+    unresolved_ancestor = root
+    for component in rel.split("/")[:-1]:
+        unresolved_ancestor = os.path.join(unresolved_ancestor, component)
+        if os.path.islink(unresolved_ancestor):
+            raise DeployContractError(
+                "source revision file ancestor must not be a symlink: "
+                f"{rel!r}"
+            )
     full = os.path.realpath(requested_full)
     try:
         contained = os.path.commonpath((root, full)) == root

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -110,10 +110,10 @@ def materialize_source_revision_file(repo_root, requested_path, source_sha):
         raise DeployContractError(
             "source revision file must not be inside Git metadata"
         )
-    if rel == "Dockerfile":
+    if rel in {"Dockerfile", "Dockerfile.dockerignore"}:
         raise DeployContractError(
             "source revision file collides with reserved Hugging Face "
-            "Dockerfile target"
+            "Dockerfile target or its build-context policy"
         )
     root = os.path.realpath(repo_root)
     requested_full = os.path.join(root, *rel.split("/"))
@@ -261,6 +261,10 @@ def source_revision_is_dockerignored(repo_root, dockerfile_rel, revision_rel):
 
     path = normalize_repo_path(revision_rel, label="source revision file")
     parents = path.split("/")[:-1]
+    parent_candidates = [
+        "/".join(parents[: index + 1])
+        for index in range(len(parents))
+    ]
     candidates = [path] + [
         "/".join(parents[: index + 1])
         for index in range(len(parents))
@@ -269,6 +273,10 @@ def source_revision_is_dockerignored(repo_root, dockerfile_rel, revision_rel):
     for negated, pattern in _dockerignore_patterns(ignore_path):
         if negated != matched:
             continue
+        if not negated and any(
+            pattern.fullmatch(parent) for parent in parent_candidates
+        ):
+            return ignore_rel
         if any(pattern.fullmatch(candidate) for candidate in candidates):
             matched = not negated
     return ignore_rel if matched else None
@@ -276,6 +284,8 @@ def source_revision_is_dockerignored(repo_root, dockerfile_rel, revision_rel):
 
 def read_source_bytes(repo_root, target_path, meta):
     """Read the GitHub source mapped to an HF target path."""
+    if "generated_content_utf8" in meta:
+        return str(meta["generated_content_utf8"]).encode("utf-8")
     source_path = meta.get("source_path") or target_path
     _, full = source_file(repo_root, source_path)
     with open(full, "rb") as fh:
@@ -724,7 +734,23 @@ def derive(args):
                     "source revision file collides with the manifest output"
                 )
     dockerfile_rel, df_path = source_file(args.repo_root, args.dockerfile_path)
+    with open(df_path, "rb") as fh:
+        dockerfile_text = fh.read().decode("utf-8", "replace")
+    eligible_sources = []
+    sources = parse_copy_sources(
+        dockerfile_text,
+        eligible_sources=eligible_sources,
+    )
+
+    revision_rel = None
+    revision_content = None
     if requested_revision:
+        source_sha = str(getattr(args, "source_sha", "") or "")
+        if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+            raise DeployContractError(
+                "--source-revision-file requires --source-sha to be an exact "
+                "lowercase 40-character SHA"
+            )
         ignored_by = source_revision_is_dockerignored(
             args.repo_root,
             dockerfile_rel,
@@ -735,19 +761,12 @@ def derive(args):
                 "source revision file is excluded from the Docker build "
                 f"context by {ignored_by!r}: {revision_candidate!r}"
             )
-    revision_rel = materialize_source_revision_file(
-        args.repo_root,
-        requested_revision,
-        getattr(args, "source_sha", ""),
-    )
-    with open(df_path, "rb") as fh:
-        dockerfile_text = fh.read().decode("utf-8", "replace")
-    eligible_sources = []
-    sources = parse_copy_sources(
-        dockerfile_text,
-        eligible_sources=eligible_sources,
-    )
+        revision_rel = revision_candidate
+        revision_content = source_sha + "\n"
+
     tree = local_tree(args.repo_root)
+    if revision_rel:
+        tree[revision_rel] = git_blob_sha1(revision_content.encode("ascii"))
     targets, unresolved = expand_sources(sources, tree)
     eligible_targets, _ = expand_sources(eligible_sources, tree)
 
@@ -756,7 +775,7 @@ def derive(args):
     # when the caller owns the Space card separately. Normalize the CLI path to
     # the forward-slash form used by local_tree/expand_sources, without filtering
     # unrelated nested README files.
-    if not args.include_readme:
+    if not args.include_readme and readme_path != revision_rel:
         targets.pop(readme_path, None)
 
     if unresolved:
@@ -773,7 +792,10 @@ def derive(args):
 
     files = {}
     for rel, src in sorted(targets.items()):
-        data = read_source_bytes(args.repo_root, rel, {"source_path": rel})
+        source_meta = {"source_path": rel}
+        if rel == revision_rel:
+            source_meta["generated_content_utf8"] = revision_content
+        data = read_source_bytes(args.repo_root, rel, source_meta)
         files[rel] = {
             "git_blob_sha1": git_blob_sha1(data),
             "sha256": sha256(data),
@@ -783,6 +805,7 @@ def derive(args):
         }
         if rel == revision_rel:
             files[rel]["generated_from_source_sha"] = True
+            files[rel]["generated_content_utf8"] = revision_content
 
     readme_rel = None
     if args.include_readme:
@@ -811,6 +834,45 @@ def derive(args):
         "copy_source": "(dockerfile)",
         "source_path": dockerfile_rel,
     }
+
+    if revision_rel:
+        ignore_rel, ignore_path = _effective_dockerignore(
+            args.repo_root,
+            dockerfile_rel,
+        )
+        if ignore_path is None:
+            ignore_source = "(generated-empty-dockerignore)"
+            ignore_meta = {
+                "source_path": ignore_source,
+                "generated_content_utf8": "",
+            }
+        else:
+            ignore_source = ignore_rel
+            ignore_meta = {"source_path": ignore_rel}
+        ignore_bytes = read_source_bytes(
+            args.repo_root,
+            "Dockerfile.dockerignore",
+            ignore_meta,
+        )
+        files["Dockerfile.dockerignore"] = {
+            "git_blob_sha1": git_blob_sha1(ignore_bytes),
+            "sha256": sha256(ignore_bytes),
+            "size": len(ignore_bytes),
+            "copy_source": "(dockerignore)",
+            "source_path": ignore_source,
+        }
+        if "generated_content_utf8" in ignore_meta:
+            files["Dockerfile.dockerignore"]["generated_content_utf8"] = ""
+
+        materialized_revision = materialize_source_revision_file(
+            args.repo_root,
+            revision_rel,
+            source_sha,
+        )
+        if materialized_revision != revision_rel:
+            raise DeployContractError(
+                "source revision materialization changed the validated target"
+            )
 
     smoke_paths = normalize_smoke_paths(getattr(args, "smoke_paths", None))
 

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -167,7 +167,7 @@ class TestDeriveReadmePolicy(unittest.TestCase):
     def _derive(
         self, dockerfile, files, *, include_readme, readme_path="README.md",
         dockerfile_path="Dockerfile", smoke_paths=None,
-        source_revision_file="", source_sha="",
+        source_revision_file="", source_sha="", manifest_out_rel="",
     ):
         with tempfile.TemporaryDirectory() as repo_root:
             for rel, content in {dockerfile_path: dockerfile, **files}.items():
@@ -186,6 +186,11 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 smoke_paths=smoke_paths,
                 source_revision_file=source_revision_file,
                 source_sha=source_sha,
+                manifest_out=(
+                    os.path.join(repo_root, *manifest_out_rel.split("/"))
+                    if manifest_out_rel
+                    else ""
+                ),
             )
             return dep.derive(args)
 
@@ -306,6 +311,54 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 dockerfile_path="space/Dockerfile",
                 source_revision_file="Dockerfile",
                 source_sha="a" * 40,
+            )
+
+    def test_generated_source_revision_rejects_git_metadata_target(self):
+        with tempfile.TemporaryDirectory() as repo_root:
+            target = os.path.join(repo_root, ".git", "refs", "heads", "generated")
+            os.makedirs(os.path.dirname(target))
+
+            with self.assertRaisesRegex(dep.DeployContractError, "Git metadata"):
+                dep.materialize_source_revision_file(
+                    repo_root, ".git/refs/heads/generated", "a" * 40
+                )
+            self.assertFalse(os.path.exists(target))
+
+    def test_generated_source_revision_rejects_included_readme_collision(self):
+        with self.assertRaisesRegex(
+            dep.DeployContractError, "included README target"
+        ):
+            self._derive(
+                "FROM scratch\nCOPY space /app/space\n",
+                {"space/app.py": "pass\n"},
+                include_readme=True,
+                readme_path="space/SOURCE_REVISION",
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
+
+    def test_generated_source_revision_rejects_excluded_copy_coverage(self):
+        with self.assertRaisesRegex(
+            dep.DeployContractError, "without --exclude"
+        ):
+            self._derive(
+                "FROM scratch\n"
+                "COPY --exclude=SOURCE_REVISION space /app/space\n",
+                {"space/app.py": "pass\n"},
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
+
+    def test_generated_source_revision_rejects_manifest_output_collision(self):
+        with self.assertRaisesRegex(dep.DeployContractError, "manifest output"):
+            self._derive(
+                "FROM scratch\nCOPY manifest.json /app/manifest.json\n",
+                {},
+                include_readme=False,
+                source_revision_file="manifest.json",
+                source_sha="a" * 40,
+                manifest_out_rel="manifest.json",
             )
 
     def test_generated_source_revision_rejects_dangling_symlink(self):

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -361,6 +361,65 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 manifest_out_rel="manifest.json",
             )
 
+    def test_generated_source_revision_rejects_root_dockerignore_match(self):
+        with self.assertRaisesRegex(
+            dep.DeployContractError, "excluded from the Docker build context"
+        ):
+            self._derive(
+                "FROM scratch\nCOPY space /app/space\n",
+                {
+                    ".dockerignore": "space/SOURCE_REVISION\n",
+                    "space/app.py": "pass\n",
+                },
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
+
+    def test_dockerfile_specific_ignore_takes_precedence_over_root(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY space /app/space\n",
+            {
+                ".dockerignore": "space/SOURCE_REVISION\n",
+                "Dockerfile.dockerignore": "# source revision remains included\n",
+                "space/app.py": "pass\n",
+            },
+            include_readme=False,
+            source_revision_file="space/SOURCE_REVISION",
+            source_sha="a" * 40,
+        )
+
+        self.assertEqual(
+            manifest["source_revision_file"],
+            "space/SOURCE_REVISION",
+        )
+        self.assertTrue(
+            files["space/SOURCE_REVISION"]["generated_from_source_sha"]
+        )
+
+    def test_dockerignore_negation_reincludes_source_revision(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY space /app/space\n",
+            {
+                ".dockerignore": (
+                    "space/**\n"
+                    "!space/SOURCE_REVISION\n"
+                ),
+                "space/app.py": "pass\n",
+            },
+            include_readme=False,
+            source_revision_file="space/SOURCE_REVISION",
+            source_sha="a" * 40,
+        )
+
+        self.assertEqual(
+            manifest["source_revision_file"],
+            "space/SOURCE_REVISION",
+        )
+        self.assertTrue(
+            files["space/SOURCE_REVISION"]["generated_from_source_sha"]
+        )
+
     def test_generated_source_revision_rejects_dangling_symlink(self):
         with tempfile.TemporaryDirectory() as repo_root:
             os.makedirs(os.path.join(repo_root, "space"))

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -167,6 +167,7 @@ class TestDeriveReadmePolicy(unittest.TestCase):
     def _derive(
         self, dockerfile, files, *, include_readme, readme_path="README.md",
         dockerfile_path="Dockerfile", smoke_paths=None,
+        source_revision_file="", source_sha="",
     ):
         with tempfile.TemporaryDirectory() as repo_root:
             for rel, content in {dockerfile_path: dockerfile, **files}.items():
@@ -183,6 +184,8 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 hf_repo="SZLHOLDINGS/example",
                 ref="main",
                 smoke_paths=smoke_paths,
+                source_revision_file=source_revision_file,
+                source_sha=source_sha,
             )
             return dep.derive(args)
 
@@ -253,6 +256,43 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 "FROM scratch\nCOPY missing.py /app/missing.py\n",
                 {},
                 include_readme=False,
+            )
+
+    def test_generated_source_revision_is_copy_covered_and_manifest_bound(self):
+        revision = "a" * 40
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY space /app/space\n",
+            {"space/app.py": "print('bound')\n"},
+            include_readme=False,
+            source_revision_file="space/SOURCE_REVISION",
+            source_sha=revision,
+        )
+
+        self.assertEqual(manifest["source_revision_file"], "space/SOURCE_REVISION")
+        self.assertTrue(
+            files["space/SOURCE_REVISION"]["generated_from_source_sha"]
+        )
+        self.assertEqual(
+            files["space/SOURCE_REVISION"]["sha256"],
+            dep.sha256((revision + "\n").encode("ascii")),
+        )
+
+    def test_generated_source_revision_must_be_new_and_copy_covered(self):
+        with self.assertRaisesRegex(dep.DeployContractError, "already exist"):
+            self._derive(
+                "FROM scratch\nCOPY space /app/space\n",
+                {"space/SOURCE_REVISION": "b" * 40 + "\n"},
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
+        with self.assertRaisesRegex(dep.DeployContractError, "not covered"):
+            self._derive(
+                "FROM scratch\nCOPY app.py /app/app.py\n",
+                {"app.py": "pass\n", "space/keep": "tracked\n"},
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
             )
 
     def test_manifest_smoke_paths_default_to_root(self):
@@ -617,6 +657,15 @@ class TestReusableWorkflowContract(unittest.TestCase):
             "GITHUB_TOKEN: ${{ github.token }}",
             "SOURCE_SHA: ${{ steps.hf.outputs.source_sha }}",
             '--source-sha "$SOURCE_SHA"',
+        ):
+            self.assertIn(contract, self.workflow)
+
+    def test_generated_source_revision_file_is_optional_and_forwarded(self):
+        for contract in (
+            "source-revision-file:",
+            "SOURCE_REVISION_FILE: ${{ inputs.source-revision-file }}",
+            'SOURCE_REVISION_ARGS+=(--source-revision-file "$SOURCE_REVISION_FILE")',
+            '"${SOURCE_REVISION_ARGS[@]}"',
         ):
             self.assertIn(contract, self.workflow)
 

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -505,6 +505,26 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 source_sha="a" * 40,
             )
 
+    def test_later_rule_can_reinclude_ignored_parent(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY space /app/space\n",
+            {
+                ".dockerignore": "space\n!space\n",
+                "space/app.py": "pass\n",
+            },
+            include_readme=False,
+            source_revision_file="space/SOURCE_REVISION",
+            source_sha="a" * 40,
+        )
+
+        self.assertEqual(
+            manifest["source_revision_file"],
+            "space/SOURCE_REVISION",
+        )
+        self.assertTrue(
+            files["space/SOURCE_REVISION"]["generated_from_source_sha"]
+        )
+
     def test_dockerignore_negation_reincludes_source_revision(self):
         manifest, files = self._derive(
             "FROM scratch\nCOPY space /app/space\n",

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -281,6 +281,14 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             files["space/SOURCE_REVISION"]["sha256"],
             dep.sha256((revision + "\n").encode("ascii")),
         )
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["source_path"],
+            "(generated-empty-dockerignore)",
+        )
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["generated_content_utf8"],
+            "",
+        )
 
     def test_generated_source_revision_must_be_new_and_copy_covered(self):
         with self.assertRaisesRegex(dep.DeployContractError, "already exist"):
@@ -299,6 +307,32 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 source_revision_file="space/SOURCE_REVISION",
                 source_sha="a" * 40,
             )
+
+    def test_copy_coverage_failure_does_not_materialize_revision(self):
+        with tempfile.TemporaryDirectory() as repo_root:
+            os.makedirs(os.path.join(repo_root, "space"))
+            with open(os.path.join(repo_root, "Dockerfile"), "w") as fh:
+                fh.write("FROM scratch\nCOPY app.py /app/app.py\n")
+            with open(os.path.join(repo_root, "app.py"), "w") as fh:
+                fh.write("pass\n")
+            revision = os.path.join(repo_root, "space", "SOURCE_REVISION")
+            args = types.SimpleNamespace(
+                repo_root=repo_root,
+                dockerfile_path="Dockerfile",
+                include_readme=False,
+                readme_path="README.md",
+                github_repo="szl-holdings/example",
+                hf_repo="SZLHOLDINGS/example",
+                ref="main",
+                smoke_paths=None,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+                manifest_out="",
+            )
+
+            with self.assertRaisesRegex(dep.DeployContractError, "not covered"):
+                dep.derive(args)
+            self.assertFalse(os.path.lexists(revision))
 
     def test_generated_source_revision_rejects_dockerfile_target_collision(self):
         with self.assertRaisesRegex(
@@ -396,6 +430,50 @@ class TestDeriveReadmePolicy(unittest.TestCase):
         self.assertTrue(
             files["space/SOURCE_REVISION"]["generated_from_source_sha"]
         )
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["source_path"],
+            "Dockerfile.dockerignore",
+        )
+
+    def test_nested_dockerfile_ignore_is_published_at_hf_root(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY space /app/space\n",
+            {
+                ".dockerignore": "space/SOURCE_REVISION\n",
+                "space/Dockerfile.dockerignore": (
+                    "# source revision remains included\n"
+                ),
+                "space/app.py": "pass\n",
+            },
+            include_readme=False,
+            dockerfile_path="space/Dockerfile",
+            source_revision_file="space/SOURCE_REVISION",
+            source_sha="a" * 40,
+        )
+
+        self.assertEqual(
+            manifest["source_revision_file"],
+            "space/SOURCE_REVISION",
+        )
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["source_path"],
+            "space/Dockerfile.dockerignore",
+        )
+
+    def test_ignored_parent_cannot_reinclude_source_revision(self):
+        with self.assertRaisesRegex(
+            dep.DeployContractError, "excluded from the Docker build context"
+        ):
+            self._derive(
+                "FROM scratch\nCOPY space /app/space\n",
+                {
+                    ".dockerignore": "space\n!space/SOURCE_REVISION\n",
+                    "space/app.py": "pass\n",
+                },
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
 
     def test_dockerignore_negation_reincludes_source_revision(self):
         manifest, files = self._derive(

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -410,6 +410,36 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 source_sha="a" * 40,
             )
 
+    def test_basename_dockerignore_rule_matches_nested_source_revision(self):
+        with self.assertRaisesRegex(
+            dep.DeployContractError, "excluded from the Docker build context"
+        ):
+            self._derive(
+                "FROM scratch\nCOPY space /app/space\n",
+                {
+                    ".dockerignore": "SOURCE_REVISION\n",
+                    "space/app.py": "pass\n",
+                },
+                include_readme=False,
+                source_revision_file="space/SOURCE_REVISION",
+                source_sha="a" * 40,
+            )
+
+    def test_smoke_path_failure_precedes_revision_materialization(self):
+        with mock.patch.object(
+            dep, "materialize_source_revision_file"
+        ) as materialize:
+            with self.assertRaises(dep.DeployContractError):
+                self._derive(
+                    "FROM scratch\nCOPY space /app/space\n",
+                    {"space/app.py": "pass\n"},
+                    include_readme=False,
+                    smoke_paths='["https://example.com/"]',
+                    source_revision_file="space/SOURCE_REVISION",
+                    source_sha="a" * 40,
+                )
+        materialize.assert_not_called()
+
     def test_dockerfile_specific_ignore_takes_precedence_over_root(self):
         manifest, files = self._derive(
             "FROM scratch\nCOPY space /app/space\n",

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -322,6 +322,25 @@ class TestDeriveReadmePolicy(unittest.TestCase):
                 )
             self.assertFalse(os.path.exists(escaped))
 
+    def test_generated_source_revision_rejects_symlinked_ancestor(self):
+        with tempfile.TemporaryDirectory() as repo_root:
+            escaped_parent = os.path.join(repo_root, ".git", "refs", "heads")
+            os.makedirs(escaped_parent)
+            os.symlink(
+                os.path.join(".git", "refs", "heads"),
+                os.path.join(repo_root, "space"),
+                target_is_directory=True,
+            )
+            escaped = os.path.join(escaped_parent, "SOURCE_REVISION")
+
+            with self.assertRaisesRegex(
+                dep.DeployContractError, "ancestor must not be a symlink"
+            ):
+                dep.materialize_source_revision_file(
+                    repo_root, "space/SOURCE_REVISION", "a" * 40
+                )
+            self.assertFalse(os.path.exists(escaped))
+
     def test_manifest_smoke_paths_default_to_root(self):
         manifest, _ = self._derive(
             "FROM scratch\nCOPY app.py /app/app.py\n",

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: "Dockerfile"
+      source-revision-file:
+        description: "Optional generated file, covered by Dockerfile COPY, that receives the exact checked-out Git SHA."
+        required: false
+        type: string
+        default: ""
       include-readme:
         description: "Mirror README.md so the Space card remains source-controlled."
         required: false
@@ -160,6 +165,7 @@ jobs:
           HF_REPO: ${{ steps.hf.outputs.hf_repo }}
           DEPLOY_REF: ${{ inputs.ref }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+          SOURCE_REVISION_FILE: ${{ inputs.source-revision-file }}
           INCLUDE_README: ${{ inputs.include-readme }}
           PRUNE: ${{ inputs.prune }}
           REQUIRE_DEFAULT_BRANCH_TIP: ${{ inputs.require-default-branch-tip }}
@@ -173,6 +179,10 @@ jobs:
           if [ "$REQUIRE_DEFAULT_BRANCH_TIP" = "true" ]; then
             TIP_GUARD_ARGS+=(--require-default-branch-tip)
           fi
+          SOURCE_REVISION_ARGS=()
+          if [ -n "$SOURCE_REVISION_FILE" ]; then
+            SOURCE_REVISION_ARGS+=(--source-revision-file "$SOURCE_REVISION_FILE")
+          fi
           python3 tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root caller \
             --github-repo "$GH_REPO" \
@@ -180,6 +190,7 @@ jobs:
             --ref "$DEPLOY_REF" \
             --source-sha "$SOURCE_SHA" \
             --dockerfile-path "$DOCKERFILE_PATH" \
+            "${SOURCE_REVISION_ARGS[@]}" \
             --include-readme "$INCLUDE_README" \
             --smoke-paths "${SMOKE_PATHS}" \
             "${PRUNE_ARGS[@]}" \


### PR DESCRIPTION
Adds a fail-closed optional source-revision-file contract to the canonical Hugging Face deployer.

- writes only an exact lowercase checked-out Git SHA
- rejects existing, escaping, or uncovered paths
- requires Dockerfile COPY coverage
- hashes and attests the generated file in the immutable deployment manifest
- includes focused offline unit and workflow-contract coverage

This is the protected central dependency for szl-holdings/yarqa#30.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>