### PR TITLE
fix(dco): bind protected squashes to source history

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import re
@@ -12,7 +13,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 from urllib.error import URLError
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 from urllib.request import Request, urlopen
 
 
@@ -24,6 +25,7 @@ SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 PATCH_DIVIDER_PATTERN = re.compile(r"^---(?:[ \t\r]|$)")
 QUEUE_REF_PREFIX = "refs/heads/gh-readonly-queue/main/"
 ALLOWED_PR_ACTIONS = {"opened", "synchronize", "reopened", "ready_for_review", "edited"}
+GITHUB_WEB_FLOW_COMMITTER = ("GitHub", "noreply@github.com")
 
 # Audited horizontal separators: TAB, SPACE, and every Unicode Zs code point.
 # Name, email, and trailer text separately reject C0/C1 controls, Unicode line
@@ -603,7 +605,10 @@ def git_bytes(repo: Path, *args: str) -> bytes:
     return completed.stdout
 
 
-def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
+def commit_record(
+    repo: Path,
+    sha: str,
+) -> tuple[list[str], str, str, str, str, str]:
     require_sha(sha, "commit SHA")
     raw_bytes = git_bytes(repo, "cat-file", "commit", sha)
     try:
@@ -618,8 +623,8 @@ def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
 
     parents: list[str] = []
     author: tuple[str, str] | None = None
+    committer: tuple[str, str] | None = None
     tree_seen = False
-    committer_seen = False
     encoding_seen = False
     current_header: str | None = None
     for line in headers.split("\n"):
@@ -645,8 +650,16 @@ def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
             require(match is not None, f"commit author header is malformed for {sha}")
             author = (match.group("name"), match.group("email"))
         elif key == "committer":
-            require(not committer_seen, f"commit has duplicate committer headers for {sha}")
-            committer_seen = True
+            require(
+                committer is None,
+                f"commit has duplicate committer headers for {sha}",
+            )
+            match = re.fullmatch(
+                r"(?P<name>.+) <(?P<email>[^<>]+)> -?[0-9]+ [+-][0-9]{4}",
+                value,
+            )
+            require(match is not None, f"commit committer header is malformed for {sha}")
+            committer = (match.group("name"), match.group("email"))
         elif key == "encoding":
             require(not encoding_seen, f"commit has duplicate encoding headers for {sha}")
             require(value.casefold() == "utf-8", "commit encoding must be UTF-8")
@@ -654,8 +667,8 @@ def commit_record(repo: Path, sha: str) -> tuple[list[str], str, str, str]:
 
     require(tree_seen, f"commit has no tree header for {sha}")
     require(author is not None, f"commit has no author header for {sha}")
