### PR TITLE
fix(hf): retarget protected-main redeploy to current a11oy

### DIFF
--- a/.github/workflows/redeploy-a11oy-protected-main.yml
+++ b/.github/workflows/redeploy-a11oy-protected-main.yml
@@ -28,7 +28,7 @@ jobs:
       SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
       HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      EXPECTED_A11OY_MAIN: 389c26224437b5e38da44396e1c8bae5ee061557
+      EXPECTED_A11OY_MAIN: 90ed8c7289efbda085d82f0dc60cf821b22f5caf
       REPORT_ISSUE_TITLE: '[a11oy-canonical-redeploy] protected-main restoration'
     steps:
       - name: Checkout organization control plane


### PR DESCRIPTION
## Outcome

Retarget the existing protected A11oy recovery controller to the exact current protected `szl-holdings/a11oy@90ed8c7289efbda085d82f0dc60cf821b22f5caf`.

The recovery workflow already dispatches the canonical `a11oy/.github/workflows/hf-sync.yml`, waits for its own source-binding/parity gates, verifies one public RUNNING canonical Space, and rejects retired clone IDs. The stale hard-coded expected SHA prevented that recovery lane from being used against current protected main.

## Root cause

A11oy protected `main` advanced beyond the last canonical Hugging Face relock, while the recovery workflow remained pinned to an obsolete expected main SHA. Current PR drift guards therefore correctly fail because live `/api/build-info` is not yet source-bound to current protected main.

## Exact source

- `.github` protected base: `265f9f55aaaf2c478fbd72e9545784b2237b545b`
- Repair head: `6a6263227f79aa74c8909623a06b679a0109b6ca`
- Target A11oy protected main: `90ed8c7289efbda085d82f0dc60cf821b22f5caf`
- Changed paths: one
- Change: one exact SHA substitution only

## Contract metadata

Satisfies: C-158

Labels: PROVED source-only retarget of the existing protected recovery workflow; MEASURED deployment only after the workflow's own exact-run and Hugging Face readback succeed; NOT CLAIMED deployment from this PR itself.

Rollback: Before merge, close this PR. After merge, if the recovery lane is no longer appropriate, revert the protected merge through a new signed+DCO PR; do not alter Hugging Face state outside the canonical `hf-sync.yml` path.

Risk: B — retargets the existing one-shot recovery controller to current protected A11oy main; no secret value, model, dataset, ruleset, branch-protection, or direct Hugging Face mutation is included in this source change.

Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>