### PR TITLE
fix: bootstrap observed squash queue DCO

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -22,7 +22,7 @@ MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 QUEUE_REF_PREFIX = "refs/heads/gh-readonly-queue/main/"
-ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review"}
+ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review", "edited"}
 
 # Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
 # Name and email tokens separately reject C0/C1 controls plus Unicode line and
@@ -733,8 +733,6 @@ def validate_merge_group(repo: Path, base_sha: str, head_sha: str) -> int:
     base_sha = require_sha(base_sha, "merge-group base SHA")
     head_sha = require_sha(head_sha, "merge-group head SHA")
     require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match merge-group head")
-    parents, _, _, _ = commit_record(repo, head_sha)
-    require(len(parents) == 2, "merge-group head is not a two-parent synthetic merge")
     ancestor = subprocess.run(
         ["git", "merge-base", "--is-ancestor", base_sha, head_sha],
         cwd=repo,
@@ -749,13 +747,19 @@ def validate_merge_group(repo: Path, base_sha: str, head_sha: str) -> int:
         if line.strip()
     ]
     require(range_shas and range_shas[-1] == head_sha, "merge-group range does not end at head")
-    candidate_shas = range_shas[:-1]
-    require(candidate_shas, "merge-group contains no constituent commits")
+    previous_sha = base_sha
+    for sha in range_shas:
+        parents, _, _, _ = commit_record(repo, sha)
+        require(
+            parents == [previous_sha],
+            "merge-group range is not a linear single-parent squash sequence",
+        )
+        previous_sha = sha
     return validate_commits(
         repo,
-        candidate_shas,
-        candidate_shas[-1],
-        allow_merge_commits=True,
+        range_shas,
+        head_sha,
+        allow_merge_commits=False,
         checked_out_head_sha=head_sha,
     )
 