-    require(committer_seen, f"commit has no committer header for {sha}")
-    return parents, author[0], author[1], message
+    require(committer is not None, f"commit has no committer header for {sha}")
+    return parents, author[0], author[1], committer[0], committer[1], message
 
 
 def validate_commit(
@@ -664,7 +677,7 @@ def validate_commit(
     *,
     allow_merge_commit: bool = False,
 ) -> None:
-    parents, author_name, author_email, message = commit_record(repo, sha)
+    parents, author_name, author_email, _, _, message = commit_record(repo, sha)
     allowed_parent_counts = {1, 2} if allow_merge_commit else {1}
     require(
         len(parents) in allowed_parent_counts,
@@ -742,16 +755,121 @@ def github_get(path: str, token: str) -> Any:
     return json.loads(data)
 
 
+def fetch_pull_head(
+    repo: Path,
+    repository: str,
+    number: int,
+    expected_head: str,
+    token: str,
+) -> None:
+    """Fetch an exact GitHub pull ref as inert raw-object validation data."""
+    require(
+        isinstance(repository, str)
+        and repository.count("/") == 1
+        and all(repository.split("/")),
+        "GitHub repository slug is invalid",
+    )
+    require(
+        isinstance(number, int) and not isinstance(number, bool) and number > 0,
+        "pull-request number is invalid",
+    )
+    expected_head = require_sha(expected_head, "pull-request source head SHA")
+    require(bool(token), "GITHUB_TOKEN is required to fetch pull-request source history")
+
+    server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    parsed_server = urlsplit(server_url)
+    require(
+        parsed_server.scheme == "https"
+        and bool(parsed_server.netloc)
+        and parsed_server.username is None
+        and parsed_server.password is None
+        and parsed_server.path in {"", "/"}
+        and not parsed_server.query
+        and not parsed_server.fragment,
+        "GITHUB_SERVER_URL is not a canonical HTTPS origin",
+    )
+    canonical_server = f"https://{parsed_server.netloc}"
+    repository_url = f"{canonical_server}/{quote(repository, safe='/')}.git"
+    authorization = base64.b64encode(
+        f"x-access-token:{token}".encode("utf-8")
+    ).decode("ascii")
+    fetch_environment = os.environ.copy()
+    trace_environment = {
+        "GIT_CURL_VERBOSE",
+        "GIT_TRACE",
+        "GIT_TRACE_CURL",
+        "GIT_TRACE_CURL_NO_DATA",
+        "GIT_TRACE_PACKET",
+    }
+    for key in list(fetch_environment):
+        if (
+            key == "GIT_CONFIG_COUNT"
+            or key in trace_environment
+            or re.fullmatch(r"GIT_CONFIG_(?:KEY|VALUE)_[0-9]+", key)
+        ):
+            del fetch_environment[key]
+    fetch_environment.update(
+        {
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_TRACE_REDACT": "1",
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": f"http.{repository_url}.extraheader",
+            "GIT_CONFIG_VALUE_0": f"AUTHORIZATION: basic {authorization}",
+            "GIT_CONFIG_KEY_1": "credential.helper",
+            "GIT_CONFIG_VALUE_1": "",
+        }
+    )
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "fetch",
+                "--no-tags",
+                repository_url,
+                f"refs/pull/{number}/head",
+            ],
+            cwd=repo,
+            env=fetch_environment,
+            text=False,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DcoContractError("exact pull-request source fetch failed") from exc
+    require(
+        completed.returncode == 0,
+        "exact pull-request source fetch failed",
+    )
+    require(
+        require_sha(
+            git(repo, "rev-parse", "FETCH_HEAD").strip(),
+            "fetched pull-request source head SHA",
+        )
+        == expected_head,
+        "fetched pull-request source head differs from the associated pull request",
+    )
+    require(
+        git(repo, "cat-file", "-t", expected_head).strip() == "commit",
+        "fetched pull-request source head is not a commit",
+    )
+
+
 def validate_github_squash_attestation(
+    repo: Path,
     repository: str,
     sha: str,
     parents: list[str],
     author_name: str,
     author_email: str,
     message: str,
+    push_head_sha: str,
+    token: str,
     api_get: Callable[[str], Any],
+    *,
+    source_fetch: Callable[[int, str], None] | None = None,
 ) -> None:
-    """Prove a name-canonicalized push commit is a GitHub squash merge."""
+    """Prove a GitHub squash and strictly validate its exact source history."""
     require(
         isinstance(repository, str)
         and repository.count("/") == 1
@@ -808,6 +926,7 @@ def validate_github_squash_attestation(
         for parent in api_parents
     ]
     require(parent_shas == parents, "provider commit parents differ from the raw commit")
+    require(len(parents) == 1, "provider squash commit is not single-parent")
 
     pulls_path = f"/repos/{encoded_repo}/commits/{sha}/pulls"
     pulls = api_get(f"{pulls_path}?per_page=100&page=1")
@@ -848,16 +967,83 @@ def validate_github_squash_attestation(
         and base["repo"].get("full_name") == repository,
         "provider squash pull request does not target this repository main",
     )
-    require(
-        isinstance(head, dict)
-        and isinstance(head.get("sha"), str)
-        and SHA_PATTERN.fullmatch(head["sha"]) is not None,
-        "provider squash pull-request head SHA is invalid",
+    base_sha = require_sha(base.get("sha"), "provider squash pull-request base SHA")
+    require(isinstance(head, dict), "provider squash pull-request head is missing")
+    source_head = require_sha(
+        head.get("sha"),
+        "provider squash pull-request head SHA",
     )
     subject = message.partition("\n")[0]
     require(
         subject.endswith(f"(#{number})"),
         "provider squash subject does not bind the merged pull-request number",
+    )
+
+    if source_fetch is None:
+        fetch_pull_head(repo, repository, number, source_head, token)
+    else:
+        source_fetch(number, source_head)
+    source_shas = collect_pr_commits(
+        repository,
+        number,
+        base_sha,
+        source_head,
+        api_get,
+    )
+    # A queued PR's recorded base can legitimately predate the squash's
+    # direct parent after main advances. Stable API equality plus ancestry is
+    # the exact binding; direct equality would reject valid protected queues.
+    base_ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", base_sha, parents[0]],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    require(
+        base_ancestor.returncode == 0,
+        "provider squash pull-request base is not an ancestor of the squash parent",
+    )
+    merge_base = require_sha(
+        git(repo, "merge-base", base_sha, source_head).strip(),
+        "provider squash pull-request merge base",
+    )
+    local_source_shas = [
+        line.strip()
+        for line in git(
+            repo,
+            "rev-list",
+            "--reverse",
+            f"{merge_base}..{source_head}",
+        ).splitlines()
+        if line.strip()
+    ]
+    require(
+        local_source_shas == source_shas,
+        "provider squash API commit set differs from the fetched source history",
+    )
+    validate_commits(
+        repo,
+        source_shas,
+        source_head,
+        allow_merge_commits=True,
+        checked_out_head_sha=push_head_sha,
+    )
+    source_author_identities: set[tuple[str, str]] = set()
+    for source_sha in source_shas:
+        _, source_author_name, source_author_email, _, _, _ = commit_record(
+            repo,
+            source_sha,
+        )
+        source_author_identities.add((source_author_name, source_author_email))
+    squash_identities = valid_dco_identities(message)
+    require(
+        any(
+            identity[1] == author_email and identity in source_author_identities
+            for identity in squash_identities
+        ),
+        "provider squash Signed-off-by identity is not an exact validated "
+        "source-commit author identity",
     )
 
 
@@ -869,6 +1055,7 @@ def validate_push_range(
     token: str,
     *,
     api_get: Callable[[str], Any] | None = None,
+    source_fetch: Callable[[int, str], None] | None = None,
 ) -> int:
     """Validate main pushes, admitting only proven GitHub name canonicalization."""
     base_sha = require_sha(base_sha, "push base SHA")
@@ -893,14 +1080,25 @@ def validate_push_range(
     provider_get = api_get
     previous_sha = base_sha
     for sha in shas:
-        parents, author_name, author_email, message = commit_record(repo, sha)
+        (
+            parents,
+            author_name,
+            author_email,
+            committer_name,
+            committer_email,
+            message,
+        ) = commit_record(repo, sha)
         require(
             parents == [previous_sha],
             "push range is not a linear single-parent sequence",
         )
         identities = valid_dco_identities(message)
         require(identities, f"{sha} has no valid terminal Signed-off-by trailer")
-        if (author_name, author_email) not in identities:
+        provider_candidate = (
+            committer_name,
+            committer_email,
+        ) == GITHUB_WEB_FLOW_COMMITTER
+        if provider_candidate:
             require(
                 any(identity_email == author_email for _, identity_email in identities),
                 f"{sha} Signed-off-by email does not exactly match the push commit author email",
@@ -909,13 +1107,22 @@ def validate_push_range(
                 require(bool(token), "GITHUB_TOKEN is required for provider squash attestation")
                 provider_get = lambda path: github_get(path, token)
             validate_github_squash_attestation(
+                repo,
                 repository,
                 sha,
                 parents,
                 author_name,
                 author_email,
                 message,
+                head_sha,
+                token,
                 provider_get,
+                source_fetch=source_fetch,
+            )
+        else:
+            require(
+                (author_name, author_email) in identities,
+                f"{sha} Signed-off-by does not exactly match the push commit author",
             )
         previous_sha = sha
     return len(shas)
@@ -1029,7 +1236,7 @@ def validate_merge_group(repo: Path, base_sha: str, head_sha: str) -> int:
     )
     previous_sha = base_sha
     for sha in range_shas:
-        parents, _, author_email, message = commit_record(repo, sha)
+        parents, _, author_email, _, _, message = commit_record(repo, sha)
         require(
             parents == [previous_sha],
             "merge-group range is not a linear single-parent squash sequence",

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import os
 from pathlib import Path
@@ -10,6 +11,7 @@ import re
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 
 import dco_check as dco
 
@@ -305,13 +307,15 @@ class DcoCheckTests(unittest.TestCase):
         message: str,
         name: str = "Series A Builder",
         email: str = "builder@example.com",
+        committer_name: str | None = None,
+        committer_email: str | None = None,
     ) -> str:
         env = {
             **os.environ,
             "GIT_AUTHOR_NAME": name,
             "GIT_AUTHOR_EMAIL": email,
-            "GIT_COMMITTER_NAME": name,
-            "GIT_COMMITTER_EMAIL": email,
+            "GIT_COMMITTER_NAME": committer_name or name,
+            "GIT_COMMITTER_EMAIL": committer_email or email,
         }
         subprocess.run(
             ["git", "commit", "--allow-empty", "-F", "-"],
@@ -327,6 +331,108 @@ class DcoCheckTests(unittest.TestCase):
     def assert_rejected(self, pattern: str, function, *args, **kwargs) -> None:
         with self.assertRaisesRegex(dco.DcoError, pattern):
             function(*args, **kwargs)
+
+    def provider_api(
+        self,
+        squash_sha: str,
+        source_shas: list[str],
+        source_head: str,
+        *,
+        number: int = 411,
+        pr_base_sha: str | None = None,
+    ):
+        (
+            parents,
+            author_name,
+            author_email,
+            committer_name,
+            committer_email,
+            _,
+        ) = dco.commit_record(
+            self.repo,
+            squash_sha,
+        )
+        if (
+            committer_name,
+            committer_email,
+        ) != dco.GITHUB_WEB_FLOW_COMMITTER:
+            raise AssertionError("provider fixture is not a raw GitHub/web-flow commit")
+        commit_path = f"/repos/szl-holdings/.github/commits/{squash_sha}"
+        pulls_path = f"{commit_path}/pulls"
+        metadata_path = f"/repos/szl-holdings/.github/pulls/{number}"
+        commits_path = f"{metadata_path}/commits"
+        provider_base = parents[0] if pr_base_sha is None else pr_base_sha
+        responses: dict[str, object] = {
+            commit_path: {
+                "sha": squash_sha,
+                "commit": {
+                    "author": {"name": author_name, "email": author_email},
+                    "committer": {
+                        "name": committer_name,
+                        "email": committer_email,
+                    },
+                    "verification": {
+                        "verified": True,
+                        "reason": "valid",
+                        "signature": "signed",
+                        "payload": "bound payload",
+                    },
+                },
+                "committer": {"login": "web-flow", "type": "User"},
+                "parents": [{"sha": parent} for parent in parents],
+            },
+            f"{pulls_path}?per_page=100&page=1": [
+                {
+                    "number": number,
+                    "state": "closed",
+                    "draft": False,
+                    "merged_at": "2026-08-11T05:49:54Z",
+                    "merge_commit_sha": squash_sha,
+                    "base": {
+                        "ref": "main",
+                        "sha": provider_base,
+                        "repo": {"full_name": "szl-holdings/.github"},
+                    },
+                    "head": {"sha": source_head},
+                }
+            ],
+            f"{pulls_path}?per_page=100&page=2": [],
+            metadata_path: {
+                "base": {"sha": provider_base},
+                "head": {"sha": source_head},
+                "commits": len(source_shas),
+                "draft": False,
+            },
+        }
+        page_count = (
+            len(source_shas) + dco.COMMITS_PER_PAGE - 1
+        ) // dco.COMMITS_PER_PAGE
+        for page in range(1, page_count + 1):
+            start = (page - 1) * dco.COMMITS_PER_PAGE
+            responses[f"{commits_path}?per_page=100&page={page}"] = [
+                {"sha": sha}
+                for sha in source_shas[start : start + dco.COMMITS_PER_PAGE]
+            ]
+        responses[f"{commits_path}?per_page=100&page={page_count + 1}"] = []
+        calls: list[str] = []
+
+        def api_get(path: str):
+            calls.append(path)
+            if path not in responses:
+                raise AssertionError(f"unexpected provider lookup: {path}")
+            return responses[path]
+
+        paths = {
+            "commit": commit_path,
+            "pulls_page": f"{pulls_path}?per_page=100&page=1",
+            "pulls_boundary": f"{pulls_path}?per_page=100&page=2",
+            "metadata": metadata_path,
+            "commits_page": f"{commits_path}?per_page=100&page=1",
+            "commits_boundary": (
+                f"{commits_path}?per_page=100&page={page_count + 1}"
+            ),
+        }
+        return api_get, responses, calls, paths
 
     def test_two_and_five_entry_signed_groups_pass(self) -> None:
         second = self.commit("fix: one\n\nSigned-off-by: Series A Builder <builder@example.com>")
@@ -587,70 +693,155 @@ class DcoCheckTests(unittest.TestCase):
         self.assertEqual(dco.push_subject(payload, head), (self.base, head))
         self.assert_rejected("not main", dco.push_subject, {**payload, "ref": "refs/heads/dev"}, head)
 
-    def test_push_provider_name_canonicalization_requires_verified_merged_pr(self) -> None:
+    def test_fetch_pull_head_uses_exact_ref_without_persisting_credentials(self) -> None:
+        expected_head = "d" * 40
+        token = "fake-read-token"
+        completed = subprocess.CompletedProcess([], 0, b"", b"")
+        inherited_config = {
+            "GITHUB_SERVER_URL": "https://github.example",
+            "GIT_CONFIG_COUNT": "10",
+            "GIT_CONFIG_KEY_9": "malicious.inherited",
+            "GIT_CONFIG_VALUE_9": "ignored",
+            "GIT_TRACE_CURL": "1",
+            "GIT_CURL_VERBOSE": "1",
+        }
+        with (
+            mock.patch.dict(dco.os.environ, inherited_config, clear=False),
+            mock.patch.object(
+                dco.subprocess,
+                "run",
+                return_value=completed,
+            ) as fetch_run,
+            mock.patch.object(
+                dco,
+                "git",
+                side_effect=[expected_head + "\n", "commit\n"],
+            ) as git_call,
+        ):
+            dco.fetch_pull_head(
+                self.repo,
+                "szl-holdings/.github",
+                411,
+                expected_head,
+                token,
+            )
+
+        command = fetch_run.call_args.args[0]
+        environment = fetch_run.call_args.kwargs["env"]
+        self.assertEqual(
+            command,
+            [
+                "git",
+                "fetch",
+                "--no-tags",
+                "https://github.example/szl-holdings/.github.git",
+                "refs/pull/411/head",
+            ],
+        )
+        self.assertNotIn(token, repr(command))
+        self.assertEqual(environment["GIT_TERMINAL_PROMPT"], "0")
+        self.assertEqual(environment["GIT_TRACE_REDACT"], "1")
+        self.assertEqual(environment["GIT_CONFIG_COUNT"], "2")
+        self.assertEqual(
+            environment["GIT_CONFIG_KEY_0"],
+            "http.https://github.example/szl-holdings/.github.git.extraheader",
+        )
+        self.assertEqual(
+            environment["GIT_CONFIG_VALUE_0"],
+            "AUTHORIZATION: basic "
+            + base64.b64encode(f"x-access-token:{token}".encode()).decode(),
+        )
+        self.assertEqual(environment["GIT_CONFIG_KEY_1"], "credential.helper")
+        self.assertEqual(environment["GIT_CONFIG_VALUE_1"], "")
+        self.assertNotIn("GIT_CONFIG_KEY_9", environment)
+        self.assertNotIn("GIT_CONFIG_VALUE_9", environment)
+        self.assertNotIn("GIT_TRACE_CURL", environment)
+        self.assertNotIn("GIT_CURL_VERBOSE", environment)
+        self.assertEqual(
+            git_call.call_args_list,
+            [
+                mock.call(self.repo, "rev-parse", "FETCH_HEAD"),
+                mock.call(self.repo, "cat-file", "-t", expected_head),
+            ],
+        )
+
+        with (
+            mock.patch.dict(dco.os.environ, inherited_config, clear=False),
+            mock.patch.object(
+                dco.subprocess,
+                "run",
+                return_value=completed,
+            ),
+            mock.patch.object(dco, "git", return_value="e" * 40 + "\n"),
+        ):
+            self.assert_rejected(
+                "differs from the associated pull request",
+                dco.fetch_pull_head,
+                self.repo,
+                "szl-holdings/.github",
+                411,
+                expected_head,
+                token,
+            )
+
+    def test_push_provider_name_canonicalization_requires_exact_source_dco(self) -> None:
+        source_first = self.commit(
+            "fix: source one\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        source_head = self.commit(
+            "fix: source two\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        source_shas = [source_first, source_head]
+        self.git("reset", "--hard", self.base)
+        protected_parent = self.commit(
+            "fix: intervening protected main change\n\n"
+            "Signed-off-by: Series A Builder <builder@example.com>"
+        )
         head = self.commit(
             "fix: provider squash (#411)\n\n"
             "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
             name="Lutar, Stephen P.",
             email="builder@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
         )
-        commit_path = f"/repos/szl-holdings/.github/commits/{head}"
-        pulls_path = f"{commit_path}/pulls"
-        responses = {
-            commit_path: {
-                "sha": head,
-                "commit": {
-                    "author": {"name": "Lutar, Stephen P.", "email": "builder@example.com"},
-                    "committer": {"name": "GitHub", "email": "noreply@github.com"},
-                    "verification": {
-                        "verified": True,
-                        "reason": "valid",
-                        "signature": "signed",
-                        "payload": "bound payload",
-                    },
-                },
-                "committer": {"login": "web-flow", "type": "User"},
-                "parents": [{"sha": self.base}],
-            },
-            f"{pulls_path}?per_page=100&page=1": [
-                {
-                    "number": 411,
-                    "state": "closed",
-                    "draft": False,
-                    "merged_at": "2026-08-11T05:49:54Z",
-                    "merge_commit_sha": head,
-                    "base": {
-                        "ref": "main",
-                        "repo": {"full_name": "szl-holdings/.github"},
-                    },
-                    "head": {"sha": "d" * 40},
-                }
-            ],
-            f"{pulls_path}?per_page=100&page=2": [],
-        }
-        calls: list[str] = []
-
-        def api_get(path: str):
-            calls.append(path)
-            return responses[path]
+        api_get, _, calls, paths = self.provider_api(
+            head,
+            source_shas,
+            source_head,
+            pr_base_sha=self.base,
+        )
+        source_fetches: list[tuple[int, str]] = []
 
         self.assertEqual(
             dco.validate_push_range(
                 self.repo,
-                self.base,
+                protected_parent,
                 head,
                 "szl-holdings/.github",
                 "",
                 api_get=api_get,
+                source_fetch=lambda number, sha: source_fetches.append(
+                    (number, sha)
+                ),
             ),
             1,
         )
+        self.assertEqual(source_fetches, [(411, source_head)])
         self.assertEqual(
             calls,
             [
-                commit_path,
-                f"{pulls_path}?per_page=100&page=1",
-                f"{pulls_path}?per_page=100&page=2",
+                paths["commit"],
+                paths["pulls_page"],
+                paths["pulls_boundary"],
+                paths["metadata"],
+                paths["commits_page"],
+                paths["commits_boundary"],
+                paths["metadata"],
             ],
         )
 
@@ -670,85 +861,134 @@ class DcoCheckTests(unittest.TestCase):
             1,
         )
 
+    def test_push_exact_identity_provider_squash_rejects_unsigned_source(self) -> None:
+        unsigned_source = self.commit(
+            "fix: unsigned provider source",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: exact-identity provider squash (#411)\n\n"
+            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, calls, paths = self.provider_api(
+            head,
+            [unsigned_source],
+            unsigned_source,
+        )
+        source_fetches: list[tuple[int, str]] = []
+
+        self.assert_rejected(
+            "no valid terminal",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: source_fetches.append((number, sha)),
+        )
+        self.assertIn(paths["commit"], calls)
+        self.assertIn(paths["commits_page"], calls)
+        self.assertEqual(source_fetches, [(411, unsigned_source)])
+
+    def test_push_exact_identity_provider_squash_validates_all_sources(self) -> None:
+        source_first = self.commit(
+            "fix: first exact-identity source\n\n"
+            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        source_head = self.commit(
+            "fix: second exact-identity source\n\n"
+            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: exact-identity provider squash (#411)\n\n"
+            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            email="builder@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, calls, paths = self.provider_api(
+            head,
+            [source_first, source_head],
+            source_head,
+        )
+        source_fetches: list[tuple[int, str]] = []
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                head,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+                source_fetch=lambda number, sha: source_fetches.append((number, sha)),
+            ),
+            1,
+        )
+        self.assertIn(paths["commit"], calls)
+        self.assertIn(paths["commits_page"], calls)
+        self.assertEqual(source_fetches, [(411, source_head)])
+
     def test_push_provider_canonicalization_fails_closed(self) -> None:
+        source_head = self.commit(
+            "fix: governed source\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        self.git("reset", "--hard", self.base)
         head = self.commit(
             "fix: provider squash (#411)\n\n"
             "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
             name="Lutar, Stephen P.",
             email="builder@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
         )
-        commit_path = f"/repos/szl-holdings/.github/commits/{head}"
-        pulls_path = f"{commit_path}/pulls"
-
-        def api_get(
-            path: str,
-            *,
-            verified: bool = True,
-            login: str = "web-flow",
-            merge_sha: str | None = None,
-            base_ref: str = "main",
+        for case, error in (
+            ("verification", "not validly signed"),
+            ("account", "web-flow"),
+            ("merge", "unique exact merged"),
+            ("base_ref", "does not target"),
         ):
-            if path == commit_path:
-                return {
-                    "sha": head,
-                    "commit": {
-                        "author": {
-                            "name": "Lutar, Stephen P.",
-                            "email": "builder@example.com",
-                        },
-                        "committer": {
-                            "name": "GitHub",
-                            "email": "noreply@github.com",
-                        },
-                        "verification": {
-                            "verified": verified,
-                            "reason": "valid" if verified else "unsigned",
-                            "signature": "signed" if verified else None,
-                            "payload": "bound payload" if verified else None,
-                        },
-                    },
-                    "committer": {"login": login, "type": "User"},
-                    "parents": [{"sha": self.base}],
-                }
-            if path == f"{pulls_path}?per_page=100&page=1":
-                return [
-                    {
-                        "number": 411,
-                        "state": "closed",
-                        "draft": False,
-                        "merged_at": "2026-08-11T05:49:54Z",
-                        "merge_commit_sha": merge_sha or head,
-                        "base": {
-                            "ref": base_ref,
-                            "repo": {"full_name": "szl-holdings/.github"},
-                        },
-                        "head": {"sha": "d" * 40},
-                    }
-                ]
-            if path == f"{pulls_path}?per_page=100&page=2":
-                return []
-            raise AssertionError(f"unexpected provider lookup: {path}")
+            with self.subTest(case=case):
+                api_get, responses, _, paths = self.provider_api(
+                    head,
+                    [source_head],
+                    source_head,
+                )
+                commit_response = responses[paths["commit"]]
+                associated_pull = responses[paths["pulls_page"]][0]
+                if case == "verification":
+                    verification = commit_response["commit"]["verification"]
+                    verification.update(
+                        {
+                            "verified": False,
+                            "reason": "unsigned",
+                            "signature": None,
+                            "payload": None,
+                        }
+                    )
+                elif case == "account":
+                    commit_response["committer"]["login"] = "attacker"
+                elif case == "merge":
+                    associated_pull["merge_commit_sha"] = "f" * 40
+                else:
+                    associated_pull["base"]["ref"] = "release/unsafe"
 
-        cases = (
-            (
-                "not validly signed",
-                lambda path: api_get(path, verified=False),
-            ),
-            (
-                "web-flow",
-                lambda path: api_get(path, login="attacker"),
-            ),
-            (
-                "unique exact merged",
-                lambda path: api_get(path, merge_sha="f" * 40),
-            ),
-            (
-                "does not target",
-                lambda path: api_get(path, base_ref="release/unsafe"),
-            ),
-        )
-        for error, provider in cases:
-            with self.subTest(error=error):
                 with self.assertRaisesRegex(dco.DcoContractError, error):
                     dco.validate_push_range(
                         self.repo,
@@ -756,7 +996,8 @@ class DcoCheckTests(unittest.TestCase):
                         head,
                         "szl-holdings/.github",
                         "",
-                        api_get=provider,
+                        api_get=api_get,
+                        source_fetch=lambda number, sha: None,
                     )
 
         self.git("reset", "--hard", self.base)
@@ -765,6 +1006,8 @@ class DcoCheckTests(unittest.TestCase):
             "Signed-off-by: Stephen P. Lutar Jr. <other@example.com>",
             name="Lutar, Stephen P.",
             email="builder@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
         )
         with self.assertRaisesRegex(dco.DcoContractError, "email does not exactly match"):
             dco.validate_push_range(
@@ -775,6 +1018,288 @@ class DcoCheckTests(unittest.TestCase):
                 "",
                 api_get=lambda path: self.fail(f"unexpected provider lookup: {path}"),
             )
+
+    def test_push_provider_source_validation_uses_overall_push_head(self) -> None:
+        source_head = self.commit(
+            "fix: source before a batched push\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        self.git("reset", "--hard", self.base)
+        provider_squash = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        push_head = self.commit(
+            "fix: later strict push commit\n\n"
+            "Signed-off-by: Series A Builder <builder@example.com>"
+        )
+        api_get, _, _, _ = self.provider_api(
+            provider_squash,
+            [source_head],
+            source_head,
+        )
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                push_head,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+                source_fetch=lambda number, sha: None,
+            ),
+            2,
+        )
+
+    def test_push_provider_validates_two_source_bound_squashes(self) -> None:
+        source_one = self.commit(
+            "fix: first queued source\n\n"
+            "Signed-off-by: Source One <one@example.com>",
+            name="Source One",
+            email="one@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        source_two = self.commit(
+            "fix: second queued source\n\n"
+            "Signed-off-by: Source Two <two@example.com>",
+            name="Source Two",
+            email="two@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        squash_one = self.commit(
+            "fix: first provider squash (#411)\n\n"
+            "Signed-off-by: Source One <one@example.com>",
+            name="Canonical One",
+            email="one@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        squash_two = self.commit(
+            "fix: second provider squash (#412)\n\n"
+            "Signed-off-by: Source Two <two@example.com>",
+            name="Canonical Two",
+            email="two@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        _, responses_one, _, _ = self.provider_api(
+            squash_one,
+            [source_one],
+            source_one,
+            number=411,
+        )
+        _, responses_two, _, _ = self.provider_api(
+            squash_two,
+            [source_two],
+            source_two,
+            number=412,
+            pr_base_sha=self.base,
+        )
+        responses = {**responses_one, **responses_two}
+
+        def api_get(path: str):
+            if path not in responses:
+                raise AssertionError(f"unexpected provider lookup: {path}")
+            return responses[path]
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                squash_two,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+                source_fetch=lambda number, sha: None,
+            ),
+            2,
+        )
+
+    def test_push_provider_squash_binds_exact_pr_base_and_head(self) -> None:
+        source_head = self.commit(
+            "fix: exact source refs\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+
+        api_get, responses, _, paths = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+        )
+        responses[paths["pulls_page"]][0]["base"]["sha"] = "e" * 40
+        self.assert_rejected(
+            "pull-request base moved during validation",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
+
+        api_get, responses, _, paths = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+        )
+        responses[paths["pulls_page"]][0]["head"]["sha"] = "d" * 40
+        self.assert_rejected(
+            "pull-request head moved during validation",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
+
+        tree = self.git("rev-parse", f"{self.base}^{{tree}}")
+        unrelated_base = self.git(
+            "commit-tree",
+            tree,
+            input_text=(
+                "chore: unrelated base\n\n"
+                "Signed-off-by: Series A Builder <builder@example.com>\n"
+            ),
+        )
+        api_get, _, _, _ = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+            pr_base_sha=unrelated_base,
+        )
+        self.assert_rejected(
+            "base is not an ancestor of the squash parent",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
+
+    def test_push_provider_squash_rejects_invalid_raw_source_history(self) -> None:
+        source_first = self.commit(
+            "fix: signed source one\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        unsigned_middle = self.commit(
+            "fix: unsigned source middle",
+            name="Stephen P. Lutar Jr.",
+        )
+        source_head = self.commit(
+            "fix: signed source head\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        source_shas = [source_first, unsigned_middle, source_head]
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, _, _ = self.provider_api(
+            head,
+            source_shas,
+            source_head,
+        )
+        self.assert_rejected(
+            "no valid terminal",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
+
+        self.git("reset", "--hard", self.base)
+        mismatched_source = self.commit(
+            "fix: mismatched source\n\n"
+            "Signed-off-by: Any Name <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Lutar, Stephen P.",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, _, _ = self.provider_api(
+            head,
+            [mismatched_source],
+            mismatched_source,
+        )
+        self.assert_rejected(
+            "does not exactly match",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
+
+    def test_push_provider_squash_rejects_arbitrary_same_email_name(self) -> None:
+        source_head = self.commit(
+            "fix: valid source identity\n\n"
+            "Signed-off-by: Stephen P. Lutar Jr. <builder@example.com>",
+            name="Stephen P. Lutar Jr.",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: provider squash (#411)\n\n"
+            "Signed-off-by: Any Name <builder@example.com>",
+            name="Lutar, Stephen P.",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, _, _ = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+        )
+        self.assert_rejected(
+            "not an exact validated source-commit author identity",
+            dco.validate_push_range,
+            self.repo,
+            self.base,
+            head,
+            "szl-holdings/.github",
+            "",
+            api_get=api_get,
+            source_fetch=lambda number, sha: None,
+        )
 
     def test_pr_pagination_boundaries_and_freshness(self) -> None:
         for count in (249, 250):


### PR DESCRIPTION
## Summary

- classify every GitHub web-flow squash before the ordinary raw-author DCO path
- bind the provider exception to one exact merged PR, base, head, pull ref, and stable complete source-commit set
- validate every source commit from strict raw Git objects before accepting the squash trailer

This is a current-main fix-forward for the provider-squash source-history gap. It does not rewrite, excuse, or relabel historical protected-main commits.

## Exact boundary

- base: `ee8d094db200dda56e4ebcf756e9fc1962904881`
- head: `3d4146a273cbeaa00b0628dfa8481fa19abdcdaa`
- history: one SSH-signed commit with exact-author DCO
- scope: `.github/scripts/dco_check.py` and `.github/scripts/test_dco_events.py`

## Security contract

A provider-generated squash now requires:

- exact raw/API author, committer, parent, signature, and payload agreement
- one unique associated merged PR for the exact squash subject
- stable exact PR base/head metadata and complete paginated commit enumeration
- exact `refs/pull/<n>/head` fetch and local graph equality
- strict UTF-8 raw-object DCO validation for every source commit
- an exact squash signoff drawn from a validated source-author identity

Ordinary non-provider commits retain the exact raw author name+email path without provider API calls. Merge-group semantics remain unchanged.

## Local validation

- raw DCO checker: 65/65 PASS
- event/controller suite: 39/39 PASS
- activation suite: 8/8 PASS
- total distinct tests: 112/112 PASS
- FORGE-9 bootstrap invariants: PASS
- Python AST and `git diff --check`: PASS
- independent full-diff review: CLEAN, no P0-P2

## Admission

Keep this PR draft until exact-head hosted checks and a fresh exact-head independent review are terminal, with zero unresolved actionable threads. Use only the normal protected path; no bypass, self-approval, force update, settings change, or unchanged rerun.