### PR TITLE
fix(hf): retarget protected-main redeploy after DCO repair

### DIFF
--- a/.github/workflows/redeploy-a11oy-protected-main.yml
+++ b/.github/workflows/redeploy-a11oy-protected-main.yml
@@ -28,7 +28,7 @@ jobs:
       SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
       HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      EXPECTED_A11OY_MAIN: 389c26224437b5e38da44396e1c8bae5ee061557
+      EXPECTED_A11OY_MAIN: 90ed8c7289efbda085d82f0dc60cf821b22f5caf
       REPORT_ISSUE_TITLE: '[a11oy-canonical-redeploy] protected-main restoration'
     steps:
       - name: Checkout organization control plane


### PR DESCRIPTION
## Outcome

Current-main successor to #419 after protected DCO queue repair #417 merged. Retargets the existing protected A11oy recovery controller to exact `szl-holdings/a11oy@90ed8c7289efbda085d82f0dc60cf821b22f5caf` from current `.github` protected main.

## Root cause

The recovery controller remained hard-pinned to obsolete A11oy source `389c262...`, while the canonical live Space is still source-bound to an older protected revision. The controller itself is already designed to dispatch `a11oy/hf-sync.yml` through managed repository authority, wait for that exact run, then verify the canonical public RUNNING Space and retired-clone absence.

## Exact source

- `.github` protected base: `5c2119e3a97447471bd1f14f4f306e12edc04203`
- Repair head: `b87dd92939a92dbfe3d7689b1ada35eb8576a1d3`
- Target A11oy protected main: `90ed8c7289efbda085d82f0dc60cf821b22f5caf`
- Changed paths: one
- Change: one exact SHA substitution only

## Contract metadata

Satisfies: C-158

Labels: PROVED current-main source-only recovery retarget; MEASURED deployment only after protected recovery, exact hf-sync run, and Hugging Face live readback succeed; NOT CLAIMED deployment from this PR.

Rollback: Before merge, close this PR. After merge, revert only through a new protected signed+DCO PR; keep Hugging Face writes on canonical `a11oy/hf-sync.yml`.

Risk: B — current-main retarget of an existing protected recovery controller; no secret value, ruleset, branch-protection, model, dataset, or direct Hub mutation.

Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>