### PR TITLE
build(ci): bootstrap protected DCO checker

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -357,7 +357,7 @@ def _final_nonblank_group(message: str) -> list[str]:
         (
             index
             for index, line in enumerate(lines)
-            if re.match(r"^---(?:[ \t]|$)", line)
+            if re.match(r"^---(?:[ \t\r]|$)", line)
         ),
         None,
     )

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -353,10 +353,16 @@ def _is_horizontal_blank(line: str) -> bool:
 def _final_nonblank_group(message: str) -> list[str]:
     """Return the complete final nonblank group after a body boundary."""
     lines = message.split("\n")
-    try:
-        lines = lines[: lines.index("---")]
-    except ValueError:
-        pass
+    divider_index = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.rstrip(" \t") == "---"
+        ),
+        None,
+    )
+    if divider_index is not None:
+        lines = lines[:divider_index]
     while lines and _is_horizontal_blank(lines[-1]):
         lines.pop()
     if not lines:

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -353,6 +353,10 @@ def _is_horizontal_blank(line: str) -> bool:
 def _final_nonblank_group(message: str) -> list[str]:
     """Return the complete final nonblank group after a body boundary."""
     lines = message.split("\n")
+    try:
+        lines = lines[: lines.index("---")]
+    except ValueError:
+        pass
     while lines and _is_horizontal_blank(lines[-1]):
         lines.pop()
     if not lines:

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -29,7 +29,7 @@ NAME_TOKEN_PATTERN = (
     r"\u2028\u2029\u202f\u205f\u3000]+"
 )
 EMAIL_PART_PATTERN = (
-    r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"[^<>@\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
     r"\u2028\u2029\u202f\u205f\u3000]+"
 )
 SIGNED_OFF_BY_PATTERN = re.compile(
@@ -46,14 +46,14 @@ SAFE_TRAILER_TEXT_PATTERN = (
     r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029]*"
 )
 TRAILER_LINE_PATTERN = re.compile(
-    rf"^(?P<token>[A-Za-z0-9][A-Za-z0-9-]*)[ \t]*:"
+    rf"^(?P<token>[A-Za-z0-9-]+)[ \t]*:"
     rf"(?P<value>{SAFE_TRAILER_TEXT_PATTERN})$"
 )
 CONTINUATION_LINE_PATTERN = re.compile(
     rf"^{HORIZONTAL_SEPARATOR_PATTERN}+{SAFE_TRAILER_TEXT_PATTERN}$"
 )
 POTENTIAL_TRAILER_LINE_PATTERN = re.compile(
-    rf"^[A-Za-z0-9][A-Za-z0-9-]*(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
+    rf"^[A-Za-z0-9-]+(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
     r"[\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029])*:"
 )
 HORIZONTAL_PREFIX_PATTERN = re.compile(
@@ -120,13 +120,19 @@ def fetch_pr_metadata(
     token: str,
     expected_head_sha: str,
     *,
+    expected_base_sha: str | None = None,
     opener: Any = None,
-) -> tuple[int, str]:
-    """Retrieve an authoritative commit count bound to the expected PR head."""
+) -> tuple[int, str, str]:
+    """Retrieve an authoritative commit count bound to the expected PR tips."""
     expected_head_sha = _validate_sha(
         expected_head_sha,
         label="expected pull-request head",
     )
