### PR TITLE
fix(dco): validate draft canaries in protected controller

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -748,6 +748,8 @@ def collect_pr_commits(
     expected_base: str,
     expected_head: str,
     api_get: Callable[[str], Any],
+    *,
+    allow_draft: bool = False,
 ) -> list[str]:
     expected_base = require_sha(expected_base, "pull-request base SHA")
     expected_head = require_sha(expected_head, "pull-request head SHA")
@@ -769,7 +771,9 @@ def collect_pr_commits(
             and 0 < declared <= MAX_PULL_REQUEST_COMMITS,
             "pull-request commit count is outside the supported range",
         )
-        require(current.get("draft") is False, "draft pull requests cannot satisfy DCO")
+        draft = current.get("draft")
+        require(isinstance(draft, bool), "pull-request draft state is not boolean")
+        require(allow_draft or not draft, "draft pull requests cannot satisfy DCO")
         return declared
 
     declared_count = stable_metadata()
@@ -887,6 +891,7 @@ def validate_pull_request_target(
     *,
     expected_base_sha: str | None = None,
     expected_head_sha: str | None = None,
+    allow_draft: bool = False,
 ) -> int:
     require(payload.get("action") in ALLOWED_PR_ACTIONS, "pull-request action is unsupported")
     require(
@@ -926,7 +931,14 @@ def validate_pull_request_target(
     require(isinstance(number, int) and number > 0, "pull-request number is invalid")
     require(bool(token), "GITHUB_TOKEN is required for trusted PR validation")
     getter = api_get or (lambda path: github_get(path, token))
-    shas = collect_pr_commits(repository, number, base_sha, head_sha, getter)
+    shas = collect_pr_commits(
+        repository,
+        number,
+        base_sha,
+        head_sha,
+        getter,
+        allow_draft=allow_draft,
+    )
     require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match event head")
     merge_base = require_sha(
         git(repo, "merge-base", base_sha, head_sha).strip(),
@@ -948,6 +960,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo-root", type=Path, required=True)
     parser.add_argument("--event-path", type=Path, required=True)
+    parser.add_argument(
+        "--allow-draft",
+        action="store_true",
+        help="validate DCO on draft PRs when GitHub cannot dispatch ready_for_review",
+    )
     return parser.parse_args()
 
 
@@ -976,6 +993,7 @@ def main() -> int:
                 _required_environment("GITHUB_TOKEN"),
                 expected_base_sha=_required_environment("EXPECTED_BASE_SHA"),
                 expected_head_sha=_required_environment("EXPECTED_HEAD_SHA"),
+                allow_draft=args.allow_draft,
             )
         elif event_name == "merge_group":
             base_sha, head_sha = merge_group_subject(payload, github_sha)

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -18,7 +18,7 @@ DOCTRINE_REQUIRED_WORKFLOW = (
     Path(__file__).resolve().parents[1] / "workflows" / "doctrine-required-dco.yml"
 )
 DOCTRINE_REQUIRED_WORKFLOW_SHA256 = (
-    "b1d3c05f6572637b3116893047e6ce7d33840bdb050adf36c36824a72beeac3f"
+    "43b210ab34819bd617b0892b3fa60a9c910d63fca2ca59fc93874b27ab22d51a"
 )
 
 
@@ -78,6 +78,7 @@ def validate_doctrine_required_workflow(workflow: str) -> None:
         "status --porcelain=v1 --untracked-files=all",
         '--repo-root "$GITHUB_WORKSPACE/candidate"',
         '--event-path "$GITHUB_EVENT_PATH"',
+        "--allow-draft",
     )
     for marker in required_markers:
         if marker not in workflow:
@@ -91,6 +92,8 @@ def validate_doctrine_required_workflow(workflow: str) -> None:
         raise ValueError("every Doctrine workflow checkout must discard credentials")
     if workflow.count("GITHUB_TOKEN: ${{ github.token }}") != 1:
         raise ValueError("Doctrine validation must have one read-only API token binding")
+    if workflow.count("--allow-draft") != 1:
+        raise ValueError("Doctrine required workflow must explicitly validate draft PR commits")
     if workflow.count("name: Required DCO enforcement\n") != 1:
         raise ValueError("Doctrine required context must have one producer")
     if workflow.count("branches: [__doctrine-ruleset-only__]") != 2:
@@ -169,8 +172,8 @@ def validate_doctrine_required_workflow(workflow: str) -> None:
         (
             "Validate exact target commits with protected DCO code",
             ("env", "run"),
-            "05b556ae578705413e6180e4ab764dabc230db463cf0ab6b1299714a952cfe60",
-            "9e85bf2913790c46cfc9db72378ebfba6a87ce78547eada2bc7d607054c16b05",
+            "925c200c57a237dfd8c21ec158b14018fed30a984c4d29deb677308cb484bbbf",
+            "8b357ad998cea49994f3a9e44525d3ec5ded8618462d6263e2ff9a2d963e7866",
         ),
     )
     workflow_lines = workflow.splitlines()
