### PR TITLE
fix(hf): admit exact deployed PR candidates

### DIFF
--- a/.github/scripts/hf_source_bound_baseline.py
+++ b/.github/scripts/hf_source_bound_baseline.py
@@ -10,9 +10,10 @@ identity planes:
 * Dockerfile-managed bytes can be compared at those two immutable revisions.
 
 This verifier observes both live planes more than once with cache bypass, requires
-stable exact values, proves the observed Git source is an ancestor of the pull
-request base, compares the exact deployed pair without an allowlist, and reports
-the candidate's managed-file delta without deploying it. It performs no mutation.
+stable exact values, proves the observed Git source is either an ancestor of the
+pull request base or the exact pull request candidate after controlled deployment,
+compares the exact deployed pair without an allowlist, and reports the candidate's
+managed-file delta without deploying it. It performs no mutation.
 """
 from __future__ import annotations
 
@@ -305,10 +306,16 @@ def source_bound_baseline_compare(args: argparse.Namespace):
         )
     ancestry_status = None
     if drift.FULL_SHA_RE.fullmatch(source_sha) is not None:
-        is_ancestor, ancestry_status = drift.github_ref_is_ancestor(
-            args.github_repo, source_sha, trusted_base_ref
+        source_matches_candidate = bool(
+            candidate_ref and source_sha == candidate_ref
         )
-        if not is_ancestor:
+        if source_matches_candidate:
+            ancestry_status = "exact-candidate"
+        else:
+            is_ancestor, ancestry_status = drift.github_ref_is_ancestor(
+                args.github_repo, source_sha, trusted_base_ref
+            )
+        if not source_matches_candidate and not is_ancestor:
             contract_errors.append(
                 {
                     "path": "(source-probe)",
@@ -316,9 +323,10 @@ def source_bound_baseline_compare(args: argparse.Namespace):
                     "severity": "error",
                     "observed_source_sha": source_sha,
                     "trusted_base_ref": trusted_base_ref,
+                    "candidate_ref": candidate_ref or None,
                     "detail": (
-                        "live build-info source is not an ancestor of the exact pull "
-                        "request base"
+                        "live build-info source is neither an ancestor of the exact "
+                        "pull request base nor the exact pull request candidate"
                     ),
                 }
             )

--- a/.github/scripts/test_hf_source_bound_baseline.py
+++ b/.github/scripts/test_hf_source_bound_baseline.py
@@ -206,6 +206,40 @@ class SourceBoundBaselineTests(unittest.TestCase):
         self.assertFalse(report["allowlist_used"])
         self.assertEqual(candidate["baseline_ref"], self.SOURCE)
 
+    def test_exact_deployed_candidate_is_a_valid_source_bound_baseline(self):
+        calls = self.install_clean()
+        baseline.source_probe_state = lambda _repo, _path: {
+            "observation_status": "stable",
+            "observation_count": 2,
+            "required_observation_count": 2,
+            "source_revision": self.HEAD,
+            "observations": [],
+        }
+        drift.github_ref_is_ancestor = lambda *_args: self.fail(
+            "exact candidate must not require ancestry against the PR base"
+        )
+        drift.candidate_managed_delta = (
+            lambda _repo, baseline_ref, candidate_ref, _dockerfile: {
+                "status": "no-changes",
+                "new_unresolved_sources": [],
+                "delta_count": 0,
+                "deltas": [],
+                "baseline_ref": baseline_ref,
+                "candidate_ref": candidate_ref,
+            }
+        )
+
+        report, errors, warns, candidate = baseline.source_bound_baseline_compare(
+            self.args()
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warns, [])
+        self.assertEqual(calls["refs"], (self.HEAD, self.LIVE))
+        self.assertEqual(report["observed_source_ancestry_status"], "exact-candidate")
+        self.assertEqual(candidate["status"], "no-changes")
+        self.assertEqual(candidate["baseline_ref"], self.HEAD)
+
     def test_split_runtime_or_unstable_probe_fails_closed_without_compare(self):
         self.install_clean()
         drift.hf_space_state = lambda _repo: {
@@ -240,7 +274,7 @@ class SourceBoundBaselineTests(unittest.TestCase):
         self.install_clean()
         drift.github_ref_is_ancestor = lambda *_args: (False, "diverged")
         report, errors, _warns, _candidate = baseline.source_bound_baseline_compare(
-            self.args(candidate=False)
+            self.args()
         )
         self.assertEqual(report["status"], "drift")
         self.assertIn("observed-source-not-ancestor", {item["kind"] for item in errors})


### PR DESCRIPTION
## Summary

- accept a stable live source only when it is an ancestor of the exact PR base or equals the exact PR candidate
- preserve immutable live-HF byte comparison with no allowlist
- add regression coverage for post-deployment candidate closure and unrelated descendant rejection

## Production evidence

A11oy deployment run 31294062204 proved exact candidate ed0f515886134250334331f404ae37ecac3daacf live and operational. The current checker then failed because that exact candidate is not an ancestor of its PR base, while candidate managed delta was zero. This change closes that pre-merge deployment state without accepting any other descendant.

## Validation

- test_hf_source_bound_baseline.py: 11 passed
- py_compile: passed
- git diff --check: passed
- SSH signature verified locally
- DCO trailer present

## Truth boundary

This PR changes read-only verification semantics only. It does not deploy, mutate Hugging Face, waive byte parity, or merge A11oy.