### PR TITLE
feat: bootstrap trusted multi-event DCO checker

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -3,12 +3,16 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
+import subprocess
 import sys
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 from urllib.error import URLError
+from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 
@@ -17,6 +21,8 @@ COMMITS_PER_PAGE = 100
 MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+QUEUE_REF_PREFIX = "refs/heads/gh-readonly-queue/main/"
+ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review"}
 
 # Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
 # Name and email tokens separately reject C0/C1 controls plus Unicode line and
@@ -37,6 +43,14 @@ SIGNED_OFF_BY_PATTERN = re.compile(
     rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN})*"
     rf"{HORIZONTAL_SEPARATOR_PATTERN}+<{EMAIL_PART_PATTERN}@"
     rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$",
+    re.IGNORECASE,
+)
+SIGNED_OFF_BY_IDENTITY_PATTERN = re.compile(
+    rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+"
+    rf"(?P<name>{NAME_TOKEN_PATTERN}(?:{HORIZONTAL_SEPARATOR_PATTERN}+"
+    rf"{NAME_TOKEN_PATTERN})*){HORIZONTAL_SEPARATOR_PATTERN}+"
+    rf"<(?P<email>{EMAIL_PART_PATTERN}@{EMAIL_PART_PATTERN})>"
+    rf"{HORIZONTAL_SEPARATOR_PATTERN}*$",
     re.IGNORECASE,
 )
 HORIZONTAL_ONLY_PATTERN = re.compile(
@@ -67,6 +81,22 @@ GIT_RECOGNIZED_SIGNOFF_PREFIX = "Signed-off-by: "
 
 class DcoContractError(RuntimeError):
     """Raised when the API response cannot prove complete DCO coverage."""
+
+
+DcoError = DcoContractError
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise DcoContractError(message)
+
+
+def require_sha(value: object, label: str) -> str:
+    require(
+        isinstance(value, str) and bool(SHA_PATTERN.fullmatch(value)),
+        f"{label} is invalid",
+    )
+    return value
 
 
 def _validate_sha(value: str, *, label: str) -> str:
@@ -491,6 +521,316 @@ def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
     return unsigned
 
 
+def git(
+    repo: Path,
+    *args: str,
+    input_text: str | None = None,
+    check: bool = True,
+) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if check and completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise DcoContractError(f"git {' '.join(args)} failed: {detail}")
+    return completed.stdout
+
+
+def normalized_identity(name: str, email: str) -> tuple[str, str]:
+    return " ".join(name.split()).casefold(), email.strip().casefold()
+
+
+def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
+    require_sha(sha, "commit SHA")
+    raw = git(repo, "show", "-s", "--format=%P%x00%an%x00%ae%x00%B", sha)
+    fields = raw.split("\x00", 3)
+    require(len(fields) == 4, f"commit metadata is incomplete for {sha}")
+    parents = fields[0].strip().split()
+    return parents, fields[1], fields[2], fields[3]
+
+
+def terminal_signoffs(repo: Path, message: str) -> list[tuple[str, str]]:
+    parsed = git(repo, "interpret-trailers", "--parse", input_text=message)
+    signoffs: list[tuple[str, str]] = []
+    for line in parsed.splitlines():
+        match = SIGNED_OFF_BY_IDENTITY_PATTERN.fullmatch(line)
+        if match is not None:
+            signoffs.append(
+                normalized_identity(match.group("name"), match.group("email"))
+            )
+    return signoffs
+
+
+def validate_commit(
+    repo: Path,
+    sha: str,
+    *,
+    allow_merge_commit: bool = False,
+) -> None:
+    parents, author_name, author_email, message = commit_record(repo, sha)
+    allowed_parent_counts = {1, 2} if allow_merge_commit else {1}
+    require(
+        len(parents) in allowed_parent_counts,
+        f"{sha} has an unsupported parent count: {len(parents)}",
+    )
+    author = normalized_identity(author_name, author_email)
+    signoffs = terminal_signoffs(repo, message)
+    require(signoffs, f"{sha} has no valid terminal Signed-off-by trailer")
+    require(author in signoffs, f"{sha} Signed-off-by does not match the commit author")
+
+
+def checked_out_head(repo: Path) -> str:
+    return require_sha(git(repo, "rev-parse", "HEAD").strip(), "checked-out HEAD")
+
+
+def validate_commits(
+    repo: Path,
+    shas: list[str],
+    expected_head: str,
+    *,
+    allow_merge_commits: bool = False,
+    checked_out_head_sha: str | None = None,
+) -> int:
+    require(shas, "candidate commit set is empty")
+    require(len(shas) == len(set(shas)), "candidate commit set contains duplicate SHAs")
+    require(shas[-1] == expected_head, "last candidate commit does not match expected head")
+    expected_checkout = checked_out_head_sha or expected_head
+    require(
+        checked_out_head(repo) == expected_checkout,
+        "checked-out HEAD does not match expected head",
+    )
+    for sha in shas:
+        validate_commit(repo, sha, allow_merge_commit=allow_merge_commits)
+    return len(shas)
+
+
+def validate_range(repo: Path, base_sha: str, head_sha: str) -> int:
+    base_sha = require_sha(base_sha, "base SHA")
+    head_sha = require_sha(head_sha, "head SHA")
+    require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match event head")
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    require(ancestor.returncode == 0, "base SHA is not an ancestor of head SHA")
+    shas = [
+        line.strip()
+        for line in git(repo, "rev-list", "--reverse", f"{base_sha}..{head_sha}").splitlines()
+        if line.strip()
+    ]
+    return validate_commits(repo, shas, head_sha)
+
+
+def github_get(path: str, token: str) -> Any:
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    request = Request(
+        api_url + path,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "szl-dco-attestor/2",
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    with urlopen(request, timeout=20) as response:
+        require(response.status == 200, f"GitHub API returned HTTP {response.status}")
+        require(response.geturl().startswith(api_url + "/"), "GitHub API redirected")
+        data = response.read(2_000_001)
+    require(len(data) <= 2_000_000, "GitHub API response is too large")
+    return json.loads(data)
+
+
+def collect_pr_commits(
+    repository: str,
+    number: int,
+    expected_base: str,
+    expected_head: str,
+    api_get: Callable[[str], Any],
+) -> list[str]:
+    expected_base = require_sha(expected_base, "pull-request base SHA")
+    expected_head = require_sha(expected_head, "pull-request head SHA")
+    encoded_repo = quote(repository, safe="/")
+    metadata_path = f"/repos/{encoded_repo}/pulls/{number}"
+
+    def stable_metadata() -> int:
+        current = api_get(metadata_path)
+        require(isinstance(current, dict), "pull-request metadata is not an object")
+        base = current.get("base")
+        head = current.get("head")
+        require(isinstance(base, dict) and isinstance(head, dict), "pull-request refs are missing")
+        require(base.get("sha") == expected_base, "pull-request base moved during validation")
+        require(head.get("sha") == expected_head, "pull-request head moved during validation")
+        declared = current.get("commits")
+        require(
+            isinstance(declared, int)
+            and not isinstance(declared, bool)
+            and 0 < declared <= MAX_PULL_REQUEST_COMMITS,
+            "pull-request commit count is outside the supported range",
+        )
+        require(current.get("draft") is False, "draft pull requests cannot satisfy DCO")
+        return declared
+
+    declared_count = stable_metadata()
+    rows: list[dict[str, Any]] = []
+    page_count = (declared_count + COMMITS_PER_PAGE - 1) // COMMITS_PER_PAGE
+    endpoint = f"/repos/{encoded_repo}/pulls/{number}/commits"
+    for page in range(1, page_count + 1):
+        batch = api_get(f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={page}")
+        require(isinstance(batch, list), "pull-request commit page is not an array")
+        expected_size = min(COMMITS_PER_PAGE, declared_count - len(rows))
+        require(
+            len(batch) == expected_size,
+            "pull-request commit page differs from the declared count",
+        )
+        require(all(isinstance(item, dict) for item in batch), "commit page row is invalid")
+        rows.extend(batch)
+    boundary = api_get(
+        f"{endpoint}?per_page={COMMITS_PER_PAGE}&page={page_count + 1}"
+    )
+    require(
+        isinstance(boundary, list) and not boundary,
+        "pull-request commit boundary page was not empty",
+    )
+    require(
+        stable_metadata() == declared_count,
+        "pull-request commit count changed during validation",
+    )
+    shas = [require_sha(item.get("sha"), "pull-request commit SHA") for item in rows]
+    require(len(shas) == len(set(shas)), "retrieved commits contain duplicate SHAs")
+    require(shas and shas[-1] == expected_head, "retrieved commits do not end at expected head")
+    return shas
+
+
+def merge_group_subject(payload: dict[str, Any], github_sha: str) -> tuple[str, str]:
+    require(payload.get("action") == "checks_requested", "merge_group action is not checks_requested")
+    group = payload.get("merge_group")
+    require(isinstance(group, dict), "merge_group payload is missing")
+    require(group.get("base_ref") == "refs/heads/main", "merge_group base_ref is not main")
+    head_ref = group.get("head_ref")
+    require(
+        isinstance(head_ref, str) and head_ref.startswith(QUEUE_REF_PREFIX),
+        "merge_group head_ref is outside the protected queue namespace",
+    )
+    base_sha = require_sha(group.get("base_sha"), "merge_group base SHA")
+    head_sha = require_sha(group.get("head_sha"), "merge_group head SHA")
+    require(
+        head_sha == require_sha(github_sha, "GITHUB_SHA"),
+        "merge_group head differs from GITHUB_SHA",
+    )
+    return base_sha, head_sha
+
+
+def validate_merge_group(repo: Path, base_sha: str, head_sha: str) -> int:
+    base_sha = require_sha(base_sha, "merge-group base SHA")
+    head_sha = require_sha(head_sha, "merge-group head SHA")
+    require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match merge-group head")
+    parents, _, _, _ = commit_record(repo, head_sha)
+    require(len(parents) == 2, "merge-group head is not a two-parent synthetic merge")
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    require(ancestor.returncode == 0, "merge-group base SHA is not an ancestor of head SHA")
+    range_shas = [
+        line.strip()
+        for line in git(repo, "rev-list", "--reverse", f"{base_sha}..{head_sha}").splitlines()
+        if line.strip()
+    ]
+    require(range_shas and range_shas[-1] == head_sha, "merge-group range does not end at head")
+    candidate_shas = range_shas[:-1]
+    require(candidate_shas, "merge-group contains no constituent commits")
+    return validate_commits(
+        repo,
+        candidate_shas,
+        candidate_shas[-1],
+        allow_merge_commits=True,
+        checked_out_head_sha=head_sha,
+    )
+
+
+def push_subject(payload: dict[str, Any], github_sha: str) -> tuple[str, str]:
+    require(payload.get("ref") == "refs/heads/main", "push ref is not main")
+    base_sha = require_sha(payload.get("before"), "push before SHA")
+    head_sha = require_sha(payload.get("after"), "push after SHA")
+    require(head_sha == require_sha(github_sha, "GITHUB_SHA"), "push head differs from GITHUB_SHA")
+    return base_sha, head_sha
+
+
+def validate_pull_request_target(
+    repo: Path,
+    payload: dict[str, Any],
+    repository: str,
+    token: str,
+    api_get: Callable[[str], Any] | None = None,
+    *,
+    expected_base_sha: str | None = None,
+    expected_head_sha: str | None = None,
+) -> int:
+    require(payload.get("action") in ALLOWED_PR_ACTIONS, "pull_request_target action is unsupported")
+    require(
+        isinstance(payload.get("repository"), dict)
+        and payload["repository"].get("full_name") == repository,
+        "event repository does not match GITHUB_REPOSITORY",
+    )
+    pr = payload.get("pull_request")
+    require(isinstance(pr, dict), "pull_request payload is missing")
+    base = pr.get("base")
+    head = pr.get("head")
+    require(isinstance(base, dict) and isinstance(head, dict), "pull-request refs are missing")
+    require(base.get("ref") == "main", "pull-request base ref is not main")
+    base_sha = require_sha(base.get("sha"), "pull-request base SHA")
+    head_sha = require_sha(head.get("sha"), "pull-request head SHA")
+    if expected_base_sha is not None:
+        require(
+            base_sha == require_sha(expected_base_sha, "expected pull-request base SHA"),
+            "pull-request base differs from EXPECTED_BASE_SHA",
+        )
+    if expected_head_sha is not None:
+        require(
+            head_sha == require_sha(expected_head_sha, "expected pull-request head SHA"),
+            "pull-request head differs from EXPECTED_HEAD_SHA",
+        )
+    number = pr.get("number") or payload.get("number")
+    require(isinstance(number, int) and number > 0, "pull-request number is invalid")
+    require(bool(token), "GITHUB_TOKEN is required for trusted PR validation")
+    getter = api_get or (lambda path: github_get(path, token))
+    shas = collect_pr_commits(repository, number, base_sha, head_sha, getter)
+    require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match event head")
+    merge_base = require_sha(
+        git(repo, "merge-base", base_sha, head_sha).strip(),
+        "pull-request merge base",
+    )
+    local_shas = [
+        line.strip()
+        for line in git(repo, "rev-list", "--reverse", f"{merge_base}..{head_sha}").splitlines()
+        if line.strip()
+    ]
+    require(
+        local_shas == shas,
+        "pull-request API commit set differs from the checked-out history",
+    )
+    return validate_commits(repo, shas, head_sha, allow_merge_commits=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--event-path", type=Path, required=True)
+    return parser.parse_args()
+
+
 def _required_environment(name: str) -> str:
     value = os.environ.get(name, "").strip()
     if not value:
@@ -500,41 +840,36 @@ def _required_environment(name: str) -> str:
 
 def main() -> int:
     try:
-        api_url = _required_environment("GITHUB_API_URL")
+        args = parse_args()
+        payload = json.loads(args.event_path.read_text(encoding="utf-8"))
+        require(isinstance(payload, dict), "event payload must be an object")
+        event_name = _required_environment("GITHUB_EVENT_NAME")
+        github_sha = _required_environment("GITHUB_SHA")
         repository = _required_environment("GITHUB_REPOSITORY")
-        token = _required_environment("GITHUB_TOKEN")
-        pr_number_text = _required_environment("PR_NUMBER")
-        expected_head_sha = _required_environment("EXPECTED_HEAD_SHA")
-        expected_base_sha = _required_environment("EXPECTED_BASE_SHA")
-        try:
-            pr_number = int(pr_number_text)
-        except ValueError as exc:
-            raise DcoContractError("PR_NUMBER must be an integer") from exc
-        if pr_number <= 0:
-            raise DcoContractError("PR_NUMBER must be positive")
+        repo = args.repo_root.resolve()
 
-        declared_count, commits = fetch_authoritative_pr_commits(
-            api_url,
-            repository,
-            pr_number,
-            token,
-            expected_head_sha,
-            expected_base_sha=expected_base_sha,
-        )
-        unsigned = unsigned_commit_shas(commits)
-        if unsigned:
-            print(
-                "DCO check failed: commits without a Signed-off-by trailer:",
-                file=sys.stderr,
+        if event_name == "pull_request_target":
+            count = validate_pull_request_target(
+                repo,
+                payload,
+                repository,
+                _required_environment("GITHUB_TOKEN"),
+                expected_base_sha=_required_environment("EXPECTED_BASE_SHA"),
+                expected_head_sha=_required_environment("EXPECTED_HEAD_SHA"),
             )
-            for sha in unsigned:
-                print(f"  {sha}", file=sys.stderr)
-            return 1
+        elif event_name == "merge_group":
+            base_sha, head_sha = merge_group_subject(payload, github_sha)
+            count = validate_merge_group(repo, base_sha, head_sha)
+        elif event_name == "push":
+            base_sha, head_sha = push_subject(payload, github_sha)
+            count = validate_range(repo, base_sha, head_sha)
+        else:
+            raise DcoContractError(f"unsupported event: {event_name!r}")
 
-        print(f"DCO check passed for all {declared_count} pull-request commits")
+        print(f"DCO OK: validated {count} exact commit(s) for {event_name}")
         return 0
-    except DcoContractError as exc:
-        print(f"DCO check failed closed: {exc}", file=sys.stderr)
+    except (DcoContractError, json.JSONDecodeError, OSError) as exc:
+        print(f"DCO FAILED: {type(exc).__name__}: {exc}", file=sys.stderr)
         return 1
 
 

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import subprocess
 import tempfile
 import unittest
@@ -241,7 +242,7 @@ class DcoCheckTests(unittest.TestCase):
         self.assert_rejected("not main", dco.push_subject, {**payload, "ref": "refs/heads/dev"}, head)
 
     def test_pr_pagination_boundaries_and_freshness(self) -> None:
-        for count in (249, 250, 251):
+        for count in (249, 250):
             shas = [f"{number + 1:040x}" for number in range(count)]
 
             def api_get(path: str, rows=shas):
@@ -263,12 +264,35 @@ class DcoCheckTests(unittest.TestCase):
                 shas,
             )
 
+        rejected = [f"{number + 1:040x}" for number in range(251)]
+
+        def over_limit(path: str):
+            if "/commits?" in path:
+                raise AssertionError("commit pages must not be fetched over the cap")
+            return {
+                "base": {"sha": "a" * 40},
+                "head": {"sha": rejected[-1]},
+                "commits": len(rejected),
+                "draft": False,
+            }
+
+        self.assert_rejected(
+            "supported range",
+            dco.collect_pr_commits,
+            "szl-holdings/.github",
+            400,
+            "a" * 40,
+            rejected[-1],
+            over_limit,
+        )
+
     def test_pr_duplicate_and_count_churn_fail(self) -> None:
         head = "b" * 40
 
         def duplicate(path: str):
             if "/commits?" in path:
-                return [{"sha": head}, {"sha": head}]
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": head}, {"sha": head}] if page == 1 else []
             return {"base": {"sha": "a" * 40}, "head": {"sha": head}, "commits": 2, "draft": False}
 
         self.assert_rejected(
@@ -281,10 +305,20 @@ class DcoCheckTests(unittest.TestCase):
             duplicate,
         )
 
+        metadata_calls = 0
+
         def churn(path: str):
+            nonlocal metadata_calls
             if "/commits?" in path:
-                return [{"sha": head}]
-            return {"base": {"sha": "a" * 40}, "head": {"sha": head}, "commits": 2, "draft": False}
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": head}] if page == 1 else []
+            metadata_calls += 1
+            return {
+                "base": {"sha": "a" * 40},
+                "head": {"sha": head},
+                "commits": 1 if metadata_calls == 1 else 2,
+                "draft": False,
+            }
 
         self.assert_rejected(
             "count changed",
@@ -315,7 +349,8 @@ class DcoCheckTests(unittest.TestCase):
 
         def complete(path: str):
             if "/commits?" in path:
-                return [{"sha": sha} for sha in shas]
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": sha} for sha in shas] if page == 1 else []
             return {
                 "base": {"sha": self.base},
                 "head": {"sha": merged},
@@ -336,7 +371,8 @@ class DcoCheckTests(unittest.TestCase):
 
         def incomplete(path: str):
             if "/commits?" in path:
-                return [{"sha": merged}]
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": merged}] if page == 1 else []
             return {
                 "base": {"sha": self.base},
                 "head": {"sha": merged},
@@ -375,7 +411,8 @@ class DcoCheckTests(unittest.TestCase):
 
         def complete(path: str):
             if "/commits?" in path:
-                return [{"sha": head}]
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": head}] if page == 1 else []
             return {
                 "base": {"sha": current_base},
                 "head": {"sha": head},

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Executable adversarial contract for the trusted DCO checker."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+
+import dco_check as dco
+
+
+class DcoCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp.name)
+        self.git("init", "-b", "main")
+        self.git("config", "user.name", "Series A Builder")
+        self.git("config", "user.email", "builder@example.com")
+        self.base = self.commit("chore: base\n\nSigned-off-by: Series A Builder <builder@example.com>")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def git(self, *args: str, input_text: str | None = None) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return completed.stdout.strip()
+
+    def commit(
+        self,
+        message: str,
+        name: str = "Series A Builder",
+        email: str = "builder@example.com",
+    ) -> str:
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+        }
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-F", "-"],
+            cwd=self.repo,
+            input=message,
+            text=True,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+        return self.git("rev-parse", "HEAD")
+
+    def assert_rejected(self, pattern: str, function, *args, **kwargs) -> None:
+        with self.assertRaisesRegex(dco.DcoError, pattern):
+            function(*args, **kwargs)
+
+    def test_two_and_five_entry_signed_groups_pass(self) -> None:
+        second = self.commit("fix: one\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.commit("fix: two\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.assertEqual(dco.validate_range(self.repo, self.base, self.git("rev-parse", "HEAD")), 2)
+        for number in range(3):
+            self.commit(
+                f"fix: grouped {number}\n\nSigned-off-by: Series A Builder <builder@example.com>"
+            )
+        self.assertEqual(dco.validate_range(self.repo, self.base, self.git("rev-parse", "HEAD")), 5)
+        self.assertTrue(second)
+
+    def test_unsigned_middle_commit_fails(self) -> None:
+        self.commit("fix: signed\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.commit("fix: unsigned")
+        self.commit("fix: signed again\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.assert_rejected("no valid terminal", dco.validate_range, self.repo, self.base, self.git("rev-parse", "HEAD"))
+
+    def test_author_mismatch_fails(self) -> None:
+        head = self.commit(
+            "fix: mismatch\n\nSigned-off-by: Different Person <other@example.com>"
+        )
+        self.assert_rejected("does not match", dco.validate_range, self.repo, self.base, head)
+
+    def test_malformed_and_body_only_signoffs_fail(self) -> None:
+        malformed = self.commit("fix: malformed\n\nSigned-off-by: no-address")
+        self.assert_rejected("no valid terminal", dco.validate_range, self.repo, self.base, malformed)
+        self.git("reset", "--hard", self.base)
+        body_only = self.commit(
+            "fix: body only\n\nSigned-off-by: Series A Builder <builder@example.com>\n\nNot a trailer block."
+        )
+        self.assert_rejected("no valid terminal", dco.validate_range, self.repo, self.base, body_only)
+
+    def test_unsigned_empty_and_merge_prefixed_commits_do_not_skip(self) -> None:
+        empty = self.commit("chore: empty")
+        self.assert_rejected("no valid terminal", dco.validate_range, self.repo, self.base, empty)
+        self.git("reset", "--hard", self.base)
+        merge_named = self.commit("Merge queue artifact")
+        self.assert_rejected("no valid terminal", dco.validate_range, self.repo, self.base, merge_named)
+
+    def test_empty_range_and_non_ancestor_fail(self) -> None:
+        self.assert_rejected("empty", dco.validate_range, self.repo, self.base, self.base)
+        tree = self.git("rev-parse", f"{self.base}^{{tree}}")
+        unrelated = self.git("commit-tree", tree, input_text="chore: unrelated\n")
+        self.assert_rejected("not an ancestor", dco.validate_range, self.repo, unrelated, self.base)
+
+    def test_signed_two_parent_pr_merge_passes(self) -> None:
+        first = self.commit("fix: first\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        tree = self.git("rev-parse", f"{first}^{{tree}}")
+        message = "fix: synthetic merge\n\nSigned-off-by: Series A Builder <builder@example.com>\n"
+        merged = self.git("commit-tree", tree, "-p", first, "-p", self.base, input_text=message)
+        self.git("reset", "--hard", merged)
+        shas = self.git("rev-list", "--reverse", f"{self.base}..{merged}").splitlines()
+        self.assertEqual(
+            dco.validate_commits(
+                self.repo,
+                shas,
+                merged,
+                allow_merge_commits=True,
+            ),
+            2,
+        )
+        self.assert_rejected("unsupported parent count", dco.validate_range, self.repo, self.base, merged)
+
+    def test_unsigned_second_parent_cannot_hide_behind_signed_pr_merge(self) -> None:
+        first = self.commit("fix: first\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.git("switch", "-c", "unsigned-side", self.base)
+        unsigned = self.commit("fix: unsigned side")
+        self.git("switch", "main")
+        tree = self.git("rev-parse", f"{first}^{{tree}}")
+        message = "fix: synthetic merge\n\nSigned-off-by: Series A Builder <builder@example.com>\n"
+        merged = self.git("commit-tree", tree, "-p", first, "-p", unsigned, input_text=message)
+        self.git("reset", "--hard", merged)
+        shas = self.git("rev-list", "--reverse", f"{self.base}..{merged}").splitlines()
+        self.assert_rejected(
+            "no valid terminal",
+            dco.validate_commits,
+            self.repo,
+            shas,
+            merged,
+            allow_merge_commits=True,
+        )
+
+    def test_octopus_merge_fails_even_for_pr_history(self) -> None:
+        first = self.commit("fix: first\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.git("switch", "-c", "side-one", self.base)
+        side_one = self.commit("fix: side one\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.git("switch", "-c", "side-two", self.base)
+        side_two = self.commit("fix: side two\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        self.git("switch", "main")
+        tree = self.git("rev-parse", f"{first}^{{tree}}")
+        message = "fix: synthetic merge\n\nSigned-off-by: Series A Builder <builder@example.com>\n"
+        merged = self.git(
+            "commit-tree",
+            tree,
+            "-p",
+            first,
+            "-p",
+            side_one,
+            "-p",
+            side_two,
+            input_text=message,
+        )
+        self.git("reset", "--hard", merged)
+        self.assert_rejected(
+            "unsupported parent count",
+            dco.validate_commits,
+            self.repo,
+            [first, merged],
+            merged,
+            allow_merge_commits=True,
+        )
+
+    def test_merge_group_identity_and_hostile_ref_contract(self) -> None:
+        head = self.commit("fix: queue\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        payload = {
+            "action": "checks_requested",
+            "merge_group": {
+                "base_ref": "refs/heads/main",
+                "head_ref": "refs/heads/gh-readonly-queue/main/pr-400-deadbeef",
+                "base_sha": self.base,
+                "head_sha": head,
+            },
+        }
+        self.assertEqual(dco.merge_group_subject(payload, head), (self.base, head))
+        hostile = {**payload, "merge_group": {**payload["merge_group"], "head_ref": "refs/heads/main"}}
+        self.assert_rejected("queue namespace", dco.merge_group_subject, hostile, head)
+        wrong_action = {**payload, "action": "destroy"}
+        self.assert_rejected("checks_requested", dco.merge_group_subject, wrong_action, head)
+        self.assert_rejected("differs", dco.merge_group_subject, payload, "f" * 40)
+
+    def test_merge_group_validates_constituents_not_synthetic_head(self) -> None:
+        candidate = self.commit(
+            "fix: queued change\n\nSigned-off-by: Series A Builder <builder@example.com>"
+        )
+        tree = self.git("rev-parse", f"{candidate}^{{tree}}")
+        queue_head = self.git(
+            "commit-tree",
+            tree,
+            "-p",
+            self.base,
+            "-p",
+            candidate,
+            input_text="Merge queue candidate\n",
+        )
+        self.git("reset", "--hard", queue_head)
+
+        self.assertEqual(
+            dco.validate_merge_group(self.repo, self.base, queue_head),
+            1,
+        )
+
+        self.git("reset", "--hard", self.base)
+        unsigned = self.commit("fix: unsigned queued change")
+        tree = self.git("rev-parse", f"{unsigned}^{{tree}}")
+        unsigned_queue_head = self.git(
+            "commit-tree",
+            tree,
+            "-p",
+            self.base,
+            "-p",
+            unsigned,
+            input_text="Merge queue candidate\n",
+        )
+        self.git("reset", "--hard", unsigned_queue_head)
+        self.assert_rejected(
+            "no valid terminal",
+            dco.validate_merge_group,
+            self.repo,
+            self.base,
+            unsigned_queue_head,
+        )
+
+    def test_push_identity_contract(self) -> None:
+        head = self.commit("fix: push\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        payload = {"ref": "refs/heads/main", "before": self.base, "after": head}
+        self.assertEqual(dco.push_subject(payload, head), (self.base, head))
+        self.assert_rejected("not main", dco.push_subject, {**payload, "ref": "refs/heads/dev"}, head)
+
+    def test_pr_pagination_boundaries_and_freshness(self) -> None:
+        for count in (249, 250, 251):
+            shas = [f"{number + 1:040x}" for number in range(count)]
+
+            def api_get(path: str, rows=shas):
+                if "/commits?" in path:
+                    page = int(path.rsplit("page=", 1)[1])
+                    start = (page - 1) * 100
+                    return [{"sha": sha} for sha in rows[start : start + 100]]
+                return {
+                    "base": {"sha": "a" * 40},
+                    "head": {"sha": rows[-1]},
+                    "commits": len(rows),
+                    "draft": False,
+                }
+
+            self.assertEqual(
+                dco.collect_pr_commits(
+                    "szl-holdings/.github", 400, "a" * 40, shas[-1], api_get
+                ),
+                shas,
+            )
+
+    def test_pr_duplicate_and_count_churn_fail(self) -> None:
+        head = "b" * 40
+
+        def duplicate(path: str):
+            if "/commits?" in path:
+                return [{"sha": head}, {"sha": head}]
+            return {"base": {"sha": "a" * 40}, "head": {"sha": head}, "commits": 2, "draft": False}
+
+        self.assert_rejected(
+            "duplicate",
+            dco.collect_pr_commits,
+            "szl-holdings/.github",
+            400,
+            "a" * 40,
+            head,
+            duplicate,
+        )
+
+        def churn(path: str):
+            if "/commits?" in path:
+                return [{"sha": head}]
+            return {"base": {"sha": "a" * 40}, "head": {"sha": head}, "commits": 2, "draft": False}
+
+        self.assert_rejected(
+            "count changed",
+            dco.collect_pr_commits,
+            "szl-holdings/.github",
+            400,
+            "a" * 40,
+            head,
+            churn,
+        )
+
+    def test_pr_history_allows_signed_merge_and_requires_graph_parity(self) -> None:
+        first = self.commit("fix: first\n\nSigned-off-by: Series A Builder <builder@example.com>")
+        tree = self.git("rev-parse", f"{first}^{{tree}}")
+        message = "fix: reconcile main\n\nSigned-off-by: Series A Builder <builder@example.com>\n"
+        merged = self.git("commit-tree", tree, "-p", first, "-p", self.base, input_text=message)
+        self.git("reset", "--hard", merged)
+        shas = self.git("rev-list", "--reverse", f"{self.base}..{merged}").splitlines()
+        payload = {
+            "action": "synchronize",
+            "repository": {"full_name": "szl-holdings/.github"},
+            "pull_request": {
+                "number": 400,
+                "base": {"ref": "main", "sha": self.base},
+                "head": {"sha": merged},
+            },
+        }
+
+        def complete(path: str):
+            if "/commits?" in path:
+                return [{"sha": sha} for sha in shas]
+            return {
+                "base": {"sha": self.base},
+                "head": {"sha": merged},
+                "commits": len(shas),
+                "draft": False,
+            }
+
+        self.assertEqual(
+            dco.validate_pull_request_target(
+                self.repo,
+                payload,
+                "szl-holdings/.github",
+                "token",
+                complete,
+            ),
+            2,
+        )
+
+        def incomplete(path: str):
+            if "/commits?" in path:
+                return [{"sha": merged}]
+            return {
+                "base": {"sha": self.base},
+                "head": {"sha": merged},
+                "commits": 1,
+                "draft": False,
+            }
+
+        self.assert_rejected(
+            "differs from the checked-out history",
+            dco.validate_pull_request_target,
+            self.repo,
+            payload,
+            "szl-holdings/.github",
+            "token",
+            incomplete,
+        )
+
+    def test_pr_history_uses_actual_merge_base_when_main_advances(self) -> None:
+        head = self.commit(
+            "fix: branch work\n\nSigned-off-by: Series A Builder <builder@example.com>"
+        )
+        self.git("reset", "--hard", self.base)
+        current_base = self.commit(
+            "chore: advance main\n\nSigned-off-by: Series A Builder <builder@example.com>"
+        )
+        self.git("reset", "--hard", head)
+        payload = {
+            "action": "synchronize",
+            "repository": {"full_name": "szl-holdings/.github"},
+            "pull_request": {
+                "number": 400,
+                "base": {"ref": "main", "sha": current_base},
+                "head": {"sha": head},
+            },
+        }
+
+        def complete(path: str):
+            if "/commits?" in path:
+                return [{"sha": head}]
+            return {
+                "base": {"sha": current_base},
+                "head": {"sha": head},
+                "commits": 1,
+                "draft": False,
+            }
+
+        self.assertEqual(
+            dco.validate_pull_request_target(
+                self.repo,
+                payload,
+                "szl-holdings/.github",
+                "token",
+                complete,
+            ),
+            1,
+        )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           python-version: "3.12.10"
 
+      - name: DCO bootstrap and event contract self-tests
+        run: |
+          python3 .github/scripts/test_dco_check.py
+          python3 .github/scripts/test_dco_events.py
+
       # A full 40-character ref is not enough for a reusable workflow: the
       # target file can be absent at that exact commit (the a11oy/docs-site
       # pre-merge-pin startup_failure). This network-free test locks three


### PR DESCRIPTION
## Scope

Bootstrap the trusted multi-event DCO checker before workflow activation.

- retains the bounded exact-base/head PR API contract merged in #405
- adds exact checked-out history validation for pull-request, merge-group, and protected-push events
- uses Git trailer parsing plus strict author/sign-off identity validation
- adds the functional multi-event adversarial suite
- does **not** activate `pull_request_target`, `merge_group`, or push workflow wiring

Activation remains independently gated in draft #400 so its trusted-checker checkout can bind to this code from the protected predecessor.