### PR TITLE
fix(security): remove privileged DCO trigger

### DIFF
--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -24,29 +24,18 @@ class DcoActivationWorkflowTests(unittest.TestCase):
     def test_native_workflow_preserves_all_governed_event_gates(self) -> None:
         for marker in (
             "name: Native DCO enforcement",
-            "pull_request" + "_target:",
+            "pull_request:",
             "- main",
             "- 'release/*'",
             "types: [opened, synchronize, reopened, ready_for_review, edited, closed]",
             "merge_" + "group:",
             "types: [checks_requested]",
-            "Reconcile surviving DCO status",
             "github.event.before",
-            "AFFECTED_HEAD_SHA:",
-            "reconcile-candidate",
-            "reconcile-base",
-            "reconcile-trusted",
-            "dco-reconcile-event.json",
-            "Finalize pull-request DCO failure",
-            "Finalize reconciliation failure",
             "persist-credentials: false",
             "github.event.pull_request.base.sha",
             "github.event.pull_request.head.sha",
             "EXPECTED_BASE_SHA:",
             "EXPECTED_HEAD_SHA:",
-            "statuses: write",
-            "statuses/$EXPECTED_HEAD_SHA",
-            '-f context="DCO sign-off check"',
             "github.workflow_sha",
             "--paginate --slurp",
             "trusted/.github/scripts/dco_check.py",
@@ -54,12 +43,15 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "native-dco-compatibility:",
             "name: DCO sign-off check",
             "needs: dco",
-            "if: always() && github.event_name != 'pull_request_target'",
+            "github.event.action != 'closed'",
             "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
             'test "$NATIVE_DCO_RESULT" = "success"',
         ):
             self.assertIn(marker, self.native)
-        self.assertNotIn("\n  pull_request:\n", self.native)
+        self.assertNotIn("pull_request" + "_target:", self.native)
+        self.assertNotIn("statuses: write", self.native)
+        self.assertNotIn("/statuses/", self.native)
+        self.assertNotIn("reconcile-old-head:", self.native)
         self.assertNotIn("workflow_" + "dispatch:", self.native)
 
     def test_reusable_workflow_is_exact_and_secretless(self) -> None:
@@ -94,7 +86,8 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.assertNotIn("name: Reusable DCO validation", self.native)
         self.assertIn("name: Reusable DCO validation", self.reusable)
         self.assertNotIn("name: Native DCO enforcement", self.reusable)
-        self.assertIn('context="DCO sign-off check"', self.native)
+        self.assertIn("name: DCO sign-off check", self.native)
+        self.assertNotIn('context="DCO sign-off check"', self.native)
         self.assertEqual(self.native.count("name: DCO sign-off check\n"), 1)
         self.assertNotIn("continue-on-error", self.native)
 