@@ -627,6 +630,41 @@ class DcoCheckTests(unittest.TestCase):
             "a" * 40,
             rejected[-1],
             over_limit,
+        )
+
+    def test_draft_pr_requires_explicit_protected_controller_opt_in(self) -> None:
+        head = "b" * 40
+
+        def draft_pr(path: str):
+            if "/commits?" in path:
+                page = int(path.rsplit("page=", 1)[1])
+                return [{"sha": head}] if page == 1 else []
+            return {
+                "base": {"sha": "a" * 40},
+                "head": {"sha": head},
+                "commits": 1,
+                "draft": True,
+            }
+
+        self.assert_rejected(
+            "draft pull requests cannot satisfy DCO",
+            dco.collect_pr_commits,
+            "szl-holdings/.github",
+            400,
+            "a" * 40,
+            head,
+            draft_pr,
+        )
+        self.assertEqual(
+            dco.collect_pr_commits(
+                "szl-holdings/.github",
+                400,
+                "a" * 40,
+                head,
+                draft_pr,
+                allow_draft=True,
+            ),
+            [head],
         )
 
     def test_pr_duplicate_and_count_churn_fail(self) -> None:

--- a/.github/workflows/doctrine-required-dco.yml
+++ b/.github/workflows/doctrine-required-dco.yml
@@ -135,3 +135,4 @@ jobs:
           python -B "$GITHUB_WORKSPACE/trusted-dco/.github/scripts/dco_check.py"
           --repo-root "$GITHUB_WORKSPACE/candidate"
           --event-path "$GITHUB_EVENT_PATH"
+          --allow-draft


### PR DESCRIPTION
## Outcome

Closes the remaining draft-controller deadlock after protected merge #417 without weakening native/default DCO enforcement.

The external Doctrine required-workflow controller can now validate an exact draft PR commit range. Ordinary pull-request, push, and merge-group DCO paths still reject drafts unless the protected controller explicitly supplies `--allow-draft`.

## Root cause

The organization ruleset evaluates an external required workflow while candidate canaries are still drafts. The protected controller used the default parser behavior, which correctly rejected drafts, but GitHub does not guarantee another ruleset-workflow dispatch on an unchanged draft-to-ready transition. That could strand otherwise valid signed+DCO canaries before activation.

## Scope

- Add an explicit `allow_draft` parameter to the trusted PR commit collector and validator.
- Require the draft value to be a real boolean.
- Expose `--allow-draft` as a fail-closed CLI opt-in.
- Pass the flag only from `.github/workflows/doctrine-required-dco.yml`.
- Bind the protected workflow's exact digest and add regressions proving default rejection plus protected opt-in.

## Validation

Exact protected base: `0d5637707cd491e7de8740e1773b205e9dda2e45`

Signed+DCO head: `82ae2a3f2d85c96c0792f75e2c08a4519e1b424a`

Local exact-base results:

- `test_dco_check.py`: 65/65 PASS
- `test_dco_events.py`: 29/29 PASS
- `test_dco_activation.py`: 6/6 PASS
- FORGE-9 `gate/verify-all`: PASS
- Merge-queue contract: 7/7 PASS
- `py_compile`: PASS
- `git diff --check`: PASS

Hosted actionlint, CodeQL, DCO, FORGE-9, and exact-head review remain required before any ready transition.

## Governance boundary

This PR does not activate ruleset 20678558, change bypass actors, alter branch protection, read or change secrets, deploy to Hugging Face, or mutate canary PRs. Activation and collision-canary evidence remain separate protected steps after this exact successor merges and exact-main checks pass.

Rollback: close this draft before merge; after merge, revert only through a new protected signed+DCO PR.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>