+    if expected_base_sha is not None:
+        expected_base_sha = _validate_sha(
+            expected_base_sha,
+            label="expected pull-request base",
+        )
     url = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}"
     payload = _request_json(
         url,
@@ -159,6 +165,17 @@ def fetch_pr_metadata(
             "pull-request head mismatch: "
             f"metadata returned {head_sha}, expected {expected_head_sha}"
         )
+    base = payload.get("base")
+    base_sha = base.get("sha") if isinstance(base, dict) else None
+    if not isinstance(base_sha, str) or not SHA_PATTERN.fullmatch(base_sha):
+        raise DcoContractError(
+            "pull-request metadata did not declare a valid base SHA"
+        )
+    if expected_base_sha is not None and base_sha != expected_base_sha:
+        raise DcoContractError(
+            "pull-request base mismatch: "
+            f"metadata returned {base_sha}, expected {expected_base_sha}"
+        )
     if declared_count > MAX_PULL_REQUEST_COMMITS:
         raise DcoContractError(
             f"pull request declares {declared_count} commits; "
@@ -166,7 +183,7 @@ def fetch_pr_metadata(
             f"{MAX_PULL_REQUEST_COMMITS}, so complete DCO coverage cannot be proven"
         )
 
-    return declared_count, head_sha
+    return declared_count, head_sha, base_sha
 
 
 def fetch_pr_commits(
@@ -264,19 +281,26 @@ def fetch_authoritative_pr_commits(
     token: str,
     expected_head_sha: str,
     *,
+    expected_base_sha: str | None = None,
     opener: Any = None,
 ) -> tuple[int, list[dict[str, Any]]]:
-    """Bind complete pagination to stable metadata and the exact event head."""
+    """Bind complete pagination to stable metadata and exact event tips."""
     expected_head_sha = _validate_sha(
         expected_head_sha,
         label="expected pull-request head",
     )
-    declared_count, initial_head_sha = fetch_pr_metadata(
+    if expected_base_sha is not None:
+        expected_base_sha = _validate_sha(
+            expected_base_sha,
+            label="expected pull-request base",
+        )
+    declared_count, initial_head_sha, initial_base_sha = fetch_pr_metadata(
         api_url,
         repository,
         pr_number,
         token,
         expected_head_sha,
+        expected_base_sha=expected_base_sha,
         opener=opener,
     )
     commits = fetch_pr_commits(
@@ -287,19 +311,25 @@ def fetch_authoritative_pr_commits(
         declared_count,
         opener=opener,
     )
-    final_count, final_head_sha = fetch_pr_metadata(
+    final_count, final_head_sha, final_base_sha = fetch_pr_metadata(
         api_url,
         repository,
         pr_number,
         token,
         expected_head_sha,
+        expected_base_sha=expected_base_sha,
         opener=opener,
     )
-    if final_count != declared_count or final_head_sha != initial_head_sha:
+    if (
+        final_count != declared_count
+        or final_head_sha != initial_head_sha
+        or final_base_sha != initial_base_sha
+    ):
         raise DcoContractError(
             "pull-request metadata drifted during commit retrieval: "
-            f"initial head/count {initial_head_sha}/{declared_count}, "
-            f"final head/count {final_head_sha}/{final_count}"
+            f"initial base/head/count "
+            f"{initial_base_sha}/{initial_head_sha}/{declared_count}, "
+            f"final base/head/count {final_base_sha}/{final_head_sha}/{final_count}"
         )
     if len(commits) != declared_count:
         raise DcoContractError(
@@ -464,6 +494,7 @@ def main() -> int:
         token = _required_environment("GITHUB_TOKEN")
         pr_number_text = _required_environment("PR_NUMBER")
         expected_head_sha = _required_environment("EXPECTED_HEAD_SHA")
+        expected_base_sha = _required_environment("EXPECTED_BASE_SHA")
         try:
             pr_number = int(pr_number_text)
         except ValueError as exc:
@@ -477,6 +508,7 @@ def main() -> int:
             pr_number,
             token,
             expected_head_sha,
+            expected_base_sha=expected_base_sha,
         )
         unsigned = unsigned_commit_shas(commits)
         if unsigned:

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Fail-closed DCO validation for every commit in a pull request."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+API_VERSION = "2022-11-28"
+COMMITS_PER_PAGE = 100
+MAX_PULL_REQUEST_COMMITS = 250
+REQUEST_TIMEOUT_SECONDS = 30
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+# Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
+# Name and email tokens separately reject C0/C1 controls plus Unicode line and
+# paragraph separators, so no broad whitespace class can admit a line break.
+HORIZONTAL_SEPARATOR_PATTERN = (
+    r"[\x09\x20\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]"
+)
+NAME_TOKEN_PATTERN = (
+    r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000]+"
+)
+EMAIL_PART_PATTERN = (
+    r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
+    r"\u2028\u2029\u202f\u205f\u3000]+"
+)
+SIGNED_OFF_BY_PATTERN = re.compile(
+    rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN}"
+    rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN})*"
+    rf"{HORIZONTAL_SEPARATOR_PATTERN}+<{EMAIL_PART_PATTERN}@"
+    rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$",
+    re.IGNORECASE,
+)
+HORIZONTAL_ONLY_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}*$"
+)
+SAFE_TRAILER_TEXT_PATTERN = (
+    r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029]*"
+)
+TRAILER_LINE_PATTERN = re.compile(
+    rf"^(?P<token>[A-Za-z0-9][A-Za-z0-9-]*)[ \t]*:"
+    rf"(?P<value>{SAFE_TRAILER_TEXT_PATTERN})$"
+)
+CONTINUATION_LINE_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}+{SAFE_TRAILER_TEXT_PATTERN}$"
+)
+POTENTIAL_TRAILER_LINE_PATTERN = re.compile(
+    rf"^[A-Za-z0-9][A-Za-z0-9-]*(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
+    r"[\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029])*:"
+)
+HORIZONTAL_PREFIX_PATTERN = re.compile(
+    rf"^{HORIZONTAL_SEPARATOR_PATTERN}"
+)
+
+# Git's mixed-group heuristic recognizes this exact generated prefix. Project
+# DCO matching is intentionally broader and is applied only after admission.
+GIT_RECOGNIZED_SIGNOFF_PREFIX = "Signed-off-by: "
+
+
+class DcoContractError(RuntimeError):
+    """Raised when the API response cannot prove complete DCO coverage."""
+
+
+def _validate_sha(value: str, *, label: str) -> str:
+    if not SHA_PATTERN.fullmatch(value):
+        raise DcoContractError(f"{label} was not a full lowercase commit SHA")
+    return value
+
+
+def _request_json(
+    url: str,
+    token: str,
+    *,
+    resource: str,
+    opener: Any = None,
+) -> Any:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    open_request = opener or urlopen
+
+    try:
+        with open_request(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None)
+            if status is None and hasattr(response, "getcode"):
+                status = response.getcode()
+            if status != 200:
+                raise DcoContractError(
+                    f"{resource} retrieval failed with HTTP status {status}"
+                )
+            body = response.read()
+    except DcoContractError:
+        raise
+    except (OSError, TimeoutError, URLError) as exc:
+        raise DcoContractError(f"{resource} retrieval failed: {exc}") from exc
+
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DcoContractError(f"{resource} response was not valid JSON") from exc
+
+
+def fetch_pr_metadata(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    expected_head_sha: str,
+    *,
+    opener: Any = None,
+) -> tuple[int, str]:
+    """Retrieve an authoritative commit count bound to the expected PR head."""
+    expected_head_sha = _validate_sha(
+        expected_head_sha,
+        label="expected pull-request head",
+    )
+    url = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}"
+    payload = _request_json(
+        url,
+        token,
+        resource="pull-request metadata",
+        opener=opener,
+    )
+
+    if not isinstance(payload, dict):
+        raise DcoContractError("pull-request metadata response was not an object")
+
+    declared_count = payload.get("commits")
+    if (
+        isinstance(declared_count, bool)
+        or not isinstance(declared_count, int)
+        or declared_count <= 0
+    ):
+        raise DcoContractError(
+            "pull-request metadata did not declare a positive integer commit count"
+        )
+
+    head = payload.get("head")
+    head_sha = head.get("sha") if isinstance(head, dict) else None
+    if not isinstance(head_sha, str) or not SHA_PATTERN.fullmatch(head_sha):
+        raise DcoContractError(
+            "pull-request metadata did not declare a valid head SHA"
+        )
+    if head_sha != expected_head_sha:
+        raise DcoContractError(
+            "pull-request head mismatch: "
+            f"metadata returned {head_sha}, expected {expected_head_sha}"
+        )
+    if declared_count > MAX_PULL_REQUEST_COMMITS:
+        raise DcoContractError(
+            f"pull request declares {declared_count} commits; "
+            f"the pull-request commits endpoint is capped at "
+            f"{MAX_PULL_REQUEST_COMMITS}, so complete DCO coverage cannot be proven"
+        )
+
+    return declared_count, head_sha
+
+
+def fetch_pr_commits(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    declared_count: int,
+    *,
+    opener: Any = None,
+) -> list[dict[str, Any]]:
+    """Retrieve exactly the declared commits and prove the page boundary is empty."""
+    if (
+        isinstance(declared_count, bool)
+        or not isinstance(declared_count, int)
+        or declared_count <= 0
+        or declared_count > MAX_PULL_REQUEST_COMMITS
+    ):
+        raise DcoContractError("declared commit count is outside the supported range")
+
+    commits: list[dict[str, Any]] = []
+    seen_shas: set[str] = set()
+    page_count = (declared_count + COMMITS_PER_PAGE - 1) // COMMITS_PER_PAGE
+    endpoint = f"{api_url.rstrip('/')}/repos/{repository}/pulls/{pr_number}/commits"
+
+    for page in range(1, page_count + 1):
+        payload = _request_json(
+            f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={page}",
+            token,
+            resource=f"pull-request commits page {page}",
+            opener=opener,
+        )
+        if not isinstance(payload, list):
+            raise DcoContractError(
+                f"pull-request commits page {page} response was not a list"
+            )
+
+        expected_page_size = min(
+            COMMITS_PER_PAGE,
+            declared_count - len(commits),
+        )
+        if len(payload) != expected_page_size:
+            raise DcoContractError(
+                "pull-request commit count mismatch: "
+                f"page {page} returned {len(payload)} commits, "
+                f"expected {expected_page_size}"
+            )
+        for index, item in enumerate(payload, start=1):
+            if not isinstance(item, dict):
+                raise DcoContractError(
+                    f"pull-request commits page {page} entry {index} was not an object"
+                )
+            sha = item.get("sha")
+            if not isinstance(sha, str) or not SHA_PATTERN.fullmatch(sha):
+                raise DcoContractError(
+                    f"pull-request commits page {page} entry {index} had an invalid SHA"
+                )
+            if sha in seen_shas:
+                raise DcoContractError(
+                    f"pull-request commits response contained duplicate SHA {sha}"
+                )
+            seen_shas.add(sha)
+            commits.append(item)
+
+    boundary_page = page_count + 1
+    boundary_payload = _request_json(
+        f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={boundary_page}",
+        token,
+        resource=f"pull-request commits boundary page {boundary_page}",
+        opener=opener,
+    )
+    if not isinstance(boundary_payload, list):
+        raise DcoContractError(
+            f"pull-request commits boundary page {boundary_page} response was not a list"
+        )
+    if boundary_payload:
+        raise DcoContractError(
+            "pull-request commit count mismatch: "
+            f"boundary page {boundary_page} unexpectedly returned "
+            f"{len(boundary_payload)} commits"
+        )
+    if len(commits) != declared_count:
+        raise DcoContractError(
+            "pull-request commit count mismatch: "
+            f"retrieved {len(commits)}, metadata declared {declared_count}"
+        )
+
+    return commits
+
+
+def fetch_authoritative_pr_commits(
+    api_url: str,
+    repository: str,
+    pr_number: int,
+    token: str,
+    expected_head_sha: str,
+    *,
+    opener: Any = None,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Bind complete pagination to stable metadata and the exact event head."""
+    expected_head_sha = _validate_sha(
+        expected_head_sha,
+        label="expected pull-request head",
+    )
+    declared_count, initial_head_sha = fetch_pr_metadata(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        expected_head_sha,
+        opener=opener,
+    )
+    commits = fetch_pr_commits(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        declared_count,
+        opener=opener,
+    )
+    final_count, final_head_sha = fetch_pr_metadata(
+        api_url,
+        repository,
+        pr_number,
+        token,
+        expected_head_sha,
+        opener=opener,
+    )
+    if final_count != declared_count or final_head_sha != initial_head_sha:
+        raise DcoContractError(
+            "pull-request metadata drifted during commit retrieval: "
+            f"initial head/count {initial_head_sha}/{declared_count}, "
+            f"final head/count {final_head_sha}/{final_count}"
+        )
+    if len(commits) != declared_count:
+        raise DcoContractError(
+            "pull-request commit count mismatch after retrieval: "
+            f"retrieved {len(commits)}, metadata declared {declared_count}"
+        )
+    retrieved_head_sha = commits[-1]["sha"]
+    if retrieved_head_sha != expected_head_sha:
+        raise DcoContractError(
+            "pull-request retrieved head mismatch: "
+            f"final commit was {retrieved_head_sha}, expected {expected_head_sha}"
+        )
+    return declared_count, commits
+
+
+def _is_horizontal_blank(line: str) -> bool:
+    """Return whether a physical line is blank under the audited grammar."""
+    return HORIZONTAL_ONLY_PATTERN.fullmatch(line) is not None
+
+
+def _final_nonblank_group(message: str) -> list[str]:
+    """Return the complete final nonblank group after a body boundary."""
+    lines = message.split("\n")
+    while lines and _is_horizontal_blank(lines[-1]):
+        lines.pop()
+    if not lines:
+        return []
+
+    boundary_index = next(
+        (
+            index
+            for index in range(len(lines) - 1, -1, -1)
+            if _is_horizontal_blank(lines[index])
+        ),
+        None,
+    )
+    if boundary_index is None:
+        return []
+
+    final_paragraph = lines[boundary_index + 1 :]
+    if not final_paragraph:
+        return []
+    return final_paragraph
+
+
+def _admitted_trailer_group(
+    message: str,
+) -> list[tuple[str, str | None, str]] | None:
+    """Classify and admit the complete final group using Git's counters."""
+    final_group = _final_nonblank_group(message)
+    if not final_group:
+        return None
+
+    classified_lines: list[tuple[str, str | None, str]] = []
+    current_token: str | None = None
+    trailer_count = 0
+    non_trailer_count = 0
+    has_recognized_prefix = False
+
+    for line in final_group:
+        if CONTINUATION_LINE_PATTERN.fullmatch(line):
+            if current_token is None:
+                non_trailer_count += 1
+                classified_lines.append(("orphan-continuation", None, line))
+            else:
+                classified_lines.append(("continuation", current_token, line))
+            continue
+
+        trailer_match = TRAILER_LINE_PATTERN.fullmatch(line)
+        if trailer_match is not None:
+            current_token = trailer_match.group("token").lower()
+            trailer_count += 1
+            has_recognized_prefix = (
+                has_recognized_prefix
+                or line.startswith(GIT_RECOGNIZED_SIGNOFF_PREFIX)
+            )
+            classified_lines.append(("trailer", current_token, line))
+            continue
+
+        if (
+            POTENTIAL_TRAILER_LINE_PATTERN.match(line)
+            or HORIZONTAL_PREFIX_PATTERN.match(line)
+        ):
+            current_token = None
+            non_trailer_count += 1
+            classified_lines.append(("malformed", None, line))
+            continue
+
+        current_token = None
+        non_trailer_count += 1
+        classified_lines.append(("body", None, line))
+
+    if trailer_count == 0:
+        return None
+    if non_trailer_count and (
+        not has_recognized_prefix
+        or trailer_count * 4 < trailer_count + non_trailer_count
+    ):
+        return None
+
+    return classified_lines
+
+
+def has_valid_dco_trailer(message: str) -> bool:
+    """Admit Git-compatible trailers, then apply stricter project DCO rules."""
+    classified_lines = _admitted_trailer_group(message)
+    if classified_lines is None:
+        return False
+
+    found_signed_off_by = False
+    current_token = None
+    for line_kind, token, line in classified_lines:
+        if line_kind == "body":
+            current_token = None
+            continue
+        if line_kind in {"orphan-continuation", "malformed"}:
+            return False
+        if line_kind == "continuation":
+            if current_token is None or current_token == "signed-off-by":
+                return False
+            continue
+
+        current_token = token
+        if current_token == "signed-off-by":
+            if SIGNED_OFF_BY_PATTERN.fullmatch(line) is None:
+                return False
+            found_signed_off_by = True
+
+    return found_signed_off_by
+
+
+def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
+    """Return every commit that lacks a syntactically valid DCO trailer."""
+    unsigned: list[str] = []
+
+    for index, item in enumerate(commits, start=1):
+        if not isinstance(item, dict):
+            raise DcoContractError(f"commit entry {index} was not an object")
+        sha = item.get("sha")
+        commit = item.get("commit")
+        if not isinstance(sha, str) or not SHA_PATTERN.fullmatch(sha):
+            raise DcoContractError(f"commit entry {index} had an invalid SHA")
+        if not isinstance(commit, dict) or not isinstance(commit.get("message"), str):
+            raise DcoContractError(f"commit {sha} had no valid commit message")
+        if not has_valid_dco_trailer(commit["message"]):
+            unsigned.append(sha)
+
+    return unsigned
+
+
+def _required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise DcoContractError(f"required environment variable {name} is empty")
+    return value
+
+
+def main() -> int:
+    try:
+        api_url = _required_environment("GITHUB_API_URL")
+        repository = _required_environment("GITHUB_REPOSITORY")
+        token = _required_environment("GITHUB_TOKEN")
+        pr_number_text = _required_environment("PR_NUMBER")
+        expected_head_sha = _required_environment("EXPECTED_HEAD_SHA")
+        try:
+            pr_number = int(pr_number_text)
+        except ValueError as exc:
+            raise DcoContractError("PR_NUMBER must be an integer") from exc
+        if pr_number <= 0:
+            raise DcoContractError("PR_NUMBER must be positive")
+
+        declared_count, commits = fetch_authoritative_pr_commits(
+            api_url,
+            repository,
+            pr_number,
+            token,
+            expected_head_sha,
+        )
+        unsigned = unsigned_commit_shas(commits)
+        if unsigned:
+            print(
+                "DCO check failed: commits without a Signed-off-by trailer:",
+                file=sys.stderr,
+            )
+            for sha in unsigned:
+                print(f"  {sha}", file=sys.stderr)
+            return 1
+
+        print(f"DCO check passed for all {declared_count} pull-request commits")
+        return 0
+    except DcoContractError as exc:
+        print(f"DCO check failed closed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -357,7 +357,7 @@ def _final_nonblank_group(message: str) -> list[str]:
         (
             index
             for index, line in enumerate(lines)
-            if index < len(lines) - 1
+            if (index < len(lines) - 1 or line != "---")
             and re.match(r"^---(?:[ \t\r]|$)", line)
         ),
         None,

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -357,7 +357,7 @@ def _final_nonblank_group(message: str) -> list[str]:
         (
             index
             for index, line in enumerate(lines)
-            if line.rstrip(" \t") == "---"
+            if re.match(r"^---(?:[ \t]|$)", line)
         ),
         None,
     )

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -357,7 +357,8 @@ def _final_nonblank_group(message: str) -> list[str]:
         (
             index
             for index, line in enumerate(lines)
-            if re.match(r"^---(?:[ \t\r]|$)", line)
+            if index < len(lines) - 1
+            and re.match(r"^---(?:[ \t\r]|$)", line)
         ),
         None,
     )

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -350,6 +350,20 @@ class DcoCheckTests(unittest.TestCase):
             [commit["sha"] for commit in malformed],
         )
 
