### PR TITLE
chore(deps): update pinned GitHub Actions group

### DIFF
--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -49,7 +49,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/anatomy-map-hf-drift.yml
+++ b/.github/workflows/anatomy-map-hf-drift.yml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/bundle-ref-check.yml
+++ b/.github/workflows/bundle-ref-check.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -83,7 +83,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4.3.0
       - name: Markdown lint
-        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: '**/*.md'
         continue-on-error: true

--- a/.github/workflows/code-security-drift.yml
+++ b/.github/workflows/code-security-drift.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/codename-gate.yml
+++ b/.github/workflows/codename-gate.yml
@@ -47,7 +47,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,15 +28,15 @@ jobs:
           echo "Found $JS_FILES JS/TS files"
       - name: Initialize CodeQL
         if: steps.check-code.outputs.js_files != '0'
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: javascript-typescript
       - name: Autobuild
         if: steps.check-code.outputs.js_files != '0'
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       - name: Perform CodeQL Analysis
         if: steps.check-code.outputs.js_files != '0'
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       - name: CodeQL skipped (no analyzable code)
         if: steps.check-code.outputs.js_files == '0'
         run: echo "No JavaScript/TypeScript files found — CodeQL analysis not applicable for this repo type."

--- a/.github/workflows/energy-provenance-sweep.yml
+++ b/.github/workflows/energy-provenance-sweep.yml
@@ -58,7 +58,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-dataset-badge-refresh.yml
+++ b/.github/workflows/hf-dataset-badge-refresh.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-license-consistency.yml
+++ b/.github/workflows/hf-license-consistency.yml
@@ -50,7 +50,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-module-drift-check.yml
+++ b/.github/workflows/hf-module-drift-check.yml
@@ -56,7 +56,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-module-drift-prune.yml
+++ b/.github/workflows/hf-module-drift-prune.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/hf-org-card-embed-check.yml
+++ b/.github/workflows/hf-org-card-embed-check.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/license-consistency.yml
+++ b/.github/workflows/license-consistency.yml
@@ -50,7 +50,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/lockfile-registry-check.yml
+++ b/.github/workflows/lockfile-registry-check.yml
@@ -76,7 +76,7 @@ jobs:
       contents: write # only to commit the refreshed report + dedup state in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/merge-queue-enqueue.yml
+++ b/.github/workflows/merge-queue-enqueue.yml
@@ -34,7 +34,7 @@ jobs:
       SOURCE_GATE_RUN_ID: ${{ github.event.workflow_run.id }}
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/organization-control-sweep.yml
+++ b/.github/workflows/organization-control-sweep.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout exact source
@@ -86,7 +86,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout current protected main
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout current protected main
@@ -199,7 +199,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout current protected main
@@ -250,7 +250,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout current protected main

--- a/.github/workflows/overclaim-guard.yml
+++ b/.github/workflows/overclaim-guard.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/overclaim-sweep.yml
+++ b/.github/workflows/overclaim-sweep.yml
@@ -61,7 +61,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/pin-check-reusable.yml
+++ b/.github/workflows/pin-check-reusable.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/public-repo-link-check.yml
+++ b/.github/workflows/public-repo-link-check.yml
@@ -69,7 +69,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/receipt-shape-sweep.yml
+++ b/.github/workflows/receipt-shape-sweep.yml
@@ -63,7 +63,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/required-check-drift.yml
+++ b/.github/workflows/required-check-drift.yml
@@ -58,7 +58,7 @@ jobs:
       contents: write # only to commit the refreshed report in szl-holdings/.github
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-bundle-ref-check.yml
+++ b/.github/workflows/reusable-bundle-ref-check.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -43,7 +43,7 @@ jobs:
         language: ${{ fromJSON(inputs.languages) }}
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -51,13 +51,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ inputs.build-mode }}
           queries: ${{ inputs.queries }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/reusable-dco.yml
+++ b/.github/workflows/reusable-dco.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-docs-ci.yml
+++ b/.github/workflows/reusable-docs-ci.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout
@@ -134,7 +134,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout
@@ -158,7 +158,7 @@ jobs:
     if: inputs.run-link-check
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout
@@ -181,7 +181,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
       - name: Checkout

--- a/.github/workflows/reusable-energy-provenance-guard.yml
+++ b/.github/workflows/reusable-energy-provenance-guard.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-gitleaks.yml
+++ b/.github/workflows/reusable-gitleaks.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-hf-deploy.yml
+++ b/.github/workflows/reusable-hf-deploy.yml
@@ -92,7 +92,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-hf-module-drift-check.yml
+++ b/.github/workflows/reusable-hf-module-drift-check.yml
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-lockfile-registry-check.yml
+++ b/.github/workflows/reusable-lockfile-registry-check.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-node-ci.yml
+++ b/.github/workflows/reusable-node-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Harden runner
         if: steps.skip.outputs.enabled == 'true'
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -120,11 +120,11 @@ jobs:
 
       - name: Setup pnpm (from package.json packageManager)
         if: steps.skip.outputs.enabled == 'true' && inputs.package-manager == 'pnpm' && steps.pkgmgr.outputs.present == 'true'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4.1.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup pnpm (from input version)
         if: steps.skip.outputs.enabled == 'true' && inputs.package-manager == 'pnpm' && steps.pkgmgr.outputs.present != 'true'
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v4.1.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ inputs.pnpm-version }}
 

