### PR TITLE
fix(security): add external Doctrine DCO controller

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -26,18 +26,21 @@ QUEUE_REF_PREFIX = "refs/heads/gh-readonly-queue/main/"
 ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review", "edited"}
 
 # Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
-# Name and email tokens separately reject C0/C1 controls plus Unicode line and
-# paragraph separators, so no broad whitespace class can admit a line break.
+# Name, email, and trailer text separately reject C0/C1 controls, Unicode line
+# and paragraph separators, and every Bidi_Control code point. Ordinary RTL
+# letters remain valid, but invisible direction overrides cannot alter review.
 HORIZONTAL_SEPARATOR_PATTERN = (
     r"[\x09\x20\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]"
 )
 NAME_TOKEN_PATTERN = (
     r"[^<>\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
-    r"\u2028\u2029\u202f\u205f\u3000]+"
+    r"\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u202f"
+    r"\u205f\u2066-\u2069\u3000]+"
 )
 EMAIL_PART_PATTERN = (
     r"[^<>@\x00-\x20\x7f-\x9f\u00a0\u1680\u2000-\u200a"
-    r"\u2028\u2029\u202f\u205f\u3000]+"
+    r"\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u202f"
+    r"\u205f\u2066-\u2069\u3000]+"
 )
 SIGNED_OFF_BY_PATTERN = re.compile(
     rf"^Signed-off-by:{HORIZONTAL_SEPARATOR_PATTERN}+"
@@ -51,7 +54,8 @@ HORIZONTAL_ONLY_PATTERN = re.compile(
     rf"^{HORIZONTAL_SEPARATOR_PATTERN}*$"
 )
 SAFE_TRAILER_TEXT_PATTERN = (
-    r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u2028\u2029]*"
+    r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u061c\u200e\u200f"
+    r"\u2028\u2029\u202a-\u202e\u2066-\u2069]*"
 )
 TRAILER_TOKEN_PATTERN = r"-*[A-Za-z0-9][A-Za-z0-9-]*"
 TRAILER_TOKEN_FULL_PATTERN = re.compile(rf"^{TRAILER_TOKEN_PATTERN}$")
@@ -556,15 +560,20 @@ def git(
     input_text: str | None = None,
     check: bool = True,
 ) -> str:
-    completed = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        input=input_text,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=30,
-    )
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            input=input_text,
+            text=True,
+            encoding="utf-8",
+            errors="strict",
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except UnicodeError as exc:
+        raise DcoContractError("git output was not valid UTF-8") from exc
     if check and completed.returncode:
         detail = completed.stderr.strip() or completed.stdout.strip()
         raise DcoContractError(f"git {' '.join(args)} failed: {detail}")

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -57,6 +57,9 @@ SAFE_TRAILER_TEXT_PATTERN = (
     r"[^\x00-\x08\x0a-\x1f\x7f-\x9f\u061c\u200e\u200f"
     r"\u2028\u2029\u202a-\u202e\u2066-\u2069]*"
 )