@@ -789,7 +793,17 @@ def validate_pull_request_target(
     base = pr.get("base")
     head = pr.get("head")
     require(isinstance(base, dict) and isinstance(head, dict), "pull-request refs are missing")
-    require(base.get("ref") == "main", "pull-request base ref is not main")
+    base_ref = base.get("ref")
+    require(
+        base_ref == "main"
+        or (
+            isinstance(base_ref, str)
+            and base_ref.startswith("release/")
+            and len(base_ref) > len("release/")
+            and "/" not in base_ref[len("release/") :]
+        ),
+        "pull-request base ref is not governed",
+    )
     base_sha = require_sha(base.get("sha"), "pull-request base SHA")
     head_sha = require_sha(head.get("sha"), "pull-request head SHA")
     if expected_base_sha is not None:

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -193,46 +193,46 @@ class DcoCheckTests(unittest.TestCase):
         self.assert_rejected("checks_requested", dco.merge_group_subject, wrong_action, head)
         self.assert_rejected("differs", dco.merge_group_subject, payload, "f" * 40)
 
-    def test_merge_group_validates_constituents_not_synthetic_head(self) -> None:
-        candidate = self.commit(
-            "fix: queued change\n\nSigned-off-by: Series A Builder <builder@example.com>"
+    def test_merge_group_validates_linear_squash_sequence(self) -> None:
+        first = self.commit(
+            "fix: first queued squash\n\nSigned-off-by: Series A Builder <builder@example.com>"
         )
-        tree = self.git("rev-parse", f"{candidate}^{{tree}}")
-        queue_head = self.git(
-            "commit-tree",
-            tree,
-            "-p",
-            self.base,
-            "-p",
-            candidate,
-            input_text="Merge queue candidate\n",
+        second = self.commit(
+            "fix: second queued squash\n\nSigned-off-by: Series A Builder <builder@example.com>"
         )
-        self.git("reset", "--hard", queue_head)
-
-        self.assertEqual(
-            dco.validate_merge_group(self.repo, self.base, queue_head),
-            1,
-        )
+        self.assertEqual(dco.validate_merge_group(self.repo, self.base, second), 2)
 
         self.git("reset", "--hard", self.base)
         unsigned = self.commit("fix: unsigned queued change")
-        tree = self.git("rev-parse", f"{unsigned}^{{tree}}")
-        unsigned_queue_head = self.git(
-            "commit-tree",
-            tree,
-            "-p",
-            self.base,
-            "-p",
-            unsigned,
-            input_text="Merge queue candidate\n",
-        )
-        self.git("reset", "--hard", unsigned_queue_head)
         self.assert_rejected(
             "no valid terminal",
             dco.validate_merge_group,
             self.repo,
             self.base,
-            unsigned_queue_head,
+            unsigned,
+        )
+
+        self.git("reset", "--hard", first)
+        tree = self.git("rev-parse", f"{first}^{{tree}}")
+        nonlinear_head = self.git(
+            "commit-tree",
+            tree,
+            "-p",
+            first,
+            "-p",
+            self.base,
+            input_text=(
+                "fix: nonlinear queue head\n\n"
+                "Signed-off-by: Series A Builder <builder@example.com>\n"
+            ),
+        )
+        self.git("reset", "--hard", nonlinear_head)
+        self.assert_rejected(
+            "linear single-parent",
+            dco.validate_merge_group,
+            self.repo,
+            self.base,
+            nonlinear_head,
         )
 
     def test_push_identity_contract(self) -> None:
@@ -368,6 +368,62 @@ class DcoCheckTests(unittest.TestCase):
             ),
             2,
         )
+
+        payload["action"] = "edited"
+        self.assertEqual(
+            dco.validate_pull_request_target(
+                self.repo,
+                payload,
+                "szl-holdings/.github",
+                "token",
+                complete,
+            ),
+            2,
+        )
+        payload["action"] = "synchronize"
+
+        payload["pull_request"]["base"]["ref"] = "release/2026.08"
+        self.assertEqual(
+            dco.validate_pull_request_target(
+                self.repo,
+                payload,
+                "szl-holdings/.github",
+                "token",
+                complete,
+            ),
+            2,
+        )
+        payload["pull_request"]["base"]["ref"] = "release/"
+        self.assert_rejected(
+            "not governed",
+            dco.validate_pull_request_target,
+            self.repo,
+            payload,
+            "szl-holdings/.github",
+            "token",
+            complete,
+        )
+        payload["pull_request"]["base"]["ref"] = "release/team/2026.08"
+        self.assert_rejected(
+            "not governed",
+            dco.validate_pull_request_target,
+            self.repo,
+            payload,
+            "szl-holdings/.github",
+            "token",
+            complete,
+        )
+        payload["pull_request"]["base"]["ref"] = "feature/unprotected"
+        self.assert_rejected(
+            "not governed",
+            dco.validate_pull_request_target,
+            self.repo,
+            payload,
+            "szl-holdings/.github",
+            "token",
+            complete,
+        )
+        payload["pull_request"]["base"]["ref"] = "main"
 
         def incomplete(path: str):
             if "/commits?" in path:


### PR DESCRIPTION
## Scope

Bootstrap the observed GitHub squash-queue DCO topology into a protected predecessor before activating the status-reporting workflow in #400.

- updates only `.github/scripts/dco_check.py` and `.github/scripts/test_dco_events.py`
- requires the exact merge-group `base..head` range to be a contiguous single-parent squash sequence
- validates every queued squash commit for terminal DCO author/sign-off identity
- rejects unsigned commits and nonlinear/merge topology
- retains exact event base/head and protected queue-ref binding
- does not activate `pull_request_target`, `merge_group`, status publication, or ruleset changes

## Immutable live evidence

Merge-group runs `31303974084` and `31304031837` produced signed GitHub queue commits `2bb1f67d0cb36e25f3a5fdf362dd5545e789d6b2` and `518bc7f53c9b9621947475aff3341345b46e7c22`. Each had exactly one parent, protected base `480fdf265fd6d35b959419549df7c7da72b59b32`.

Activation remains gated in #400 until this predecessor is independently reviewed, hosted-green, normally merged, and read back from protected `main`.