### PR TITLE
fix(dco): attest protected squash pushes

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -742,6 +742,185 @@ def github_get(path: str, token: str) -> Any:
     return json.loads(data)
 
 
+def validate_github_squash_attestation(
+    repository: str,
+    sha: str,
+    parents: list[str],
+    author_name: str,
+    author_email: str,
+    message: str,
+    api_get: Callable[[str], Any],
+) -> None:
+    """Prove a name-canonicalized push commit is a GitHub squash merge."""
+    require(
+        isinstance(repository, str)
+        and repository.count("/") == 1
+        and all(repository.split("/")),
+        "GitHub repository slug is invalid",
+    )
+    sha = require_sha(sha, "provider squash SHA")
+    encoded_repo = quote(repository, safe="/")
+    payload = api_get(f"/repos/{encoded_repo}/commits/{sha}")
+    require(isinstance(payload, dict), "provider commit response is not an object")
+    require(payload.get("sha") == sha, "provider commit response SHA differs")
+
+    commit = payload.get("commit")
+    require(isinstance(commit, dict), "provider commit metadata is missing")
+    api_author = commit.get("author")
+    api_committer = commit.get("committer")
+    require(
+        isinstance(api_author, dict)
+        and (api_author.get("name"), api_author.get("email"))
+        == (author_name, author_email),
+        "provider commit author differs from the raw commit",
+    )
+    require(
+        isinstance(api_committer, dict)
+        and (api_committer.get("name"), api_committer.get("email"))
+        == ("GitHub", "noreply@github.com"),
+        "provider commit does not have the GitHub committer identity",
+    )
+    provider_account = payload.get("committer")
+    require(
+        isinstance(provider_account, dict)
+        and provider_account.get("login") == "web-flow"
+        and provider_account.get("type") == "User",
+        "provider commit is not attributed to the web-flow account",
+    )
+    verification = commit.get("verification")
+    require(
+        isinstance(verification, dict)
+        and verification.get("verified") is True
+        and verification.get("reason") == "valid"
+        and isinstance(verification.get("signature"), str)
+        and bool(verification["signature"])
+        and isinstance(verification.get("payload"), str)
+        and bool(verification["payload"]),
+        "provider commit is not validly signed by GitHub",
+    )
+
+    api_parents = payload.get("parents")
+    require(isinstance(api_parents, list), "provider commit parents are missing")
+    parent_shas = [
+        require_sha(parent.get("sha"), "provider commit parent SHA")
+        if isinstance(parent, dict)
+        else require(False, "provider commit parent is invalid")
+        for parent in api_parents
+    ]
+    require(parent_shas == parents, "provider commit parents differ from the raw commit")
+
+    pulls_path = f"/repos/{encoded_repo}/commits/{sha}/pulls"
+    pulls = api_get(f"{pulls_path}?per_page=100&page=1")
+    boundary = api_get(f"{pulls_path}?per_page=100&page=2")
+    require(isinstance(pulls, list), "associated pull requests are not an array")
+    require(
+        isinstance(boundary, list) and not boundary,
+        "associated pull-request boundary page was not empty",
+    )
+    matches = [
+        pull
+        for pull in pulls
+        if isinstance(pull, dict) and pull.get("merge_commit_sha") == sha
+    ]
+    require(
+        len(matches) == 1,
+        "provider commit is not the unique exact merged pull-request commit",
+    )
+    pull = matches[0]
+    number = pull.get("number")
+    require(
+        isinstance(number, int) and not isinstance(number, bool) and number > 0,
+        "associated pull-request number is invalid",
+    )
+    require(
+        pull.get("state") == "closed"
+        and pull.get("draft") is False
+        and isinstance(pull.get("merged_at"), str)
+        and bool(pull["merged_at"]),
+        "provider commit is not bound to a closed non-draft merged pull request",
+    )
+    base = pull.get("base")
+    head = pull.get("head")
+    require(
+        isinstance(base, dict)
+        and base.get("ref") == "main"
+        and isinstance(base.get("repo"), dict)
+        and base["repo"].get("full_name") == repository,
+        "provider squash pull request does not target this repository main",
+    )
+    require(
+        isinstance(head, dict)
+        and isinstance(head.get("sha"), str)
+        and SHA_PATTERN.fullmatch(head["sha"]) is not None,
+        "provider squash pull-request head SHA is invalid",
+    )
+    subject = message.partition("\n")[0]
+    require(
+        subject.endswith(f"(#{number})"),
+        "provider squash subject does not bind the merged pull-request number",
+    )
+
+
+def validate_push_range(
+    repo: Path,
+    base_sha: str,
+    head_sha: str,
+    repository: str,
+    token: str,
+    *,
+    api_get: Callable[[str], Any] | None = None,
+) -> int:
+    """Validate main pushes, admitting only proven GitHub name canonicalization."""
+    base_sha = require_sha(base_sha, "push base SHA")
+    head_sha = require_sha(head_sha, "push head SHA")
+    require(checked_out_head(repo) == head_sha, "checked-out HEAD does not match push head")
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", base_sha, head_sha],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    require(ancestor.returncode == 0, "push base SHA is not an ancestor of head SHA")
+    shas = [
+        line.strip()
+        for line in git(repo, "rev-list", "--reverse", f"{base_sha}..{head_sha}").splitlines()
+        if line.strip()
+    ]
+    require(shas and shas[-1] == head_sha, "push range does not end at head")
+    require(len(shas) == len(set(shas)), "push range contains duplicate SHAs")
+
+    provider_get = api_get
+    previous_sha = base_sha
+    for sha in shas:
+        parents, author_name, author_email, message = commit_record(repo, sha)
+        require(
+            parents == [previous_sha],
+            "push range is not a linear single-parent sequence",
+        )
+        identities = valid_dco_identities(message)
+        require(identities, f"{sha} has no valid terminal Signed-off-by trailer")
+        if (author_name, author_email) not in identities:
+            require(
+                any(identity_email == author_email for _, identity_email in identities),
+                f"{sha} Signed-off-by email does not exactly match the push commit author email",
+            )
+            if provider_get is None:
+                require(bool(token), "GITHUB_TOKEN is required for provider squash attestation")
+                provider_get = lambda path: github_get(path, token)
+            validate_github_squash_attestation(
+                repository,
+                sha,
+                parents,
+                author_name,
+                author_email,
+                message,
+                provider_get,
+            )
+        previous_sha = sha
+    return len(shas)
+
+
 def collect_pr_commits(
     repository: str,
     number: int,
@@ -969,7 +1148,13 @@ def main() -> int:
             count = validate_merge_group(repo, base_sha, head_sha)
         elif event_name == "push":
             base_sha, head_sha = push_subject(payload, github_sha)
-            count = validate_range(repo, base_sha, head_sha)
+            count = validate_push_range(
+                repo,
+                base_sha,
+                head_sha,
+                repository,
+                _required_environment("GITHUB_TOKEN"),
+            )
         else:
             raise DcoContractError(f"unsupported event: {event_name!r}")
 

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -542,6 +542,195 @@ class DcoCheckTests(unittest.TestCase):
         self.assertEqual(dco.push_subject(payload, head), (self.base, head))
         self.assert_rejected("not main", dco.push_subject, {**payload, "ref": "refs/heads/dev"}, head)
 
+    def test_push_provider_name_canonicalization_requires_verified_merged_pr(self) -> None:
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        commit_path = f"/repos/szl-holdings/.github/commits/{head}"
+        pulls_path = f"{commit_path}/pulls"
+        responses = {
+            commit_path: {
+                "sha": head,
+                "commit": {
+                    "author": {"name": "Lutar, Stephen P.", "email": "builder@example.com"},
+                    "committer": {"name": "GitHub", "email": "noreply@github.com"},
+                    "verification": {
+                        "verified": True,
+                        "reason": "valid",
+                        "signature": "signed",
+                        "payload": "bound payload",
+                    },
+                },
+                "committer": {"login": "web-flow", "type": "User"},
+                "parents": [{"sha": self.base}],
+            },
+            f"{pulls_path}?per_page=100&page=1": [
+                {
+                    "number": 411,
+                    "state": "closed",
+                    "draft": False,
+                    "merged_at": "2026-08-11T05:49:54Z",
+                    "merge_commit_sha": head,
+                    "base": {
+                        "ref": "main",
+                        "repo": {"full_name": "szl-holdings/.github"},
+                    },
+                    "head": {"sha": "d" * 40},
+                }
+            ],
+            f"{pulls_path}?per_page=100&page=2": [],
+        }
+        calls: list[str] = []
+
+        def api_get(path: str):
+            calls.append(path)
+            return responses[path]
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                head,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+            ),
+            1,
+        )
+        self.assertEqual(
+            calls,
+            [
+                commit_path,
+                f"{pulls_path}?per_page=100&page=1",
+                f"{pulls_path}?per_page=100&page=2",
+            ],
+        )
+
+        self.git("reset", "--hard", self.base)
+        strict = self.commit(
+            "fix: strict push\n\nSigned-off-by: Series A Builder <builder@example.com>"
+        )
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                strict,
+                "szl-holdings/.github",
+                "",
+                api_get=lambda path: self.fail(f"unexpected provider lookup: {path}"),
+            ),
+            1,
+        )
+
+    def test_push_provider_canonicalization_fails_closed(self) -> None:
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        commit_path = f"/repos/szl-holdings/.github/commits/{head}"
+        pulls_path = f"{commit_path}/pulls"
+
+        def api_get(
+            path: str,
+            *,
+            verified: bool = True,
+            login: str = "web-flow",
+            merge_sha: str | None = None,
+            base_ref: str = "main",
+        ):
+            if path == commit_path:
+                return {
+                    "sha": head,
+                    "commit": {
+                        "author": {
+                            "name": "Lutar, Stephen P.",
+                            "email": "builder@example.com",
+                        },
+                        "committer": {
+                            "name": "GitHub",
+                            "email": "noreply@github.com",
+                        },
+                        "verification": {
+                            "verified": verified,
+                            "reason": "valid" if verified else "unsigned",
+                            "signature": "signed" if verified else None,
+                            "payload": "bound payload" if verified else None,
+                        },
+                    },
+                    "committer": {"login": login, "type": "User"},
+                    "parents": [{"sha": self.base}],
+                }
+            if path == f"{pulls_path}?per_page=100&page=1":
+                return [
+                    {
+                        "number": 411,
+                        "state": "closed",
+                        "draft": False,
+                        "merged_at": "2026-08-11T05:49:54Z",
+                        "merge_commit_sha": merge_sha or head,
+                        "base": {
+                            "ref": base_ref,
+                            "repo": {"full_name": "szl-holdings/.github"},
+                        },
+                        "head": {"sha": "d" * 40},
+                    }
+                ]
+            if path == f"{pulls_path}?per_page=100&page=2":
+                return []
+            self.fail(f"unexpected provider lookup: {path}")
+
+        cases = (
+            (
+                "not validly signed",
+                lambda path: api_get(path, verified=False),
+            ),
+            (
+                "web-flow",
+                lambda path: api_get(path, login="attacker"),
+            ),
+            (
+                "unique exact merged",
+                lambda path: api_get(path, merge_sha="f" * 40),
+            ),
+            (
+                "does not target",
+                lambda path: api_get(path, base_ref="release/unsafe"),
+            ),
+        )
+        for error, provider in cases:
+            with self.subTest(error=error):
+                with self.assertRaisesRegex(dco.DcoContractError, error):
+                    dco.validate_push_range(
+                        self.repo,
+                        self.base,
+                        head,
+                        "szl-holdings/.github",
+                        "",
+                        api_get=provider,
+                    )
+
+        self.git("reset", "--hard", self.base)
+        wrong_email = self.commit(
+            "fix: provider mismatch (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <other@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        with self.assertRaisesRegex(dco.DcoContractError, "email does not exactly match"):
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                wrong_email,
+                "szl-holdings/.github",
+                "",
+                api_get=lambda path: self.fail(f"unexpected provider lookup: {path}"),
+            )
+
     def test_pr_pagination_boundaries_and_freshness(self) -> None:
         for count in (249, 250):
             shas = [f"{number + 1:040x}" for number in range(count)]

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -682,7 +682,7 @@ class DcoCheckTests(unittest.TestCase):
                 ]
             if path == f"{pulls_path}?per_page=100&page=2":
                 return []