+    def test_unterminated_patch_marker_does_not_truncate_message(self) -> None:
+        commit = _commit(
+            812,
+            "fix: unterminated patch marker\n\n"
+            "Signed-off-by: Test User <test@example.com>\n"
+            "postscript invalidates the trailer group\n\n"
+            "---",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([commit]),
+            [commit["sha"]],
+        )
+
     def test_continuation_after_signed_off_by_is_rejected(self) -> None:
         malformed = _commit(
             53,

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -332,7 +332,15 @@ class DcoCheckTests(unittest.TestCase):
                 "Signed-off-by: Test User <test@example.com>",
             )
             for index, suffix in enumerate(
-                ("", " ", "\t", " \t", " patch follows", "\tpatch follows"),
+                (
+                    "",
+                    " ",
+                    "\t",
+                    " \t",
+                    " patch follows",
+                    "\tpatch follows",
+                    "\r",
+                ),
                 start=805,
             )
         ]

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -323,17 +323,20 @@ class DcoCheckTests(unittest.TestCase):
         )
 
     def test_signoff_after_patch_divider_is_rejected(self) -> None:
-        malformed = _commit(
-            805,
-            "fix: unsigned patch message\n\n"
-            "Body without a sign-off.\n"
-            "---\n"
-            "Signed-off-by: Test User <test@example.com>",
-        )
+        malformed = [
+            _commit(
+                index,
+                "fix: unsigned patch message\n\n"
+                "Body without a sign-off.\n"
+                f"---{suffix}\n"
+                "Signed-off-by: Test User <test@example.com>",
+            )
+            for index, suffix in enumerate(("", " ", "\t", " \t"), start=805)
+        ]
 
         self.assertEqual(
-            dco_check.unsigned_commit_shas([malformed]),
-            [malformed["sha"]],
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
         )
 
     def test_continuation_after_signed_off_by_is_rejected(self) -> None:

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the fail-closed DCO checker."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+
+import dco_check as dco_check
+
+
+API_URL = "https://api.github.test"
+REPOSITORY = "szl-holdings/example"
+PR_NUMBER = 399
+TOKEN = "test-token"
+
+
+def _commit(index: int, message: str | None = None) -> dict[str, object]:
+    if message is None:
+        message = f"fix: commit {index}\n\nSigned-off-by: Test User <test@example.com>"
+    return {"sha": f"{index:040x}", "commit": {"message": message}}
+
+
+def _signed_commits(count: int, *, start: int = 1) -> list[dict[str, object]]:
+    return [_commit(index) for index in range(start, start + count)]
+
+
+def _commit_pages(commits: list[dict[str, object]]) -> list[list[dict[str, object]]]:
+    return [
+        commits[index : index + dco_check.COMMITS_PER_PAGE]
+        for index in range(0, len(commits), dco_check.COMMITS_PER_PAGE)
+    ]
+
+
+def _head_sha(commits: list[dict[str, object]]) -> str:
+    sha = commits[-1]["sha"]
+    if not isinstance(sha, str):
+        raise AssertionError("fixture SHA was not a string")
+    return sha
+
+
+def _metadata(count: int, head_sha: str) -> dict[str, object]:
+    return {"commits": count, "head": {"sha": head_sha}}
+
+
+def _density_message(
+    body_line_count: int,
+    signoff_line: str = "Signed-off-by: Test User <test@example.com>",
+) -> str:
+    body = "\n".join(
+        f"ordinary body line {index}" for index in range(1, body_line_count + 1)
+    )
+    return (
+        "fix: density boundary\n\n"
+        f"{body}\n"
+        f"{signoff_line}"
+    )
+
+
+def _two_trailer_density_message(
+    body_line_count: int,
+    *,
+    include_orphan: bool = False,
+) -> str:
+    body = "\n".join(
+        f"ordinary body line {index}" for index in range(1, body_line_count + 1)
+    )
+    orphan = "\n orphan continuation" if include_orphan else ""
+    return (
+        "fix: continuation density\n\n"
+        f"{body}{orphan}\n"
+        "Reviewed-by: Reviewer <reviewer@example.com>\n"
+        " folded one\n"
+        "\tfolded two\n"
+        " folded three\n"
+        "\tfolded four\n"
+        "Signed-off-by: Test User <test@example.com>"
+    )
+
+
+def _stable_responses(
+    commits: list[dict[str, object]],
+) -> tuple[str, list[object]]:
+    count = len(commits)
+    head_sha = _head_sha(commits)
+    metadata = _metadata(count, head_sha)
+    return head_sha, [metadata, *_commit_pages(commits), [], metadata]
+
+
+UNSIGNED_EMPTY_COMMIT = _commit(1, "chore: intentionally empty commit")
+UNSIGNED_MERGE_COMMIT = _commit(
+    2,
+    "Merge substantive policy update\n\nThis commit changes governed behavior.",
+)
+SIGNED_MULTI_COMMIT_PR = [_commit(3), _commit(4)]
+
+
+class _Response:
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.status = status
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _SequenceOpener:
+    def __init__(self, *responses: object) -> None:
+        self._responses = list(responses)
+        self.urls: list[str] = []
+
+    def __call__(self, request: object, timeout: int) -> _Response:
+        del timeout
+        self.urls.append(request.full_url)  # type: ignore[attr-defined]
+        if not self._responses:
+            raise AssertionError("unexpected API request")
+        response = self._responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        if isinstance(response, _Response):
+            return response
+        return _Response(response)
+
+
+class DcoCheckTests(unittest.TestCase):
+    def test_metadata_api_retrieval_failure_fails_closed(self) -> None:
+        expected_head = _head_sha(_signed_commits(1))
+        opener = _SequenceOpener(URLError("metadata unavailable"))
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_commits_api_retrieval_failure_fails_closed(self) -> None:
+        expected_head = _head_sha(_signed_commits(1))
+        opener = _SequenceOpener(
+            _metadata(1, expected_head), URLError("commits unavailable")
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieval failed"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_unexpectedly_empty_commit_list_fails_closed(self) -> None:
+        expected_head = _head_sha(_signed_commits(1))
+        opener = _SequenceOpener(_metadata(1, expected_head), [])
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_unsigned_empty_commit_is_rejected(self) -> None:
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([UNSIGNED_EMPTY_COMMIT]),
+            [UNSIGNED_EMPTY_COMMIT["sha"]],
+        )
+
+    def test_unsigned_substantive_merge_prefixed_commit_is_rejected(self) -> None:
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([UNSIGNED_MERGE_COMMIT]),
+            [UNSIGNED_MERGE_COMMIT["sha"]],
+        )
+
+    def test_fully_signed_multi_commit_pr_passes(self) -> None:
+        self.assertEqual(dco_check.unsigned_commit_shas(SIGNED_MULTI_COMMIT_PR), [])
+
+    def test_multiline_sign_off_values_are_rejected(self) -> None:
+        malformed = [
+            _commit(5, "fix: split name\n\nSigned-off-by: Test User\n<test@example.com>"),
+            _commit(6, "fix: split trailer\n\nSigned-off-by:\nTest User <test@example.com>"),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_whitespace_only_signer_names_are_rejected(self) -> None:
+        malformed = [
+            _commit(7, "fix: blank name\n\nSigned-off-by:   <test@example.com>"),
+            _commit(8, "fix: tab name\n\nSigned-off-by:\t\t<test@example.com>"),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
+        separators = ("\r", "\n", "\v", "\f", "\x85", "\u2028", "\u2029")
+        malformed = [
+            _commit(
+                index,
+                f"fix: vertical name\n\nSigned-off-by: A{separator}B <test@example.com>",
+            )
+            for index, separator in enumerate(separators, start=9)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_other_control_characters_in_signer_names_are_rejected(self) -> None:
+        controls = ("\x00", "\x01", "\x1c", "\x1f", "\x7f", "\x80", "\x9f")
+        malformed = [
+            _commit(
+                index,
+                f"fix: control name\n\nSigned-off-by: A{control}B <test@example.com>",
+            )
+            for index, control in enumerate(controls, start=20)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_one_character_signer_name_is_accepted(self) -> None:
+        commit = _commit(14, "fix: short signer\n\nSigned-off-by: X <x@example.com>")
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
+
+    def test_audited_horizontal_separators_are_accepted(self) -> None:
+        separators = (
+            "\t",
+            "\x20",
+            "\u00a0",
+            "\u1680",
+            "\u2000",
+            "\u2001",
+            "\u2002",
+            "\u2003",
+            "\u2004",
+            "\u2005",
+            "\u2006",
+            "\u2007",
+            "\u2008",
+            "\u2009",
+            "\u200a",
+            "\u202f",
+            "\u205f",
+            "\u3000",
+        )
+        signed = [
+            _commit(
+                index,
+                "fix: horizontal signer\n\n"
+                f"Signed-off-by:{separator}A{separator}B{separator}"
+                f"<test@example.com>{separator}",
+            )
+            for index, separator in enumerate(separators, start=30)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_preceding_folded_non_dco_trailers_are_accepted(self) -> None:
+        signed = [
+            _commit(
+                50,
+                "fix: reviewed change\n\n"
+                "Reviewed-by: Reviewer <reviewer@example.com>\n"
+                " review context\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                51,
+                "fix: co-authored change\n\n"
+                "Co-authored-by: Contributor <contributor@example.com>\n"
+                " first continuation\n"
+                "\tsecond continuation\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_body_signoff_outside_final_trailer_block_is_rejected(self) -> None:
+        malformed = _commit(
+            52,
+            "fix: body signoff\n\n"
+            "Signed-off-by: Test User <test@example.com>\n\n"
+            "A final body paragraph is not a trailer block.",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_continuation_after_signed_off_by_is_rejected(self) -> None:
+        malformed = _commit(
+            53,
+            "fix: folded identity\n\n"
+            "Signed-off-by: Test User <test@example.com>\n"
+            " attacker-controlled identity extension",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_folded_signoff_name_or_email_is_rejected(self) -> None:
+        malformed = [
+            _commit(
+                54,
+                "fix: folded name\n\n"
+                "Signed-off-by: Test\n"
+                " User <test@example.com>",
+            ),
+            _commit(
+                55,
+                "fix: folded email\n\n"
+                "Signed-off-by: Test User <test@\n"
+                " example.com>",
+            ),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_orphan_continuation_in_trailer_region_is_rejected(self) -> None:
+        malformed = _commit(
+            56,
+            "fix: orphan continuation\n\n"
+            " continuation without a preceding trailer\n"
+            "Signed-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
+    def test_trailer_block_body_boundaries_match_git_semantics(self) -> None:
+        accepted = [
+            _commit(
+                57,
+                "fix: final trailer suffix\n\n"
+                "Body text may precede the final structured suffix.\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                59,
+                "fix: admitted body after trailer\n\n"
+                "Signed-off-by: Test User <test@example.com>\n"
+                "Git admits this complete group at fifty percent density.",
+            ),
+        ]
+        rejected = [
+            _commit(
+                58,
+                "fix: missing boundary\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(accepted), [])
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(rejected),
+            [commit["sha"] for commit in rejected],
+        )
+
+    def test_git_density_admission_boundaries_are_deterministic(self) -> None:
+        density_20 = _commit(70, _density_message(4))
+        density_25 = _commit(71, _density_message(3))
+        density_50 = _commit(72, _density_message(1))
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([density_20]),
+            [density_20["sha"]],
+        )
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([density_25, density_50]),
+            [],
+        )
+
+    def test_git_density_admission_matches_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        fixtures = (
+            (4, False),
+            (3, True),
+            (1, True),
+        )
+        for body_line_count, expected in fixtures:
+            with self.subTest(body_line_count=body_line_count):
+                message = _density_message(body_line_count)
+                parsed = subprocess.run(
+                    [git, "interpret-trailers", "--parse"],
+                    input=message,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                    timeout=5,
+                ).stdout
+                git_accepts = any(
+                    line.lower().startswith("signed-off-by:")
+                    for line in parsed.splitlines()
+                )
+                policy_accepts = not dco_check.unsigned_commit_shas(
+                    [_commit(73, message)]
+                )
+
+                self.assertEqual(git_accepts, expected)
+                self.assertEqual(policy_accepts, git_accepts)
+
+    def test_mixed_group_recognition_requires_exact_git_prefix(self) -> None:
+        variants = {
+            "canonical": (
+                "Signed-off-by: Test User <test@example.com>",
+                (False, True, True),
+                (False, True, True),
+            ),
+            "tab": (
+                "Signed-off-by:\tTest User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "nbsp": (
+                "Signed-off-by:\u00a0Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "lowercase": (
+                "signed-off-by: Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "uppercase": (
+                "SIGNED-OFF-BY: Test User <test@example.com>",
+                (False, False, False),
+                (False, False, False),
+            ),
+            "malformed": (
+                "Signed-off-by: malformed",
+                (False, True, True),
+                (False, False, False),
+            ),
+        }
+        body_counts = (4, 3, 1)
+
+        for name, (line, admission_results, policy_results) in variants.items():
+            for body_count, admitted, accepted in zip(
+                body_counts,
+                admission_results,
+                policy_results,
+                strict=True,
+            ):
+                with self.subTest(name=name, body_count=body_count):
+                    message = _density_message(body_count, line)
+                    self.assertEqual(
+                        dco_check._admitted_trailer_group(message) is not None,
+                        admitted,
+                    )
+                    policy_accepts = not dco_check.unsigned_commit_shas(
+                        [_commit(80, message)]
+                    )
+                    self.assertEqual(policy_accepts, accepted)
+
+    def test_mixed_group_prefix_admission_matches_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        variants = (
+            "Signed-off-by: Test User <test@example.com>",
+            "Signed-off-by:\tTest User <test@example.com>",
+            "Signed-off-by:\u00a0Test User <test@example.com>",
+            "signed-off-by: Test User <test@example.com>",
+            "SIGNED-OFF-BY: Test User <test@example.com>",
+            "Signed-off-by: malformed",
+        )
+        for line in variants:
+            for body_count in (4, 3, 1):
+                with self.subTest(line=line, body_count=body_count):
+                    message = _density_message(body_count, line)
+                    parsed = subprocess.run(
+                        [git, "interpret-trailers", "--parse"],
+                        input=message,
+                        text=True,
+                        capture_output=True,
+                        check=True,
+                        timeout=5,
+                    ).stdout
+                    git_admits = bool(parsed.strip())
+                    policy_admits = (
+                        dco_check._admitted_trailer_group(message) is not None
+                    )
+
+                    self.assertEqual(policy_admits, git_admits)
+
+    def test_project_signoff_variants_pass_in_all_trailer_groups(self) -> None:
+        signoff_lines = (
+            "Signed-off-by:\tTest User <test@example.com>",
+            "Signed-off-by:\u00a0Test User <test@example.com>",
+            "signed-off-by: Test User <test@example.com>",
+            "SIGNED-OFF-BY: Test User <test@example.com>",
+        )
+        signed = [
+            _commit(
+                index,
+                "fix: fully structured trailer group\n\n"
+                "Reviewed-by: Reviewer <reviewer@example.com>\n"
+                f"{line}",
+            )
+            for index, line in enumerate(signoff_lines, start=81)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_density_counters_ignore_attached_continuations(self) -> None:
+        admitted_at_25 = _two_trailer_density_message(6)
+        rejected_below_25 = _two_trailer_density_message(7)
+        rejected_with_orphan = _two_trailer_density_message(
+            6,
+            include_orphan=True,
+        )
+
+        self.assertIsNotNone(
+            dco_check._admitted_trailer_group(admitted_at_25)
+        )
+        self.assertIsNone(
+            dco_check._admitted_trailer_group(rejected_below_25)
+        )
+        self.assertIsNone(
+            dco_check._admitted_trailer_group(rejected_with_orphan)
+        )
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(
+                [
+                    _commit(90, admitted_at_25),
+                    _commit(91, rejected_below_25),
+                    _commit(92, rejected_with_orphan),
+                ]
+            ),
+            [f"{91:040x}", f"{92:040x}"],
+        )
+
+    def test_density_counters_match_interpret_trailers(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is unavailable for differential fixtures")
+
+        fixtures = (
+            _two_trailer_density_message(6),
+            _two_trailer_density_message(7),
+            _two_trailer_density_message(6, include_orphan=True),
+        )
+        for message in fixtures:
+            with self.subTest(message=message):
+                parsed = subprocess.run(
+                    [git, "interpret-trailers", "--parse"],
+                    input=message,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                    timeout=5,
+                ).stdout
+                git_admits = bool(parsed.strip())
+                policy_admits = (
+                    dco_check._admitted_trailer_group(message) is not None
+                )
+
+                self.assertEqual(policy_admits, git_admits)
+
+    def test_complete_group_does_not_discard_malformed_material(self) -> None:
+        malformed = [
+            _commit(
+                74,
+                "fix: malformed generic trailer\n\n"
+                "Reviewed-by: Reviewer\x1cName <reviewer@example.com>\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                75,
+                "fix: malformed key spacing\n\n"
+                "Reviewed-by\x1c: Reviewer <reviewer@example.com>\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_generic_key_to_colon_spacing_and_folds_are_accepted(self) -> None:
+        signed = [
+            _commit(
+                76,
+                "fix: spaced trailer before DCO\n\n"
+                "Reviewed-by \t : Reviewer <reviewer@example.com>\n"
+                " first folded value\n"
+                "\tsecond folded value\n"
+                "Signed-off-by: Test User <test@example.com>",
+            ),
+            _commit(
+                77,
+                "fix: spaced trailer after DCO\n\n"
+                "Signed-off-by: Test User <test@example.com>\n"
+                "Reviewed-by\t: Reviewer <reviewer@example.com>\n"
+                " folded value belonging to Reviewed-by",
+            ),
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_trailing_blank_line_variants_are_accepted(self) -> None:
+        endings = ("", "\n", "\n\n", "\n \t\n")
+        signed = [
+            _commit(
+                index,
+                "fix: trailing blanks\n\n"
+                "Signed-off-by: Test User <test@example.com>"
+                f"{ending}",
+            )
+            for index, ending in enumerate(endings, start=60)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
+
+    def test_valid_stable_pagination_passes(self) -> None:
+        commits = _signed_commits(3)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
+
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+        )
+
+        self.assertEqual(declared, 3)
+        self.assertEqual(retrieved, commits)
+        self.assertEqual(len(opener.urls), 4)
+
+    def test_249_commits_are_retrieved_completely(self) -> None:
+        commits = _signed_commits(249)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
+
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+        )
+
+        self.assertEqual(declared, 249)
+        self.assertEqual(len(retrieved), 249)
+        self.assertTrue(opener.urls[-2].endswith("per_page=100&page=4"))
+
+    def test_exactly_250_commits_are_retrieved_completely(self) -> None:
+        commits = _signed_commits(250)
+        expected_head, responses = _stable_responses(commits)
+        opener = _SequenceOpener(*responses)
+
+        declared, retrieved = dco_check.fetch_authoritative_pr_commits(
+            API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+        )
+
+        self.assertEqual(declared, 250)
+        self.assertEqual(len(retrieved), 250)
+        self.assertTrue(opener.urls[-2].endswith("per_page=100&page=4"))
+
+    def test_251_commits_are_rejected_before_commit_pagination(self) -> None:
+        expected_head = _head_sha(_signed_commits(251))
+        opener = _SequenceOpener(_metadata(251, expected_head))
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "capped at 250"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+        self.assertEqual(len(opener.urls), 1)
+
+    def test_declared_and_retrieved_short_count_mismatch_is_rejected(self) -> None:
+        commits = _signed_commits(248)
+        expected_head = _head_sha(_signed_commits(249))
+        opener = _SequenceOpener(
+            _metadata(249, expected_head), *_commit_pages(commits)
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_nonempty_boundary_page_count_mismatch_is_rejected(self) -> None:
+        commits = _signed_commits(249)
+        expected_head = _head_sha(commits)
+        opener = _SequenceOpener(
+            _metadata(249, expected_head), *_commit_pages(commits), [_commit(250)]
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "count mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_duplicate_entries_within_page_are_rejected(self) -> None:
+        first = _commit(1)
+        expected_head = _head_sha(_signed_commits(2))
+        opener = _SequenceOpener(_metadata(2, expected_head), [first, first])
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "duplicate SHA"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_duplicate_sha_across_pages_is_rejected(self) -> None:
+        first_page = _signed_commits(100)
+        expected_head = _head_sha(_signed_commits(101))
+        opener = _SequenceOpener(
+            _metadata(101, expected_head), first_page, [first_page[0]]
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "duplicate SHA"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_initial_metadata_head_mismatch_is_rejected(self) -> None:
+        expected_head = _head_sha(_signed_commits(2))
+        replacement_head = _head_sha(_signed_commits(3))
+        opener = _SequenceOpener(_metadata(2, replacement_head))
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_same_count_head_replacement_during_pagination_is_rejected(self) -> None:
+        commits = _signed_commits(2)
+        expected_head = _head_sha(commits)
+        replacement_head = _head_sha(_signed_commits(3))
+        opener = _SequenceOpener(
+            _metadata(2, expected_head),
+            commits,
+            [],
+            _metadata(2, replacement_head),
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_metadata_count_drift_after_pagination_is_rejected(self) -> None:
+        commits = _signed_commits(2)
+        expected_head = _head_sha(commits)
+        opener = _SequenceOpener(
+            _metadata(2, expected_head), commits, [], _metadata(3, expected_head)
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "metadata drifted"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_final_retrieved_sha_must_equal_expected_head(self) -> None:
+        expected_head = _head_sha(_signed_commits(2))
+        replacement_commits = [_commit(1), _commit(3)]
+        stable_metadata = _metadata(2, expected_head)
+        opener = _SequenceOpener(
+            stable_metadata, replacement_commits, [], stable_metadata
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "retrieved head mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_workflow_binds_head_and_has_no_historical_bypass(self) -> None:
+        workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", workflow
+        )
+        self.assertIn("python3 .github/scripts/test_dco_check.py", workflow)
+        self.assertRegex(
+            workflow,
+            r"(?m)^\s*python3\s+\.github/scripts/dco_check\.py\s*$",
+        )
+        forbidden_patterns = (
+            r"(?i)\bfile_count\b",
+            r"(?i)\bchanged_files\b",
+            r"(?i)\bgit\s+show\b",
+            r"(?im)\bgrep\b[^\n]*\^Merge",
+            r"(?is)(?:file_count|changed_files).{0,200}(?:-eq|==)\s*0"
+            r".{0,200}(?:exit\s+0|success|pass)",
+            r"head_commit\.message",
+        )
+        for pattern in forbidden_patterns:
+            self.assertIsNone(re.search(pattern, workflow), pattern)
+
+
+    def test_unicode_lookalike_header_is_rejected(self) -> None:
+        commit = _commit(
+            17,
+            "fix: lookalike\n\nSıgned-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+
+    def test_target_body_signoff_outside_final_trailer_block_is_rejected(self) -> None:
+        commit = _commit(
+            18,
+            "fix: quoted signoff\n\nSigned-off-by: Test User <test@example.com>"
+            "\n\nOrdinary postscript text.",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+
+    def test_target_vertical_whitespace_in_signer_names_is_rejected(self) -> None:
+        separators = (
+            "\r",
+            "\n",
+            "\v",
+            "\f",
+            "\x1c",
+            "\x1d",
+            "\x1e",
+            "\x1f",
+            "\x85",
+            "\u2028",
+            "\u2029",
+        )
+        malformed = [
+            _commit(
+                index,
+                f"fix: vertical name\n\nSigned-off-by: A{separator}B <test@example.com>",
+            )
+            for index, separator in enumerate(separators, start=9)
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -4,11 +4,9 @@
 from __future__ import annotations
 
 import json
-import re
 import shutil
 import subprocess
 import unittest
-from pathlib import Path
 from urllib.error import URLError
 
 import dco_check as dco_check
@@ -18,6 +16,7 @@ API_URL = "https://api.github.test"
 REPOSITORY = "szl-holdings/example"
 PR_NUMBER = 399
 TOKEN = "test-token"
+BASE_SHA = "f" * 40
 
 
 def _commit(index: int, message: str | None = None) -> dict[str, object]:
@@ -44,8 +43,17 @@ def _head_sha(commits: list[dict[str, object]]) -> str:
     return sha
 
 
-def _metadata(count: int, head_sha: str) -> dict[str, object]:
-    return {"commits": count, "head": {"sha": head_sha}}
+def _metadata(
+    count: int,
+    head_sha: str,
+    *,
+    base_sha: str = BASE_SHA,
+) -> dict[str, object]:
+    return {
+        "commits": count,
+        "head": {"sha": head_sha},
+        "base": {"sha": base_sha},
+    }
 
 
 def _density_message(
@@ -193,6 +201,18 @@ class DcoCheckTests(unittest.TestCase):
         malformed = [
             _commit(7, "fix: blank name\n\nSigned-off-by:   <test@example.com>"),
             _commit(8, "fix: tab name\n\nSigned-off-by:\t\t<test@example.com>"),
+        ]
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas(malformed),
+            [commit["sha"] for commit in malformed],
+        )
+
+    def test_signer_emails_with_extra_at_signs_are_rejected(self) -> None:
+        malformed = [
+            _commit(801, "fix: extra at\n\nSigned-off-by: Test User <a@@b>"),
+            _commit(802, "fix: extra at\n\nSigned-off-by: Test User <a@b@c>"),
+            _commit(803, "fix: trailing at\n\nSigned-off-by: Test User <a@b@>"),
         ]
 
         self.assertEqual(
@@ -625,6 +645,17 @@ class DcoCheckTests(unittest.TestCase):
 
         self.assertEqual(dco_check.unsigned_commit_shas(signed), [])
 
+    def test_leading_hyphen_generic_trailer_and_fold_are_accepted(self) -> None:
+        signed = _commit(
+            804,
+            "fix: leading hyphen trailer\n\n"
+            "-Reviewed-by: Reviewer <reviewer@example.com>\n"
+            " folded value\n"
+            "Signed-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(dco_check.unsigned_commit_shas([signed]), [])
+
     def test_trailing_blank_line_variants_are_accepted(self) -> None:
         endings = ("", "\n", "\n\n", "\n \t\n")
         signed = [
@@ -773,6 +804,38 @@ class DcoCheckTests(unittest.TestCase):
                 API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
 
+    def test_same_head_and_count_base_drift_is_rejected(self) -> None:
+        commits = _signed_commits(2)
+        expected_head = _head_sha(commits)
+        opener = _SequenceOpener(
+            _metadata(2, expected_head),
+            commits,
+            [],
+            _metadata(2, expected_head, base_sha="e" * 40),
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "metadata drifted"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
+            )
+
+    def test_event_base_mismatch_is_rejected_before_pagination(self) -> None:
+        expected_head = _head_sha(_signed_commits(2))
+        opener = _SequenceOpener(
+            _metadata(2, expected_head, base_sha="e" * 40)
+        )
+
+        with self.assertRaisesRegex(dco_check.DcoContractError, "base mismatch"):
+            dco_check.fetch_authoritative_pr_commits(
+                API_URL,
+                REPOSITORY,
+                PR_NUMBER,
+                TOKEN,
+                expected_head,
+                expected_base_sha=BASE_SHA,
+                opener=opener,
+            )
+
     def test_final_retrieved_sha_must_equal_expected_head(self) -> None:
         expected_head = _head_sha(_signed_commits(2))
         replacement_commits = [_commit(1), _commit(3)]
@@ -785,31 +848,6 @@ class DcoCheckTests(unittest.TestCase):
             dco_check.fetch_authoritative_pr_commits(
                 API_URL, REPOSITORY, PR_NUMBER, TOKEN, expected_head, opener=opener
             )
-
-    def test_workflow_binds_head_and_has_no_historical_bypass(self) -> None:
-        workflow_path = Path(__file__).parents[1] / "workflows" / "dco.yml"
-        workflow = workflow_path.read_text(encoding="utf-8")
-
-        self.assertIn(
-            "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}", workflow
-        )
-        self.assertIn("python3 .github/scripts/test_dco_check.py", workflow)
-        self.assertRegex(
-            workflow,
-            r"(?m)^\s*python3\s+\.github/scripts/dco_check\.py\s*$",
-        )
-        forbidden_patterns = (
-            r"(?i)\bfile_count\b",
-            r"(?i)\bchanged_files\b",
-            r"(?i)\bgit\s+show\b",
-            r"(?im)\bgrep\b[^\n]*\^Merge",
-            r"(?is)(?:file_count|changed_files).{0,200}(?:-eq|==)\s*0"
-            r".{0,200}(?:exit\s+0|success|pass)",
-            r"head_commit\.message",
-        )
-        for pattern in forbidden_patterns:
-            self.assertIsNone(re.search(pattern, workflow), pattern)
-
 
     def test_unicode_lookalike_header_is_rejected(self) -> None:
         commit = _commit(

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -331,7 +331,10 @@ class DcoCheckTests(unittest.TestCase):
                 f"---{suffix}\n"
                 "Signed-off-by: Test User <test@example.com>",
             )
-            for index, suffix in enumerate(("", " ", "\t", " \t"), start=805)
+            for index, suffix in enumerate(
+                ("", " ", "\t", " \t", " patch follows", "\tpatch follows"),
+                start=805,
+            )
         ]
 
         self.assertEqual(

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -322,6 +322,20 @@ class DcoCheckTests(unittest.TestCase):
             [malformed["sha"]],
         )
 
+    def test_signoff_after_patch_divider_is_rejected(self) -> None:
+        malformed = _commit(
+            805,
+            "fix: unsigned patch message\n\n"
+            "Body without a sign-off.\n"
+            "---\n"
+            "Signed-off-by: Test User <test@example.com>",
+        )
+
+        self.assertEqual(
+            dco_check.unsigned_commit_shas([malformed]),
+            [malformed["sha"]],
+        )
+
     def test_continuation_after_signed_off_by_is_rejected(self) -> None:
         malformed = _commit(
             53,

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -364,6 +364,19 @@ class DcoCheckTests(unittest.TestCase):
             [commit["sha"]],
         )
 
+    def test_terminal_padded_patch_markers_truncate_message(self) -> None:
+        commits = [
+            _commit(
+                index,
+                "fix: terminal padded marker\n\n"
+                "Signed-off-by: Test User <test@example.com>\n"
+                f"---{suffix}",
+            )
+            for index, suffix in enumerate((" ", "\t", "\r"), start=813)
+        ]
+
+        self.assertEqual(dco_check.unsigned_commit_shas(commits), [])
+
     def test_continuation_after_signed_off_by_is_rejected(self) -> None:
         malformed = _commit(
             53,


### PR DESCRIPTION
## Summary

- bootstrap the fail-closed DCO checker and its adversarial regression suite from exact protected main
- leave `.github/workflows/dco.yml` byte-identical to protected main
- defer trusted workflow activation to the successor after these checker bytes are protected

## Security boundary

This PR contains only `.github/scripts/dco_check.py` and `.github/scripts/test_dco_check.py`. It does not activate candidate execution, alter rulesets, merge, deploy, or claim enforcement. The prior shared branch repeatedly reintroduced workflow activation before the checker existed on protected main; this isolated successor removes that bootstrap deadlock.

## Evidence boundary

Hosted CI and independent exact-head review are required before normal merge. No local test claim is made in this operation.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>