--- a/.github/workflows/reusable-overclaim-guard.yml
+++ b/.github/workflows/reusable-overclaim-guard.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-receipt-shape-guard.yml
+++ b/.github/workflows/reusable-receipt-shape-guard.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-release-please.yml
+++ b/.github/workflows/reusable-release-please.yml
@@ -49,7 +49,7 @@ jobs:
       pull-requests: write  # update the release PR body
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write   # only used when attach-to-release runs on a tag push
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -70,7 +70,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         if: always() && hashFiles('trivy.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy.sarif
           category: trivy-fs

--- a/.github/workflows/reusable-scorecard.yml
+++ b/.github/workflows/reusable-scorecard.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -57,6 +57,6 @@ jobs:
           retention-days: 7
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/reusable-secret-scan.yml
+++ b/.github/workflows/reusable-secret-scan.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-trivy.yml
+++ b/.github/workflows/reusable-trivy.yml
@@ -30,7 +30,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload SARIF to code-scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-results.sarif
           category: trivy-fs

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -45,7 +45,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload SARIF to code-scanning
         if: always() && hashFiles('zizmor.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: zizmor.sarif
           category: zizmor

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,7 +54,7 @@ jobs:
           fi
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         if: always()
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Root cause

Dependabot PR #412 was generated from stale base 265f9f55aaaf2c478fbd72e9545784b2237b545b, remained behind current protected main, and failed the exact DCO identity contract because its trailer identity did not match the GitHub-authored commit identity. Restoring its old workflow snapshots would overwrite later governance work.

This successor re-derives only the intended action pin transitions from current protected main 0d5637707cd491e7de8740e1773b205e9dda2e45.

## Exact mappings

- step-security/harden-runner: 55 substitutions to b09bb98e06d4d774595224525879c09bc6e98c40, v2.20.1
- DavidAnson/markdownlint-cli2-action: 1 substitution to 21c1be1b93ad9ed58fa840aacc3f279cde2a72ff, v24.2.0
- github/codeql-action: 11 substitutions to 5595ccaf912efad79be6eef63a5619ff05969be3, v4.37.6
- pnpm/action-setup: 2 substitutions to 0977fd99725f1db4007ccb2928dbb4e90d06cc86, v6.0.10

## Validation

- 49 current-main workflow files changed
- 69 removed pin lines and 69 added pin lines
- Every removed and added line matched one approved old/new mapping
- No staged path escaped .github/workflows
- git diff --cached --check: PASS
- git verify-commit: PASS
- Exact signed+DCO head: 91f348b1a60e3627c538cb61499af75ae9fb1077

## Governance boundary

No workflow permissions, triggers, jobs, scripts, rulesets, secrets, or branch protections changed. Hosted action pin, DCO, security, and FORGE-9 checks remain required.

## Risk and rollback

Risk: B, dependency pin updates only. Before merge, close this PR. After merge, revert through a new signed+DCO protected PR.

Supersedes #412 without rewriting or deleting its branch.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>