### PR TITLE
fix(dco): bind queue signoff by author email

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -840,21 +840,34 @@ def validate_merge_group(repo: Path, base_sha: str, head_sha: str) -> int:
         if line.strip()
     ]
     require(range_shas and range_shas[-1] == head_sha, "merge-group range does not end at head")
+    require(
+        len(range_shas) == len(set(range_shas)),
+        "merge-group range contains duplicate SHAs",
+    )
     previous_sha = base_sha
     for sha in range_shas:
-        parents, _, _, _ = commit_record(repo, sha)
+        parents, _, author_email, message = commit_record(repo, sha)
         require(
             parents == [previous_sha],
             "merge-group range is not a linear single-parent squash sequence",
         )
+        identities = valid_dco_identities(message)
+        require(
+            identities,
+            f"{sha} has no valid terminal Signed-off-by trailer",
+        )
+        # GitHub creates merge-queue squash commits on a protected temporary
+        # ref and can canonicalize the account display name independently of
+        # the exact source-commit author name. The source commits retain the
+        # stricter name-and-email check above; only this provider-generated
+        # merge_group path accepts an exact, case-sensitive author-email match.
+        require(
+            any(identity_email == author_email for _, identity_email in identities),
+            f"{sha} Signed-off-by email does not exactly match "
+            "the merge-group commit author email",
+        )
         previous_sha = sha
-    return validate_commits(
-        repo,
-        range_shas,
-        head_sha,
-        allow_merge_commits=False,
-        checked_out_head_sha=head_sha,
-    )
+    return len(range_shas)
 
 
 def push_subject(payload: dict[str, Any], github_sha: str) -> tuple[str, str]:

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -536,6 +536,48 @@ class DcoCheckTests(unittest.TestCase):
             nonlinear_head,
         )
 
+    def test_merge_group_provider_name_canonicalization_is_email_bound(self) -> None:
+        provider_head = self.commit(
+            "fix: provider-generated squash\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        self.assertEqual(
+            dco.validate_merge_group(self.repo, self.base, provider_head),
+            1,
+        )
+
+        self.git("reset", "--hard", self.base)
+        wrong_email = self.commit(
+            "fix: provider-generated mismatch\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <other@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        self.assert_rejected(
+            "email does not exactly match",
+            dco.validate_merge_group,
+            self.repo,
+            self.base,
+            wrong_email,
+        )
+
+        self.git("reset", "--hard", self.base)
+        wrong_case = self.commit(
+            "fix: provider-generated case mismatch\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <Builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        self.assert_rejected(
+            "email does not exactly match",
+            dco.validate_merge_group,
+            self.repo,
+            self.base,
+            wrong_case,
+        )
+
     def test_push_identity_contract(self) -> None:
         head = self.commit("fix: push\n\nSigned-off-by: Series A Builder <builder@example.com>")
         payload = {"ref": "refs/heads/main", "before": self.base, "after": head}


### PR DESCRIPTION
## Governance metadata

Satisfies: AT-22

Rollback: Before merge, close this pull request. After merge, revert the protected merge commit only after an independently green replacement validates GitHub-generated squash merge-group heads without weakening ordinary source-commit DCO identity checks.

Labels: governance, security, ci

Risk: D - changes the privileged native DCO merge-queue validation path; no ruleset, branch-protection, secret value, App credential, deployment, Hugging Face, model, dataset, or product-runtime mutation.

Solo-Operator-Authorization: confirmed

## Incident

PR #411 entered the protected merge queue with a signed exact head, 45 passing checks, zero unresolved threads, and an exact-head QILLQAQ App approval. GitHub generated temporary squash head `45f2a2b6e38711abbdf5b038a94cbcf093309994`; Native DCO then rejected GitHub's provider-normalized author name even though the valid terminal sign-off preserved the exact author email.

Failed PR 411 run: https://github.com/szl-holdings/.github/actions/runs/31461211561

Failed controller-repair bootstrap run: https://github.com/szl-holdings/.github/actions/runs/31462352402

## What changed

- Keeps exact name-and-email DCO matching unchanged for ordinary source commits, pull-request commits, and protected pushes.
- Scopes provider display-name canonicalization handling to the already-admitted `merge_group` path.
- Requires the queue range to remain unique, linear, single-parent, and bound to the protected merge-group head.
- Requires every queue squash commit to contain a valid terminal DCO trailer whose email exactly and case-sensitively matches the generated commit author email.
- Adds positive provider-normalization coverage plus wrong-email and wrong-case fail-closed regressions.

## Validation

- Focused DCO regressions: 4/4 PASS in 52.14 seconds.
- `git diff --check`: PASS.
- Provider queue identity bootstrap: verified signed+DCO zero-tree-delta commit `580bb52dbf4bc1eb2d28329c24fa6263de370561`.
- Complete three-suite Windows run: UNAVAILABLE after the 120-second execution bound; not claimed green.
- Hosted exact-head DCO self-tests and required workflows: PENDING.

## Exact source

- Protected base: `265f9f55aaaf2c478fbd72e9545784b2237b545b`
- Signed+DCO head: `580bb52dbf4bc1eb2d28329c24fa6263de370561`
- Scope: `.github/scripts/dco_check.py` and `.github/scripts/test_dco_events.py`