@@ -140,5 +133,21 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             self.assertIn(suite, self.forge_runner)
 
 
+
+class NativeDCOUnprivilegedTriggerTests(unittest.TestCase):
+    def test_native_workflow_has_no_privileged_candidate_checkout(self) -> None:
+        from pathlib import Path
+
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows" / "dco.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("  pull_request:\n", workflow)
+        self.assertNotIn("pull_request" + "_target:", workflow)
+        self.assertNotIn("statuses: write", workflow)
+        self.assertNotIn("/statuses/", workflow)
+        self.assertNotIn("reconcile-old-head:", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("name: DCO sign-off check", workflow)
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -211,13 +211,15 @@ class DcoCheckTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertEqual(workflow.count("name: DCO sign-off check\n"), 1)
         self.assertIn("needs: dco", workflow)
-        self.assertIn(
-            "if: always() && github.event_name != 'pull_request_target'",
-            workflow,
-        )
+        self.assertIn("github.event.action != 'closed'", workflow)
         self.assertIn("NATIVE_DCO_RESULT: ${{ needs.dco.result }}", workflow)
         self.assertIn('test "$NATIVE_DCO_RESULT" = "success"', workflow)
         self.assertNotIn("continue-on-error", workflow)
+        self.assertIn("  pull_request:\n", workflow)
+        self.assertNotIn("pull_request" + "_target:", workflow)
+        self.assertNotIn("statuses: write", workflow)
+        self.assertNotIn("/statuses/", workflow)
+        self.assertNotIn("reconcile-old-head:", workflow)
 
     def test_reusable_legacy_context_faithfully_propagates_validation(self) -> None:
         workflow = (

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -223,7 +223,7 @@ def verify_gate_contract() -> None:
 
     dco_template = (ROOT / ".github/workflows/dco.yml").read_text(encoding="utf-8")
     for marker in (
-        "pull_request_target:",
+        "pull_request:",
         "merge_group:",
         "types: [checks_requested]",
         "persist-credentials: false",
@@ -233,18 +233,25 @@ def verify_gate_contract() -> None:
         "native-dco-compatibility:",
         "name: DCO sign-off check",
         "needs: dco",
-        "if: always() && github.event_name != 'pull_request_target'",
+        "github.event.action != 'closed'",
         "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
         'test "$NATIVE_DCO_RESULT" = "success"',
     ):
         if marker not in dco_template:
             fail(f"trusted DCO workflow is missing {marker!r}")
-    if "\n  pull_request:\n" in dco_template:
-        fail("DCO must not execute PR-controlled code under pull_request")
+    if "pull_request" + "_target:" in dco_template:
+        fail("native DCO must not execute candidate code under a privileged trigger")
+    if "statuses: write" in dco_template or "/statuses/" in dco_template:
+        fail("native DCO must rely on check runs instead of writable commit statuses")
+    if "reconcile-old-head:" in dco_template:
+        fail("native DCO must not retain obsolete manual status reconciliation")
     if "workflow_dispatch:" in dco_template:
         fail("DCO must not publish a manual false-green status")
-    if "github.event_name != 'pull_request'" in dco_template:
-        fail("DCO merge-group and push validation must not use a fallback pass")
+    if (
+        "if: github.event_name != 'pull_request' "
+        "|| github.event.action != 'closed'"
+    ) not in dco_template:
+        fail("native DCO must skip only a closed pull-request event")
     if dco_template.count("name: DCO sign-off check\n") != 1:
         fail("native DCO must expose exactly one legacy compatibility job")
     if "continue-on-error" in dco_template:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,7 +3,7 @@ name: Native DCO enforcement
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - 'release/*'
@@ -14,41 +14,27 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  statuses: write
 
 jobs:
   dco:
     name: Native DCO enforcement
-    if: github.event_name != 'pull_request_target' || github.event.action != 'closed'
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     concurrency:
-      group: dco-${{ github.event_name == 'pull_request_target' && format('head-{0}', github.event.pull_request.head.sha) || github.sha }}
+      group: dco-${{ github.event_name == 'pull_request' && format('head-{0}', github.event.pull_request.head.sha) || github.sha }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Publish pending DCO status on exact pull-request head
-        if: github.event_name == 'pull_request_target'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="pending" \
-            -f context="DCO sign-off check" \
-            -f description="DCO validation in progress" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
       - name: Checkout exact candidate without credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
           path: candidate
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout exact protected pull-request base
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
@@ -59,14 +45,14 @@ jobs:
       - name: Checkout protected default-branch checker revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+          ref: ${{ github.event_name == 'pull_request' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
           path: trusted
           fetch-depth: 1
           persist-credentials: false
 
       - name: Assert exact trusted checker revision
         env:
-          EXPECTED_TRUSTED_SHA: ${{ github.event_name == 'pull_request_target' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+          EXPECTED_TRUSTED_SHA: ${{ github.event_name == 'pull_request' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
         run: |
           set -euo pipefail
           test "$(git -C "$GITHUB_WORKSPACE/trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
@@ -79,7 +65,7 @@ jobs:
           python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_activation.py"
 
       - name: Import current protected base into candidate graph
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -90,7 +76,7 @@ jobs:
 
       - name: Validate exact pull-request commits from trusted base
         id: validate_pr
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -164,44 +150,7 @@ jobs:
             dco_exit=1
           fi
 
-          state="failure"
-          description="DCO validation failed"
-          if [[ "$revalidation_error" == "true" ]]; then
-            description="DCO live revalidation failed"
-          elif [[ "$shared_head" == "true" ]]; then
-            description="DCO head is shared by governed PRs"
-          elif [[ "$stale_event" == "true" ]]; then
-            description="DCO event is stale"
-          elif [[ "$dco_exit" -eq 0 ]]; then
-            state="success"
-            description="DCO validation passed"
-          fi
-
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="$state" \
-            -f context="DCO sign-off check" \
-            -f description="$description" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
-          echo "published=true" >>"$GITHUB_OUTPUT"
           exit "$dco_exit"
-
-      - name: Finalize pull-request DCO failure
-        if: >-
-          always()
-          && github.event_name == 'pull_request_target'
-          && steps.validate_pr.outputs.published != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="failure" \
-            -f context="DCO sign-off check" \
-            -f description="DCO workflow setup failed" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - name: Validate exact merge-group range
         if: github.event_name == 'merge_group'
@@ -220,7 +169,13 @@ jobs:
   native-dco-compatibility:
     name: DCO sign-off check
     needs: dco
-    if: always() && github.event_name != 'pull_request_target'
+    if: >-
+      always()
+      && (
+        github.event_name == 'push'
+        || github.event_name == 'merge_group'
+        || github.event.action != 'closed'
+      )
     permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -231,234 +186,3 @@ jobs:
         run: |
           set -euo pipefail
           test "$NATIVE_DCO_RESULT" = "success"
-
-  reconcile-old-head:
-    name: Reconcile surviving DCO status
-    if: >-
-      github.event_name == 'pull_request_target'
-      && (github.event.action == 'closed' || github.event.action == 'synchronize')
-    concurrency:
-      group: dco-${{ format('head-{0}', github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha) }}
-      cancel-in-progress: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Resolve the surviving governed PR for the old head
-        id: subject
-        env:
-          GH_TOKEN: ${{ github.token }}
-          AFFECTED_HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          governed_prs="$(
-            gh api --paginate --slurp \
-              "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
-              | jq -ce --arg head "$AFFECTED_HEAD_SHA" '
-                  [
-                    .[][]
-                    | select(.head.sha == $head)
-                    | select(
-                        .base.ref == "main"
-                        or (.base.ref | test("^release/[^/]+$"))
-                      )
-                  ]
-                '
-          )"
-          count="$(jq -r 'length' <<<"$governed_prs")"
-          echo "reconcile=false" >>"$GITHUB_OUTPUT"
-
-          if [[ "$count" -eq 0 ]]; then
-            exit 0
-          fi
-          if [[ "$count" -ne 1 ]]; then
-            gh api --method POST \
-              "repos/$GITHUB_REPOSITORY/statuses/$AFFECTED_HEAD_SHA" \
-              -f state="failure" \
-              -f context="DCO sign-off check" \
-              -f description="DCO head is shared by governed PRs" \
-              -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            exit 0
-          fi
-
-          pr_number="$(jq -r '.[0].number' <<<"$governed_prs")"
-          base_ref="$(jq -r '.[0].base.ref' <<<"$governed_prs")"
-          base_sha="$(jq -r '.[0].base.sha' <<<"$governed_prs")"
-          head_sha="$(jq -r '.[0].head.sha' <<<"$governed_prs")"
-          test "$head_sha" = "$AFFECTED_HEAD_SHA"
-
-          {
-            echo "reconcile=true"
-            echo "pr_number=$pr_number"
-            echo "base_ref=$base_ref"
-            echo "base_sha=$base_sha"
-            echo "head_sha=$head_sha"
-          } >>"$GITHUB_OUTPUT"
-
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
-            -f state="pending" \
-            -f context="DCO sign-off check" \
-            -f description="DCO reconciliation in progress" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
-      - name: Checkout surviving exact candidate without credentials
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: refs/pull/${{ steps.subject.outputs.pr_number }}/head
-          path: reconcile-candidate
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout surviving exact protected base
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.subject.outputs.base_sha }}
-          path: reconcile-base
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout immutable reconciliation checker
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: reconcile-trusted
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Validate and republish surviving DCO evidence
-        id: validate_reconciliation
-        if: steps.subject.outputs.reconcile == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.subject.outputs.pr_number }}
-          EXPECTED_BASE_REF: ${{ steps.subject.outputs.base_ref }}
-          EXPECTED_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
-          EXPECTED_HEAD_SHA: ${{ steps.subject.outputs.head_sha }}
-          EXPECTED_TRUSTED_SHA: ${{ github.workflow_sha }}
-        run: |
-          set -euo pipefail
-          test "$(git -C "$GITHUB_WORKSPACE/reconcile-trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
-          git -C "$GITHUB_WORKSPACE/reconcile-candidate" fetch \
-            --no-tags "$GITHUB_WORKSPACE/reconcile-base" "$EXPECTED_BASE_SHA"
-          git -C "$GITHUB_WORKSPACE/reconcile-candidate" cat-file -e "$EXPECTED_BASE_SHA^{commit}"
-          jq -n \
-            --arg repository "$GITHUB_REPOSITORY" \
-            --arg base_ref "$EXPECTED_BASE_REF" \
-            --arg base_sha "$EXPECTED_BASE_SHA" \
-            --arg head_sha "$EXPECTED_HEAD_SHA" \
-            --argjson number "$PR_NUMBER" \
-            '{
-              action: "synchronize",
-              repository: {full_name: $repository},
-              number: $number,
-              pull_request: {
-                number: $number,
-                base: {ref: $base_ref, sha: $base_sha},
-                head: {sha: $head_sha}
-              }
-            }' >"$RUNNER_TEMP/dco-reconcile-event.json"
-
-          set +e
-          python "$GITHUB_WORKSPACE/reconcile-trusted/.github/scripts/dco_check.py" \
-            --repo-root "$GITHUB_WORKSPACE/reconcile-candidate" \
-            --event-path "$RUNNER_TEMP/dco-reconcile-event.json"
-          dco_exit=$?
-          current_pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
-          current_lookup_exit=$?
-          current_tuple="$(
-            jq -er '[.state, .base.ref, .base.sha, .head.sha] | @tsv' \
-              <<<"$current_pr"
-          )"
-          current_tuple_exit=$?
-          governed_pr_numbers="$(
-            gh api --paginate --slurp \
-              "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
-              | jq -er --arg head "$EXPECTED_HEAD_SHA" '
-                  [
-                    .[][]
-                    | select(.head.sha == $head)
-                    | select(
-                        .base.ref == "main"
-                        or (.base.ref | test("^release/[^/]+$"))
-                      )
-                    | .number
-                  ]
-                  | sort
-                  | map(tostring)
-                  | join(",")
-                '
-          )"
-          shared_lookup_exit=$?
-          set -e
-
-          current_state=""
-          current_base_ref=""
-          current_base_sha=""
-          current_head_sha=""
-          if [[ "$current_tuple_exit" -eq 0 ]]; then
-            IFS=$'\t' read -r \
-              current_state current_base_ref current_base_sha current_head_sha \
-              <<<"$current_tuple"
-          fi
-
-          revalidation_error=false
-          stale_event=false
-          shared_head=false
-          if [[ "$current_lookup_exit" -ne 0 \
-            || "$current_tuple_exit" -ne 0 \
-            || "$shared_lookup_exit" -ne 0 ]]; then
-            revalidation_error=true
-            dco_exit=1
-          elif [[ "$governed_pr_numbers" != "$PR_NUMBER" ]]; then
-            shared_head=true
-            dco_exit=1
-          elif [[ "$current_state" != "open" \
-            || "$current_base_ref" != "$EXPECTED_BASE_REF" \
-            || "$current_base_sha" != "$EXPECTED_BASE_SHA" \
-            || "$current_head_sha" != "$EXPECTED_HEAD_SHA" ]]; then
-            stale_event=true
-            dco_exit=1
-          fi
-
-          state="failure"
-          description="DCO reconciliation failed"
-          if [[ "$revalidation_error" == "true" ]]; then
-            description="DCO live revalidation failed"
-          elif [[ "$shared_head" == "true" ]]; then
-            description="DCO head is shared by governed PRs"
-          elif [[ "$stale_event" == "true" ]]; then
-            description="DCO reconciliation is stale"
-          elif [[ "$dco_exit" -eq 0 ]]; then
-            state="success"
-            description="DCO validation passed"
-          fi
-
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="$state" \
-            -f context="DCO sign-off check" \
-            -f description="$description" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
-          echo "published=true" >>"$GITHUB_OUTPUT"
-          exit "$dco_exit"
-
-      - name: Finalize reconciliation failure
-        if: >-
-          always()
-          && steps.subject.outputs.reconcile == 'true'
-          && steps.validate_reconciliation.outputs.published != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EXPECTED_HEAD_SHA: ${{ steps.subject.outputs.head_sha }}
-        run: |
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="failure" \
-            -f context="DCO sign-off check" \
-            -f description="DCO reconciliation setup failed" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"


### PR DESCRIPTION
## Summary
- replace native DCO `pull_request_target` with unprivileged `pull_request`
- remove `statuses: write`, manual status publication, and old-head reconciliation
- retain immutable checker, exact candidate/base validation, merge-group/push validation, and the legacy required-check name
- add executable invariants for the reduced trust boundary

## Security boundary
Structurally addresses Scorecard alerts #120 and #121 without dismissal.

## Validation
- 52 DCO parser tests passed
- 19 event tests passed
- 7 activation tests passed
- FORGE-9 governance verifier passed
- staged diff check passed

## Deployment boundary
GitHub only. This does not mutate Hugging Face, rulesets, secrets, environments, or runtime deployments.