### PR TITLE
docs(security): link live alert dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All Actions are SHA-pinned and wrapped with [`step-security/harden-runner`](http
 - Email: `security@szlholdings.com`
 - Canonical RFC 9116 record: [`security.txt`](./security.txt)
 - Org-wide: branch protection rulesets, signed-commit enforcement, CODEOWNERS, OpenSSF Scorecard
-- Live security status is authoritative only in GitHub's [Dependabot](https://github.com/szl-holdings/.github/security/dependabot), [secret-scanning](https://github.com/szl-holdings/.github/security/secret-scanning), and [CodeQL](https://github.com/szl-holdings/.github/security/code-scanning) dashboards; this README does not freeze alert counts.
+- This repository's live security status is authoritative only in GitHub's [Dependabot](https://github.com/szl-holdings/.github/security/dependabot), [secret-scanning](https://github.com/szl-holdings/.github/security/secret-scanning), and [CodeQL](https://github.com/szl-holdings/.github/security/code-scanning) dashboards; organization-wide alert state is not asserted here, and this README does not freeze alert counts.
 
 ## Tooling for contributors
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All Actions are SHA-pinned and wrapped with [`step-security/harden-runner`](http
 - Email: `security@szlholdings.com`
 - Canonical RFC 9116 record: [`security.txt`](./security.txt)
 - Org-wide: branch protection rulesets, signed-commit enforcement, CODEOWNERS, OpenSSF Scorecard
-- Live status: 0 open Dependabot · 0 open secret-scanning · 0 open CodeQL
+- Live security status is authoritative only in GitHub's [Dependabot](https://github.com/szl-holdings/.github/security/dependabot), [secret-scanning](https://github.com/szl-holdings/.github/security/secret-scanning), and [CodeQL](https://github.com/szl-holdings/.github/security/code-scanning) dashboards; this README does not freeze alert counts.
 
 ## Tooling for contributors
 


### PR DESCRIPTION
## Root cause

The README froze zero security-alert counts that can become stale immediately. This current-main successor replaces that unsupported snapshot with links to the authoritative GitHub Dependabot, secret-scanning, and CodeQL dashboards.

## Scope

- One README line
- No alert dismissal, workflow, ruleset, secret, deployment, model, dataset, or runtime mutation

## Validation

- git diff --cached --check: PASS
- git verify-commit: PASS
- Exact source head: eaba651f02417bf5555cc181ecd7ab8755beb589
- Exact base: 0d5637707cd491e7de8740e1773b205e9dda2e45

## Truth boundary

The links identify authoritative live dashboards; this PR does not claim that their current alert counts are zero.

## Risk and rollback

Risk: B, public documentation truth correction only. Before merge, close this PR. After merge, revert through a new signed+DCO protected PR.

Supersedes stale draft #418.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>