-            self.fail(f"unexpected provider lookup: {path}")
+            raise AssertionError(f"unexpected provider lookup: {path}")
 
         cases = (
             (

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -212,6 +212,8 @@ jobs:
 
       - name: Validate exact protected push range
         if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           python "$GITHUB_WORKSPACE/trusted/.github/scripts/dco_check.py"
           --repo-root "$GITHUB_WORKSPACE/candidate"


### PR DESCRIPTION
## Governance metadata

Satisfies: AT-22

Rollback: Before merge, close this pull request. After merge, revert the protected merge commit through a new signed+DCO pull request. Do not weaken the strict ordinary-commit identity path or rewrite protected history.

Labels: governance, security, ci

Risk: D - changes the protected native DCO controller and its read-only token binding. It does not grant write access, change branch protection, expose a secret, bypass review, or mutate product runtime.

Solo-Operator-Authorization: CONFIRMED

## Observed failure

PR #411 passed the repaired merge-group DCO gate and merged normally, but GitHub generated main commit `0d5637707cd491e7de8740e1773b205e9dda2e45` with author display name `Lutar, Stephen P.` while preserving terminal signoff name `Stephen P. Lutar Jr.` at the same exact email. The strict post-merge push path rejected that provider canonicalization.

## Change

- Keeps exact case-sensitive author name and email matching for ordinary commits.
- Allows name-only canonicalization on a linear protected-main push only after the commit API proves a valid GitHub signature, the `web-flow` committer, exact raw author and parent metadata, and a unique closed non-draft merged pull request into this repository main.
- Requires the terminal signoff email to match the raw commit author email exactly and binds the squash subject to the merged PR number.
- Fails closed on API errors, wrong email or case, unsigned or non-GitHub commits, ambiguous PR association, pagination drift, non-main targets, and nonlinear history.
- Adds only the existing read-only `github.token` to the push validation step; workflow permissions remain `contents: read`, `pull-requests: read`, and `statuses: write`.

## Validation

- Provider/push regression slice: 3/3 PASS.
- DCO activation-contract suite: 6/6 PASS.
- `git diff --check`: PASS.
- Exact commit signature: VERIFIED locally with the authorized SSH signer.
- Full hosted checks: PENDING.

## Exact source

- Protected base: `0d5637707cd491e7de8740e1773b205e9dda2e45`
- Exact signed+DCO head: `fc5060e`
- Files: `.github/scripts/dco_check.py`, `.github/scripts/test_dco_events.py`, `.github/workflows/dco.yml`

## Release state

- QILLQAQ exact-head App attestation: PENDING.
- Protected merge queue: NOT ENTERED.
- Merge: NOT PERFORMED.
- No protection, ruleset, environment, secret, or deployment mutation was performed by this PR.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>