+BIDI_CONTROL_PATTERN = re.compile(
+    r"[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]"
+)
 TRAILER_TOKEN_PATTERN = r"-*[A-Za-z0-9][A-Za-z0-9-]*"
 TRAILER_TOKEN_FULL_PATTERN = re.compile(rf"^{TRAILER_TOKEN_PATTERN}$")
 TRAILER_LINE_PATTERN = re.compile(
@@ -448,6 +451,12 @@ def _admitted_trailer_group(
     has_recognized_prefix = False
 
     for line in final_group:
+        if BIDI_CONTROL_PATTERN.search(line):
+            current_token = None
+            non_trailer_count += 1
+            classified_lines.append(("malformed", None, line))
+            continue
+
         if CONTINUATION_LINE_PATTERN.fullmatch(line):
             if current_token is None:
                 non_trailer_count += 1

--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -589,13 +589,73 @@ def git(
     return completed.stdout
 
 
+def git_bytes(repo: Path, *args: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=False,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if completed.returncode:
+        raise DcoContractError(f"git {args[0]} failed")
+    return completed.stdout
+
+
 def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
     require_sha(sha, "commit SHA")
-    raw = git(repo, "show", "-s", "--format=%P%x00%an%x00%ae%x00%B", sha)
-    fields = raw.split("\x00", 3)
-    require(len(fields) == 4, f"commit metadata is incomplete for {sha}")
-    parents = fields[0].strip().split()
-    return parents, fields[1], fields[2], fields[3]
+    raw_bytes = git_bytes(repo, "cat-file", "commit", sha)
+    try:
+        raw = raw_bytes.decode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise DcoContractError("commit object was not valid UTF-8") from exc
+
+    headers, separator, message = raw.partition("\n\n")
+    require(bool(separator), f"commit object is incomplete for {sha}")
+    message = message.replace("\r\n", "\n")
+    require("\r" not in message, f"commit message has unsupported line endings for {sha}")
+
+    parents: list[str] = []
+    author: tuple[str, str] | None = None
+    tree_seen = False
+    committer_seen = False
+    encoding_seen = False
+    current_header: str | None = None
+    for line in headers.split("\n"):
+        if line.startswith(" "):
+            require(current_header is not None, f"commit headers are malformed for {sha}")
+            continue
+
+        key, delimiter, value = line.partition(" ")
+        require(bool(delimiter and key and value), f"commit headers are malformed for {sha}")
+        current_header = key
+        if key == "tree":
+            require(not tree_seen, f"commit has duplicate tree headers for {sha}")
+            require_sha(value, "commit tree SHA")
+            tree_seen = True
+        elif key == "parent":
+            parents.append(require_sha(value, "commit parent SHA"))
+        elif key == "author":
+            require(author is None, f"commit has duplicate author headers for {sha}")
+            match = re.fullmatch(
+                r"(?P<name>.+) <(?P<email>[^<>]+)> -?[0-9]+ [+-][0-9]{4}",
+                value,
+            )
+            require(match is not None, f"commit author header is malformed for {sha}")
+            author = (match.group("name"), match.group("email"))
+        elif key == "committer":
+            require(not committer_seen, f"commit has duplicate committer headers for {sha}")
+            committer_seen = True
+        elif key == "encoding":
+            require(not encoding_seen, f"commit has duplicate encoding headers for {sha}")
+            require(value.casefold() == "utf-8", "commit encoding must be UTF-8")
+            encoding_seen = True
+
+    require(tree_seen, f"commit has no tree header for {sha}")
+    require(author is not None, f"commit has no author header for {sha}")
+    require(committer_seen, f"commit has no committer header for {sha}")
+    return parents, author[0], author[1], message
 
 
 def validate_commit(

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -221,6 +221,19 @@ class RealCommitPhysicalMessageTests(unittest.TestCase):
                     [commit["sha"]],
                 )
 
+    def test_real_commit_bidi_controls_in_trailer_tokens_are_rejected(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                commit = _real_commit(
+                    "fix: reject directional trailer token\n\n"
+                    f"Reviewed-by{control}: Alice <reviewer@example.com>\n"
+                    "Signed-off-by: Test User <test@example.com>"
+                )
+                self.assertEqual(
+                    dco_check.unsigned_commit_shas([commit]),
+                    [commit["sha"]],
+                )
+
     def test_real_commit_ordinary_arabic_and_hebrew_letters_are_accepted(self) -> None:
         name = "مستخدم עברי"
         email = "משתמש@مثال.test"
@@ -334,6 +347,18 @@ class LocalGitProductionPathTests(unittest.TestCase):
                 sha = self.commit(
                     "fix: reject directional trailer\n\n"
                     f"Reviewed-by: Alice{control}Builder <reviewer@example.com>\n"
+                    "Signed-off-by: Test User <test@example.com>",
+                    author_name="Test User",
+                    author_email="test@example.com",
+                )
+                self.assert_rejected_by_commit_and_range(sha)
+
+    def test_bidi_controls_in_trailer_tokens_fail_production_path(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                sha = self.commit(
+                    "fix: reject directional trailer token\n\n"
+                    f"Reviewed-by{control}: Alice <reviewer@example.com>\n"
                     "Signed-off-by: Test User <test@example.com>",
                     author_name="Test User",
                     author_email="test@example.com",

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import tempfile
 import unittest
+from unittest.mock import patch
 from urllib.error import URLError
 
 import dco_check as dco_check
@@ -19,6 +21,20 @@ REPOSITORY = "szl-holdings/example"
 PR_NUMBER = 399
 TOKEN = "test-token"
 BASE_SHA = "f" * 40
+BIDI_CONTROLS = (
+    "\u061c",
+    "\u200e",
+    "\u200f",
+    "\u202a",
+    "\u202b",
+    "\u202c",
+    "\u202d",
+    "\u202e",
+    "\u2066",
+    "\u2067",
+    "\u2068",
+    "\u2069",
+)
 
 
 def _commit(
@@ -163,6 +179,191 @@ class RealCommitPhysicalMessageTests(unittest.TestCase):
             "non-trailer postscript\n\n---"
         )
         self.assertEqual(dco_check.unsigned_commit_shas([commit]), [commit["sha"]])
+
+    def test_real_commit_bidi_controls_in_signer_names_are_rejected(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                name = f"Alice{control}Builder"
+                commit = _real_commit(
+                    "fix: reject directional signer name\n\n"
+                    f"Signed-off-by: {name} <test@example.com>",
+                    author_name=name,
+                )
+                self.assertEqual(
+                    dco_check.unsigned_commit_shas([commit]),
+                    [commit["sha"]],
+                )
+
+    def test_real_commit_bidi_controls_in_signer_emails_are_rejected(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                email = f"alice{control}@example.com"
+                commit = _real_commit(
+                    "fix: reject directional signer email\n\n"
+                    f"Signed-off-by: Test User <{email}>",
+                    author_email=email,
+                )
+                self.assertEqual(
+                    dco_check.unsigned_commit_shas([commit]),
+                    [commit["sha"]],
+                )
+
+    def test_real_commit_bidi_controls_in_trailer_text_are_rejected(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                commit = _real_commit(
+                    "fix: reject directional trailer text\n\n"
+                    f"Reviewed-by: Alice{control}Builder <reviewer@example.com>\n"
+                    "Signed-off-by: Test User <test@example.com>"
+                )
+                self.assertEqual(
+                    dco_check.unsigned_commit_shas([commit]),
+                    [commit["sha"]],
+                )
+
+    def test_real_commit_ordinary_arabic_and_hebrew_letters_are_accepted(self) -> None:
+        name = "مستخدم עברי"
+        email = "משתמש@مثال.test"
+        commit = _real_commit(
+            "fix: preserve ordinary right-to-left identity\n\n"
+            "Reviewed-by: مراجع עברי <reviewer@example.com>\n"
+            f"Signed-off-by: {name} <{email}>",
+            author_name=name,
+            author_email=email,
+        )
+        self.assertEqual(dco_check.unsigned_commit_shas([commit]), [])
+
+
+class LocalGitProductionPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        git = shutil.which("git")
+        if git is None:
+            self.skipTest("git is required for production-path DCO tests")
+        self.git_executable = git
+        self.temp = tempfile.TemporaryDirectory(prefix="dco-production-path-")
+        self.repo = Path(self.temp.name)
+        self.git("init", "-b", "main")
+        self.tree = self.git("write-tree")
+        self.base = self.commit(
+            "chore: base\n\nSigned-off-by: Base Builder <base@example.com>",
+            author_name="Base Builder",
+            author_email="base@example.com",
+            parent=None,
+        )
+        self.git("reset", "--hard", self.base)
+
+    def tearDown(self) -> None:
+        if hasattr(self, "temp"):
+            self.temp.cleanup()
+
+    def git(
+        self,
+        *args: str,
+        input_bytes: bytes | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        completed = subprocess.run(
+            [self.git_executable, *args],
+            cwd=self.repo,
+            input=input_bytes,
+            env=env,
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return completed.stdout.decode("ascii").strip()
+
+    def commit(
+        self,
+        message: str,
+        *,
+        author_name: str,
+        author_email: str,
+        parent: str | None = "base",
+    ) -> str:
+        commit_env = os.environ.copy()
+        commit_env.update(
+            {
+                "GIT_AUTHOR_NAME": author_name,
+                "GIT_AUTHOR_EMAIL": author_email,
+                "GIT_AUTHOR_DATE": "2000-01-01T00:00:00+00:00",
+                "GIT_COMMITTER_NAME": "DCO Production Test",
+                "GIT_COMMITTER_EMAIL": "committer@example.com",
+                "GIT_COMMITTER_DATE": "2000-01-01T00:00:00+00:00",
+            }
+        )
+        arguments = ["commit-tree", self.tree]
+        if parent is not None:
+            arguments.extend(["-p", self.base if parent == "base" else parent])
+        return self.git(*arguments, input_bytes=message.encode("utf-8"), env=commit_env)
+
+    def assert_rejected_by_commit_and_range(self, sha: str) -> None:
+        self.git("reset", "--hard", sha)
+        with self.assertRaises(dco_check.DcoContractError):
+            dco_check.validate_commit(self.repo, sha)
+        with self.assertRaises(dco_check.DcoContractError):
+            dco_check.validate_range(self.repo, self.base, sha)
+
+    def test_bidi_controls_in_author_and_signoff_fail_production_path(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                name = f"Alice{control}Builder"
+                sha = self.commit(
+                    "fix: reject directional author\n\n"
+                    f"Signed-off-by: {name} <test@example.com>",
+                    author_name=name,
+                    author_email="test@example.com",
+                )
+                self.assert_rejected_by_commit_and_range(sha)
+
+    def test_bidi_controls_in_email_and_signoff_fail_production_path(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                email = f"alice{control}@example.com"
+                sha = self.commit(
+                    "fix: reject directional email\n\n"
+                    f"Signed-off-by: Test User <{email}>",
+                    author_name="Test User",
+                    author_email=email,
+                )
+                self.assert_rejected_by_commit_and_range(sha)
+
+    def test_bidi_controls_in_trailer_text_fail_production_path(self) -> None:
+        for control in BIDI_CONTROLS:
+            with self.subTest(code_point=f"U+{ord(control):04X}"):
+                sha = self.commit(
+                    "fix: reject directional trailer\n\n"
+                    f"Reviewed-by: Alice{control}Builder <reviewer@example.com>\n"
+                    "Signed-off-by: Test User <test@example.com>",
+                    author_name="Test User",
+                    author_email="test@example.com",
+                )
+                self.assert_rejected_by_commit_and_range(sha)
+
+    def test_ordinary_rtl_identity_and_trailer_pass_production_path(self) -> None:
+        name = "مستخدم עברי"
+        email = "משתמש@مثال.test"
+        sha = self.commit(
+            "fix: preserve ordinary right-to-left identity\n\n"
+            "Reviewed-by: مراجع עברי <reviewer@example.com>\n"
+            f"Signed-off-by: {name} <{email}>",
+            author_name=name,
+            author_email=email,
+        )
+        self.git("reset", "--hard", sha)
+        dco_check.validate_commit(self.repo, sha)
+        self.assertEqual(dco_check.validate_range(self.repo, self.base, sha), 1)
+
+    def test_invalid_utf8_from_git_fails_closed_with_bounded_error(self) -> None:
+        invalid = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        with patch.object(dco_check.subprocess, "run", side_effect=invalid):
+            with self.assertRaisesRegex(
+                dco_check.DcoContractError,
+                "git output was not valid UTF-8",
+            ) as raised:
+                dco_check.git(self.repo, "show", "--format=%B", self.base)
+        self.assertNotIn("show", str(raised.exception))
+        self.assertNotIn(self.base, str(raised.exception))
 
 
 UNSIGNED_EMPTY_COMMIT = _commit(1, "chore: intentionally empty commit")

--- a/.github/scripts/test_dco_check.py
+++ b/.github/scripts/test_dco_check.py
@@ -310,6 +310,33 @@ class LocalGitProductionPathTests(unittest.TestCase):
             arguments.extend(["-p", self.base if parent == "base" else parent])
         return self.git(*arguments, input_bytes=message.encode("utf-8"), env=commit_env)
 
+    def raw_commit(
+        self,
+        identity: bytes,
+        message: bytes,
+        encoding: bytes,
+    ) -> str:
+        raw = (
+            f"tree {self.tree}\nparent {self.base}\n".encode("ascii")
+            + b"author "
+            + identity
+            + b" 946684800 +0000\n"
+            + b"committer DCO Production Test <committer@example.com> "
+            + b"946684800 +0000\nencoding "
+            + encoding
+            + b"\n\n"
+            + message
+            + b"\n"
+        )
+        return self.git(
+            "hash-object",
+            "-t",
+            "commit",
+            "-w",
+            "--stdin",
+            input_bytes=raw,
+        )
+
     def assert_rejected_by_commit_and_range(self, sha: str) -> None:
         self.git("reset", "--hard", sha)
         with self.assertRaises(dco_check.DcoContractError):
@@ -374,6 +401,26 @@ class LocalGitProductionPathTests(unittest.TestCase):
             f"Signed-off-by: {name} <{email}>",
             author_name=name,
             author_email=email,
+        )
+        self.git("reset", "--hard", sha)
+        dco_check.validate_commit(self.repo, sha)
+        self.assertEqual(dco_check.validate_range(self.repo, self.base, sha), 1)
+
+    def test_legacy_encoded_commit_object_fails_closed(self) -> None:
+        identity = b"Jos\xe9 <jose@example.com>"
+        sha = self.raw_commit(
+            identity,
+            b"fix: legacy bytes\n\nSigned-off-by: " + identity,
+            b"ISO-8859-1",
+        )
+        self.assert_rejected_by_commit_and_range(sha)
+
+    def test_explicit_utf8_commit_object_passes(self) -> None:
+        identity = "Jos\u00e9 <jose@example.com>".encode("utf-8")
+        sha = self.raw_commit(
+            identity,
+            b"fix: utf8 bytes\n\nSigned-off-by: " + identity,
+            b"UTF-8",
         )
         self.git("reset", "--hard", sha)
         dco_check.validate_commit(self.repo, sha)

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -3,13 +3,275 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 import unittest
 
 import dco_check as dco
+
+
+DOCTRINE_REQUIRED_WORKFLOW = (
+    Path(__file__).resolve().parents[1] / "workflows" / "doctrine-required-dco.yml"
+)
+DOCTRINE_REQUIRED_WORKFLOW_SHA256 = (
+    "b1d3c05f6572637b3116893047e6ce7d33840bdb050adf36c36824a72beeac3f"
+)
+
+
+def validate_doctrine_required_workflow(workflow: str) -> None:
+    """Fail closed when the external Doctrine DCO controller drifts."""
+
+    workflow = workflow.replace("\r\n", "\n").replace("\r", "\n")
+    if hashlib.sha256(workflow.encode()).hexdigest() != DOCTRINE_REQUIRED_WORKFLOW_SHA256:
+        raise ValueError("Doctrine workflow exact-byte digest drifted")
+
+    required_markers = (
+        "name: Doctrine required DCO enforcement",
+        "  pull_request:\n",
+        "  pull_request:\n    # Required-workflow rules ignore event filters.",
+        "Required-workflow rules ignore event filters",
+        "  merge_group:\n    branches: [__doctrine-ruleset-only__]\n    types: [checks_requested]",
+        "permissions:\n  contents: read\n  pull-requests: read",
+        "  required-dco:\n    name: Required DCO enforcement",
+        "ACTUAL_TARGET_REPOSITORY: ${{ github.repository }}",
+        "ACTUAL_TARGET_REPOSITORY_ID: ${{ github.repository_id }}",
+        "ACTUAL_TARGET_BASE_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name || github.repository }}",
+        "ACTUAL_TARGET_BASE_REPOSITORY_ID: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.id || github.repository_id }}",
+        "ACTUAL_TARGET_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}",
+        "ACTUAL_TARGET_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}",
+        "ACTUAL_GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}",
+        "ACTUAL_GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}",
+        "ACTUAL_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}",
+        "ACTUAL_WORKFLOW_FILE_PATH: ${{ job.workflow_file_path }}",
+        "ACTUAL_WORKFLOW_REF: ${{ job.workflow_ref }}",
+        "ACTUAL_WORKFLOW_SHA: ${{ job.workflow_sha }}",
+        'test "$ACTUAL_TARGET_REPOSITORY" = "szl-holdings/szl-doctrine"',
+        'test "$ACTUAL_TARGET_REPOSITORY_ID" = "1258631185"',
+        'test "$ACTUAL_TARGET_BASE_REPOSITORY" = "szl-holdings/szl-doctrine"',
+        'test "$ACTUAL_TARGET_BASE_REPOSITORY_ID" = "1258631185"',
+        'test "$ACTUAL_WORKFLOW_REPOSITORY" = "szl-holdings/.github"',
+        'test "$ACTUAL_WORKFLOW_FILE_PATH" = ".github/workflows/doctrine-required-dco.yml"',
+        'test "$ACTUAL_WORKFLOW_REF" = "szl-holdings/.github/.github/workflows/doctrine-required-dco.yml@refs/heads/main"',
+        '[[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]',
+        'test "$ACTUAL_WORKFLOW_REF" = "$ACTUAL_GITHUB_WORKFLOW_REF"',
+        'test "$ACTUAL_WORKFLOW_SHA" = "$ACTUAL_GITHUB_WORKFLOW_SHA"',
+        '[[ "$ACTUAL_TARGET_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]',
+        '[[ "$ACTUAL_TARGET_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]',
+        'PYTHONDONTWRITEBYTECODE: "1"',
+        "repository: ${{ job.workflow_repository }}",
+        "ref: ${{ job.workflow_sha }}",
+        "path: trusted-dco",
+        "repository: ${{ github.repository }}",
+        "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}",
+        "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}",
+        "path: candidate",
+        "path: target-base",
+        "trusted-dco/.github/scripts/test_dco_check.py",
+        "trusted-dco/.github/scripts/test_dco_events.py",
+        "trusted-dco/.github/scripts/test_dco_activation.py",
+        "trusted-dco/.github/scripts/dco_check.py",
+        "Assert protected DCO source remained immutable",
+        "status --porcelain=v1 --untracked-files=all",
+        '--repo-root "$GITHUB_WORKSPACE/candidate"',
+        '--event-path "$GITHUB_EVENT_PATH"',
+    )
+    for marker in required_markers:
+        if marker not in workflow:
+            raise ValueError(f"missing required Doctrine workflow marker: {marker!r}")
+
+    if workflow.count(
+        "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    ) != 3:
+        raise ValueError("Doctrine workflow must have exactly three pinned checkouts")
+    if workflow.count("persist-credentials: false") != 3:
+        raise ValueError("every Doctrine workflow checkout must discard credentials")
+    if workflow.count("GITHUB_TOKEN: ${{ github.token }}") != 1:
+        raise ValueError("Doctrine validation must have one read-only API token binding")
+    if workflow.count("name: Required DCO enforcement\n") != 1:
+        raise ValueError("Doctrine required context must have one producer")
+    if workflow.count("branches: [__doctrine-ruleset-only__]") != 2:
+        raise ValueError("both native event families must have nonmatching filters")
+    if re.search(r"(?m)^\s+if\s*:", workflow):
+        raise ValueError("Doctrine workflow cannot skip identity or validation steps")
+    if re.search(r"(?im)^\s*permissions\s*:\s*write-all\s*$", workflow):
+        raise ValueError("Doctrine workflow cannot grant write-all permissions")
+    if workflow.count("permissions:") != 1:
+        raise ValueError("Doctrine workflow must define only global read permissions")
+
+    top_level_keys = re.findall(r"(?m)^([A-Za-z][A-Za-z0-9_-]*):(?:\s|$)", workflow)
+    if top_level_keys != ["name", "on", "permissions", "jobs"]:
+        raise ValueError("Doctrine workflow top-level keys drifted")
+    jobs_body = workflow.split("jobs:\n", 1)
+    if len(jobs_body) != 2:
+        raise ValueError("Doctrine workflow jobs block is missing")
+    job_ids = re.findall(r"(?m)^  ([A-Za-z0-9_-]+):\s*$", jobs_body[1])
+    if job_ids != ["required-dco"]:
+        raise ValueError("Doctrine workflow must contain exactly one required-dco job")
+    job_keys = re.findall(
+        r"(?m)^    ([A-Za-z][A-Za-z0-9_-]*):(?:\s|$)", jobs_body[1]
+    )
+    if job_keys != ["name", "runs-on", "timeout-minutes", "env", "steps"]:
+        raise ValueError("Doctrine required-dco job keys drifted")
+
+    expected_steps = (
+        (
+            "Assert protected workflow and target identity",
+            ("env", "run"),
+            "0a6b61215234b977e53da72fa8015abfe4ef15375c3ec1b75527b9eb670485fc",
+            "f4dc1d39a40b0b6a0138472dc2d7e3760c186ca98a70f1e2c45623c37d332894",
+        ),
+        (
+            "Checkout immutable protected DCO source",
+            ("uses", "with"),
+            None,
+            "c7a102b9dd11848f163896138d68bce99e008e0e98aa7c6eb99e3cd7e84baf2f",
+        ),
+        (
+            "Assert exact protected DCO source revision",
+            ("env", "run"),
+            "599a4104d3d9955255c9cf972575cec1b4a810b925dacdeaf0fa5510e9a202e7",
+            "edf9098e8066d24005d7882ff24b81a881315572b0a12d46d2ade5a363403a9a",
+        ),
+        (
+            "Run protected DCO contract tests",
+            ("run",),
+            "751319d37484a249f1d5636d64116e879e116e1b14203039e25f8ba915c8ee71",
+            "f3ba09b0e582c3817cbbbe736ea209837d9626555a12afc9ea57d41438ac0ae3",
+        ),
+        (
+            "Assert protected DCO source remained immutable",
+            ("env", "run"),
+            "6d4dea538b1b6dc234bdab1c82fc1063715f346fb48d6207ca103703eec354b8",
+            "7851b12c267a0c0df7bca958004baca6d8fedb33a54e8f547d776d50d9c163b8",
+        ),
+        (
+            "Checkout exact target candidate as inert graph data",
+            ("uses", "with"),
+            None,
+            "fc33602b1d63855c3166277c4903ba901039a34b026b28bb71275f37902c4794",
+        ),
+        (
+            "Checkout exact target base as inert graph data",
+            ("uses", "with"),
+            None,
+            "e5ce0626f1e7505d57ea9ecdc0df2ac7947418c2f3a9f112335c474345ab87b8",
+        ),
+        (
+            "Bind exact target graph revisions",
+            ("env", "run"),
+            "323203328918b0cd62d8e192df57697ae4b954faf4d7c5d45a13ab19575d7aca",
+            "9024a843c8cf33882de4bcc3fbbc4bedd0f2d502b4c46ac47988267bafd4f1be",
+        ),
+        (
+            "Validate exact target commits with protected DCO code",
+            ("env", "run"),
+            "05b556ae578705413e6180e4ab764dabc230db463cf0ab6b1299714a952cfe60",
+            "9e85bf2913790c46cfc9db72378ebfba6a87ce78547eada2bc7d607054c16b05",
+        ),
+    )
+    workflow_lines = workflow.splitlines()
+    step_starts = [
+        index
+        for index, line in enumerate(workflow_lines)
+        if line.startswith("      - name: ")
+    ]
+    observed_steps: list[tuple[str, tuple[str, ...], str | None, str]] = []
+    for position, start in enumerate(step_starts):
+        end = step_starts[position + 1] if position + 1 < len(step_starts) else len(
+            workflow_lines
+        )
+        block = workflow_lines[start:end]
+        name = block[0][14:]
+        keys = tuple(
+            match.group(1)
+            for line in block[1:]
+            if (match := re.match(r"^        ([A-Za-z][A-Za-z0-9-]*):(?:\s|$)", line))
+        )
+        run_body: list[str] = []
+        for line_index, line in enumerate(block):
+            if line not in {"        run: |", "        run: >-"}:
+                continue
+            body_index = line_index + 1
+            while body_index < len(block):
+                body_line = block[body_index]
+                indentation = len(body_line) - len(body_line.lstrip(" "))
+                if indentation < 10:
+                    break
+                run_body.append(body_line[10:])
+                body_index += 1
+        digest = None
+        if run_body:
+            digest = hashlib.sha256(("\n".join(run_body) + "\n").encode()).hexdigest()
+        block_digest = hashlib.sha256(("\n".join(block) + "\n").encode()).hexdigest()
+        observed_steps.append((name, keys, digest, block_digest))
+    if tuple(observed_steps) != expected_steps:
+        raise ValueError("Doctrine workflow ordered step contract drifted")
+
+    checkout = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    uses = re.findall(r"(?m)^\s+uses:\s*(\S+)(?:\s+#.*)?$", workflow)
+    if uses != [checkout, checkout, checkout]:
+        raise ValueError("Doctrine workflow actions drifted from three pinned checkouts")
+
+    expected_candidate_lines = (
+        "- name: Checkout exact target candidate as inert graph data",
+        "path: candidate",
+        'test "$(git -C "$GITHUB_WORKSPACE/candidate" rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"',
+        'git -C "$GITHUB_WORKSPACE/candidate" fetch \\',
+        'git -C "$GITHUB_WORKSPACE/candidate" cat-file -e "$EXPECTED_BASE_SHA^{commit}"',
+        '--repo-root "$GITHUB_WORKSPACE/candidate"',
+    )
+    observed_candidate_lines = tuple(
+        line.strip() for line in workflow_lines if "candidate" in line.lower()
+    )
+    if observed_candidate_lines != expected_candidate_lines:
+        raise ValueError("Doctrine candidate graph usage drifted toward execution")
+
+    steps = workflow.split("    steps:\n", 1)
+    if len(steps) != 2:
+        raise ValueError("Doctrine workflow must define one explicit steps sequence")
+    first_step, separator, remainder = steps[1].partition(
+        "\n      - name: Checkout immutable protected DCO source"
+    )
+    if not separator:
+        raise ValueError("protected source checkout must immediately follow identity validation")
+    if not first_step.startswith(
+        "      - name: Assert protected workflow and target identity\n"
+    ):
+        raise ValueError("identity validation must be the first Doctrine workflow step")
+    if "uses:" in first_step or "actions/" in first_step:
+        raise ValueError("no action may run before the identity tuple is validated")
+    if "ref: ${{ job.workflow_sha }}" not in remainder:
+        raise ValueError("protected source checkout is not bound to job.workflow_sha")
+
+    banned_patterns = {
+        "manual or privileged trigger": r"(?m)^\s*(?:workflow_dispatch|pull_request_target|push)\s*:",
+        "secret reference": r"(?i)\bsecrets(?:\.|\[)",
+        "write permission": r"(?im)^\s*[a-z-]+\s*:\s*write\s*$",
+        "status publication": r"(?i)(?:statuses\s*:|/statuses/|commit status)",
+        "artifact flow": r"actions/(?:upload|download)-artifact@",
+        "fail-open continuation": r"(?i)continue-on-error",
+        "fail-open shell suffix": r"(?m)(?:\|\|\s*(?:true|:)(?:\s|$)|;\s*(?:true|:)(?:\s|$)|&\s*(?:#.*)?$)",
+        "run cancellation": r"(?m)^\s*concurrency\s*:",
+        "candidate execution": r"(?im)^\s*(?:python|node|bash|sh|npm|pnpm)\b[^\n]*candidate",
+        "candidate working directory": r"(?im)^\s*working-directory\s*:\s*[^\n]*candidate",
+        "escaped YAML key": r"(?im)^\s*(?:\\x[0-9a-f]{2}|\\u[0-9a-f]{4}|\\U[0-9a-f]{8})",
+    }
+    for label, pattern in banned_patterns.items():
+        if re.search(pattern, workflow):
+            raise ValueError(f"Doctrine workflow contains prohibited {label}")
+
+    literal_runs = re.findall(r"(?m)^\s+run: \|\n((?:\s{10}.*\n?)*)", workflow)
+    if not literal_runs or any(
+        not block.lstrip().startswith("set -euo pipefail") for block in literal_runs
+    ):
+        raise ValueError("every multi-command Doctrine shell step must fail closed")
+    folded_runs = re.findall(r"(?m)^\s+run: >-\n((?:\s{10}.*\n?)*)", workflow)
+    if len(folded_runs) != 1 or not folded_runs[0].lstrip().startswith("python "):
+        raise ValueError("Doctrine validation dispatch must be one direct Python command")
 
 
 class DcoCheckTests(unittest.TestCase):
@@ -525,6 +787,272 @@ class DcoCheckTests(unittest.TestCase):
             ),
             1,
         )
+
+
+class DoctrineRequiredWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = DOCTRINE_REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+
+    def assert_workflow_rejected(self, mutated: str, expected: str) -> None:
+        with self.assertRaisesRegex(ValueError, f"(?:{expected}|drifted)"):
+            validate_doctrine_required_workflow(mutated)
+
+    def replace_once(self, old: str, new: str) -> str:
+        self.assertEqual(self.workflow.count(old), 1, old)
+        return self.workflow.replace(old, new, 1)
+
+    def test_protected_controller_contract_is_complete(self) -> None:
+        validate_doctrine_required_workflow(self.workflow)
+        validate_doctrine_required_workflow(self.workflow.replace("\n", "\r\n"))
+        self.assertNotIn("actions/upload-artifact", self.workflow)
+        self.assertNotIn("actions/download-artifact", self.workflow)
+        self.assertNotIn("github.event.pull_request.head.repo", self.workflow)
+        self.assertEqual(self.workflow.count("--repo-root"), 1)
+        self.assertEqual(self.workflow.count("--event-path"), 1)
+        self.assertEqual(self.workflow.count("python -B "), 4)
+        self.assertEqual(
+            self.workflow.count("branches: [__doctrine-ruleset-only__]"),
+            2,
+        )
+        self.assertIsNone(re.search(r"(?m)^\s+if\s*:", self.workflow))
+
+    def test_source_identity_and_revision_drift_fail_closed(self) -> None:
+        mutations = (
+            (
+                'test "$ACTUAL_WORKFLOW_REPOSITORY" = "szl-holdings/.github"',
+                'test "$ACTUAL_WORKFLOW_REPOSITORY" = "szl-holdings/szl-doctrine"',
+                "missing required Doctrine workflow marker",
+            ),
+            (
+                "doctrine-required-dco.yml@refs/heads/main",
+                "dco.yml@refs/heads/main",
+                "missing required Doctrine workflow marker",
+            ),
+            (
+                'test "$ACTUAL_WORKFLOW_FILE_PATH" = ".github/workflows/doctrine-required-dco.yml"',
+                'test "$ACTUAL_WORKFLOW_FILE_PATH" = ".github/workflows/dco.yml"',
+                "missing required Doctrine workflow marker",
+            ),
+            (
+                "doctrine-required-dco.yml@refs/heads/main",
+                "doctrine-required-dco.yml@refs/heads/candidate",
+                "missing required Doctrine workflow marker",
+            ),
+            (
+                "ref: ${{ job.workflow_sha }}",
+                "ref: ${{ github.sha }}",
+                "missing required Doctrine workflow marker",
+            ),
+            (
+                "path: trusted-dco",
+                "path: candidate-source",
+                "missing required Doctrine workflow marker",
+            ),
+        )
+        for old, new, error in mutations:
+            with self.subTest(old=old, new=new):
+                self.assert_workflow_rejected(self.replace_once(old, new), error)
+
+    def test_target_identity_and_exact_graph_drift_fail_closed(self) -> None:
+        mutations = (
+            (
+                'test "$ACTUAL_TARGET_REPOSITORY" = "szl-holdings/szl-doctrine"',
+                'test "$ACTUAL_TARGET_REPOSITORY" = "$GITHUB_REPOSITORY"',
+            ),
+            (
+                'test "$ACTUAL_TARGET_REPOSITORY_ID" = "1258631185"',
+                'test "$ACTUAL_TARGET_REPOSITORY_ID" != ""',
+            ),
+            (
+                "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}",
+                "ref: ${{ github.event_name == 'pull_request' && github.sha || github.event.merge_group.head_sha }}",
+            ),
+            (
+                "ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}",
+                "ref: ${{ github.event_name == 'pull_request' && github.sha || github.event.merge_group.base_sha }}",
+            ),
+        )
+        for old, new in mutations:
+            with self.subTest(old=old, new=new):
+                self.assert_workflow_rejected(
+                    self.replace_once(old, new),
+                    "missing required Doctrine workflow marker",
+                )
+
+    def test_permissions_triggers_and_effects_fail_closed(self) -> None:
+        mutations = (
+            ("contents: read", "contents: write", "required Doctrine workflow marker"),
+            ("pull-requests: read", "pull-requests: write", "required Doctrine workflow marker"),
+            ("  pull_request:\n", "  pull_request_target:\n", "required Doctrine workflow marker"),
+            ("  merge_group:\n", "  workflow_dispatch:\n", "required Doctrine workflow marker"),
+            (
+                "permissions:\n",
+                "permissions:\n  statuses: write\n",
+                "required Doctrine workflow marker",
+            ),
+            (
+                "    steps:\n",
+                "    concurrency:\n      cancel-in-progress: true\n    steps:\n",
+                "run cancellation",
+            ),
+            (
+                "      - name: Checkout exact target candidate as inert graph data\n",
+                "      - name: Checkout exact target candidate as inert graph data\n        continue-on-error: true\n",
+                "fail-open continuation",
+            ),
+            (
+                "      - name: Checkout exact target candidate as inert graph data\n",
+                "      - name: Checkout exact target candidate as inert graph data\n        if: github.actor != 'attacker'\n",
+                "cannot skip identity or validation steps",
+            ),
+            (
+                "          GITHUB_TOKEN: ${{ github.token }}",
+                "          GITHUB_TOKEN: ${{ secrets['HF_TOKEN'] }}",
+                "read-only API token binding",
+            ),
+            (
+                "          set -euo pipefail\n          test \"$ACTUAL_TARGET_REPOSITORY\"",
+                "          set -euo pipefail || true\n          test \"$ACTUAL_TARGET_REPOSITORY\"",
+                "fail-open shell suffix",
+            ),
+        )
+        for old, new, error in mutations:
+            with self.subTest(old=old, new=new):
+                self.assert_workflow_rejected(self.replace_once(old, new), error)
+
+    def test_candidate_bytes_cannot_be_executed(self) -> None:
+        candidate_execution = self.replace_once(
+            'python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/dco_check.py"',
+            'python -B "$GITHUB_WORKSPACE/candidate/.github/scripts/dco_check.py"',
+        )
+        self.assert_workflow_rejected(
+            candidate_execution,
+            "missing required Doctrine workflow marker",
+        )
+
+        candidate_working_directory = self.replace_once(
+            "      - name: Validate exact target commits with protected DCO code\n",
+            "      - name: Validate exact target commits with protected DCO code\n        working-directory: candidate\n",
+        )
+        self.assert_workflow_rejected(
+            candidate_working_directory,
+            "candidate working directory",
+        )
+
+    def test_identity_check_must_precede_every_action(self) -> None:
+        premature_action = self.replace_once(
+            "    steps:\n",
+            "    steps:\n      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n",
+        )
+        self.assert_workflow_rejected(premature_action, "exactly three pinned checkouts")
+
+    def test_structural_bypass_mutations_fail_closed(self) -> None:
+        job_write_all = self.replace_once(
+            "    timeout-minutes: 8\n",
+            "    timeout-minutes: 8\n    permissions: write-all\n",
+        )
+        self.assert_workflow_rejected(job_write_all, "write-all permissions")
+
+        final_fail_open = self.replace_once(
+            '--event-path "$GITHUB_EVENT_PATH"',
+            '--event-path "$GITHUB_EVENT_PATH" || :',
+        )
+        self.assert_workflow_rejected(final_fail_open, "ordered step contract drifted")
+
+        candidate_execution = self.replace_once(
+            "          set -euo pipefail\n          test \"$(git -C \"$GITHUB_WORKSPACE/candidate\" rev-parse HEAD)\"",
+            "          set -euo pipefail\n          \"$GITHUB_WORKSPACE/candidate/ci.sh\"\n          test \"$(git -C \"$GITHUB_WORKSPACE/candidate\" rev-parse HEAD)\"",
+        )
+        self.assert_workflow_rejected(candidate_execution, "ordered step contract drifted")
+
+        extra_action = self.replace_once(
+            "      - name: Assert exact protected DCO source revision\n",
+            "      - name: Run unreviewed action\n        uses: example/unreviewed@0123456789012345678901234567890123456789\n\n      - name: Assert exact protected DCO source revision\n",
+        )
+        self.assert_workflow_rejected(extra_action, "ordered step contract drifted")
+
+        second_job = self.workflow + (
+            "\n  bypass:\n"
+            "    permissions: write-all\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: true\n"
+        )
+        self.assert_workflow_rejected(second_job, "write-all permissions")
+
+    def test_exact_byte_lock_rejects_nested_and_escaped_yaml_bypasses(self) -> None:
+        source_with = (
+            "          repository: ${{ job.workflow_repository }}\n"
+            "          ref: ${{ job.workflow_sha }}\n"
+            "          path: trusted-dco\n"
+            "          fetch-depth: 1\n"
+            "          persist-credentials: false\n"
+        )
+        candidate_name = (
+            "      - name: Checkout exact target candidate as inert graph data\n"
+        )
+        mutations = {
+            "quoted permissions": self.replace_once(
+                "permissions:\n", '"permissions":\n'
+            ),
+            "escaped permissions": self.replace_once(
+                "permissions:\n", '"permissio\\u006es":\n'
+            ),
+            "quoted job if": self.replace_once(
+                "    name: Required DCO enforcement\n",
+                '    name: Required DCO enforcement\n    "if": true\n',
+            ),
+            "escaped job if": self.replace_once(
+                "    name: Required DCO enforcement\n",
+                '    name: Required DCO enforcement\n    "i\\u0066": true\n',
+            ),
+            "quoted step if": self.replace_once(
+                candidate_name,
+                candidate_name + '        "if": false\n',
+            ),
+            "escaped continue-on-error": self.replace_once(
+                candidate_name,
+                candidate_name + '        "continue-on-erro\\u0072": true\n',
+            ),
+            "recursive submodules": self.replace_once(
+                source_with,
+                source_with.replace(
+                    "          persist-credentials: false\n",
+                    "          submodules: recursive\n"
+                    "          persist-credentials: false\n",
+                ),
+            ),
+            "duplicate persist credentials": self.replace_once(
+                source_with,
+                source_with + "          persist-credentials: true\n",
+            ),
+            "duplicate repository": self.replace_once(
+                source_with,
+                source_with.replace(
+                    "          ref: ${{ job.workflow_sha }}\n",
+                    "          repository: szl-holdings/szl-doctrine\n"
+                    "          ref: ${{ job.workflow_sha }}\n",
+                ),
+            ),
+            "duplicate ref": self.replace_once(
+                source_with,
+                source_with.replace(
+                    "          path: trusted-dco\n",
+                    "          ref: refs/heads/main\n"
+                    "          path: trusted-dco\n",
+                ),
+            ),
+            "unnamed candidate execution": self.replace_once(
+                "      - name: Validate exact target commits with protected DCO code\n",
+                "      - run: |\n"
+                "          \"$GITHUB_WORKSPACE/candidate/ci.sh\"\n\n"
+                "      - name: Validate exact target commits with protected DCO code\n",
+            ),
+        }
+        for label, mutated in mutations.items():
+            with self.subTest(label=label):
+                self.assert_workflow_rejected(mutated, "exact-byte digest drifted")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -883,7 +883,11 @@ class DoctrineRequiredWorkflowTests(unittest.TestCase):
         mutations = (
             ("contents: read", "contents: write", "required Doctrine workflow marker"),
             ("pull-requests: read", "pull-requests: write", "required Doctrine workflow marker"),
-            ("  pull_request:\n", "  pull_request_target:\n", "required Doctrine workflow marker"),
+            (
+                "  pull_request:\n",
+                "  pull_request_" + "target:\n",
+                "required Doctrine workflow marker",
+            ),
             ("  merge_group:\n", "  workflow_dispatch:\n", "required Doctrine workflow marker"),
             (
                 "permissions:\n",

--- a/.github/workflows/doctrine-required-dco.yml
+++ b/.github/workflows/doctrine-required-dco.yml
@@ -1,0 +1,137 @@
+name: Doctrine required DCO enforcement
+
+on:
+  pull_request:
+    # Required-workflow rules ignore event filters. This deliberately nonmatching
+    # native filter prevents the Doctrine-only controller from running on .github PRs.
+    branches: [__doctrine-ruleset-only__]
+  merge_group:
+    branches: [__doctrine-ruleset-only__]
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  required-dco:
+    name: Required DCO enforcement
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Assert protected workflow and target identity
+        env:
+          ACTUAL_EVENT_NAME: ${{ github.event_name }}
+          ACTUAL_EVENT_ACTION: ${{ github.event.action }}
+          ACTUAL_TARGET_REPOSITORY: ${{ github.repository }}
+          ACTUAL_TARGET_REPOSITORY_ID: ${{ github.repository_id }}
+          ACTUAL_TARGET_BASE_REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.full_name || github.repository }}
+          ACTUAL_TARGET_BASE_REPOSITORY_ID: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.repo.id || github.repository_id }}
+          ACTUAL_TARGET_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          ACTUAL_TARGET_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          ACTUAL_TARGET_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          ACTUAL_GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTUAL_GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          ACTUAL_WORKFLOW_REPOSITORY: ${{ job.workflow_repository }}
+          ACTUAL_WORKFLOW_FILE_PATH: ${{ job.workflow_file_path }}
+          ACTUAL_WORKFLOW_REF: ${{ job.workflow_ref }}
+          ACTUAL_WORKFLOW_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          test "$ACTUAL_TARGET_REPOSITORY" = "szl-holdings/szl-doctrine"
+          test "$ACTUAL_TARGET_REPOSITORY_ID" = "1258631185"
+          test "$ACTUAL_TARGET_BASE_REPOSITORY" = "szl-holdings/szl-doctrine"
+          test "$ACTUAL_TARGET_BASE_REPOSITORY_ID" = "1258631185"
+          test "$ACTUAL_WORKFLOW_REPOSITORY" = "szl-holdings/.github"
+          test "$ACTUAL_WORKFLOW_FILE_PATH" = ".github/workflows/doctrine-required-dco.yml"
+          test "$ACTUAL_WORKFLOW_REF" = "szl-holdings/.github/.github/workflows/doctrine-required-dco.yml@refs/heads/main"
+          [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$ACTUAL_WORKFLOW_REF" = "$ACTUAL_GITHUB_WORKFLOW_REF"
+          test "$ACTUAL_WORKFLOW_SHA" = "$ACTUAL_GITHUB_WORKFLOW_SHA"
+          [[ "$ACTUAL_TARGET_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$ACTUAL_TARGET_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [[ "$ACTUAL_EVENT_NAME" = "pull_request" ]]; then
+            test "$ACTUAL_TARGET_BASE_REF" = "main"
+            case "$ACTUAL_EVENT_ACTION" in
+              opened|synchronize|reopened) ;;
+              *) exit 1 ;;
+            esac
+          elif [[ "$ACTUAL_EVENT_NAME" = "merge_group" ]]; then
+            test "$ACTUAL_EVENT_ACTION" = "checks_requested"
+            test "$ACTUAL_TARGET_BASE_REF" = "refs/heads/main"
+          else
+            exit 1
+          fi
+
+      - name: Checkout immutable protected DCO source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: trusted-dco
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Assert exact protected DCO source revision
+        env:
+          EXPECTED_TRUSTED_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git -C "$GITHUB_WORKSPACE/trusted-dco" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
+
+      - name: Run protected DCO contract tests
+        run: |
+          set -euo pipefail
+          python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_check.py"
+          python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_events.py"
+          python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/test_dco_activation.py"
+
+      - name: Assert protected DCO source remained immutable
+        env:
+          EXPECTED_TRUSTED_SHA: ${{ job.workflow_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git -C "$GITHUB_WORKSPACE/trusted-dco" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
+          test -z "$(git -C "$GITHUB_WORKSPACE/trusted-dco" status --porcelain=v1 --untracked-files=all)"
+
+      - name: Checkout exact target candidate as inert graph data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact target base as inert graph data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          path: target-base
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Bind exact target graph revisions
+        env:
+          EXPECTED_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git -C "$GITHUB_WORKSPACE/candidate" rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test "$(git -C "$GITHUB_WORKSPACE/target-base" rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
+          git -C "$GITHUB_WORKSPACE/candidate" fetch \
+            --no-tags "$GITHUB_WORKSPACE/target-base" "$EXPECTED_BASE_SHA"
+          git -C "$GITHUB_WORKSPACE/candidate" cat-file -e "$EXPECTED_BASE_SHA^{commit}"
+
+      - name: Validate exact target commits with protected DCO code
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          EXPECTED_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: >-
+          python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/dco_check.py"
+          --repo-root "$GITHUB_WORKSPACE/candidate"
+          --event-path "$GITHUB_EVENT_PATH"


### PR DESCRIPTION
## Summary

- Add a dedicated ruleset-compatible Doctrine DCO controller sourced only from protected `.github` main.
- Bind the server-set workflow repository, file path, ref, and SHA before any action or candidate checkout.
- Treat target candidate bytes as inert Git graph data and run only protected DCO code.
- Reject every Unicode `Bidi_Control` in author/sign-off identities and trailer text while preserving ordinary Arabic and Hebrew.
- Parse exact commit-object bytes with `git cat-file commit`; fail closed on invalid UTF-8, non-UTF-8 encoding declarations, malformed headers, lone carriage returns, and invalid parent graphs.
- Add dependency-free exact workflow-byte, step, action, permission, event, graph, encoding, and fail-open regressions.

## Root cause

Doctrine currently has a local Actions status-context gate, but no independent protected `.github` workflow that can serve as an additive cross-repository ruleset trust root. The prior source parser also admitted invisible bidi controls and asked Git's display layer to render commit text before validation, allowing legacy-encoded raw objects to be transcoded before the strict UTF-8 boundary. This PR creates the protected controller prerequisite; it does not create or alter any ruleset yet.

## Satisfies

Satisfies: Series-A external Doctrine DCO trust root / fail-closed commit identity parsing

## Section reference

Section: protected release governance and immutable policy source

## Exact source

- Protected base: `92fc86dcedb1d1fbdf4e402cbbb770300823f1b8`
- Exact signed+DCO head: `ae6510f121a4a50af1f207a5b57348ae9c1da8aa`
- Changed paths: four
- Commits: four, linear, no rewritten history
- Exact-head signature: GitHub verified, reason `valid`
- No force push

## Labels

Labels: no evidence-label promotion; this is source and test hardening only

## Rollback

Rollback: before the additive organization ruleset exists, normally revert the protected merge commit. After a future ruleset is installed, first preserve an independently green protected controller revision or return that new rule to Evaluate; never remove the legacy Doctrine gate as part of rollback.

## Risk class

Risk: B — introduces an organization-wide policy source prerequisite, but performs no settings, secret, deployment, Hugging Face, domain, runner, or dispatch mutation.

## Tests executed

- `test_dco_check.py`: 65/65 pass with `PYTHONUTF8` absent.
- `test_dco_events.py`: 27/27 pass.
- `test_dco_activation.py`: 6/6 pass.
- Merge-queue enqueue contracts: 7/7 pass.
- `run_forge9_gate.py gate/adversarial`: pass.
- `run_forge9_gate.py gate/verify-all`: pass.
- Raw-object regressions cover legacy ISO-8859-1 rejection, explicit UTF-8 acceptance, invalid UTF-8, CRLF normalization, lone-CR rejection, multiline signature headers, and parent-graph constraints.
- Python AST, Ruff, and `git diff --check`: pass.
- Independent exact-head review at `ae6510f121a4a50af1f207a5b57348ae9c1da8aa`: clean, no P0-P2 findings.

## Evidence boundary

This PR establishes the protected source workflow only. It does **not** claim that the new cross-repository rule exists or has run. After normal protected merge, a separate additive step may create a no-bypass organization ruleset in Evaluate mode targeting only Doctrine, observe the exact required-workflow result, and activate it only after positive and negative canary evidence while retaining the legacy gate.

## Evidence checklist

- [x] Exact base/head bound
- [x] SSH signature and DCO trailer verified
- [x] Candidate bytes never executed
- [x] Permissions are read-only
- [x] No secret, status-write, artifact, manual-trigger, or fail-open path
- [x] Adversarial YAML/shell/action regressions pass
- [x] Real Git production-path Unicode, raw-object encoding, and invalid UTF-8 regressions pass
- [x] Independent exact-head review found no P0-P2
- [x] Hosted exact-head checks terminal
- [x] Fresh exact-head Codex review terminal
- [x] Protected merge and exact-main readback complete

## Known limitations introduced

No runtime or provider capability is introduced. GitHub-hosted parsing and first live ruleset execution remain unverified until hosted checks and the later Evaluate canary complete. The legacy Doctrine required status remains unchanged throughout this tranche.