### PR TITLE
fix(hf): retarget protected-main redeploy to current a11oy

### DIFF
--- a/.github/workflows/redeploy-a11oy-protected-main.yml
+++ b/.github/workflows/redeploy-a11oy-protected-main.yml
@@ -28,7 +28,7 @@ jobs:
       SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
       HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      EXPECTED_A11OY_MAIN: 389c26224437b5e38da44396e1c8bae5ee061557
+      EXPECTED_A11OY_MAIN: 90ed8c7289efbda085d82f0dc60cf821b22f5caf
       REPORT_ISSUE_TITLE: '[a11oy-canonical-redeploy] protected-main restoration'
     steps:
       - name: Checkout organization control plane


### PR DESCRIPTION
## Satisfies

Satisfies: C-158

## Root cause

The protected A11oy recovery controller remains pinned to obsolete source 389c26224437b5e38da44396e1c8bae5ee061557. PRs #419 and #420 carry the intended current-source retarget but their commits are cryptographically unsigned. This successor performs only the one exact SHA substitution from current protected main.

## Exact source

- .github base: 0d5637707cd491e7de8740e1773b205e9dda2e45
- Signed+DCO head: 22b695dacdaec0310bd315bc5e6f3857d7138e9d
- Target a11oy protected main: 90ed8c7289efbda085d82f0dc60cf821b22f5caf

## Validation

- Exact old pin occurrence: 1
- git diff --cached --check: PASS
- git verify-commit: PASS

## Truth boundary

This source-only controller retarget does not claim that a redeploy occurred. Deployment and exact Hugging Face live readback remain post-merge workflow evidence.

## Risk and rollback

Risk: B, one exact source pin in an existing protected controller. Before merge, close this PR. After merge, revert through a new signed+DCO protected PR; do not mutate Hugging Face directly.

Supersedes unsigned #419 and #420.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>