### PR TITLE
docs(security): link live alert dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All Actions are SHA-pinned and wrapped with [`step-security/harden-runner`](http
 - Email: `security@szlholdings.com`
 - Canonical RFC 9116 record: [`security.txt`](./security.txt)
 - Org-wide: branch protection rulesets, signed-commit enforcement, CODEOWNERS, OpenSSF Scorecard
-- Live status: 0 open Dependabot · 0 open secret-scanning · 0 open CodeQL
+- Live security status is authoritative only in GitHub's [Dependabot](https://github.com/szl-holdings/.github/security/dependabot), [secret-scanning](https://github.com/szl-holdings/.github/security/secret-scanning), and [CodeQL](https://github.com/szl-holdings/.github/security/code-scanning) dashboards; this README does not freeze alert counts.
 
 ## Tooling for contributors
 


### PR DESCRIPTION
## Scope

One-file public-truth canary built directly from protected main at 265f9f55aaaf2c478fbd72e9545784b2237b545b.

The README no longer freezes zero-valued Dependabot, secret-scanning, or CodeQL claims. It routes readers to GitHub's live security dashboards and states that alert counts are runtime state.

## Exact source

- Head: a55fa89b5bdd4e11e34d426c33b233b4258b2fbf
- Parent: 265f9f55aaaf2c478fbd72e9545784b2237b545b
- Changed path: README.md only
- Commit signature: verified SSH signature
- DCO: one exact canonical trailer

## Validation

- git diff --check: pass
- Scope: 1 insertion, 1 deletion, 1 file
- Local markdownlint-cli2: unavailable; no dependency installation attempted
- Hosted Markdown, security, DCO, pinning, and doctrine checks remain required evidence

## Governance boundary

Protected main already contains the external Doctrine DCO controller from PR #413. This canary does not change DCO workflows, rulesets, publisher workflows, secrets, or privilege domains. Native DCO removal remains a separate overlap-and-witness operation.

## Required before merge

- Exact-head hosted checks must pass.
- Independent exact-head review must find no actionable issue.
- All actionable review threads must be resolved.
- Protected merge and exact-main readback remain separate evidence.