### PR TITLE
fix(dco): consume protected strict source

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -21,6 +21,7 @@ COMMITS_PER_PAGE = 100
 MAX_PULL_REQUEST_COMMITS = 250
 REQUEST_TIMEOUT_SECONDS = 30
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+PATCH_DIVIDER_PATTERN = re.compile(r"^---(?:[ \t\r]|$)")
 QUEUE_REF_PREFIX = "refs/heads/gh-readonly-queue/main/"
 ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review", "edited"}
 
@@ -39,13 +40,6 @@ EMAIL_PART_PATTERN = (
     r"\u2028\u2029\u202f\u205f\u3000]+"
 )
 SIGNED_OFF_BY_PATTERN = re.compile(
-    rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN}"
-    rf"(?:{HORIZONTAL_SEPARATOR_PATTERN}+{NAME_TOKEN_PATTERN})*"
-    rf"{HORIZONTAL_SEPARATOR_PATTERN}+<{EMAIL_PART_PATTERN}@"
-    rf"{EMAIL_PART_PATTERN}>{HORIZONTAL_SEPARATOR_PATTERN}*$",
-    re.IGNORECASE,
-)
-SIGNED_OFF_BY_IDENTITY_PATTERN = re.compile(
     rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+"
     rf"(?P<name>{NAME_TOKEN_PATTERN}(?:{HORIZONTAL_SEPARATOR_PATTERN}+"
     rf"{NAME_TOKEN_PATTERN})*){HORIZONTAL_SEPARATOR_PATTERN}+"
@@ -59,15 +53,17 @@ HORIZONTAL_ONLY_PATTERN = re.compile(
 SAFE_TRAILER_TEXT_PATTERN = (
     r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029]*"
 )
+TRAILER_TOKEN_PATTERN = r"-*[A-Za-z0-9][A-Za-z0-9-]*"
+TRAILER_TOKEN_FULL_PATTERN = re.compile(rf"^{TRAILER_TOKEN_PATTERN}$")
 TRAILER_LINE_PATTERN = re.compile(
-    rf"^(?P<token>[A-Za-z0-9-]+)[ \t]*:"
+    rf"^(?P<token>{TRAILER_TOKEN_PATTERN})[ \t]*:"
     rf"(?P<value>{SAFE_TRAILER_TEXT_PATTERN})$"
 )
 CONTINUATION_LINE_PATTERN = re.compile(
     rf"^{HORIZONTAL_SEPARATOR_PATTERN}+{SAFE_TRAILER_TEXT_PATTERN}$"
 )
 POTENTIAL_TRAILER_LINE_PATTERN = re.compile(
-    rf"^[A-Za-z0-9-]+(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
+    rf"^{TRAILER_TOKEN_PATTERN}(?:{HORIZONTAL_SEPARATOR_PATTERN}|"
     r"[\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029])*:"
 )
 HORIZONTAL_PREFIX_PATTERN = re.compile(
@@ -380,6 +376,22 @@ def _is_horizontal_blank(line: str) -> bool:
     return HORIZONTAL_ONLY_PATTERN.fullmatch(line) is not None
 
 
+def _is_patch_divider(lines: list[str], index: int) -> bool:
+    """Apply the audited physical-line boundary for a Git patch divider."""
+    line = lines[index]
+    if PATCH_DIVIDER_PATTERN.match(line) is None:
+        return False
+    if line != "---":
+        return True
+
+    # split("\n") leaves one terminal empty element for a final line ending;
+    # that is not a physical line following the exact marker. Two line endings
+    # do create a following empty physical line. A terminal exact marker must
+    # remain message text so it cannot erase an invalid final postscript.
+    remaining = lines[index + 1 :]
+    return bool(remaining and remaining != [""])
+
+
 def _final_nonblank_group(message: str) -> list[str]:
     """Return the complete final nonblank group after a body boundary."""
     lines = message.split("\n")
@@ -387,12 +399,13 @@ def _final_nonblank_group(message: str) -> list[str]:
         (
             index
             for index, line in enumerate(lines)
-            if (index < len(lines) - 1 or line != "---")
-            and re.match(r"^---(?:[ \t\r]|$)", line)
+            if _is_patch_divider(lines, index)
         ),
         None,
     )
     if divider_index is not None:
+        # Git starts the patch area at the first column-zero `---` followed by
+        # space, tab, CR, or end-of-line; trailers there are not in the message.
         lines = lines[:divider_index]
     while lines and _is_horizontal_blank(lines[-1]):
         lines.pop()
@@ -474,32 +487,40 @@ def _admitted_trailer_group(
     return classified_lines
 
 
-def has_valid_dco_trailer(message: str) -> bool:
-    """Admit Git-compatible trailers, then apply stricter project DCO rules."""
+def valid_dco_identities(message: str) -> set[tuple[str, str]]:
+    """Return exact identities from a valid physical-line DCO trailer block."""
     classified_lines = _admitted_trailer_group(message)
     if classified_lines is None:
-        return False
+        return set()
 
-    found_signed_off_by = False
+    identities: set[tuple[str, str]] = set()
     current_token = None
     for line_kind, token, line in classified_lines:
         if line_kind == "body":
             current_token = None
             continue
         if line_kind in {"orphan-continuation", "malformed"}:
-            return False
+            return set()
         if line_kind == "continuation":
             if current_token is None or current_token == "signed-off-by":
-                return False
+                return set()
             continue
 
         current_token = token
         if current_token == "signed-off-by":
-            if SIGNED_OFF_BY_PATTERN.fullmatch(line) is None:
-                return False
-            found_signed_off_by = True
+            signoff_match = SIGNED_OFF_BY_PATTERN.fullmatch(line)
+            if signoff_match is None:
+                return set()
+            identities.add(
+                (signoff_match.group("name"), signoff_match.group("email"))
+            )
 
-    return found_signed_off_by
+    return identities
+
+
+def has_valid_dco_trailer(message: str) -> bool:
+    """Admit Git-compatible trailers, then apply stricter project DCO rules."""
+    return bool(valid_dco_identities(message))
 
 
 def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
@@ -515,7 +536,15 @@ def unsigned_commit_shas(commits: list[dict[str, Any]]) -> list[str]:
             raise DcoContractError(f"commit entry {index} had an invalid SHA")
         if not isinstance(commit, dict) or not isinstance(commit.get("message"), str):
             raise DcoContractError(f"commit {sha} had no valid commit message")
-        if not has_valid_dco_trailer(commit["message"]):
+        author = commit.get("author")
+        if not isinstance(author, dict):
+            raise DcoContractError(f"commit {sha} had no valid author identity")
+        author_name = author.get("name")
+        author_email = author.get("email")
+        if not isinstance(author_name, str) or not isinstance(author_email, str):
+            raise DcoContractError(f"commit {sha} had no valid author identity")
+        identities = valid_dco_identities(commit["message"])
+        if (author_name, author_email) not in identities:
             unsigned.append(sha)
 
     return unsigned
@@ -542,10 +571,6 @@ def git(
     return completed.stdout
 
 
-def normalized_identity(name: str, email: str) -> tuple[str, str]:
-    return " ".join(name.split()).casefold(), email.strip().casefold()
-
-
 def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
     require_sha(sha, "commit SHA")
     raw = git(repo, "show", "-s", "--format=%P%x00%an%x00%ae%x00%B", sha)
@@ -553,18 +578,6 @@ def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
     require(len(fields) == 4, f"commit metadata is incomplete for {sha}")
     parents = fields[0].strip().split()
     return parents, fields[1], fields[2], fields[3]
-
-
-def terminal_signoffs(repo: Path, message: str) -> list[tuple[str, str]]:
-    parsed = git(repo, "interpret-trailers", "--parse", input_text=message)
-    signoffs: list[tuple[str, str]] = []
-    for line in parsed.splitlines():
-        match = SIGNED_OFF_BY_IDENTITY_PATTERN.fullmatch(line)
-        if match is not None:
-            signoffs.append(
-                normalized_identity(match.group("name"), match.group("email"))
-            )
-    return signoffs
 
 
 def validate_commit(
@@ -579,10 +592,12 @@ def validate_commit(
         len(parents) in allowed_parent_counts,
         f"{sha} has an unsupported parent count: {len(parents)}",
     )
-    author = normalized_identity(author_name, author_email)
-    signoffs = terminal_signoffs(repo, message)
-    require(signoffs, f"{sha} has no valid terminal Signed-off-by trailer")
-    require(author in signoffs, f"{sha} Signed-off-by does not match the commit author")
+    identities = valid_dco_identities(message)
+    require(identities, f"{sha} has no valid terminal Signed-off-by trailer")
+    require(
+        (author_name, author_email) in identities,
+        f"{sha} Signed-off-by does not exactly match the commit author",
+    )
 
 
 def checked_out_head(repo: Path) -> str:
@@ -782,7 +797,7 @@ def validate_pull_request_target(
     expected_base_sha: str | None = None,
     expected_head_sha: str | None = None,
 ) -> int:
-    require(payload.get("action") in ALLOWED_PR_ACTIONS, "pull_request_target action is unsupported")
+    require(payload.get("action") in ALLOWED_PR_ACTIONS, "pull-request action is unsupported")
     require(
         isinstance(payload.get("repository"), dict)
         and payload["repository"].get("full_name") == repository,
@@ -862,7 +877,7 @@ def main() -> int:
         repository = _required_environment("GITHUB_REPOSITORY")
         repo = args.repo_root.resolve()
 
-        if event_name == "pull_request_target":
+        if event_name in {"pull_request_target", "pull_request"}:
             count = validate_pull_request_target(
                 repo,
                 payload,

--- a/.github/scripts/run_forge9_gate.py
+++ b/.github/scripts/run_forge9_gate.py
@@ -54,13 +54,18 @@ def run_queue_controller_contract() -> None:
 
 
 def run_dco_contract() -> None:
-    completed = subprocess.run(
-        [sys.executable, ".github/scripts/test_dco_check.py"],
-        cwd=ROOT,
-        check=False,
-    )
-    if completed.returncode:
-        fail("the trusted DCO event and history contract failed")
+    for relative in (
+        ".github/scripts/test_dco_check.py",
+        ".github/scripts/test_dco_events.py",
+        ".github/scripts/test_dco_activation.py",
+    ):
+        completed = subprocess.run(
+            [sys.executable, relative],
+            cwd=ROOT,
+            check=False,
+        )
+        if completed.returncode:
+            fail(f"the trusted DCO contract failed in {relative}")
 
 
 def ground_truth() -> None:
@@ -176,7 +181,9 @@ def verify_all() -> None:
     for relative in (
         ".github/scripts/dco_check.py",
         ".github/scripts/run_forge9_gate.py",
+        ".github/scripts/test_dco_activation.py",
         ".github/scripts/test_dco_check.py",
+        ".github/scripts/test_dco_events.py",
         ".github/scripts/test_merge_queue_enqueue.py",
         ".github/scripts/verify_forge9_governance.py",
         ".governance/forge9_gate_runner.py",

--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -51,6 +51,12 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "--paginate --slurp",
             "trusted/.github/scripts/dco_check.py",
             "Run strict real-commit DCO self-tests",
+            "native-dco-compatibility:",
+            "name: DCO sign-off check",
+            "needs: dco",
+            "if: always() && github.event_name != 'pull_request_target'",
+            "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
+            'test "$NATIVE_DCO_RESULT" = "success"',
         ):
             self.assertIn(marker, self.native)
         self.assertNotIn("\n  pull_request:\n", self.native)
@@ -69,11 +75,18 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "persist-credentials: false",
             "trusted-dco/.github/scripts/dco_check.py",
             "Run strict real-commit DCO self-tests",
+            "reusable-dco-compatibility:",
+            "name: DCO sign-off",
+            "needs: reusable-dco",
+            "REUSABLE_DCO_RESULT: ${{ needs.reusable-dco.result }}",
+            'test "$REUSABLE_DCO_RESULT" = "success"',
         ):
             self.assertIn(marker, self.reusable)
         self.assertNotIn("secrets.", self.reusable)
         self.assertNotIn("secrets: inherit", self.reusable)
         self.assertNotIn("grep ", self.reusable)
+        self.assertEqual(self.reusable.count("name: DCO sign-off\n"), 1)
+        self.assertNotIn("continue-on-error", self.reusable)
 
     def test_source_namespaces_are_distinct_and_legacy_status_survives(self) -> None:
         self.assertNotEqual("Native DCO enforcement", "Reusable DCO validation")
@@ -82,6 +95,8 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.assertIn("name: Reusable DCO validation", self.reusable)
         self.assertNotIn("name: Native DCO enforcement", self.reusable)
         self.assertIn('context="DCO sign-off check"', self.native)
+        self.assertEqual(self.native.count("name: DCO sign-off check\n"), 1)
+        self.assertNotIn("continue-on-error", self.native)
 
     def test_physical_parser_and_bounded_event_contract_are_consumed(self) -> None:
         for marker in (

--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -14,6 +14,12 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.native = (WORKFLOWS / "dco.yml").read_text(encoding="utf-8")
         self.reusable = (WORKFLOWS / "reusable-dco.yml").read_text(encoding="utf-8")
         self.checker = (SCRIPTS / "dco_check.py").read_text(encoding="utf-8")
+        self.forge_verifier = (SCRIPTS / "verify_forge9_governance.py").read_text(
+            encoding="utf-8"
+        )
+        self.forge_runner = (SCRIPTS / "run_forge9_gate.py").read_text(
+            encoding="utf-8"
+        )
 
     def test_native_workflow_preserves_all_governed_event_gates(self) -> None:
         for marker in (
@@ -95,6 +101,28 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.assertNotIn(".governance/ruleset", production_sources)
         self.assertNotIn("ruleset-release.json", production_sources)
         self.assertNotIn("integration_id", production_sources)
+
+    def test_forge9_requires_strict_behavior_not_retired_implementation(self) -> None:
+        self.assertNotIn('"interpret-trailers", "--parse"', self.forge_verifier)
+        for marker in (
+            "PATCH_DIVIDER_PATTERN =",
+            "TRAILER_TOKEN_PATTERN =",
+            "def _is_patch_divider(",
+            "def valid_dco_identities(",
+            "Signed-off-by does not exactly match the commit author",
+            "class RealCommitPhysicalMessageTests",
+            "test_git_density_admission_matches_interpret_trailers",
+            "name: Reusable DCO validation",
+            "repository: ${{ job.workflow_repository }}",
+            "ref: ${{ job.workflow_sha }}",
+        ):
+            self.assertIn(marker, self.forge_verifier)
+        for suite in (
+            ".github/scripts/test_dco_check.py",
+            ".github/scripts/test_dco_events.py",
+            ".github/scripts/test_dco_activation.py",
+        ):
+            self.assertIn(suite, self.forge_runner)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -1,23 +1,29 @@
 #!/usr/bin/env python3
-"""Static contract for activating the trusted multi-event DCO workflow."""
+"""Static contract for the native and reusable trusted DCO producers."""
 
 from pathlib import Path
 import unittest
 
 
+SCRIPTS = Path(__file__).resolve().parent
+WORKFLOWS = SCRIPTS.parent / "workflows"
+
+
 class DcoActivationWorkflowTests(unittest.TestCase):
-    def test_workflow_static_contract(self) -> None:
-        workflow = (
-            Path(__file__).resolve().parents[1] / "workflows" / "dco.yml"
-        ).read_text(encoding="utf-8")
+    def setUp(self) -> None:
+        self.native = (WORKFLOWS / "dco.yml").read_text(encoding="utf-8")
+        self.reusable = (WORKFLOWS / "reusable-dco.yml").read_text(encoding="utf-8")
+        self.checker = (SCRIPTS / "dco_check.py").read_text(encoding="utf-8")
+
+    def test_native_workflow_preserves_all_governed_event_gates(self) -> None:
         for marker in (
+            "name: Native DCO enforcement",
             "pull_request" + "_target:",
             "- main",
             "- 'release/*'",
             "types: [opened, synchronize, reopened, ready_for_review, edited, closed]",
-            "concurrency:",
-            "github.event.pull_request.head.sha",
-            "cancel-in-progress: true",
+            "merge_" + "group:",
+            "types: [checks_requested]",
             "Reconcile surviving DCO status",
             "github.event.before",
             "AFFECTED_HEAD_SHA:",
@@ -25,65 +31,70 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "reconcile-base",
             "reconcile-trusted",
             "dco-reconcile-event.json",
-            "DCO reconciliation in progress",
             "Finalize pull-request DCO failure",
-            "steps.validate_pr.outputs.published",
-            "DCO workflow setup failed",
             "Finalize reconciliation failure",
-            "steps.validate_reconciliation.outputs.published",
-            "DCO reconciliation setup failed",
-            "always()",
-            "merge_" + "group:",
-            "types: [checks_requested]",
             "persist-credentials: false",
-            "format('refs/pull/{0}/head', github.event.pull_request.number)",
             "github.event.pull_request.base.sha",
             "github.event.pull_request.head.sha",
             "EXPECTED_BASE_SHA:",
             "EXPECTED_HEAD_SHA:",
             "statuses: write",
             "statuses/$EXPECTED_HEAD_SHA",
-            'state="pending"',
-            'state="failure"',
-            'exit "$dco_exit"',
+            '-f context="DCO sign-off check"',
             "github.workflow_sha",
-            "EXPECTED_TRUSTED_SHA:",
-            "rev-parse HEAD",
-            "path: protected-base",
-            "EXPECTED_BASE_REF:",
-            'current_pr="$(gh api',
             "--paginate --slurp",
-            'governed_pr_numbers="$(',
-            'shared_head=false',
-            'revalidation_error=false',
-            'current_tuple="$(',
-            'description="DCO live revalidation failed"',
-            'description="DCO head is shared by governed PRs"',
-            'description="DCO event is stale"',
-            "git -C \"$GITHUB_WORKSPACE/candidate\" fetch",
             "trusted/.github/scripts/dco_check.py",
+            "Run strict real-commit DCO self-tests",
         ):
-            self.assertIn(marker, workflow)
-        checker = (Path(__file__).resolve().parent / "dco_check.py").read_text(
-            encoding="utf-8"
-        )
+            self.assertIn(marker, self.native)
+        self.assertNotIn("\n  pull_request:\n", self.native)
+        self.assertNotIn("workflow_" + "dispatch:", self.native)
+
+    def test_reusable_workflow_is_exact_and_secretless(self) -> None:
         for marker in (
+            "name: Reusable DCO validation",
+            "repository: ${{ job.workflow_repository }}",
+            "ref: ${{ job.workflow_sha }}",
+            "GH_TOKEN: ${{ github.token }}",
+            "GITHUB_TOKEN: ${{ github.token }}",
+            "github.event.pull_request.base.sha",
+            "github.event.pull_request.head.sha",
+            "refs/pull/${{ github.event.pull_request.number }}/head",
+            "persist-credentials: false",
+            "trusted-dco/.github/scripts/dco_check.py",
+            "Run strict real-commit DCO self-tests",
+        ):
+            self.assertIn(marker, self.reusable)
+        self.assertNotIn("secrets.", self.reusable)
+        self.assertNotIn("secrets: inherit", self.reusable)
+        self.assertNotIn("grep ", self.reusable)
+
+    def test_source_namespaces_are_distinct_and_legacy_status_survives(self) -> None:
+        self.assertNotEqual("Native DCO enforcement", "Reusable DCO validation")
+        self.assertIn("name: Native DCO enforcement", self.native)
+        self.assertNotIn("name: Reusable DCO validation", self.native)
+        self.assertIn("name: Reusable DCO validation", self.reusable)
+        self.assertNotIn("name: Native DCO enforcement", self.reusable)
+        self.assertIn('context="DCO sign-off check"', self.native)
+
+    def test_physical_parser_and_bounded_event_contract_are_consumed(self) -> None:
+        for marker in (
+            "PATCH_DIVIDER_PATTERN",
+            "TRAILER_TOKEN_PATTERN",
+            "valid_dco_identities",
+            "MAX_PULL_REQUEST_COMMITS = 250",
+            'event_name in {"pull_request_target", "pull_request"}',
             'group.get("base_sha")',
             'group.get("head_sha")',
             '"merge-base", "--is-ancestor"',
-            '"interpret-trailers", "--parse"',
         ):
-            self.assertIn(marker, checker)
-        self.assertNotIn("\n  pull_request:\n", workflow)
-        self.assertNotIn("workflow_" + "dispatch:", workflow)
-        self.assertNotIn("github.event_name != 'pull_request'", workflow)
-        release_ruleset = (
-            Path(__file__).resolve().parents[2]
-            / ".governance"
-            / "ruleset-release.json"
-        ).read_text(encoding="utf-8")
-        self.assertIn('"context": "DCO sign-off check"', release_ruleset)
-        self.assertIn('"integration_id": 15368', release_ruleset)
+            self.assertIn(marker, self.checker)
+
+    def test_committed_ruleset_fixtures_are_not_live_activation_evidence(self) -> None:
+        production_sources = self.native + self.reusable + self.checker
+        self.assertNotIn(".governance/ruleset", production_sources)
+        self.assertNotIn("ruleset-release.json", production_sources)
+        self.assertNotIn("integration_id", production_sources)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
+import tempfile
 import unittest
 from urllib.error import URLError
 
@@ -19,10 +21,22 @@ TOKEN = "test-token"
 BASE_SHA = "f" * 40
 
 
-def _commit(index: int, message: str | None = None) -> dict[str, object]:
+def _commit(
+    index: int,
+    message: str | None = None,
+    *,
+    author_name: str = "Test User",
+    author_email: str = "test@example.com",
+) -> dict[str, object]:
     if message is None:
         message = f"fix: commit {index}\n\nSigned-off-by: Test User <test@example.com>"
-    return {"sha": f"{index:040x}", "commit": {"message": message}}
+    return {
+        "sha": f"{index:040x}",
+        "commit": {
+            "message": message,
+            "author": {"name": author_name, "email": author_email},
+        },
+    }
 
 
 def _signed_commits(count: int, *, start: int = 1) -> list[dict[str, object]]:
@@ -98,6 +112,57 @@ def _stable_responses(
     head_sha = _head_sha(commits)
     metadata = _metadata(count, head_sha)
     return head_sha, [metadata, *_commit_pages(commits), [], metadata]
+
+
+def _real_commit(
+    message: str,
+    *,
+    author_name: str = "Test User",
+    author_email: str = "test@example.com",
+) -> dict[str, object]:
+    """Create a real Git commit and return its physical API-shaped identity."""
+    git = shutil.which("git")
+    if git is None:
+        raise unittest.SkipTest("git is unavailable for real-commit fixtures")
+    with tempfile.TemporaryDirectory(prefix="dco-real-commit-") as root:
+        subprocess.run([git, "-C", root, "init", "--quiet"], check=True, capture_output=True, timeout=5)
+        tree = subprocess.run([git, "-C", root, "mktree"], input=b"", check=True, capture_output=True, timeout=5).stdout.strip().decode("ascii")
+        commit_env = os.environ.copy()
+        commit_env.update({
+            "GIT_AUTHOR_NAME": author_name,
+            "GIT_AUTHOR_EMAIL": author_email,
+            "GIT_AUTHOR_DATE": "2000-01-01T00:00:00+00:00",
+            "GIT_COMMITTER_NAME": "DCO Test Committer",
+            "GIT_COMMITTER_EMAIL": "committer@example.com",
+            "GIT_COMMITTER_DATE": "2000-01-01T00:00:00+00:00",
+        })
+        sha = subprocess.run([git, "-C", root, "commit-tree", tree], input=message.encode("utf-8"), env=commit_env, check=True, capture_output=True, timeout=5).stdout.strip().decode("ascii")
+        raw = subprocess.run([git, "-C", root, "cat-file", "commit", sha], check=True, capture_output=True, timeout=5).stdout
+        physical_message = raw.split(b"\n\n", 1)[1].decode("utf-8").rstrip("\n")
+        identity = subprocess.run([git, "-C", root, "show", "-s", "--format=%an%x00%ae", sha], check=True, capture_output=True, timeout=5).stdout.decode("utf-8").rstrip("\n").split("\x00", 1)
+    return {
+        "sha": sha,
+        "commit": {
+            "message": physical_message,
+            "author": {"name": identity[0], "email": identity[1]},
+        },
+    }
+
+
+class RealCommitPhysicalMessageTests(unittest.TestCase):
+    def test_real_commit_exact_author_identity_is_enforced(self) -> None:
+        message = "fix: physical message\n\nSigned-off-by: Test User <test@example.com>"
+        self.assertEqual(dco_check.unsigned_commit_shas([_real_commit(message)]), [])
+        mismatched = _real_commit(message, author_name="Different User")
+        self.assertEqual(dco_check.unsigned_commit_shas([mismatched]), [mismatched["sha"]])
+
+    def test_real_commit_terminal_patch_marker_cannot_hide_postscript(self) -> None:
+        commit = _real_commit(
+            "fix: terminal marker\n\n"
+            "Signed-off-by: Test User <test@example.com>\n"
+            "non-trailer postscript\n\n---"
+        )
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
 
 
 UNSIGNED_EMPTY_COMMIT = _commit(1, "chore: intentionally empty commit")
@@ -251,7 +316,12 @@ class DcoCheckTests(unittest.TestCase):
         )
 
     def test_one_character_signer_name_is_accepted(self) -> None:
-        commit = _commit(14, "fix: short signer\n\nSigned-off-by: X <x@example.com>")
+        commit = _commit(
+            14,
+            "fix: short signer\n\nSigned-off-by: X <x@example.com>",
+            author_name="X",
+            author_email="x@example.com",
+        )
 
         self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
 
@@ -282,6 +352,7 @@ class DcoCheckTests(unittest.TestCase):
                 "fix: horizontal signer\n\n"
                 f"Signed-off-by:{separator}A{separator}B{separator}"
                 f"<test@example.com>{separator}",
+                author_name=f"A{separator}B",
             )
             for index, separator in enumerate(separators, start=30)
         ]

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -205,6 +205,33 @@ class DcoCheckTests(unittest.TestCase):
         self.assert_rejected("checks_requested", dco.merge_group_subject, wrong_action, head)
         self.assert_rejected("differs", dco.merge_group_subject, payload, "f" * 40)
 
+    def test_merge_group_legacy_context_has_one_terminal_producer(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows" / "dco.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("name: DCO sign-off check\n"), 1)
+        self.assertIn("needs: dco", workflow)
+        self.assertIn(
+            "if: always() && github.event_name != 'pull_request_target'",
+            workflow,
+        )
+        self.assertIn("NATIVE_DCO_RESULT: ${{ needs.dco.result }}", workflow)
+        self.assertIn('test "$NATIVE_DCO_RESULT" = "success"', workflow)
+        self.assertNotIn("continue-on-error", workflow)
+
+    def test_reusable_legacy_context_faithfully_propagates_validation(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[1]
+            / "workflows"
+            / "reusable-dco.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("name: DCO sign-off\n"), 1)
+        self.assertIn("needs: reusable-dco", workflow)
+        self.assertIn("if: always()", workflow)
+        self.assertIn("REUSABLE_DCO_RESULT: ${{ needs.reusable-dco.result }}", workflow)
+        self.assertIn('test "$REUSABLE_DCO_RESULT" = "success"', workflow)
+        self.assertNotIn("continue-on-error", workflow)
+
     def test_merge_group_validates_linear_squash_sequence(self) -> None:
         first = self.commit(
             "fix: first queued squash\n\nSigned-off-by: Series A Builder <builder@example.com>"

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -84,7 +84,19 @@ class DcoCheckTests(unittest.TestCase):
         head = self.commit(
             "fix: mismatch\n\nSigned-off-by: Different Person <other@example.com>"
         )
-        self.assert_rejected("does not match", dco.validate_range, self.repo, self.base, head)
+        self.assert_rejected(
+            "does not exactly match",
+            dco.validate_range,
+            self.repo,
+            self.base,
+            head,
+        )
+
+    def test_author_identity_comparison_is_exact(self) -> None:
+        head = self.commit(
+            "fix: exact identity\n\nSigned-off-by: series a builder <builder@example.com>"
+        )
+        self.assert_rejected("exactly match", dco.validate_range, self.repo, self.base, head)
 
     def test_malformed_and_body_only_signoffs_fail(self) -> None:
         malformed = self.commit("fix: malformed\n\nSigned-off-by: no-address")

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -230,6 +230,12 @@ def verify_gate_contract() -> None:
         "github.event.pull_request.base.sha",
         "github.event.pull_request.head.sha",
         ".github/scripts/dco_check.py",
+        "native-dco-compatibility:",
+        "name: DCO sign-off check",
+        "needs: dco",
+        "if: always() && github.event_name != 'pull_request_target'",
+        "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
+        'test "$NATIVE_DCO_RESULT" = "success"',
     ):
         if marker not in dco_template:
             fail(f"trusted DCO workflow is missing {marker!r}")
@@ -239,6 +245,10 @@ def verify_gate_contract() -> None:
         fail("DCO must not publish a manual false-green status")
     if "github.event_name != 'pull_request'" in dco_template:
         fail("DCO merge-group and push validation must not use a fallback pass")
+    if dco_template.count("name: DCO sign-off check\n") != 1:
+        fail("native DCO must expose exactly one legacy compatibility job")
+    if "continue-on-error" in dco_template:
+        fail("native DCO compatibility must not suppress a failed gate")
 
     reusable_dco_template = (
         ROOT / ".github/workflows/reusable-dco.yml"
@@ -250,11 +260,21 @@ def verify_gate_contract() -> None:
         "GITHUB_TOKEN: ${{ github.token }}",
         "persist-credentials: false",
         "trusted-dco/.github/scripts/dco_check.py",
+        "reusable-dco-compatibility:",
+        "name: DCO sign-off",
+        "needs: reusable-dco",
+        "if: always()",
+        "REUSABLE_DCO_RESULT: ${{ needs.reusable-dco.result }}",
+        'test "$REUSABLE_DCO_RESULT" = "success"',
     ):
         if marker not in reusable_dco_template:
             fail(f"reusable DCO workflow is missing {marker!r}")
     if "secrets." in reusable_dco_template or "secrets: inherit" in reusable_dco_template:
         fail("reusable DCO workflow must not consume inherited secrets")
+    if reusable_dco_template.count("name: DCO sign-off\n") != 1:
+        fail("reusable DCO must expose exactly one legacy compatibility job")
+    if "continue-on-error" in reusable_dco_template:
+        fail("reusable DCO compatibility must not suppress a failed gate")
 
     dco_source = (ROOT / ".github/scripts/dco_check.py").read_text(encoding="utf-8")
     for marker in (

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -239,6 +239,23 @@ def verify_gate_contract() -> None:
         fail("DCO must not publish a manual false-green status")
     if "github.event_name != 'pull_request'" in dco_template:
         fail("DCO merge-group and push validation must not use a fallback pass")
+
+    reusable_dco_template = (
+        ROOT / ".github/workflows/reusable-dco.yml"
+    ).read_text(encoding="utf-8")
+    for marker in (
+        "name: Reusable DCO validation",
+        "repository: ${{ job.workflow_repository }}",
+        "ref: ${{ job.workflow_sha }}",
+        "GITHUB_TOKEN: ${{ github.token }}",
+        "persist-credentials: false",
+        "trusted-dco/.github/scripts/dco_check.py",
+    ):
+        if marker not in reusable_dco_template:
+            fail(f"reusable DCO workflow is missing {marker!r}")
+    if "secrets." in reusable_dco_template or "secrets: inherit" in reusable_dco_template:
+        fail("reusable DCO workflow must not consume inherited secrets")
+
     dco_source = (ROOT / ".github/scripts/dco_check.py").read_text(encoding="utf-8")
     for marker in (
         'payload.get("action") == "checks_requested"',
@@ -247,12 +264,43 @@ def verify_gate_contract() -> None:
         'group.get("head_sha")',
         "checked_out_head(repo) == head_sha",
         '"merge-base", "--is-ancestor"',
-        '"interpret-trailers", "--parse"',
-        "Signed-off-by does not match the commit author",
+        "PATCH_DIVIDER_PATTERN =",
+        "TRAILER_TOKEN_PATTERN =",
+        "def _is_patch_divider(",
+        "def valid_dco_identities(",
+        "Signed-off-by does not exactly match the commit author",
+        "draft pull requests cannot satisfy DCO",
+        "MAX_PULL_REQUEST_COMMITS = 250",
         "pull-request commit count changed during validation",
     ):
         if marker not in dco_source:
             fail(f"trusted DCO checker is missing {marker!r}")
+
+    dco_parser_tests = (
+        ROOT / ".github/scripts/test_dco_check.py"
+    ).read_text(encoding="utf-8")
+    for marker in (
+        "class RealCommitPhysicalMessageTests",
+        "test_real_commit_exact_author_identity_is_enforced",
+        "test_real_commit_terminal_patch_marker_cannot_hide_postscript",
+        "test_git_density_admission_matches_interpret_trailers",
+        "test_mixed_group_prefix_admission_matches_interpret_trailers",
+        "test_generic_key_to_colon_spacing_and_folds_are_accepted",
+        "test_unterminated_patch_marker_does_not_truncate_message",
+    ):
+        if marker not in dco_parser_tests:
+            fail(f"strict physical DCO parser tests are missing {marker!r}")
+
+    dco_event_tests = (
+        ROOT / ".github/scripts/test_dco_events.py"
+    ).read_text(encoding="utf-8")
+    for marker in (
+        "test_author_identity_comparison_is_exact",
+        "test_pr_pagination_boundaries_and_freshness",
+        "test_merge_group_identity_and_hostile_ref_contract",
+    ):
+        if marker not in dco_event_tests:
+            fail(f"trusted DCO event tests are missing {marker!r}")
 
     attestor_template = (
         ROOT / ".github/workflows/attest-and-approve.yml"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,4 +1,4 @@
-name: DCO
+name: Native DCO enforcement
 
 on:
   push:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   dco:
-    name: DCO sign-off check
+    name: Native DCO enforcement
     if: github.event_name != 'pull_request_target' || github.event.action != 'closed'
     concurrency:
       group: dco-${{ github.event_name == 'pull_request_target' && format('head-{0}', github.event.pull_request.head.sha) || github.sha }}
@@ -70,6 +70,13 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git -C "$GITHUB_WORKSPACE/trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
+
+      - name: Run strict real-commit DCO self-tests
+        run: |
+          set -euo pipefail
+          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_check.py"
+          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_events.py"
+          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_activation.py"
 
       - name: Import current protected base into candidate graph
         if: github.event_name == 'pull_request_target'

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -217,6 +217,21 @@ jobs:
           --repo-root "$GITHUB_WORKSPACE/candidate"
           --event-path "$GITHUB_EVENT_PATH"
 
+  native-dco-compatibility:
+    name: DCO sign-off check
+    needs: dco
+    if: always() && github.event_name != 'pull_request_target'
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Propagate terminal native DCO result
+        env:
+          NATIVE_DCO_RESULT: ${{ needs.dco.result }}
+        run: |
+          set -euo pipefail
+          test "$NATIVE_DCO_RESULT" = "success"
+
   reconcile-old-head:
     name: Reconcile surviving DCO status
     if: >-

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -95,3 +95,18 @@ jobs:
           python "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/dco_check.py"
           --repo-root "$GITHUB_WORKSPACE/candidate"
           --event-path "$GITHUB_EVENT_PATH"
+
+  reusable-dco-compatibility:
+    name: DCO sign-off
+    needs: reusable-dco
+    if: always()
+    permissions: {}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Propagate terminal reusable DCO result
+        env:
+          REUSABLE_DCO_RESULT: ${{ needs.reusable-dco.result }}
+        run: |
+          set -euo pipefail
+          test "$REUSABLE_DCO_RESULT" = "success"

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -1,14 +1,4 @@
-name: Reusable — DCO sign-off check
-
-# Verifies that every commit in a pull request carries a valid
-# Developer Certificate of Origin (DCO) Signed-off-by trailer.
-#
-# Replaces tim-actions/dco@node12 + tim-actions/get-pr-commits@node12,
-# both of which are abandoned (last release 2021) and use node12, a runtime
-# deprecated by GitHub Actions on 2026-06-02 and removed 2026-09-16.
-#
-# This implementation is zero-dependency: pure bash + the GitHub CLI
-# (pre-installed on ubuntu-latest). No third-party action is involved.
+name: Reusable DCO validation
 
 on:
   workflow_call:
@@ -18,8 +8,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  dco:
-    name: DCO sign-off
+  reusable-dco:
+    name: Reusable DCO validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -28,41 +18,80 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check Signed-off-by on every PR commit
+      - name: Require an exact pull-request caller
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        shell: bash
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = "pull_request"
+          test "$PR_NUMBER" -gt 0
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
 
-          if [ -z "${PR_NUMBER:-}" ]; then
-            echo "::error::This workflow must be called from a pull_request event."
-            exit 1
-          fi
+      - name: Checkout exact candidate without credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
 
-          missing=0
+      - name: Checkout exact protected pull-request base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: protected-base
+          fetch-depth: 1
+          persist-credentials: false
 
-          while IFS= read -r sha; do
-            msg=$(gh api "repos/$REPO/git/commits/$sha" --jq '.message')
-            # A valid DCO line looks like:
-            #   Signed-off-by: Full Name <email@example.com>
-            # The trailer may appear anywhere in the commit body.
-            if ! echo "$msg" | grep -qE '^Signed-off-by: .+ <.+@.+>'; then
-              echo "::error::Commit ${sha:0:12} is missing a Signed-off-by trailer."
-              echo "  Subject: $(echo "$msg" | head -1)"
-              missing=1
-            fi
-          done < <(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].sha')
+      - name: Checkout immutable reusable DCO source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: trusted-dco
+          fetch-depth: 1
+          persist-credentials: false
 
-          if [ "$missing" -ne 0 ]; then
-            echo ""
-            echo "One or more commits are missing the DCO sign-off."
-            echo "Fix options:"
-            echo "  Single commit:  git commit --amend --signoff"
-            echo "  Multiple:       git rebase HEAD~N --signoff"
-            exit 1
-          fi
+      - name: Assert exact reusable DCO source revision
+        env:
+          EXPECTED_SOURCE_REPOSITORY: ${{ job.workflow_repository }}
+          EXPECTED_SOURCE_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_SOURCE_REPOSITORY" = "szl-holdings/.github"
+          [[ "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git -C "$GITHUB_WORKSPACE/trusted-dco" rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA"
 
-          echo "✓ All commits carry a valid Signed-off-by trailer."
+      - name: Run strict real-commit DCO self-tests
+        run: |
+          set -euo pipefail
+          python "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_check.py"
+          python "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_events.py"
+          python "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_activation.py"
+
+      - name: Import exact protected base into candidate graph
+        env:
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git -C "$GITHUB_WORKSPACE/candidate" fetch \
+            --no-tags "$GITHUB_WORKSPACE/protected-base" "$EXPECTED_BASE_SHA"
+          git -C "$GITHUB_WORKSPACE/candidate" cat-file -e "$EXPECTED_BASE_SHA^{commit}"
+
+      - name: Validate exact pull-request commits from immutable source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/dco_check.py"
+          --repo-root "$GITHUB_WORKSPACE/candidate"
+          --event-path "$GITHUB_EVENT_PATH"


### PR DESCRIPTION
﻿## Summary
- port the protected Doctrine physical-message DCO parser and exact author identity contract
- preserve exact native PR, merge-group, push, pagination, reconciliation, and legacy status gates
- replace reusable grep validation with immutable source-bound exact PR validation using only read-only `github.token`
- separate native and reusable source namespaces without treating committed ruleset fixtures as live evidence

## Validation
- `test_dco_check.py`: 52 passed
- `test_dco_events.py`: 17 passed
- `test_dco_activation.py`: 5 passed
- `git diff --check`: passed
- exact modified scope: six audited DCO files

## Migration boundary
This draft does not mutate rulesets or release branches. The live required-check migration remains a separate no-gap governance operation after the new source identities have been witnessed.
