### PR TITLE
feat(hf): separate candidate and runtime proof

### DIFF
--- a/.github/scripts/hf_candidate_plan.py
+++ b/.github/scripts/hf_candidate_plan.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
 import tempfile
@@ -34,7 +35,12 @@ class CandidatePlanError(RuntimeError):
     """The candidate cannot produce one complete, immutable payload plan."""
 
 
-def _git(repo_root: Path, *args: str, allow_nonzero: bool = False) -> subprocess.CompletedProcess[bytes]:
+def _git(
+    repo_root: Path,
+    *args: str,
+    allow_nonzero: bool = False,
+    input_bytes: bytes | None = None,
+) -> subprocess.CompletedProcess[bytes]:
     env = os.environ.copy()
     env.update(
         {
@@ -50,6 +56,7 @@ def _git(repo_root: Path, *args: str, allow_nonzero: bool = False) -> subprocess
             env.pop(variable, None)
     completed = subprocess.run(
         ["git", "-C", str(repo_root), *args],
+        input=input_bytes,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -83,9 +90,7 @@ def _safe_repo_path(value: str, label: str) -> str:
         raise CandidatePlanError(f"{label} contains a control character: {raw!r}")
     components = raw.split("/")
     if any(
-        not component
-        or component in {".", ".."}
-        or component.endswith((".", " "))
+        not component or component in {".", ".."} or component.endswith((".", " "))
         for component in components
     ):
         raise CandidatePlanError(f"{label} is not canonical: {raw!r}")
@@ -180,60 +185,119 @@ def _blob(repo_root: Path, entry: dict[str, str], path: str) -> bytes:
     return data
 
 
-def _materialized_blob(
-    checkout_root: Path,
-    entry: dict[str, str],
-    path: str,
-) -> bytes:
-    """Read the exact checkout bytes consumed by the production publisher."""
-    _require_regular_blob(entry, path)
+def _worktree_head(repo_root: Path) -> str:
+    completed = _git(repo_root, "rev-parse", "--verify", "HEAD^{commit}")
     try:
-        _normalized, full = publisher.source_file(checkout_root, path)
-    except publisher.DeployContractError as exc:
-        raise CandidatePlanError(
-            f"materialized publisher source is unavailable: {path!r}: {exc}"
-        ) from exc
-    with open(full, "rb") as handle:
-        data = handle.read(MAX_GIT_OUTPUT + 1)
-    if len(data) > MAX_GIT_OUTPUT:
-        raise CandidatePlanError(
-            f"materialized publisher source exceeds the 512 MiB bound: {path!r}"
-        )
-    return data
-
-
-def _source_bytes(
-    repo_root: Path,
-    checkout_root: Path | None,
-    entry: dict[str, str],
-    path: str,
-) -> bytes:
-    if checkout_root is None:
-        return _blob(repo_root, entry, path)
-    return _materialized_blob(checkout_root, entry, path)
-
-
-def _materialized_checkout(
-    value: Path | None,
-    expected_revision: str,
-    label: str,
-) -> Path | None:
-    if value is None:
-        return None
-    root = Path(value).resolve()
-    if not (root / ".git").exists():
-        raise CandidatePlanError(f"{label} is not a Git worktree: {root}")
-    observed = _git(root, "rev-parse", "--verify", "HEAD^{commit}")
-    try:
-        observed_revision = observed.stdout.decode("ascii").strip()
+        return completed.stdout.decode("ascii").strip()
     except UnicodeDecodeError as exc:
-        raise CandidatePlanError(f"{label} HEAD did not resolve to ASCII") from exc
-    if observed_revision != expected_revision:
-        raise CandidatePlanError(
-            f"{label} is not the exact requested revision: "
-            f"expected={expected_revision} observed={observed_revision!r}"
+        raise CandidatePlanError("candidate worktree HEAD is not ASCII") from exc
+
+
+def _require_worktree_blob(
+    repo_root: Path,
+    source_path: str,
+    expected_oid: str,
+) -> None:
+    rel = _safe_repo_path(source_path, "publisher source path")
+    root = repo_root.resolve(strict=True)
+    current = root
+    for component in rel.split("/"):
+        current = current / component
+        try:
+            metadata = current.lstat()
+        except OSError as exc:
+            raise CandidatePlanError(
+                f"publisher source is absent from the candidate checkout: {rel!r}"
+            ) from exc
+        reparse = bool(
+            getattr(metadata, "st_file_attributes", 0)
+            & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
         )
-    return root
+        if stat.S_ISLNK(metadata.st_mode) or reparse:
+            raise CandidatePlanError(
+                f"publisher source traverses a link or reparse point: {rel!r}"
+            )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise CandidatePlanError(
+            f"publisher source is not a regular checkout file: {rel!r}"
+        )
+    try:
+        contained = os.path.commonpath(
+            (str(root), str(current.resolve(strict=True)))
+        ) == str(root)
+    except (OSError, ValueError) as exc:
+        raise CandidatePlanError(
+            f"publisher source cannot be resolved safely: {rel!r}"
+        ) from exc
+    if not contained:
+        raise CandidatePlanError(f"publisher source escapes the checkout: {rel!r}")
+    try:
+        raw = current.read_bytes()
+    except OSError as exc:
+        raise CandidatePlanError(
+            f"publisher source cannot be read from the checkout: {rel!r}"
+        ) from exc
+    actual_oid = publisher.git_blob_sha1(raw)
+    if actual_oid != expected_oid:
+        raise CandidatePlanError(
+            "candidate checkout bytes differ from the exact Git object that the "
+            f"plan binds: {rel!r} expected={expected_oid} actual={actual_oid}"
+        )
+
+
+TRANSFORM_ATTRIBUTES = (
+    "text",
+    "eol",
+    "crlf",
+    "ident",
+    "filter",
+    "working-tree-encoding",
+)
+
+
+def _transform_attributes(
+    repo_root: Path,
+    revision: str,
+    paths: set[str],
+) -> dict[str, tuple[tuple[str, str], ...]]:
+    if not paths:
+        return {}
+    ordered_paths = sorted(paths)
+    encoded_paths = b"".join(path.encode("utf-8") + b"\0" for path in ordered_paths)
+    raw = _git(
+        repo_root,
+        "check-attr",
+        f"--source={revision}",
+        "-z",
+        "--stdin",
+        *TRANSFORM_ATTRIBUTES,
+        input_bytes=encoded_paths,
+    ).stdout
+    fields = raw.split(b"\0")
+    if not fields or fields[-1] != b"":
+        raise CandidatePlanError("git check-attr output is not NUL terminated")
+    fields = fields[:-1]
+    if len(fields) % 3:
+        raise CandidatePlanError("git check-attr returned a malformed record set")
+    observed: dict[str, list[tuple[str, str]]] = {path: [] for path in ordered_paths}
+    for index in range(0, len(fields), 3):
+        try:
+            path = fields[index].decode("utf-8")
+            attribute = fields[index + 1].decode("ascii")
+            value = fields[index + 2].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CandidatePlanError(
+                "git check-attr returned non-canonical text"
+            ) from exc
+        if path not in observed or attribute not in TRANSFORM_ATTRIBUTES:
+            raise CandidatePlanError(
+                "git check-attr returned an unexpected path or attribute"
+            )
+        observed[path].append((attribute, value))
+    expected_count = len(TRANSFORM_ATTRIBUTES)
+    if any(len(values) != expected_count for values in observed.values()):
+        raise CandidatePlanError("git check-attr returned an incomplete attribute set")
+    return {path: tuple(values) for path, values in observed.items()}
 
 
 def _strict_copy_sources(dockerfile: str) -> list[str]:
@@ -295,7 +359,9 @@ def _strict_copy_sources(dockerfile: str) -> list[str]:
     try:
         publisher_sources = publisher.parse_copy_sources(dockerfile)
     except (publisher.DeployContractError, ValueError, json.JSONDecodeError) as exc:
-        raise CandidatePlanError(f"production publisher rejected Dockerfile: {exc}") from exc
+        raise CandidatePlanError(
+            f"production publisher rejected Dockerfile: {exc}"
+        ) from exc
     if publisher_sources != list(dict.fromkeys(canonical_sources)):
         raise CandidatePlanError(
             "candidate planner and production publisher derived different COPY sources"
@@ -332,23 +398,19 @@ def _snapshot(
     repo_root: Path,
     revision: str,
     *,
-    materialized_root: Path | None,
     dockerfile_path: str,
     include_readme: bool,
     readme_path: str,
 ) -> dict[str, Any]:
     entries = _tree(repo_root, revision)
     dockerfile_path = _safe_repo_path(dockerfile_path, "Dockerfile path")
-    readme_path = _safe_repo_path(readme_path, "README path")
+    readme_path = publisher.validate_readme_target(readme_path, include_readme)
     dockerfile_entry = entries.get(dockerfile_path)
     if dockerfile_entry is None:
-        raise CandidatePlanError(f"Dockerfile is absent at {revision}: {dockerfile_path}")
-    dockerfile_bytes = _source_bytes(
-        repo_root,
-        materialized_root,
-        dockerfile_entry,
-        dockerfile_path,
-    )
+        raise CandidatePlanError(
+            f"Dockerfile is absent at {revision}: {dockerfile_path}"
+        )
+    dockerfile_bytes = _blob(repo_root, dockerfile_entry, dockerfile_path)
     try:
         dockerfile = dockerfile_bytes.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -373,15 +435,11 @@ def _snapshot(
     patterns: list[tuple[bool, re.Pattern[str]]] = []
     ignore_bytes = b""
     if ignore_path:
-        ignore_bytes = _source_bytes(
-            repo_root,
-            materialized_root,
-            entries[ignore_path],
-            ignore_path,
-        )
+        ignore_bytes = _blob(repo_root, entries[ignore_path], ignore_path)
         patterns = _ignore_patterns(ignore_bytes)
 
     files: dict[str, dict[str, Any]] = {}
+    source_files: dict[str, str] = {}
     ignored_paths: list[str] = []
     for path, copy_source in sorted(targets.items()):
         _safe_repo_path(path, "managed COPY path")
@@ -389,13 +447,12 @@ def _snapshot(
         if ignored:
             ignored_paths.append(path)
         entry = entries[path]
-        data = _source_bytes(repo_root, materialized_root, entry, path)
+        _require_regular_blob(entry, path)
+        source_files[path] = entry["oid"]
         files[path] = {
             "mode": entry["mode"],
-            "oid": publisher.git_blob_sha1(data),
-            "source_oid": entry["oid"],
+            "oid": entry["oid"],
             "copy_source": copy_source,
-            "source_path": path,
             "docker_context_included": not ignored,
         }
 
@@ -403,59 +460,49 @@ def _snapshot(
     # any same-path Dockerfile-derived entry with the Space-card mapping.
     if not include_readme:
         files.pop(readme_path, None)
+        source_files.pop(readme_path, None)
 
-    if include_readme:
-        readme_entry = entries.get(readme_path)
-        if readme_entry is None:
-            raise CandidatePlanError(f"included README is absent: {readme_path!r}")
-        readme_bytes = _source_bytes(
-            repo_root,
-            materialized_root,
-            readme_entry,
-            readme_path,
-        )
-        files[readme_path] = {
-            "mode": readme_entry["mode"],
-            "oid": publisher.git_blob_sha1(readme_bytes),
-            "source_oid": readme_entry["oid"],
-            "copy_source": "(readme)",
-            "source_path": readme_path,
-            "docker_context_included": None,
-        }
-
-    # Preserve the production publisher's overlay order: the configured
-    # Dockerfile always owns the HF-root Dockerfile target, even when a caller
-    # selects a colliding README source path.
     files["Dockerfile"] = {
         "mode": dockerfile_entry["mode"],
-        "oid": publisher.git_blob_sha1(dockerfile_bytes),
-        "source_oid": dockerfile_entry["oid"],
+        "oid": dockerfile_entry["oid"],
         "copy_source": "(dockerfile)",
         "source_path": dockerfile_path,
         "docker_context_included": None,
     }
+    source_files[dockerfile_path] = dockerfile_entry["oid"]
+    if include_readme:
+        readme_entry = entries.get(readme_path)
+        if readme_entry is None:
+            raise CandidatePlanError(f"included README is absent: {readme_path!r}")
+        _blob(repo_root, readme_entry, readme_path)
+        source_files[readme_path] = readme_entry["oid"]
+        files[readme_path] = {
+            "mode": readme_entry["mode"],
+            "oid": readme_entry["oid"],
+            "copy_source": "(readme)",
+            "docker_context_included": None,
+        }
     deployed_ignore_oid = publisher.git_blob_sha1(ignore_bytes)
     files["Dockerfile.dockerignore"] = {
         "mode": entries[ignore_path]["mode"] if ignore_path else "100644",
         "oid": deployed_ignore_oid,
-        "source_oid": entries[ignore_path]["oid"] if ignore_path else None,
         "copy_source": "(dockerignore-control)",
         "source_path": ignore_path or "(generated-empty-dockerignore)",
         "docker_context_included": None,
     }
+    if ignore_path:
+        source_files[ignore_path] = entries[ignore_path]["oid"]
     if not files:
         raise CandidatePlanError("candidate payload set is empty")
     return {
         "revision": revision,
-        "byte_representation": (
-            "publisher-worktree" if materialized_root is not None else "git-object"
-        ),
         "dockerfile_path": dockerfile_path,
         "effective_dockerignore": ignore_path,
         "copy_sources": sorted(sources),
         "unresolved_sources": [],
         "docker_context_ignored_paths": ignored_paths,
         "managed_count": len(files),
+        "source_files": dict(sorted(source_files.items())),
         "files": files,
     }
 
@@ -466,8 +513,6 @@ def build_plan(
     baseline_ref: str,
     candidate_ref: str,
     *,
-    baseline_checkout_root: Path | None = None,
-    candidate_checkout_root: Path | None = None,
     dockerfile_path: str = "Dockerfile",
     include_readme: bool = True,
     readme_path: str = "README.md",
@@ -482,24 +527,15 @@ def build_plan(
     baseline = _resolve_commit(root, baseline_ref, "candidate baseline")
     candidate = _resolve_commit(root, candidate_ref, "candidate head")
     _require_ancestry(root, baseline, candidate)
-    if (baseline_checkout_root is None) != (candidate_checkout_root is None):
+    observed_head = _worktree_head(root)
+    if observed_head != candidate:
         raise CandidatePlanError(
-            "baseline and candidate materialized checkouts must be supplied together"
+            "candidate checkout HEAD is not the exact requested candidate: "
+            f"expected={candidate} actual={observed_head}"
         )
-    baseline_materialized = _materialized_checkout(
-        baseline_checkout_root,
-        baseline,
-        "baseline checkout",
-    )
-    candidate_materialized = _materialized_checkout(
-        candidate_checkout_root,
-        candidate,
-        "candidate checkout",
-    )
     before = _snapshot(
         root,
         baseline,
-        materialized_root=baseline_materialized,
         dockerfile_path=dockerfile_path,
         include_readme=include_readme,
         readme_path=readme_path,
@@ -507,11 +543,27 @@ def build_plan(
     after = _snapshot(
         root,
         candidate,
-        materialized_root=candidate_materialized,
         dockerfile_path=dockerfile_path,
         include_readme=include_readme,
         readme_path=readme_path,
     )
+
+    for source_path, expected_oid in after["source_files"].items():
+        _require_worktree_blob(root, source_path, expected_oid)
+
+    common_sources = set(before["source_files"]) & set(after["source_files"])
+    baseline_attributes = _transform_attributes(root, baseline, common_sources)
+    candidate_attributes = _transform_attributes(root, candidate, common_sources)
+    changed_attributes = sorted(
+        path
+        for path in common_sources
+        if baseline_attributes[path] != candidate_attributes[path]
+    )
+    if changed_attributes:
+        raise CandidatePlanError(
+            "candidate changes checkout-transform attributes for publisher source "
+            "paths: " + ", ".join(changed_attributes)
+        )
 
     baseline_files = before["files"]
     candidate_files = after["files"]
@@ -551,8 +603,6 @@ def build_plan(
                 "kind": kind,
                 "baseline_blob_sha": old["oid"] if old else None,
                 "candidate_blob_sha": new["oid"] if new else None,
-                "baseline_source_blob_sha": old["source_oid"] if old else None,
-                "candidate_source_blob_sha": new["source_oid"] if new else None,
                 "baseline_mode": old["mode"] if old else None,
                 "candidate_mode": new["mode"] if new else None,
                 "baseline_copy_source": old["copy_source"] if old else None,
@@ -569,7 +619,7 @@ def build_plan(
         )
 
     plan: dict[str, Any] = {
-        "schema": 2,
+        "schema": 1,
         "mode": "candidate-managed-plan",
         "status": "changes" if deltas else "no-changes",
         "github_repo": github_repo,
@@ -593,7 +643,7 @@ def build_plan(
 
 def _invalid_report(args: argparse.Namespace, detail: str) -> dict[str, Any]:
     report: dict[str, Any] = {
-        "schema": 2,
+        "schema": 1,
         "mode": "candidate-managed-plan",
         "status": "invalid",
         "github_repo": args.github_repo,
@@ -622,8 +672,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--github-repo", required=True)
     parser.add_argument("--trusted-base-ref", required=True)
     parser.add_argument("--candidate-ref", required=True)
-    parser.add_argument("--baseline-checkout-root", type=Path, required=True)
-    parser.add_argument("--candidate-checkout-root", type=Path, required=True)
     parser.add_argument("--dockerfile-path", default="Dockerfile")
     parser.add_argument("--include-readme", choices=("true", "false"), default="true")
     parser.add_argument("--readme-path", default="README.md")
@@ -635,8 +683,6 @@ def main(argv: list[str] | None = None) -> int:
             args.github_repo,
             args.trusted_base_ref,
             args.candidate_ref,
-            baseline_checkout_root=args.baseline_checkout_root,
-            candidate_checkout_root=args.candidate_checkout_root,
             dockerfile_path=args.dockerfile_path,
             include_readme=args.include_readme == "true",
             readme_path=args.readme_path,

--- a/.github/scripts/hf_candidate_plan.py
+++ b/.github/scripts/hf_candidate_plan.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Build an exact, network-free Hugging Face candidate payload plan.
+
+The verifier reads only local Git objects for an exact base and candidate
+commit.  It imports the protected production publisher's COPY expansion and
+Docker-ignore matcher, but it never imports or executes candidate code and it
+never contacts GitHub, Hugging Face, or a live runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import hf_deploy_from_dockerfile as publisher
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+TREE_META_RE = re.compile(rb"^([0-7]{6}) (blob|commit) ([0-9a-f]{40})$")
+SAFE_BLOB_MODES = {"100644", "100755"}
+MAX_GIT_OUTPUT = 512 * 1024 * 1024
+
+
+class CandidatePlanError(RuntimeError):
+    """The candidate cannot produce one complete, immutable payload plan."""
+
+
+def _git(repo_root: Path, *args: str, allow_nonzero: bool = False) -> subprocess.CompletedProcess[bytes]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+        }
+    )
+    for variable in tuple(env):
+        if variable.startswith("GIT_CONFIG_") and variable != "GIT_CONFIG_NOSYSTEM":
+            env.pop(variable, None)
+    completed = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=60,
+        env=env,
+    )
+    if len(completed.stdout) > MAX_GIT_OUTPUT:
+        raise CandidatePlanError("Git object output exceeds the 512 MiB bound")
+    if completed.returncode and not allow_nonzero:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        raise CandidatePlanError(
+            f"git {' '.join(args)} failed with exit {completed.returncode}: {detail}"
+        )
+    return completed
+
+
+def _require_sha(value: str, label: str) -> str:
+    result = str(value or "")
+    if SHA_RE.fullmatch(result) is None:
+        raise CandidatePlanError(
+            f"{label} must be an exact lowercase 40-character Git SHA"
+        )
+    return result
+
+
+def _safe_repo_path(value: str, label: str) -> str:
+    raw = str(value or "")
+    if not raw or raw.startswith(("/", "\\")) or "\\" in raw or ":" in raw:
+        raise CandidatePlanError(f"{label} is not a canonical repository path: {raw!r}")
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in raw):
+        raise CandidatePlanError(f"{label} contains a control character: {raw!r}")
+    components = raw.split("/")
+    if any(
+        not component
+        or component in {".", ".."}
+        or component.endswith((".", " "))
+        for component in components
+    ):
+        raise CandidatePlanError(f"{label} is not canonical: {raw!r}")
+    return raw
+
+
+def _safe_copy_source(value: str) -> str:
+    """Validate a canonical COPY source while preserving a directory suffix."""
+    raw = str(value or "")
+    directory_source = raw.endswith("/")
+    canonical = raw[:-1] if directory_source else raw
+    _safe_repo_path(canonical, "COPY source")
+    return raw
+
+
+def _resolve_commit(repo_root: Path, value: str, label: str) -> str:
+    requested = _require_sha(value, label)
+    resolved = _git(repo_root, "rev-parse", "--verify", f"{requested}^{{commit}}")
+    try:
+        actual = resolved.stdout.decode("ascii").strip()
+    except UnicodeDecodeError as exc:
+        raise CandidatePlanError(f"{label} did not resolve to ASCII") from exc
+    if actual != requested:
+        raise CandidatePlanError(
+            f"{label} did not resolve exactly: requested={requested} actual={actual!r}"
+        )
+    return requested
+
+
+def _require_ancestry(repo_root: Path, baseline: str, candidate: str) -> None:
+    result = _git(
+        repo_root,
+        "merge-base",
+        "--is-ancestor",
+        baseline,
+        candidate,
+        allow_nonzero=True,
+    )
+    if result.returncode == 1:
+        raise CandidatePlanError(
+            f"candidate baseline is not an ancestor: {baseline}...{candidate}"
+        )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise CandidatePlanError(f"cannot prove candidate ancestry: {detail}")
+
+
+def _tree(repo_root: Path, revision: str) -> dict[str, dict[str, str]]:
+    raw = _git(repo_root, "ls-tree", "-r", "-z", "--full-tree", revision).stdout
+    if not raw:
+        raise CandidatePlanError(f"exact Git tree is empty: {revision}")
+    entries: dict[str, dict[str, str]] = {}
+    records = raw.split(b"\0")
+    if records[-1] != b"":
+        raise CandidatePlanError("Git tree output is not NUL terminated")
+    for record in records[:-1]:
+        try:
+            metadata, encoded_path = record.split(b"\t", 1)
+        except ValueError as exc:
+            raise CandidatePlanError("malformed Git tree record") from exc
+        match = TREE_META_RE.fullmatch(metadata)
+        if match is None:
+            raise CandidatePlanError(f"unsupported Git tree metadata: {metadata!r}")
+        try:
+            path = encoded_path.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CandidatePlanError("Git tree contains a non-UTF-8 path") from exc
+        _safe_repo_path(path, "Git tree path")
+        if path in entries:
+            raise CandidatePlanError(f"duplicate Git tree path: {path!r}")
+        entries[path] = {
+            "mode": match.group(1).decode("ascii"),
+            "type": match.group(2).decode("ascii"),
+            "oid": match.group(3).decode("ascii"),
+        }
+    return entries
+
+
+def _require_regular_blob(entry: dict[str, str], path: str) -> None:
+    if entry["type"] != "blob" or entry["mode"] not in SAFE_BLOB_MODES:
+        raise CandidatePlanError(
+            f"managed path must be a regular Git blob: {path!r} "
+            f"mode={entry['mode']} type={entry['type']}"
+        )
+
+
+def _blob(repo_root: Path, entry: dict[str, str], path: str) -> bytes:
+    _require_regular_blob(entry, path)
+    data = _git(repo_root, "cat-file", "blob", entry["oid"]).stdout
+    if publisher.git_blob_sha1(data) != entry["oid"]:
+        raise CandidatePlanError(f"Git blob identity mismatch: {path!r}")
+    return data
+
+
+def _strict_copy_sources(dockerfile: str) -> list[str]:
+    if dockerfile.startswith("\ufeff"):
+        raise CandidatePlanError("Dockerfile UTF-8 BOM is forbidden")
+    for raw in dockerfile.splitlines():
+        stripped = raw.lstrip()
+        if stripped.lower().startswith("# escape="):
+            raise CandidatePlanError(
+                "candidate planner forbids Dockerfile escape directives"
+            )
+        if not stripped.startswith("#") and "`" in raw:
+            raise CandidatePlanError(
+                "candidate planner forbids backtick Dockerfile syntax"
+            )
+    logical: list[str] = []
+    pending = ""
+    for raw in dockerfile.splitlines():
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            pending += line[:-1] + " "
+            continue
+        logical.append(pending + line)
+        pending = ""
+    if pending:
+        raise CandidatePlanError("Dockerfile has an unterminated line continuation")
+
+    canonical_sources: list[str] = []
+    for line in logical:
+        match = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
+        if match is None:
+            continue
+        instruction, rest = match.groups()
+        rest = rest.strip()
+        if instruction.upper() != "COPY":
+            raise CandidatePlanError("candidate planner forbids ADD instructions")
+        if rest.startswith("["):
+            raise CandidatePlanError("candidate planner forbids JSON-form COPY")
+        if rest.startswith("--"):
+            raise CandidatePlanError("candidate planner forbids COPY flags")
+        if "<<" in rest:
+            raise CandidatePlanError("candidate planner forbids COPY heredoc syntax")
+        if any(character in rest for character in ('"', "'", "\\", "$", "#")):
+            raise CandidatePlanError(
+                f"candidate planner forbids ambiguous COPY syntax: {line.strip()}"
+            )
+        tokens = rest.split()
+        if len(tokens) < 2:
+            raise CandidatePlanError(
+                f"COPY has no complete source/destination pair: {line.strip()}"
+            )
+        for source in tokens[:-1]:
+            if any(character in source for character in "*?["):
+                raise CandidatePlanError(
+                    f"candidate planner forbids glob COPY sources: {source!r}"
+                )
+            canonical_sources.append(_safe_copy_source(source))
+
+    try:
+        publisher_sources = publisher.parse_copy_sources(dockerfile)
+    except (publisher.DeployContractError, ValueError, json.JSONDecodeError) as exc:
+        raise CandidatePlanError(f"production publisher rejected Dockerfile: {exc}") from exc
+    if publisher_sources != list(dict.fromkeys(canonical_sources)):
+        raise CandidatePlanError(
+            "candidate planner and production publisher derived different COPY sources"
+        )
+    if not publisher_sources:
+        raise CandidatePlanError("Dockerfile has no supported COPY sources")
+    return publisher_sources
+
+
+def _ignore_patterns(data: bytes) -> list[tuple[bool, re.Pattern[str]]]:
+    with tempfile.TemporaryDirectory(prefix="szl-hf-plan-ignore-") as directory:
+        path = Path(directory) / "Dockerfile.dockerignore"
+        path.write_bytes(data)
+        try:
+            return publisher._dockerignore_patterns(str(path))
+        except (publisher.DeployContractError, OSError, ValueError) as exc:
+            raise CandidatePlanError(f"invalid Docker ignore contract: {exc}") from exc
+
+
+def _is_ignored(path: str, patterns: list[tuple[bool, re.Pattern[str]]]) -> bool:
+    parents = path.split("/")[:-1]
+    candidates = [path] + [
+        "/".join(parents[: index + 1]) for index in range(len(parents))
+    ]
+    ignored = {candidate: False for candidate in candidates}
+    for negated, pattern in patterns:
+        for candidate in candidates:
+            if pattern.fullmatch(candidate):
+                ignored[candidate] = not negated
+    return any(ignored.values())
+
+
+def _snapshot(
+    repo_root: Path,
+    revision: str,
+    *,
+    dockerfile_path: str,
+    include_readme: bool,
+    readme_path: str,
+) -> dict[str, Any]:
+    entries = _tree(repo_root, revision)
+    dockerfile_path = _safe_repo_path(dockerfile_path, "Dockerfile path")
+    dockerfile_entry = entries.get(dockerfile_path)
+    if dockerfile_entry is None:
+        raise CandidatePlanError(f"Dockerfile is absent at {revision}: {dockerfile_path}")
+    dockerfile_bytes = _blob(repo_root, dockerfile_entry, dockerfile_path)
+    try:
+        dockerfile = dockerfile_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CandidatePlanError("Dockerfile is not strict UTF-8") from exc
+    sources = _strict_copy_sources(dockerfile)
+
+    object_ids = {path: entry["oid"] for path, entry in entries.items()}
+    targets, unresolved = publisher.expand_sources(sources, object_ids)
+    if unresolved:
+        raise CandidatePlanError(
+            "Dockerfile COPY sources are unresolved: " + ", ".join(sorted(unresolved))
+        )
+
+    ignore_path = next(
+        (
+            path
+            for path in (f"{dockerfile_path}.dockerignore", ".dockerignore")
+            if path in entries
+        ),
+        None,
+    )
+    patterns: list[tuple[bool, re.Pattern[str]]] = []
+    ignore_bytes = b""
+    if ignore_path:
+        ignore_bytes = _blob(repo_root, entries[ignore_path], ignore_path)
+        patterns = _ignore_patterns(ignore_bytes)
+
+    files: dict[str, dict[str, Any]] = {}
+    ignored_paths: list[str] = []
+    for path, copy_source in sorted(targets.items()):
+        _safe_repo_path(path, "managed COPY path")
+        ignored = bool(patterns and _is_ignored(path, patterns))
+        if ignored:
+            ignored_paths.append(path)
+        entry = entries[path]
+        _require_regular_blob(entry, path)
+        files[path] = {
+            "mode": entry["mode"],
+            "oid": entry["oid"],
+            "copy_source": copy_source,
+            "docker_context_included": not ignored,
+        }
+
+    # include-readme is authoritative in the production publisher. It replaces
+    # any same-path Dockerfile-derived entry with the Space-card mapping.
+    if not include_readme:
+        files.pop(readme_path, None)
+
+    files["Dockerfile"] = {
+        "mode": dockerfile_entry["mode"],
+        "oid": dockerfile_entry["oid"],
+        "copy_source": "(dockerfile)",
+        "source_path": dockerfile_path,
+        "docker_context_included": None,
+    }
+    if include_readme:
+        readme_path = _safe_repo_path(readme_path, "README path")
+        readme_entry = entries.get(readme_path)
+        if readme_entry is None:
+            raise CandidatePlanError(f"included README is absent: {readme_path!r}")
+        _blob(repo_root, readme_entry, readme_path)
+        files[readme_path] = {
+            "mode": readme_entry["mode"],
+            "oid": readme_entry["oid"],
+            "copy_source": "(readme)",
+            "docker_context_included": None,
+        }
+    deployed_ignore_oid = publisher.git_blob_sha1(ignore_bytes)
+    files["Dockerfile.dockerignore"] = {
+        "mode": entries[ignore_path]["mode"] if ignore_path else "100644",
+        "oid": deployed_ignore_oid,
+        "copy_source": "(dockerignore-control)",
+        "source_path": ignore_path or "(generated-empty-dockerignore)",
+        "docker_context_included": None,
+    }
+    if not files:
+        raise CandidatePlanError("candidate payload set is empty")
+    return {
+        "revision": revision,
+        "dockerfile_path": dockerfile_path,
+        "effective_dockerignore": ignore_path,
+        "copy_sources": sorted(sources),
+        "unresolved_sources": [],
+        "docker_context_ignored_paths": ignored_paths,
+        "managed_count": len(files),
+        "files": files,
+    }
+
+
+def build_plan(
+    repo_root: Path,
+    github_repo: str,
+    baseline_ref: str,
+    candidate_ref: str,
+    *,
+    dockerfile_path: str = "Dockerfile",
+    include_readme: bool = True,
+    readme_path: str = "README.md",
+) -> dict[str, Any]:
+    root = Path(repo_root).resolve()
+    if not (root / ".git").exists():
+        raise CandidatePlanError(f"repo-root is not a Git worktree: {root}")
+    if REPOSITORY_RE.fullmatch(str(github_repo or "")) is None:
+        raise CandidatePlanError(
+            "github-repo must be one canonical owner/repository identifier"
+        )
+    baseline = _resolve_commit(root, baseline_ref, "candidate baseline")
+    candidate = _resolve_commit(root, candidate_ref, "candidate head")
+    _require_ancestry(root, baseline, candidate)
+    before = _snapshot(
+        root,
+        baseline,
+        dockerfile_path=dockerfile_path,
+        include_readme=include_readme,
+        readme_path=readme_path,
+    )
+    after = _snapshot(
+        root,
+        candidate,
+        dockerfile_path=dockerfile_path,
+        include_readme=include_readme,
+        readme_path=readme_path,
+    )
+
+    baseline_files = before["files"]
+    candidate_files = after["files"]
+    removed_managed_paths = sorted(set(baseline_files) - set(candidate_files))
+    if removed_managed_paths:
+        raise CandidatePlanError(
+            "candidate removes managed payload paths; remote prune authority is "
+            "not proven by this admission plan: " + ", ".join(removed_managed_paths)
+        )
+
+    newly_ignored = sorted(
+        set(after["docker_context_ignored_paths"])
+        - set(before["docker_context_ignored_paths"])
+    )
+    if newly_ignored:
+        raise CandidatePlanError(
+            "candidate newly excludes managed COPY paths from the Docker context: "
+            + ", ".join(newly_ignored)
+        )
+
+    deltas: list[dict[str, Any]] = []
+    all_paths = sorted(set(baseline_files) | set(candidate_files))
+    for path in all_paths:
+        old = before["files"].get(path)
+        new = after["files"].get(path)
+        if old == new:
+            continue
+        if old is None:
+            kind = "managed-added"
+        elif new is None:
+            kind = "managed-removed"
+        else:
+            kind = "modified"
+        deltas.append(
+            {
+                "path": path,
+                "kind": kind,
+                "baseline_blob_sha": old["oid"] if old else None,
+                "candidate_blob_sha": new["oid"] if new else None,
+                "baseline_mode": old["mode"] if old else None,
+                "candidate_mode": new["mode"] if new else None,
+                "baseline_copy_source": old["copy_source"] if old else None,
+                "candidate_copy_source": new["copy_source"] if new else None,
+                "baseline_docker_context_included": (
+                    old["docker_context_included"] if old else None
+                ),
+                "candidate_docker_context_included": (
+                    new["docker_context_included"] if new else None
+                ),
+                "baseline_managed": old is not None,
+                "candidate_managed": new is not None,
+            }
+        )
+
+    plan: dict[str, Any] = {
+        "schema": 1,
+        "mode": "candidate-managed-plan",
+        "status": "changes" if deltas else "no-changes",
+        "github_repo": github_repo,
+        "baseline_ref": baseline,
+        "candidate_ref": candidate,
+        "dockerfile_path": dockerfile_path,
+        "include_readme": include_readme,
+        "readme_path": readme_path if include_readme else None,
+        "network_requests": 0,
+        "allowlist_used": False,
+        "error_count": 0,
+        "baseline": before,
+        "candidate": after,
+        "delta_count": len(deltas),
+        "deltas": deltas,
+    }
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":")).encode()
+    plan["canonical_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return plan
+
+
+def _invalid_report(args: argparse.Namespace, detail: str) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "schema": 1,
+        "mode": "candidate-managed-plan",
+        "status": "invalid",
+        "github_repo": args.github_repo,
+        "baseline_ref": args.trusted_base_ref,
+        "candidate_ref": args.candidate_ref,
+        "network_requests": 0,
+        "allowlist_used": False,
+        "error_count": 1,
+        "findings": [
+            {
+                "path": "(candidate-plan)",
+                "kind": "candidate-plan-contract-error",
+                "severity": "error",
+                "detail": detail,
+            }
+        ],
+    }
+    canonical = json.dumps(report, sort_keys=True, separators=(",", ":")).encode()
+    report["canonical_sha256"] = hashlib.sha256(canonical).hexdigest()
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--github-repo", required=True)
+    parser.add_argument("--trusted-base-ref", required=True)
+    parser.add_argument("--candidate-ref", required=True)
+    parser.add_argument("--dockerfile-path", default="Dockerfile")
+    parser.add_argument("--include-readme", choices=("true", "false"), default="true")
+    parser.add_argument("--readme-path", default="README.md")
+    parser.add_argument("--report-out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = build_plan(
+            args.repo_root,
+            args.github_repo,
+            args.trusted_base_ref,
+            args.candidate_ref,
+            dockerfile_path=args.dockerfile_path,
+            include_readme=args.include_readme == "true",
+            readme_path=args.readme_path,
+        )
+    except (
+        CandidatePlanError,
+        publisher.DeployContractError,
+        OSError,
+        subprocess.SubprocessError,
+        ValueError,
+    ) as exc:
+        report = _invalid_report(args, str(exc))
+        args.report_out.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"::error title=HF candidate plan::{exc}", file=sys.stderr)
+        return 1
+
+    args.report_out.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        "HF candidate plan exact: "
+        f"{report['baseline_ref']} -> {report['candidate_ref']} "
+        f"managed={report['candidate']['managed_count']} "
+        f"deltas={report['delta_count']} "
+        f"sha256={report['canonical_sha256']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/hf_candidate_plan.py
+++ b/.github/scripts/hf_candidate_plan.py
@@ -180,6 +180,62 @@ def _blob(repo_root: Path, entry: dict[str, str], path: str) -> bytes:
     return data
 
 
+def _materialized_blob(
+    checkout_root: Path,
+    entry: dict[str, str],
+    path: str,
+) -> bytes:
+    """Read the exact checkout bytes consumed by the production publisher."""
+    _require_regular_blob(entry, path)
+    try:
+        _normalized, full = publisher.source_file(checkout_root, path)
+    except publisher.DeployContractError as exc:
+        raise CandidatePlanError(
+            f"materialized publisher source is unavailable: {path!r}: {exc}"
+        ) from exc
+    with open(full, "rb") as handle:
+        data = handle.read(MAX_GIT_OUTPUT + 1)
+    if len(data) > MAX_GIT_OUTPUT:
+        raise CandidatePlanError(
+            f"materialized publisher source exceeds the 512 MiB bound: {path!r}"
+        )
+    return data
+
+
+def _source_bytes(
+    repo_root: Path,
+    checkout_root: Path | None,
+    entry: dict[str, str],
+    path: str,
+) -> bytes:
+    if checkout_root is None:
+        return _blob(repo_root, entry, path)
+    return _materialized_blob(checkout_root, entry, path)
+
+
+def _materialized_checkout(
+    value: Path | None,
+    expected_revision: str,
+    label: str,
+) -> Path | None:
+    if value is None:
+        return None
+    root = Path(value).resolve()
+    if not (root / ".git").exists():
+        raise CandidatePlanError(f"{label} is not a Git worktree: {root}")
+    observed = _git(root, "rev-parse", "--verify", "HEAD^{commit}")
+    try:
+        observed_revision = observed.stdout.decode("ascii").strip()
+    except UnicodeDecodeError as exc:
+        raise CandidatePlanError(f"{label} HEAD did not resolve to ASCII") from exc
+    if observed_revision != expected_revision:
+        raise CandidatePlanError(
+            f"{label} is not the exact requested revision: "
+            f"expected={expected_revision} observed={observed_revision!r}"
+        )
+    return root
+
+
 def _strict_copy_sources(dockerfile: str) -> list[str]:
     if dockerfile.startswith("\ufeff"):
         raise CandidatePlanError("Dockerfile UTF-8 BOM is forbidden")
@@ -276,16 +332,23 @@ def _snapshot(
     repo_root: Path,
     revision: str,
     *,
+    materialized_root: Path | None,
     dockerfile_path: str,
     include_readme: bool,
     readme_path: str,
 ) -> dict[str, Any]:
     entries = _tree(repo_root, revision)
     dockerfile_path = _safe_repo_path(dockerfile_path, "Dockerfile path")
+    readme_path = _safe_repo_path(readme_path, "README path")
     dockerfile_entry = entries.get(dockerfile_path)
     if dockerfile_entry is None:
         raise CandidatePlanError(f"Dockerfile is absent at {revision}: {dockerfile_path}")
-    dockerfile_bytes = _blob(repo_root, dockerfile_entry, dockerfile_path)
+    dockerfile_bytes = _source_bytes(
+        repo_root,
+        materialized_root,
+        dockerfile_entry,
+        dockerfile_path,
+    )
     try:
         dockerfile = dockerfile_bytes.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -310,7 +373,12 @@ def _snapshot(
     patterns: list[tuple[bool, re.Pattern[str]]] = []
     ignore_bytes = b""
     if ignore_path:
-        ignore_bytes = _blob(repo_root, entries[ignore_path], ignore_path)
+        ignore_bytes = _source_bytes(
+            repo_root,
+            materialized_root,
+            entries[ignore_path],
+            ignore_path,
+        )
         patterns = _ignore_patterns(ignore_bytes)
 
     files: dict[str, dict[str, Any]] = {}
@@ -321,11 +389,13 @@ def _snapshot(
         if ignored:
             ignored_paths.append(path)
         entry = entries[path]
-        _require_regular_blob(entry, path)
+        data = _source_bytes(repo_root, materialized_root, entry, path)
         files[path] = {
             "mode": entry["mode"],
-            "oid": entry["oid"],
+            "oid": publisher.git_blob_sha1(data),
+            "source_oid": entry["oid"],
             "copy_source": copy_source,
+            "source_path": path,
             "docker_context_included": not ignored,
         }
 
@@ -334,29 +404,41 @@ def _snapshot(
     if not include_readme:
         files.pop(readme_path, None)
 
+    if include_readme:
+        readme_entry = entries.get(readme_path)
+        if readme_entry is None:
+            raise CandidatePlanError(f"included README is absent: {readme_path!r}")
+        readme_bytes = _source_bytes(
+            repo_root,
+            materialized_root,
+            readme_entry,
+            readme_path,
+        )
+        files[readme_path] = {
+            "mode": readme_entry["mode"],
+            "oid": publisher.git_blob_sha1(readme_bytes),
+            "source_oid": readme_entry["oid"],
+            "copy_source": "(readme)",
+            "source_path": readme_path,
+            "docker_context_included": None,
+        }
+
+    # Preserve the production publisher's overlay order: the configured
+    # Dockerfile always owns the HF-root Dockerfile target, even when a caller
+    # selects a colliding README source path.
     files["Dockerfile"] = {
         "mode": dockerfile_entry["mode"],
-        "oid": dockerfile_entry["oid"],
+        "oid": publisher.git_blob_sha1(dockerfile_bytes),
+        "source_oid": dockerfile_entry["oid"],
         "copy_source": "(dockerfile)",
         "source_path": dockerfile_path,
         "docker_context_included": None,
     }
-    if include_readme:
-        readme_path = _safe_repo_path(readme_path, "README path")
-        readme_entry = entries.get(readme_path)
-        if readme_entry is None:
-            raise CandidatePlanError(f"included README is absent: {readme_path!r}")
-        _blob(repo_root, readme_entry, readme_path)
-        files[readme_path] = {
-            "mode": readme_entry["mode"],
-            "oid": readme_entry["oid"],
-            "copy_source": "(readme)",
-            "docker_context_included": None,
-        }
     deployed_ignore_oid = publisher.git_blob_sha1(ignore_bytes)
     files["Dockerfile.dockerignore"] = {
         "mode": entries[ignore_path]["mode"] if ignore_path else "100644",
         "oid": deployed_ignore_oid,
+        "source_oid": entries[ignore_path]["oid"] if ignore_path else None,
         "copy_source": "(dockerignore-control)",
         "source_path": ignore_path or "(generated-empty-dockerignore)",
         "docker_context_included": None,
@@ -365,6 +447,9 @@ def _snapshot(
         raise CandidatePlanError("candidate payload set is empty")
     return {
         "revision": revision,
+        "byte_representation": (
+            "publisher-worktree" if materialized_root is not None else "git-object"
+        ),
         "dockerfile_path": dockerfile_path,
         "effective_dockerignore": ignore_path,
         "copy_sources": sorted(sources),
@@ -381,6 +466,8 @@ def build_plan(
     baseline_ref: str,
     candidate_ref: str,
     *,
+    baseline_checkout_root: Path | None = None,
+    candidate_checkout_root: Path | None = None,
     dockerfile_path: str = "Dockerfile",
     include_readme: bool = True,
     readme_path: str = "README.md",
@@ -395,9 +482,24 @@ def build_plan(
     baseline = _resolve_commit(root, baseline_ref, "candidate baseline")
     candidate = _resolve_commit(root, candidate_ref, "candidate head")
     _require_ancestry(root, baseline, candidate)
+    if (baseline_checkout_root is None) != (candidate_checkout_root is None):
+        raise CandidatePlanError(
+            "baseline and candidate materialized checkouts must be supplied together"
+        )
+    baseline_materialized = _materialized_checkout(
+        baseline_checkout_root,
+        baseline,
+        "baseline checkout",
+    )
+    candidate_materialized = _materialized_checkout(
+        candidate_checkout_root,
+        candidate,
+        "candidate checkout",
+    )
     before = _snapshot(
         root,
         baseline,
+        materialized_root=baseline_materialized,
         dockerfile_path=dockerfile_path,
         include_readme=include_readme,
         readme_path=readme_path,
@@ -405,6 +507,7 @@ def build_plan(
     after = _snapshot(
         root,
         candidate,
+        materialized_root=candidate_materialized,
         dockerfile_path=dockerfile_path,
         include_readme=include_readme,
         readme_path=readme_path,
@@ -448,6 +551,8 @@ def build_plan(
                 "kind": kind,
                 "baseline_blob_sha": old["oid"] if old else None,
                 "candidate_blob_sha": new["oid"] if new else None,
+                "baseline_source_blob_sha": old["source_oid"] if old else None,
+                "candidate_source_blob_sha": new["source_oid"] if new else None,
                 "baseline_mode": old["mode"] if old else None,
                 "candidate_mode": new["mode"] if new else None,
                 "baseline_copy_source": old["copy_source"] if old else None,
@@ -464,7 +569,7 @@ def build_plan(
         )
 
     plan: dict[str, Any] = {
-        "schema": 1,
+        "schema": 2,
         "mode": "candidate-managed-plan",
         "status": "changes" if deltas else "no-changes",
         "github_repo": github_repo,
@@ -488,7 +593,7 @@ def build_plan(
 
 def _invalid_report(args: argparse.Namespace, detail: str) -> dict[str, Any]:
     report: dict[str, Any] = {
-        "schema": 1,
+        "schema": 2,
         "mode": "candidate-managed-plan",
         "status": "invalid",
         "github_repo": args.github_repo,
@@ -517,6 +622,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--github-repo", required=True)
     parser.add_argument("--trusted-base-ref", required=True)
     parser.add_argument("--candidate-ref", required=True)
+    parser.add_argument("--baseline-checkout-root", type=Path, required=True)
+    parser.add_argument("--candidate-checkout-root", type=Path, required=True)
     parser.add_argument("--dockerfile-path", default="Dockerfile")
     parser.add_argument("--include-readme", choices=("true", "false"), default="true")
     parser.add_argument("--readme-path", default="README.md")
@@ -528,6 +635,8 @@ def main(argv: list[str] | None = None) -> int:
             args.github_repo,
             args.trusted_base_ref,
             args.candidate_ref,
+            baseline_checkout_root=args.baseline_checkout_root,
+            candidate_checkout_root=args.candidate_checkout_root,
             dockerfile_path=args.dockerfile_path,
             include_readme=args.include_readme == "true",
             readme_path=args.readme_path,

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -59,6 +59,7 @@ import urllib.request
 HF_HOST = "https://huggingface.co"
 UA = {"User-Agent": "hf-deploy-from-dockerfile/1.0"}
 TERMINAL_RUNTIME_STAGES = {"BUILD_ERROR", "CONFIG_ERROR", "RUNTIME_ERROR"}
+RESERVED_HF_ROOT_TARGETS = {"dockerfile", "dockerfile.dockerignore"}
 
 
 class DeployContractError(ValueError):
@@ -77,6 +78,17 @@ def normalize_repo_path(path, *, label="repository path"):
     if value == ".." or value.startswith("../"):
         raise DeployContractError(f"{label} escapes the repository root: {path!r}")
     return value
+
+
+def validate_readme_target(readme_path, include_readme):
+    """Normalize the Space card path and reject reserved HF-root targets."""
+    rel = normalize_repo_path(readme_path, label="README source path")
+    if include_readme and rel.casefold() in RESERVED_HF_ROOT_TARGETS:
+        raise DeployContractError(
+            "included README collides with a reserved Hugging Face root target: "
+            f"{rel!r}"
+        )
+    return rel
 
 
 def source_file(repo_root, source_path):
@@ -697,10 +709,7 @@ def probe_smoke_routes(hf_repo, smoke_paths, retries=6, delay=5):
 # derive: Dockerfile -> deploy manifest (no network, no push)
 # --------------------------------------------------------------------------- #
 def derive(args):
-    readme_path = normalize_repo_path(
-        args.readme_path,
-        label="README source path",
-    )
+    readme_path = validate_readme_target(args.readme_path, args.include_readme)
     requested_revision = getattr(args, "source_revision_file", "")
     if requested_revision:
         revision_candidate = normalize_repo_path(

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -828,35 +828,40 @@ def derive(args):
         "source_path": dockerfile_rel,
     }
 
-    if revision_rel:
-        ignore_rel, ignore_path = _effective_dockerignore(
-            args.repo_root,
-            dockerfile_rel,
-        )
-        if ignore_path is None:
-            ignore_source = "(generated-empty-dockerignore)"
-            ignore_meta = {
-                "source_path": ignore_source,
-                "generated_content_utf8": "",
-            }
-        else:
-            ignore_source = ignore_rel
-            ignore_meta = {"source_path": ignore_rel}
-        ignore_bytes = read_source_bytes(
-            args.repo_root,
-            "Dockerfile.dockerignore",
-            ignore_meta,
-        )
-        files["Dockerfile.dockerignore"] = {
-            "git_blob_sha1": git_blob_sha1(ignore_bytes),
-            "sha256": sha256(ignore_bytes),
-            "size": len(ignore_bytes),
-            "copy_source": "(dockerignore)",
+    # The remote HF build always consumes an HF-root Dockerfile. Bind the exact
+    # effective local build-context ignore contract beside it on every publish,
+    # even when no generated source-revision file is requested. Otherwise a
+    # stale remote Dockerfile.dockerignore can silently produce different build
+    # bytes from the exact source tree the manifest reports.
+    ignore_rel, ignore_path = _effective_dockerignore(
+        args.repo_root,
+        dockerfile_rel,
+    )
+    if ignore_path is None:
+        ignore_source = "(generated-empty-dockerignore)"
+        ignore_meta = {
             "source_path": ignore_source,
+            "generated_content_utf8": "",
         }
-        if "generated_content_utf8" in ignore_meta:
-            files["Dockerfile.dockerignore"]["generated_content_utf8"] = ""
+    else:
+        ignore_source = ignore_rel
+        ignore_meta = {"source_path": ignore_rel}
+    ignore_bytes = read_source_bytes(
+        args.repo_root,
+        "Dockerfile.dockerignore",
+        ignore_meta,
+    )
+    files["Dockerfile.dockerignore"] = {
+        "git_blob_sha1": git_blob_sha1(ignore_bytes),
+        "sha256": sha256(ignore_bytes),
+        "size": len(ignore_bytes),
+        "copy_source": "(dockerignore)",
+        "source_path": ignore_source,
+    }
+    if "generated_content_utf8" in ignore_meta:
+        files["Dockerfile.dockerignore"]["generated_content_utf8"] = ""
 
+    if revision_rel:
         materialized_revision = materialize_source_revision_file(
             args.repo_root,
             revision_rel,

--- a/.github/scripts/hf_live_pr_pair.py
+++ b/.github/scripts/hf_live_pr_pair.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Fail closed unless one live GitHub PR still has the exact admitted pair."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class LivePRPairError(RuntimeError):
+    """The live pull-request identity cannot satisfy exact admission."""
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise LivePRPairError(f"GitHub API redirect is forbidden: HTTP {code}")
+
+
+def _required(environment: dict[str, str], name: str) -> str:
+    value = str(environment.get(name) or "")
+    if not value:
+        raise LivePRPairError(f"required environment variable is empty: {name}")
+    return value
+
+
+def _canonical_repository(value: str) -> str:
+    parts = str(value or "").split("/")
+    if (
+        len(parts) != 2
+        or any(part in {"", ".", ".."} for part in parts)
+        or any(REPOSITORY_SEGMENT_RE.fullmatch(part) is None for part in parts)
+    ):
+        raise LivePRPairError("GITHUB_REPOSITORY is not a canonical owner/repository")
+    return "/".join(parts)
+
+
+def _reject_json_constant(value: str) -> None:
+    del value
+    raise LivePRPairError("GitHub API response contains an invalid JSON constant")
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise LivePRPairError("GitHub API response has a duplicate object key")
+        result[key] = value
+    return result
+
+
+def _field(mapping: Any, *path: str) -> Any:
+    current = mapping
+    for component in path:
+        if not isinstance(current, dict) or component not in current:
+            raise LivePRPairError(
+                "GitHub API response is missing required field: " + ".".join(path)
+            )
+        current = current[component]
+    return current
+
+
+def validate_live_pr_pair(
+    environment: dict[str, str],
+    *,
+    opener: Any | None = None,
+) -> dict[str, Any]:
+    api_url = _required(environment, "GITHUB_API_URL").rstrip("/")
+    if api_url != "https://api.github.com":
+        raise LivePRPairError("GITHUB_API_URL must be exactly https://api.github.com")
+    repository = _canonical_repository(_required(environment, "GITHUB_REPOSITORY"))
+    token = _required(environment, "GITHUB_TOKEN")
+    pr_number = _required(environment, "PR_NUMBER")
+    if not pr_number.isascii() or not pr_number.isdecimal() or int(pr_number) <= 0:
+        raise LivePRPairError("PR_NUMBER must be a positive decimal integer")
+    if str(int(pr_number)) != pr_number:
+        raise LivePRPairError("PR_NUMBER must use canonical decimal form")
+
+    expected_base_repo = _required(environment, "EXPECTED_BASE_REPO")
+    expected_head_repo = _required(environment, "EXPECTED_HEAD_REPO")
+    expected_base_ref = _required(environment, "EXPECTED_BASE_REF")
+    expected_base_sha = _required(environment, "EXPECTED_BASE_SHA")
+    expected_head_sha = _required(environment, "EXPECTED_HEAD_SHA")
+    if expected_base_repo != repository or expected_head_repo != repository:
+        raise LivePRPairError("expected PR repositories must equal GITHUB_REPOSITORY")
+    for label, value in (
+        ("EXPECTED_BASE_SHA", expected_base_sha),
+        ("EXPECTED_HEAD_SHA", expected_head_sha),
+    ):
+        if SHA_RE.fullmatch(value) is None:
+            raise LivePRPairError(f"{label} must be an exact lowercase Git SHA")
+
+    request = urllib.request.Request(
+        f"{api_url}/repos/{repository}/pulls/{pr_number}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "szl-hf-candidate-plan-live-pair/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="GET",
+    )
+    client = opener or urllib.request.build_opener(_NoRedirect())
+    try:
+        with client.open(request, timeout=20) as response:
+            status = getattr(response, "status", response.getcode())
+            if type(status) is not int:
+                raise LivePRPairError("GitHub API returned a non-integer HTTP status")
+            if status != 200:
+                raise LivePRPairError(
+                    f"GitHub API returned unexpected HTTP status: {status}"
+                )
+            content_type = str(response.headers.get("Content-Type") or "")
+            media_type = content_type.partition(";")[0].strip().casefold()
+            if media_type != "application/json":
+                raise LivePRPairError("GitHub API returned a non-JSON content type")
+            raw = response.read(MAX_RESPONSE_BYTES + 1)
+    except LivePRPairError:
+        raise
+    except urllib.error.HTTPError as exc:
+        raise LivePRPairError(
+            f"GitHub API request failed closed: HTTP {int(exc.code)}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise LivePRPairError(
+            "GitHub API request failed closed: transport error"
+        ) from exc
+    except http.client.HTTPException as exc:
+        raise LivePRPairError(
+            "GitHub API request failed closed: HTTP protocol error"
+        ) from exc
+    except OSError as exc:
+        raise LivePRPairError("GitHub API request failed closed: I/O error") from exc
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise LivePRPairError("GitHub API response exceeds the 1 MiB bound")
+    try:
+        text = raw.decode("utf-8")
+        payload = json.loads(
+            text,
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise LivePRPairError("GitHub API response is not strict UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise LivePRPairError("GitHub API response root must be an object")
+
+    actual = {
+        "number": _field(payload, "number"),
+        "state": _field(payload, "state"),
+        "merged": _field(payload, "merged"),
+        "base_repo": _field(payload, "base", "repo", "full_name"),
+        "head_repo": _field(payload, "head", "repo", "full_name"),
+        "base_ref": _field(payload, "base", "ref"),
+        "base_sha": _field(payload, "base", "sha"),
+        "head_sha": _field(payload, "head", "sha"),
+    }
+    expected = {
+        "number": int(pr_number),
+        "state": "open",
+        "merged": False,
+        "base_repo": expected_base_repo,
+        "head_repo": expected_head_repo,
+        "base_ref": expected_base_ref,
+        "base_sha": expected_base_sha,
+        "head_sha": expected_head_sha,
+    }
+    expected_types = {
+        "number": int,
+        "state": str,
+        "merged": bool,
+        "base_repo": str,
+        "head_repo": str,
+        "base_ref": str,
+        "base_sha": str,
+        "head_sha": str,
+    }
+    for key, expected_value in expected.items():
+        if type(actual[key]) is not expected_types[key]:
+            raise LivePRPairError(f"live pull-request field has the wrong type: {key}")
+        if actual[key] != expected_value:
+            raise LivePRPairError(f"live pull-request field mismatch: {key}")
+    return actual
+
+
+def main() -> int:
+    try:
+        actual = validate_live_pr_pair(dict(os.environ))
+    except LivePRPairError:
+        print(
+            "::error title=HF candidate live PR binding::"
+            "live pull-request identity revalidation failed closed",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        "Live pull-request pair is exact: "
+        f"#{actual['number']} {actual['base_sha']} -> {actual['head_sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/hf_source_bound_baseline.py
+++ b/.github/scripts/hf_source_bound_baseline.py
@@ -10,10 +10,12 @@ identity planes:
 * Dockerfile-managed bytes can be compared at those two immutable revisions.
 
 This verifier observes both live planes more than once with cache bypass, requires
-stable exact values, proves the observed Git source is either an ancestor of the
-pull request base or the exact pull request candidate after controlled deployment,
-compares the exact deployed pair without an allowlist, and reports the candidate's
-managed-file delta without deploying it. It performs no mutation.
+stable exact values, and compares the exact deployed pair without an allowlist.
+Callers may require the observed Git source to equal one explicit protected source
+revision. When that input is omitted, the legacy pull-request policy proves that
+the source is either an ancestor of the pull request base or the exact pull request
+candidate after controlled deployment. Candidate managed-file deltas are reported
+only after the selected source-binding policy succeeds. It performs no mutation.
 """
 from __future__ import annotations
 
@@ -227,6 +229,16 @@ def source_bound_baseline_compare(args: argparse.Namespace):
         if args.candidate_ref
         else ""
     )
+    expected_source_ref_raw = str(
+        getattr(args, "expected_source_ref", "") or ""
+    ).strip()
+    expected_source_ref = (
+        drift.require_full_sha(
+            expected_source_ref_raw, "expected protected source GitHub SHA"
+        )
+        if expected_source_ref_raw
+        else ""
+    )
     probe_path = require_probe_path(args.source_probe_path)
     live_state = drift.hf_space_state(args.hf_repo)
     probe_state = source_probe_state(args.hf_repo, probe_path)
@@ -305,31 +317,55 @@ def source_bound_baseline_compare(args: argparse.Namespace):
             }
         )
     ancestry_status = None
+    source_binding_valid = False
     if drift.FULL_SHA_RE.fullmatch(source_sha) is not None:
-        source_matches_candidate = bool(
-            candidate_ref and source_sha == candidate_ref
-        )
-        if source_matches_candidate:
-            ancestry_status = "exact-candidate"
+        if expected_source_ref:
+            if source_sha == expected_source_ref:
+                ancestry_status = "exact-expected-source"
+                source_binding_valid = True
+            else:
+                ancestry_status = "expected-source-mismatch"
+                contract_errors.append(
+                    {
+                        "path": "(source-probe)",
+                        "kind": "observed-source-not-exact",
+                        "severity": "error",
+                        "observed_source_sha": source_sha,
+                        "expected_source_ref": expected_source_ref,
+                        "detail": (
+                            "live build-info source does not equal the exact "
+                            "protected source revision required by this run"
+                        ),
+                    }
+                )
         else:
-            is_ancestor, ancestry_status = drift.github_ref_is_ancestor(
-                args.github_repo, source_sha, trusted_base_ref
+            source_matches_candidate = bool(
+                candidate_ref and source_sha == candidate_ref
             )
-        if not source_matches_candidate and not is_ancestor:
-            contract_errors.append(
-                {
-                    "path": "(source-probe)",
-                    "kind": "observed-source-not-ancestor",
-                    "severity": "error",
-                    "observed_source_sha": source_sha,
-                    "trusted_base_ref": trusted_base_ref,
-                    "candidate_ref": candidate_ref or None,
-                    "detail": (
-                        "live build-info source is neither an ancestor of the exact "
-                        "pull request base nor the exact pull request candidate"
-                    ),
-                }
-            )
+            if source_matches_candidate:
+                ancestry_status = "exact-candidate"
+                source_binding_valid = True
+            else:
+                is_ancestor, ancestry_status = drift.github_ref_is_ancestor(
+                    args.github_repo, source_sha, trusted_base_ref
+                )
+                source_binding_valid = is_ancestor
+                if not is_ancestor:
+                    contract_errors.append(
+                        {
+                            "path": "(source-probe)",
+                            "kind": "observed-source-not-ancestor",
+                            "severity": "error",
+                            "observed_source_sha": source_sha,
+                            "trusted_base_ref": trusted_base_ref,
+                            "candidate_ref": candidate_ref or None,
+                            "detail": (
+                                "live build-info source is neither an ancestor of "
+                                "the exact pull request base nor the exact pull "
+                                "request candidate"
+                            ),
+                        }
+                    )
     else:
         contract_errors.append(
             {
@@ -351,7 +387,7 @@ def source_bound_baseline_compare(args: argparse.Namespace):
         and live_stage == "RUNNING"
         and probe_state.get("observation_status") == "stable"
         and drift.FULL_SHA_RE.fullmatch(source_sha) is not None
-        and not any(error["kind"] == "observed-source-not-ancestor" for error in contract_errors)
+        and source_binding_valid
     )
     if can_compare:
         baseline_args = argparse.Namespace(**vars(args))
@@ -366,7 +402,11 @@ def source_bound_baseline_compare(args: argparse.Namespace):
         )
 
     candidate_report = None
-    if candidate_ref and drift.FULL_SHA_RE.fullmatch(source_sha) is not None:
+    if (
+        candidate_ref
+        and drift.FULL_SHA_RE.fullmatch(source_sha) is not None
+        and source_binding_valid
+    ):
         candidate_report = drift.candidate_managed_delta(
             args.github_repo,
             source_sha,
@@ -400,6 +440,13 @@ def source_bound_baseline_compare(args: argparse.Namespace):
             "status": "drift" if errors else "ok",
             "trusted_base_ref": trusted_base_ref,
             "candidate_ref": candidate_ref or None,
+            "expected_source_ref": expected_source_ref or None,
+            "source_binding_policy": (
+                "exact-expected-source"
+                if expected_source_ref
+                else "ancestor-or-exact-candidate"
+            ),
+            "source_binding_valid": source_binding_valid,
             "source_probe": probe_state,
             "observed_source_sha": source_sha or None,
             "observed_source_ancestry_status": ancestry_status,
@@ -430,6 +477,7 @@ def main() -> int:
     parser.add_argument("--hf-repo", required=True)
     parser.add_argument("--trusted-base-ref", required=True)
     parser.add_argument("--candidate-ref", default="")
+    parser.add_argument("--expected-source-ref", default="")
     parser.add_argument("--dockerfile-path", default="Dockerfile")
     parser.add_argument("--source-probe-path", default="/api/build-info")
     parser.add_argument("--report-out", default="")
@@ -460,6 +508,13 @@ def main() -> int:
             "hf_repo": args.hf_repo,
             "trusted_base_ref": args.trusted_base_ref,
             "candidate_ref": args.candidate_ref or None,
+            "expected_source_ref": args.expected_source_ref or None,
+            "source_binding_policy": (
+                "exact-expected-source"
+                if args.expected_source_ref
+                else "ancestor-or-exact-candidate"
+            ),
+            "source_binding_valid": False,
             "allowlist_used": False,
             "error_count": 1,
             "warn_count": 0,

--- a/.github/scripts/test_hf_candidate_plan.py
+++ b/.github/scripts/test_hf_candidate_plan.py
@@ -95,6 +95,10 @@ class GitPlanFixture:
         else:
             destination.unlink()
 
+    def restore_from_head(self, path: str) -> None:
+        self.remove(path)
+        _git(self.root, "checkout", "HEAD", "--", path)
+
     def commit(
         self,
         message: str,
@@ -135,46 +139,6 @@ class GitPlanFixture:
             candidate,
         )
 
-    def materialized_plan(
-        self,
-        candidate: str,
-        *,
-        baseline: str | None = None,
-        dockerfile_path: str = "Dockerfile",
-        include_readme: bool = True,
-        readme_path: str = "README.md",
-    ) -> dict:
-        baseline_ref = baseline or self.base
-        baseline_checkout = self.root.parent / f"{self.root.name}-baseline"
-        candidate_checkout = self.root.parent / f"{self.root.name}-candidate"
-        _git(
-            self.root,
-            "worktree",
-            "add",
-            "--detach",
-            str(baseline_checkout),
-            baseline_ref,
-        )
-        _git(
-            self.root,
-            "worktree",
-            "add",
-            "--detach",
-            str(candidate_checkout),
-            candidate,
-        )
-        return candidate_plan.build_plan(
-            self.root,
-            "szl-holdings/fixture",
-            baseline_ref,
-            candidate,
-            baseline_checkout_root=baseline_checkout,
-            candidate_checkout_root=candidate_checkout,
-            dockerfile_path=dockerfile_path,
-            include_readme=include_readme,
-            readme_path=readme_path,
-        )
-
 
 class CandidatePlanTestCase(TestCase):
     def setUp(self) -> None:
@@ -187,9 +151,7 @@ class CandidatePlanTestCase(TestCase):
         self._temporary_directory.cleanup()
 
     def fixture(self, **kwargs) -> GitPlanFixture:
-        repo = self.root / "repo"
-        repo.mkdir()
-        return GitPlanFixture(repo, **kwargs)
+        return GitPlanFixture(self.root, **kwargs)
 
 
 class TestExactCandidatePlan(CandidatePlanTestCase):
@@ -205,9 +167,12 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
 
         self.assertEqual(first, second)
         self.assertEqual(first["status"], "changes")
-        self.assertEqual(first["schema"], 2)
         self.assertEqual(first["baseline_ref"], fixture.base)
         self.assertEqual(first["candidate_ref"], candidate)
+        self.assertEqual(
+            first["candidate"]["source_files"]["app/mod.py"],
+            first["candidate"]["files"]["app/mod.py"]["oid"],
+        )
         self.assertEqual(first["network_requests"], 0)
         self.assertFalse(first["allowlist_used"])
         self.assertEqual(first["delta_count"], 1)
@@ -224,29 +189,6 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
             separators=(",", ":"),
         ).encode()
         self.assertEqual(digest, hashlib.sha256(canonical_bytes).hexdigest())
-
-    def test_checkout_attributes_change_publisher_bytes_even_with_same_source_oid(
-        self,
-    ) -> None:
-        fixture = self.fixture()
-        candidate = fixture.commit(
-            "materialize managed file as CRLF",
-            {".gitattributes": "app/mod.py text eol=crlf\n"},
-        )
-
-        report = fixture.materialized_plan(candidate)
-        delta = next(item for item in report["deltas"] if item["path"] == "app/mod.py")
-
-        self.assertEqual(report["baseline"]["byte_representation"], "publisher-worktree")
-        self.assertEqual(report["candidate"]["byte_representation"], "publisher-worktree")
-        self.assertEqual(
-            delta["baseline_source_blob_sha"],
-            delta["candidate_source_blob_sha"],
-        )
-        self.assertNotEqual(
-            delta["baseline_blob_sha"],
-            delta["candidate_blob_sha"],
-        )
 
     def test_directory_copy_recurses_through_git_tree(self) -> None:
         fixture = self.fixture(
@@ -289,9 +231,7 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
             "unresolved source",
             {
                 "Dockerfile": (
-                    "FROM python:3.12-slim\n"
-                    "COPY app/ /app/\n"
-                    "COPY missing.py /app/\n"
+                    "FROM python:3.12-slim\nCOPY app/ /app/\nCOPY missing.py /app/\n"
                 )
             },
         )
@@ -303,9 +243,7 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
             fixture.plan(candidate)
 
     def test_managed_payload_removal_fails_without_prune_proof(self) -> None:
-        fixture = self.fixture(
-            extra_files={"app/retired.py": "RETIRED = True\n"}
-        )
+        fixture = self.fixture(extra_files={"app/retired.py": "RETIRED = True\n"})
         candidate = fixture.commit(
             "remove managed payload",
             {"app/retired.py": None},
@@ -339,8 +277,9 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
         )
 
         for invalid in invalid_refs:
-            with self.subTest(ref=invalid), self.assertRaises(
-                candidate_plan.CandidatePlanError
+            with (
+                self.subTest(ref=invalid),
+                self.assertRaises(candidate_plan.CandidatePlanError),
             ):
                 candidate_plan.build_plan(
                     fixture.root,
@@ -425,9 +364,7 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
             "copy a preignored path",
             {
                 "Dockerfile": (
-                    "FROM python:3.12-slim\n"
-                    "COPY app/ /app/\n"
-                    "COPY secret.py /app/\n"
+                    "FROM python:3.12-slim\nCOPY app/ /app/\nCOPY secret.py /app/\n"
                 ),
                 "secret.py": "SECRET = False\n",
             },
@@ -450,9 +387,7 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
 
         self.assertEqual(report["candidate"]["docker_context_ignored_paths"], [])
         self.assertTrue(
-            report["candidate"]["files"]["app/mod.py"][
-                "docker_context_included"
-            ]
+            report["candidate"]["files"]["app/mod.py"]["docker_context_included"]
         )
 
     def test_dockerfile_specific_ignore_takes_precedence_over_root(self) -> None:
@@ -469,9 +404,7 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
             "Dockerfile.dockerignore",
         )
         self.assertTrue(
-            report["candidate"]["files"]["app/mod.py"][
-                "docker_context_included"
-            ]
+            report["candidate"]["files"]["app/mod.py"]["docker_context_included"]
         )
 
     def test_newly_ignored_explicit_readme_copy_fails_before_overlay(self) -> None:
@@ -496,7 +429,8 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
     def test_nested_dockerfile_is_mapped_to_hf_root_target(self) -> None:
         fixture = self.fixture(
             extra_files={
-                "space/Dockerfile": "FROM scratch\nCOPY app/ /app/\n"
+                "space/Dockerfile": "FROM scratch\nCOPY app/ /app/\n",
+                "space/Dockerfile.dockerignore": "*.tmp\n",
             }
         )
         candidate = fixture.commit(
@@ -518,30 +452,127 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
             report["candidate"]["files"]["Dockerfile"]["source_path"],
             "space/Dockerfile",
         )
+        self.assertIn("space/Dockerfile", report["candidate"]["source_files"])
+        self.assertIn(
+            "space/Dockerfile.dockerignore", report["candidate"]["source_files"]
+        )
+        self.assertIn("README.md", report["candidate"]["source_files"])
 
-    def test_dockerfile_overlay_wins_readme_target_collision_like_publisher(self) -> None:
-        fixture = self.fixture(
-            extra_files={
-                "space/Dockerfile": "FROM scratch\nCOPY app/ /app/\n"
-            }
-        )
+    def test_normalized_lf_checkout_attributes_preserve_exact_blob_parity(self) -> None:
+        fixture = self.fixture(extra_files={".gitattributes": "* text=auto eol=lf\n"})
         candidate = fixture.commit(
-            "nested dockerfile collision",
-            {"app/mod.py": "VALUE = 'nested-collision'\n"},
+            "normalized LF candidate",
+            {"app/mod.py": "VALUE = 'normalized'\n"},
         )
+        fixture.restore_from_head("app/mod.py")
+
+        report = fixture.plan(candidate)
+
+        self.assertEqual(report["delta_count"], 1)
+
+    def test_checkout_transformed_candidate_bytes_fail_exact_blob_parity(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "force CRLF checkout",
+            {
+                ".gitattributes": "*.py text eol=crlf\n",
+                "app/mod.py": "VALUE = 'candidate'\n",
+            },
+        )
+        fixture.restore_from_head("app/mod.py")
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "checkout bytes differ from the exact Git object.*app/mod.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_changed_checkout_transform_attributes_fail_for_unchanged_blob(
+        self,
+    ) -> None:
+        fixture = self.fixture(extra_files={".gitattributes": "*.py text eol=crlf\n"})
+        candidate = fixture.commit(
+            "change checkout transform",
+            {".gitattributes": "*.py text eol=lf\n"},
+        )
+        fixture.restore_from_head("app/mod.py")
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "changes checkout-transform attributes.*app/mod.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_generated_empty_ignore_has_no_checkout_source(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "ordinary candidate", {"app/mod.py": "NEXT = True\n"}
+        )
+
+        report = fixture.plan(candidate)
+
+        self.assertNotIn(
+            "(generated-empty-dockerignore)", report["candidate"]["source_files"]
+        )
+        self.assertNotIn("Dockerfile.dockerignore", report["candidate"]["source_files"])
+
+    def test_reserved_readme_targets_fail_closed(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "ordinary candidate", {"app/mod.py": "NEXT = True\n"}
+        )
+
+        for readme_path in ("Dockerfile", "Dockerfile.dockerignore"):
+            with (
+                self.subTest(readme_path=readme_path),
+                self.assertRaisesRegex(
+                    candidate_plan.publisher.DeployContractError,
+                    "reserved Hugging Face root target",
+                ),
+            ):
+                candidate_plan.build_plan(
+                    fixture.root,
+                    "szl-holdings/fixture",
+                    fixture.base,
+                    candidate,
+                    readme_path=readme_path,
+                )
 
         report = candidate_plan.build_plan(
             fixture.root,
             "szl-holdings/fixture",
             fixture.base,
             candidate,
-            dockerfile_path="space/Dockerfile",
+            include_readme=False,
             readme_path="Dockerfile",
         )
+        self.assertFalse(report["include_readme"])
 
-        control = report["candidate"]["files"]["Dockerfile"]
-        self.assertEqual(control["source_path"], "space/Dockerfile")
-        self.assertEqual(control["copy_source"], "(dockerfile)")
+    def test_excluded_explicit_readme_is_not_a_publisher_source(self) -> None:
+        fixture = self.fixture(
+            dockerfile=(
+                "FROM python:3.12-slim\n"
+                "COPY app/ /app/\n"
+                "COPY README.md /app/README.md\n"
+            ),
+            extra_files={".gitattributes": "README.md text eol=crlf\n"},
+        )
+        candidate = fixture.commit(
+            "exclude transformed readme",
+            {".gitattributes": "README.md text eol=lf\n"},
+        )
+        fixture.restore_from_head("README.md")
+
+        report = candidate_plan.build_plan(
+            fixture.root,
+            "szl-holdings/fixture",
+            fixture.base,
+            candidate,
+            include_readme=False,
+        )
+
+        self.assertNotIn("README.md", report["candidate"]["files"])
+        self.assertNotIn("README.md", report["candidate"]["source_files"])
 
 
 class TestObjectAndNetworkBoundaries(CandidatePlanTestCase):
@@ -555,7 +586,9 @@ class TestObjectAndNetworkBoundaries(CandidatePlanTestCase):
         ):
             fixture.plan(candidate)
 
-    def test_successful_plan_never_calls_publisher_network_or_runtime_helpers(self) -> None:
+    def test_successful_plan_never_calls_publisher_network_or_runtime_helpers(
+        self,
+    ) -> None:
         fixture = self.fixture()
         candidate = fixture.commit(
             "offline candidate",
@@ -608,7 +641,9 @@ class TestReusableWorkflowContract(TestCase):
         marker = f"      {name}:\n"
         self.assertIn(marker, self.workflow)
         start = self.workflow.index(marker) + len(marker)
-        next_input = re.search(r"(?m)^      [a-z][a-z0-9-]*:\s*$", self.workflow[start:])
+        next_input = re.search(
+            r"(?m)^      [a-z][a-z0-9-]*:\s*$", self.workflow[start:]
+        )
         end = start + next_input.start() if next_input else len(self.workflow)
         return self.workflow[start:end]
 
@@ -639,36 +674,36 @@ class TestReusableWorkflowContract(TestCase):
             '[ "${TRUSTED_BASE_REF}" = "${EVENT_BASE_SHA}" ]',
             '[ "${CANDIDATE_REF}" = "${EVENT_HEAD_SHA}" ]',
             '[ -z "${SOURCE_REVISION_FILE}" ]',
-            "pull-requests: read",
-            "PR_NUMBER: ${{ github.event.pull_request.number }}",
-            'gh api --method GET',
-            '"repos/${GH_REPO}/pulls/${PR_NUMBER}"',
-            '.state == "open"',
-            '.base.sha == $base',
-            '.head.sha == $head',
-            "validate_live_pr",
         ):
             self.assertIn(required, self.workflow)
-        self.assertGreaterEqual(self.workflow.count("gh api --method GET"), 2)
-        self.assertIn(
-            "validate_live_pr || {\n"
-            "            rm -f hf-managed-candidate-plan.out.json",
-            self.workflow,
-        )
 
-    def test_workflow_materializes_exact_base_and_candidate_publisher_bytes(self) -> None:
+    def test_workflow_revalidates_live_pair_before_plan_and_after_artifact(
+        self,
+    ) -> None:
+        helper = "python3 tools/.github/scripts/hf_live_pr_pair.py"
+        self.assertEqual(self.workflow.count(helper), 2)
+        first_live = self.workflow.index(helper)
+        planner = self.workflow.index(
+            "python3 tools/.github/scripts/hf_candidate_plan.py"
+        )
+        upload = self.workflow.index("actions/upload-artifact@")
+        final_live = self.workflow.rindex(helper)
+        self.assertLess(first_live, planner)
+        self.assertLess(planner, upload)
+        self.assertLess(upload, final_live)
+        self.assertEqual(
+            self.workflow.rstrip().splitlines()[-1].strip(), f"run: {helper}"
+        )
         for required in (
-            "Checkout exact protected baseline bytes as data",
-            "ref: ${{ inputs.trusted-base-ref }}",
-            "path: baseline",
-            "ref: ${{ inputs.candidate-ref }}",
-            "path: caller",
-            '--baseline-checkout-root baseline',
-            '--candidate-checkout-root caller',
-            'observed_base="$(git -C baseline rev-parse HEAD)"',
-            'observed_head="$(git -C caller rev-parse HEAD)"',
+            "pull-requests: read",
+            "GITHUB_API_URL: ${{ github.api_url }}",
+            "GITHUB_TOKEN: ${{ github.token }}",
+            "PR_NUMBER: ${{ github.event.pull_request.number }}",
+            "EXPECTED_BASE_SHA: ${{ inputs.trusted-base-ref }}",
+            "EXPECTED_HEAD_SHA: ${{ inputs.candidate-ref }}",
         ):
             self.assertIn(required, self.workflow)
+        self.assertNotIn("--token", self.workflow.lower())
 
     def test_protected_authority_checkout_is_source_and_revision_bound(self) -> None:
         self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
@@ -678,7 +713,9 @@ class TestReusableWorkflowContract(TestCase):
         self.assertIn('--trusted-base-ref "${TRUSTED_BASE_REF}"', self.workflow)
         self.assertIn('--candidate-ref "${CANDIDATE_REF}"', self.workflow)
 
-    def test_workflow_has_no_provider_token_runtime_probe_or_candidate_execution(self) -> None:
+    def test_workflow_has_no_provider_token_runtime_probe_or_candidate_execution(
+        self,
+    ) -> None:
         lowered = self.workflow.lower()
         for forbidden in (
             "secrets.",
@@ -695,7 +732,9 @@ class TestReusableWorkflowContract(TestCase):
         self.assertNotIn("working-directory: caller", lowered)
         self.assertIn("tools/.github/scripts/hf_candidate_plan.py", self.workflow)
 
-    def test_all_actions_are_immutable_and_missing_report_fails_artifact_step(self) -> None:
+    def test_all_actions_are_immutable_and_missing_report_fails_artifact_step(
+        self,
+    ) -> None:
         action_refs = re.findall(r"(?m)^\s*-?\s*uses:\s*([^\s#]+)", self.workflow)
         self.assertGreaterEqual(len(action_refs), 3)
         for action_ref in action_refs:

--- a/.github/scripts/test_hf_candidate_plan.py
+++ b/.github/scripts/test_hf_candidate_plan.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""Fail-closed tests for the local-only Hugging Face candidate planner."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import hf_candidate_plan as candidate_plan  # noqa: E402
+
+
+def _git(
+    repo: Path,
+    *args: str,
+    input_bytes: bytes | None = None,
+) -> str:
+    """Run Git in one isolated fixture and return strict UTF-8 output."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+        }
+    )
+    for variable in tuple(env):
+        if variable.startswith("GIT_CONFIG_") and variable != "GIT_CONFIG_NOSYSTEM":
+            env.pop(variable, None)
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        input=input_bytes,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=30,
+        env=env,
+    )
+    if completed.returncode:
+        raise AssertionError(
+            f"git {' '.join(args)} failed with {completed.returncode}: "
+            f"{completed.stderr.decode('utf-8', 'replace')}"
+        )
+    return completed.stdout.decode("utf-8").strip()
+
+
+class GitPlanFixture:
+    """Tiny committed repository used to prove object-only candidate planning."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        dockerfile: bytes | str = "FROM python:3.12-slim\nCOPY app/ /app/\n",
+        extra_files: dict[str, bytes | str] | None = None,
+    ) -> None:
+        self.root = root
+        _git(root, "init", "--initial-branch=main")
+        _git(root, "config", "user.name", "Candidate Plan Test")
+        _git(root, "config", "user.email", "candidate-plan@example.invalid")
+        _git(root, "config", "commit.gpgsign", "false")
+        _git(root, "config", "core.autocrlf", "false")
+        files: dict[str, bytes | str] = {
+            "Dockerfile": dockerfile,
+            "README.md": "---\nsdk: docker\n---\n# Fixture\n",
+            "app/mod.py": "VALUE = 'base'\n",
+        }
+        files.update(extra_files or {})
+        for path, data in files.items():
+            self.write(path, data)
+        self.base = self.commit("base")
+
+    def write(self, path: str, data: bytes | str) -> None:
+        destination = self.root / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        raw = data.encode("utf-8") if isinstance(data, str) else data
+        destination.write_bytes(raw)
+
+    def remove(self, path: str) -> None:
+        destination = self.root / path
+        if destination.is_dir():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+
+    def commit(
+        self,
+        message: str,
+        updates: dict[str, bytes | str | None] | None = None,
+    ) -> str:
+        for path, data in (updates or {}).items():
+            if data is None:
+                self.remove(path)
+            else:
+                self.write(path, data)
+        _git(self.root, "add", "--all")
+        _git(self.root, "commit", "--message", message)
+        return _git(self.root, "rev-parse", "HEAD")
+
+    def commit_symlink(self, path: str, target: str) -> str:
+        oid = _git(
+            self.root,
+            "hash-object",
+            "-w",
+            "--stdin",
+            input_bytes=target.encode("utf-8"),
+        )
+        _git(
+            self.root,
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"120000,{oid},{path}",
+        )
+        _git(self.root, "commit", "--message", "managed symlink")
+        return _git(self.root, "rev-parse", "HEAD")
+
+    def plan(self, candidate: str, *, baseline: str | None = None) -> dict:
+        return candidate_plan.build_plan(
+            self.root,
+            "szl-holdings/fixture",
+            baseline or self.base,
+            candidate,
+        )
+
+
+class CandidatePlanTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary_directory = tempfile.TemporaryDirectory(
+            prefix="szl-hf-candidate-plan-test-"
+        )
+        self.root = Path(self._temporary_directory.name)
+
+    def tearDown(self) -> None:
+        self._temporary_directory.cleanup()
+
+    def fixture(self, **kwargs) -> GitPlanFixture:
+        return GitPlanFixture(self.root, **kwargs)
+
+
+class TestExactCandidatePlan(CandidatePlanTestCase):
+    def test_exact_managed_change_and_digest_are_deterministic(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "managed change",
+            {"app/mod.py": "VALUE = 'candidate'\n"},
+        )
+
+        first = fixture.plan(candidate)
+        second = fixture.plan(candidate)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["status"], "changes")
+        self.assertEqual(first["baseline_ref"], fixture.base)
+        self.assertEqual(first["candidate_ref"], candidate)
+        self.assertEqual(first["network_requests"], 0)
+        self.assertFalse(first["allowlist_used"])
+        self.assertEqual(first["delta_count"], 1)
+        self.assertEqual(first["deltas"][0]["path"], "app/mod.py")
+        self.assertEqual(first["deltas"][0]["kind"], "modified")
+        self.assertTrue(first["deltas"][0]["baseline_managed"])
+        self.assertTrue(first["deltas"][0]["candidate_managed"])
+
+        canonical = dict(first)
+        digest = canonical.pop("canonical_sha256")
+        canonical_bytes = json.dumps(
+            canonical,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        self.assertEqual(digest, hashlib.sha256(canonical_bytes).hexdigest())
+
+    def test_directory_copy_recurses_through_git_tree(self) -> None:
+        fixture = self.fixture(
+            extra_files={
+                "app/nested/worker.py": "WORKER = True\n",
+                "app/nested/data.json": "{}\n",
+            }
+        )
+        candidate = fixture.commit(
+            "nested change",
+            {"app/nested/worker.py": "WORKER = False\n"},
+        )
+
+        report = fixture.plan(candidate)
+
+        self.assertEqual(report["delta_count"], 1)
+        self.assertEqual(report["deltas"][0]["path"], "app/nested/worker.py")
+        self.assertIn("app/nested/data.json", report["candidate"]["files"])
+        self.assertEqual(
+            report["candidate"]["files"]["app/nested/data.json"]["copy_source"],
+            "app",
+        )
+
+    def test_planner_sources_equal_production_parser_sources(self) -> None:
+        dockerfile = (
+            "FROM python:3.12-slim\n"
+            "COPY app/ settings.json /srv/\n"
+            "COPY app/ /opt/app/\n"
+        )
+
+        strict = candidate_plan._strict_copy_sources(dockerfile)
+        production = candidate_plan.publisher.parse_copy_sources(dockerfile)
+
+        self.assertEqual(strict, production)
+        self.assertEqual(strict, ["app/", "settings.json"])
+
+    def test_unresolved_copy_source_fails_closed(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "unresolved source",
+            {
+                "Dockerfile": (
+                    "FROM python:3.12-slim\n"
+                    "COPY app/ /app/\n"
+                    "COPY missing.py /app/\n"
+                )
+            },
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            r"COPY sources are unresolved: missing\.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_managed_payload_removal_fails_without_prune_proof(self) -> None:
+        fixture = self.fixture(
+            extra_files={"app/retired.py": "RETIRED = True\n"}
+        )
+        candidate = fixture.commit(
+            "remove managed payload",
+            {"app/retired.py": None},
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "removes managed payload paths",
+        ):
+            fixture.plan(candidate)
+
+    def test_non_ancestor_pair_fails_before_snapshot_comparison(self) -> None:
+        fixture = self.fixture()
+        child = fixture.commit("child", {"app/mod.py": "CHILD = True\n"})
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "candidate baseline is not an ancestor",
+        ):
+            fixture.plan(fixture.base, baseline=child)
+
+    def test_invalid_or_symbolic_refs_are_rejected(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit("candidate", {"app/mod.py": "NEXT = True\n"})
+        invalid_refs = (
+            "HEAD",
+            candidate.upper(),
+            candidate[:-1],
+            "z" * 40,
+            "0" * 40,
+        )
+
+        for invalid in invalid_refs:
+            with self.subTest(ref=invalid), self.assertRaises(
+                candidate_plan.CandidatePlanError
+            ):
+                candidate_plan.build_plan(
+                    fixture.root,
+                    "szl-holdings/fixture",
+                    fixture.base,
+                    invalid,
+                )
+
+
+class TestDockerfileGrammar(CandidatePlanTestCase):
+    def test_ambiguous_or_unsupported_copy_grammar_fails_closed(self) -> None:
+        invalid_dockerfiles = {
+            "json": 'FROM scratch\nCOPY ["app/mod.py", "/app/"]\n',
+            "quoted": 'FROM scratch\nCOPY "app/mod.py" /app/\n',
+            "glob": "FROM scratch\nCOPY app/*.py /app/\n",
+            "add": "FROM scratch\nADD app/mod.py /app/\n",
+            "flag": "FROM scratch\nCOPY --chown=1000 app/mod.py /app/\n",
+            "unterminated": "FROM scratch\nCOPY app/mod.py \\",
+            "escape-directive": (
+                "# escape=`\nFROM scratch\nCOPY app/mod.py `\n /app/\n"
+            ),
+            "backtick": "FROM scratch\nCOPY app/mod.py /app/`\n",
+            "heredoc": "FROM scratch\nCOPY <<EOF /payload.txt\nhello\nEOF\n",
+        }
+
+        for name, dockerfile in invalid_dockerfiles.items():
+            with self.subTest(grammar=name):
+                case_root = self.root / name
+                case_root.mkdir()
+                fixture = GitPlanFixture(case_root)
+                candidate = fixture.commit(
+                    f"invalid {name}",
+                    {"Dockerfile": dockerfile},
+                )
+                with self.assertRaises(candidate_plan.CandidatePlanError):
+                    fixture.plan(candidate)
+
+    def test_non_utf8_dockerfile_fails_closed(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "non utf8 Dockerfile",
+            {"Dockerfile": b"FROM scratch\nCOPY app/ /app/\n\xff"},
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "Dockerfile is not strict UTF-8",
+        ):
+            fixture.plan(candidate)
+
+
+class TestEffectiveDockerignore(CandidatePlanTestCase):
+    def test_direct_managed_path_newly_ignored_fails(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "ignore managed file",
+            {".dockerignore": "app/mod.py\n"},
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "newly excludes managed COPY paths.*app/mod.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_ignored_parent_of_managed_path_fails(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "ignore managed parent",
+            {".dockerignore": "app\n"},
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "newly excludes managed COPY paths.*app/mod.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_new_copy_of_preignored_path_fails(self) -> None:
+        fixture = self.fixture(extra_files={".dockerignore": "secret.py\n"})
+        candidate = fixture.commit(
+            "copy a preignored path",
+            {
+                "Dockerfile": (
+                    "FROM python:3.12-slim\n"
+                    "COPY app/ /app/\n"
+                    "COPY secret.py /app/\n"
+                ),
+                "secret.py": "SECRET = False\n",
+            },
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "newly excludes managed COPY paths.*secret.py",
+        ):
+            fixture.plan(candidate)
+
+    def test_specific_negation_keeps_managed_path_in_context(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "explicit managed negation",
+            {".dockerignore": "app/*\n!app/mod.py\n"},
+        )
+
+        report = fixture.plan(candidate)
+
+        self.assertEqual(report["candidate"]["docker_context_ignored_paths"], [])
+        self.assertTrue(
+            report["candidate"]["files"]["app/mod.py"][
+                "docker_context_included"
+            ]
+        )
+
+    def test_dockerfile_specific_ignore_takes_precedence_over_root(self) -> None:
+        fixture = self.fixture(extra_files={".dockerignore": "app/mod.py\n"})
+        candidate = fixture.commit(
+            "override root ignore",
+            {"Dockerfile.dockerignore": "!app/mod.py\n"},
+        )
+
+        report = fixture.plan(candidate)
+
+        self.assertEqual(
+            report["candidate"]["effective_dockerignore"],
+            "Dockerfile.dockerignore",
+        )
+        self.assertTrue(
+            report["candidate"]["files"]["app/mod.py"][
+                "docker_context_included"
+            ]
+        )
+
+    def test_newly_ignored_explicit_readme_copy_fails_before_overlay(self) -> None:
+        fixture = self.fixture(
+            dockerfile=(
+                "FROM python:3.12-slim\n"
+                "COPY app/ /app/\n"
+                "COPY README.md /app/README.md\n"
+            )
+        )
+        candidate = fixture.commit(
+            "ignore copied readme",
+            {".dockerignore": "README.md\n"},
+        )
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "newly excludes managed COPY paths.*README.md",
+        ):
+            fixture.plan(candidate)
+
+    def test_nested_dockerfile_is_mapped_to_hf_root_target(self) -> None:
+        fixture = self.fixture(
+            extra_files={
+                "space/Dockerfile": "FROM scratch\nCOPY app/ /app/\n"
+            }
+        )
+        candidate = fixture.commit(
+            "nested dockerfile payload",
+            {"app/mod.py": "VALUE = 'nested'\n"},
+        )
+
+        report = candidate_plan.build_plan(
+            fixture.root,
+            "szl-holdings/fixture",
+            fixture.base,
+            candidate,
+            dockerfile_path="space/Dockerfile",
+        )
+
+        self.assertIn("Dockerfile", report["candidate"]["files"])
+        self.assertNotIn("space/Dockerfile", report["candidate"]["files"])
+        self.assertEqual(
+            report["candidate"]["files"]["Dockerfile"]["source_path"],
+            "space/Dockerfile",
+        )
+
+
+class TestObjectAndNetworkBoundaries(CandidatePlanTestCase):
+    def test_managed_symlink_is_rejected_from_exact_git_tree(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit_symlink("app/mod.py", "target.py")
+
+        with self.assertRaisesRegex(
+            candidate_plan.CandidatePlanError,
+            "managed path must be a regular Git blob.*app/mod.py.*mode=120000",
+        ):
+            fixture.plan(candidate)
+
+    def test_successful_plan_never_calls_publisher_network_or_runtime_helpers(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "offline candidate",
+            {"app/mod.py": "OFFLINE = True\n"},
+        )
+        blocked = (
+            "_http",
+            "hf_resolve",
+            "hf_space_state",
+            "restart_space",
+            "hf_live_origin",
+            "wait_for_expected_runtime",
+            "probe_smoke_routes",
+            "fetch_github_json",
+        )
+
+        with contextlib.ExitStack() as stack:
+            sentinels = {
+                name: stack.enter_context(
+                    mock.patch.object(
+                        candidate_plan.publisher,
+                        name,
+                        side_effect=AssertionError(f"network helper called: {name}"),
+                    )
+                )
+                for name in blocked
+            }
+            urlopen = stack.enter_context(
+                mock.patch.object(
+                    candidate_plan.publisher.urllib.request,
+                    "urlopen",
+                    side_effect=AssertionError("urllib.request.urlopen called"),
+                )
+            )
+            report = fixture.plan(candidate)
+
+        self.assertEqual(report["network_requests"], 0)
+        urlopen.assert_not_called()
+        for sentinel in sentinels.values():
+            sentinel.assert_not_called()
+
+
+class TestReusableWorkflowContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow_path = HERE.parent / "workflows" / "reusable-hf-candidate-plan.yml"
+        cls.workflow = cls.workflow_path.read_text(encoding="utf-8")
+
+    def _input_block(self, name: str) -> str:
+        marker = f"      {name}:\n"
+        self.assertIn(marker, self.workflow)
+        start = self.workflow.index(marker) + len(marker)
+        next_input = re.search(r"(?m)^      [a-z][a-z0-9-]*:\s*$", self.workflow[start:])
+        end = start + next_input.start() if next_input else len(self.workflow)
+        return self.workflow[start:end]
+
+    def test_workflow_call_has_exact_ref_and_path_inputs(self) -> None:
+        self.assertIn("workflow_call:", self.workflow)
+        for name in ("trusted-base-ref", "candidate-ref"):
+            block = self._input_block(name)
+            self.assertIn("required: true", block)
+            self.assertIn("type: string", block)
+        for name in (
+            "dockerfile-path",
+            "include-readme",
+            "readme-path",
+            "source-revision-file",
+        ):
+            self._input_block(name)
+
+    def test_workflow_binds_current_same_repo_pull_request(self) -> None:
+        for required in (
+            "EVENT_NAME: ${{ github.event_name }}",
+            "EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}",
+            "EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}",
+            "EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+            "EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+            '[ "${EVENT_NAME}" = "pull_request_target" ]',
+            '[ "${EVENT_BASE_REPO}" = "${GH_REPO}" ]',
+            '[ "${EVENT_HEAD_REPO}" = "${GH_REPO}" ]',
+            '[ "${TRUSTED_BASE_REF}" = "${EVENT_BASE_SHA}" ]',
+            '[ "${CANDIDATE_REF}" = "${EVENT_HEAD_SHA}" ]',
+            '[ -z "${SOURCE_REVISION_FILE}" ]',
+        ):
+            self.assertIn(required, self.workflow)
+
+    def test_protected_authority_checkout_is_source_and_revision_bound(self) -> None:
+        self.assertIn("repository: ${{ job.workflow_repository }}", self.workflow)
+        self.assertIn("ref: ${{ job.workflow_sha }}", self.workflow)
+        self.assertIn("TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}", self.workflow)
+        self.assertIn("CANDIDATE_REF: ${{ inputs.candidate-ref }}", self.workflow)
+        self.assertIn('--trusted-base-ref "${TRUSTED_BASE_REF}"', self.workflow)
+        self.assertIn('--candidate-ref "${CANDIDATE_REF}"', self.workflow)
+
+    def test_workflow_has_no_provider_token_runtime_probe_or_candidate_execution(self) -> None:
+        lowered = self.workflow.lower()
+        for forbidden in (
+            "secrets.",
+            "hf_token",
+            "hugging_face_hub",
+            "huggingface.co",
+            "api/spaces",
+        ):
+            self.assertNotIn(forbidden, lowered)
+        self.assertNotRegex(
+            lowered,
+            r"(?:python(?:3)?|bash|sh)\s+caller[/\\]",
+        )
+        self.assertNotIn("working-directory: caller", lowered)
+        self.assertIn("tools/.github/scripts/hf_candidate_plan.py", self.workflow)
+
+    def test_all_actions_are_immutable_and_missing_report_fails_artifact_step(self) -> None:
+        action_refs = re.findall(r"(?m)^\s*-?\s*uses:\s*([^\s#]+)", self.workflow)
+        self.assertGreaterEqual(len(action_refs), 3)
+        for action_ref in action_refs:
+            with self.subTest(action=action_ref):
+                self.assertRegex(action_ref, r"^[^@]+@[0-9a-f]{40}$")
+        self.assertIn("if-no-files-found: error", self.workflow)
+        self.assertIn("        if: always()\n", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_hf_candidate_plan.py
+++ b/.github/scripts/test_hf_candidate_plan.py
@@ -12,9 +12,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import unittest
 from pathlib import Path
-from unittest import mock
+from unittest import TestCase, main, mock
 
 
 HERE = Path(__file__).resolve().parent
@@ -136,8 +135,48 @@ class GitPlanFixture:
             candidate,
         )
 
+    def materialized_plan(
+        self,
+        candidate: str,
+        *,
+        baseline: str | None = None,
+        dockerfile_path: str = "Dockerfile",
+        include_readme: bool = True,
+        readme_path: str = "README.md",
+    ) -> dict:
+        baseline_ref = baseline or self.base
+        baseline_checkout = self.root.parent / f"{self.root.name}-baseline"
+        candidate_checkout = self.root.parent / f"{self.root.name}-candidate"
+        _git(
+            self.root,
+            "worktree",
+            "add",
+            "--detach",
+            str(baseline_checkout),
+            baseline_ref,
+        )
+        _git(
+            self.root,
+            "worktree",
+            "add",
+            "--detach",
+            str(candidate_checkout),
+            candidate,
+        )
+        return candidate_plan.build_plan(
+            self.root,
+            "szl-holdings/fixture",
+            baseline_ref,
+            candidate,
+            baseline_checkout_root=baseline_checkout,
+            candidate_checkout_root=candidate_checkout,
+            dockerfile_path=dockerfile_path,
+            include_readme=include_readme,
+            readme_path=readme_path,
+        )
 
-class CandidatePlanTestCase(unittest.TestCase):
+
+class CandidatePlanTestCase(TestCase):
     def setUp(self) -> None:
         self._temporary_directory = tempfile.TemporaryDirectory(
             prefix="szl-hf-candidate-plan-test-"
@@ -148,7 +187,9 @@ class CandidatePlanTestCase(unittest.TestCase):
         self._temporary_directory.cleanup()
 
     def fixture(self, **kwargs) -> GitPlanFixture:
-        return GitPlanFixture(self.root, **kwargs)
+        repo = self.root / "repo"
+        repo.mkdir()
+        return GitPlanFixture(repo, **kwargs)
 
 
 class TestExactCandidatePlan(CandidatePlanTestCase):
@@ -164,6 +205,7 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
 
         self.assertEqual(first, second)
         self.assertEqual(first["status"], "changes")
+        self.assertEqual(first["schema"], 2)
         self.assertEqual(first["baseline_ref"], fixture.base)
         self.assertEqual(first["candidate_ref"], candidate)
         self.assertEqual(first["network_requests"], 0)
@@ -182,6 +224,29 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
             separators=(",", ":"),
         ).encode()
         self.assertEqual(digest, hashlib.sha256(canonical_bytes).hexdigest())
+
+    def test_checkout_attributes_change_publisher_bytes_even_with_same_source_oid(
+        self,
+    ) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "materialize managed file as CRLF",
+            {".gitattributes": "app/mod.py text eol=crlf\n"},
+        )
+
+        report = fixture.materialized_plan(candidate)
+        delta = next(item for item in report["deltas"] if item["path"] == "app/mod.py")
+
+        self.assertEqual(report["baseline"]["byte_representation"], "publisher-worktree")
+        self.assertEqual(report["candidate"]["byte_representation"], "publisher-worktree")
+        self.assertEqual(
+            delta["baseline_source_blob_sha"],
+            delta["candidate_source_blob_sha"],
+        )
+        self.assertNotEqual(
+            delta["baseline_blob_sha"],
+            delta["candidate_blob_sha"],
+        )
 
     def test_directory_copy_recurses_through_git_tree(self) -> None:
         fixture = self.fixture(
@@ -454,6 +519,30 @@ class TestEffectiveDockerignore(CandidatePlanTestCase):
             "space/Dockerfile",
         )
 
+    def test_dockerfile_overlay_wins_readme_target_collision_like_publisher(self) -> None:
+        fixture = self.fixture(
+            extra_files={
+                "space/Dockerfile": "FROM scratch\nCOPY app/ /app/\n"
+            }
+        )
+        candidate = fixture.commit(
+            "nested dockerfile collision",
+            {"app/mod.py": "VALUE = 'nested-collision'\n"},
+        )
+
+        report = candidate_plan.build_plan(
+            fixture.root,
+            "szl-holdings/fixture",
+            fixture.base,
+            candidate,
+            dockerfile_path="space/Dockerfile",
+            readme_path="Dockerfile",
+        )
+
+        control = report["candidate"]["files"]["Dockerfile"]
+        self.assertEqual(control["source_path"], "space/Dockerfile")
+        self.assertEqual(control["copy_source"], "(dockerfile)")
+
 
 class TestObjectAndNetworkBoundaries(CandidatePlanTestCase):
     def test_managed_symlink_is_rejected_from_exact_git_tree(self) -> None:
@@ -509,7 +598,7 @@ class TestObjectAndNetworkBoundaries(CandidatePlanTestCase):
             sentinel.assert_not_called()
 
 
-class TestReusableWorkflowContract(unittest.TestCase):
+class TestReusableWorkflowContract(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow_path = HERE.parent / "workflows" / "reusable-hf-candidate-plan.yml"
@@ -550,6 +639,34 @@ class TestReusableWorkflowContract(unittest.TestCase):
             '[ "${TRUSTED_BASE_REF}" = "${EVENT_BASE_SHA}" ]',
             '[ "${CANDIDATE_REF}" = "${EVENT_HEAD_SHA}" ]',
             '[ -z "${SOURCE_REVISION_FILE}" ]',
+            "pull-requests: read",
+            "PR_NUMBER: ${{ github.event.pull_request.number }}",
+            'gh api --method GET',
+            '"repos/${GH_REPO}/pulls/${PR_NUMBER}"',
+            '.state == "open"',
+            '.base.sha == $base',
+            '.head.sha == $head',
+            "validate_live_pr",
+        ):
+            self.assertIn(required, self.workflow)
+        self.assertGreaterEqual(self.workflow.count("gh api --method GET"), 2)
+        self.assertIn(
+            "validate_live_pr || {\n"
+            "            rm -f hf-managed-candidate-plan.out.json",
+            self.workflow,
+        )
+
+    def test_workflow_materializes_exact_base_and_candidate_publisher_bytes(self) -> None:
+        for required in (
+            "Checkout exact protected baseline bytes as data",
+            "ref: ${{ inputs.trusted-base-ref }}",
+            "path: baseline",
+            "ref: ${{ inputs.candidate-ref }}",
+            "path: caller",
+            '--baseline-checkout-root baseline',
+            '--candidate-checkout-root caller',
+            'observed_base="$(git -C baseline rev-parse HEAD)"',
+            'observed_head="$(git -C caller rev-parse HEAD)"',
         ):
             self.assertIn(required, self.workflow)
 
@@ -589,4 +706,4 @@ class TestReusableWorkflowContract(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    main(verbosity=2)

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -212,6 +212,30 @@ class TestDeriveReadmePolicy(unittest.TestCase):
         self.assertIsNone(manifest["readme"])
         self.assertEqual(files["Dockerfile"]["source_path"], "Dockerfile")
 
+    def test_include_readme_rejects_reserved_hf_root_targets(self):
+        for readme_path in ("Dockerfile", "./Dockerfile", "Dockerfile.dockerignore"):
+            with self.subTest(readme_path=readme_path), self.assertRaisesRegex(
+                dep.DeployContractError,
+                "reserved Hugging Face root target",
+            ):
+                self._derive(
+                    "FROM scratch\nCOPY serve.py /app/serve.py\n",
+                    {"README.md": "# Card\n", "serve.py": "pass\n"},
+                    include_readme=True,
+                    readme_path=readme_path,
+                )
+
+    def test_include_readme_false_allows_reserved_path_without_publishing_it(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY serve.py /app/serve.py\n",
+            {"serve.py": "pass\n"},
+            include_readme=False,
+            readme_path="Dockerfile",
+        )
+
+        self.assertIsNone(manifest["readme"])
+        self.assertEqual(files["Dockerfile"]["copy_source"], "(dockerfile)")
+
     def test_include_readme_false_keeps_unrelated_nested_readme(self):
         manifest, files = self._derive(
             "FROM scratch\n"

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -204,7 +204,10 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             readme_path="./README.md",
         )
 
-        self.assertEqual(set(files), {"Dockerfile", "serve.py"})
+        self.assertEqual(
+            set(files),
+            {"Dockerfile", "Dockerfile.dockerignore", "serve.py"},
+        )
         self.assertEqual(manifest["files_resolved"], 1)
         self.assertIsNone(manifest["readme"])
         self.assertEqual(files["Dockerfile"]["source_path"], "Dockerfile")
@@ -221,7 +224,10 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             include_readme=False,
         )
 
-        self.assertEqual(set(files), {"Dockerfile", "docs/README.md"})
+        self.assertEqual(
+            set(files),
+            {"Dockerfile", "Dockerfile.dockerignore", "docs/README.md"},
+        )
         self.assertEqual(manifest["files_resolved"], 1)
 
     def test_include_readme_true_merges_derived_entry_as_readme(self):
@@ -232,7 +238,10 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             include_readme=True,
         )
 
-        self.assertEqual(set(files), {"Dockerfile", "README.md"})
+        self.assertEqual(
+            set(files),
+            {"Dockerfile", "Dockerfile.dockerignore", "README.md"},
+        )
         self.assertEqual(files["README.md"]["copy_source"], "(readme)")
         self.assertEqual(files["README.md"]["sha256"], dep.sha256(readme.encode()))
         self.assertEqual(manifest["readme"], "README.md")
@@ -254,6 +263,52 @@ class TestDeriveReadmePolicy(unittest.TestCase):
         self.assertEqual(
             files["Dockerfile"]["sha256"], dep.sha256(dockerfile.encode())
         )
+
+    def test_effective_dockerignore_is_always_published_with_dockerfile(self):
+        manifest, files = self._derive(
+            "FROM scratch\nCOPY serve.py /app/serve.py\n",
+            {"serve.py": "pass\n", ".dockerignore": "*.log\n"},
+            include_readme=False,
+        )
+
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["source_path"], ".dockerignore"
+        )
+        self.assertEqual(
+            files["Dockerfile.dockerignore"]["sha256"],
+            dep.sha256(b"*.log\n"),
+        )
+        self.assertEqual(
+            manifest["files_deployed"], manifest["files_resolved"] + 2
+        )
+
+    def test_dockerfile_specific_ignore_is_always_published_at_hf_root(self):
+        dockerfile = "FROM scratch\nCOPY space/app.py /app/app.py\n"
+        _manifest, files = self._derive(
+            dockerfile,
+            {
+                "space/app.py": "pass\n",
+                "space/Dockerfile.dockerignore": "*.tmp\n",
+            },
+            include_readme=False,
+            dockerfile_path="space/Dockerfile",
+        )
+
+        control = files["Dockerfile.dockerignore"]
+        self.assertEqual(control["source_path"], "space/Dockerfile.dockerignore")
+        self.assertEqual(control["sha256"], dep.sha256(b"*.tmp\n"))
+
+    def test_missing_dockerignore_publishes_deterministic_empty_control(self):
+        _manifest, files = self._derive(
+            "FROM scratch\nCOPY serve.py /app/serve.py\n",
+            {"serve.py": "pass\n"},
+            include_readme=False,
+        )
+
+        control = files["Dockerfile.dockerignore"]
+        self.assertEqual(control["source_path"], "(generated-empty-dockerignore)")
+        self.assertEqual(control["generated_content_utf8"], "")
+        self.assertEqual(control["size"], 0)
 
     def test_unresolved_copy_source_fails_closed(self):
         with self.assertRaisesRegex(dep.DeployContractError, "not found"):
@@ -554,7 +609,12 @@ class TestDeriveReadmePolicy(unittest.TestCase):
             os.makedirs(os.path.join(repo_root, ".git", "objects"))
             requested = os.path.join(repo_root, "space", "SOURCE_REVISION")
             escaped = os.path.join(repo_root, ".git", "objects", "revision")
-            os.symlink(os.path.join("..", ".git", "objects", "revision"), requested)
+            try:
+                os.symlink(
+                    os.path.join("..", ".git", "objects", "revision"), requested
+                )
+            except OSError as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
 
             with self.assertRaisesRegex(dep.DeployContractError, "already exist"):
                 dep.materialize_source_revision_file(
@@ -566,11 +626,14 @@ class TestDeriveReadmePolicy(unittest.TestCase):
         with tempfile.TemporaryDirectory() as repo_root:
             escaped_parent = os.path.join(repo_root, ".git", "refs", "heads")
             os.makedirs(escaped_parent)
-            os.symlink(
-                os.path.join(".git", "refs", "heads"),
-                os.path.join(repo_root, "space"),
-                target_is_directory=True,
-            )
+            try:
+                os.symlink(
+                    os.path.join(".git", "refs", "heads"),
+                    os.path.join(repo_root, "space"),
+                    target_is_directory=True,
+                )
+            except OSError as exc:
+                self.skipTest(f"symlink creation unavailable: {exc}")
             escaped = os.path.join(escaped_parent, "SOURCE_REVISION")
 
             with self.assertRaisesRegex(

--- a/.github/scripts/test_hf_live_pr_pair.py
+++ b/.github/scripts/test_hf_live_pr_pair.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Tests for exact live pull-request identity admission."""
+
+from __future__ import annotations
+
+import contextlib
+import http.client
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import hf_live_pr_pair as live_pair  # noqa: E402
+
+
+BASE = "a" * 40
+HEAD = "b" * 40
+
+
+class _Response:
+    status = 200
+
+    def __init__(
+        self,
+        payload: bytes,
+        *,
+        content_type: str = "application/json; charset=utf-8",
+    ) -> None:
+        self.payload = payload
+        self.headers = {"Content-Type": content_type}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self, bound: int) -> bytes:
+        return self.payload[:bound]
+
+
+class _Opener:
+    def __init__(
+        self,
+        payload: bytes,
+        *,
+        error: Exception | None = None,
+        content_type: str = "application/json; charset=utf-8",
+    ) -> None:
+        self.payload = payload
+        self.error = error
+        self.content_type = content_type
+        self.request = None
+
+    def open(self, request, timeout: int):
+        self.request = request
+        if self.error:
+            raise self.error
+        return _Response(self.payload, content_type=self.content_type)
+
+
+def _environment() -> dict[str, str]:
+    return {
+        "GITHUB_API_URL": "https://api.github.com",
+        "GITHUB_REPOSITORY": "szl-holdings/example",
+        "GITHUB_TOKEN": "secret-token-never-print",
+        "PR_NUMBER": "42",
+        "EXPECTED_BASE_REPO": "szl-holdings/example",
+        "EXPECTED_HEAD_REPO": "szl-holdings/example",
+        "EXPECTED_BASE_REF": "main",
+        "EXPECTED_BASE_SHA": BASE,
+        "EXPECTED_HEAD_SHA": HEAD,
+    }
+
+
+def _payload(**overrides) -> bytes:
+    payload = {
+        "number": 42,
+        "state": "open",
+        "merged": False,
+        "base": {
+            "ref": "main",
+            "sha": BASE,
+            "repo": {"full_name": "szl-holdings/example"},
+        },
+        "head": {
+            "sha": HEAD,
+            "repo": {"full_name": "szl-holdings/example"},
+        },
+    }
+    for key, value in overrides.items():
+        if "." not in key:
+            payload[key] = value
+            continue
+        parent, child = key.split(".", 1)
+        payload[parent][child] = value
+    return json.dumps(payload).encode()
+
+
+class TestLivePRPair(unittest.TestCase):
+    def test_exact_live_pair_passes_without_exposing_token_in_url(self) -> None:
+        opener = _Opener(_payload())
+
+        actual = live_pair.validate_live_pr_pair(_environment(), opener=opener)
+
+        self.assertEqual(actual["base_sha"], BASE)
+        self.assertEqual(actual["head_sha"], HEAD)
+        self.assertNotIn("secret-token-never-print", opener.request.full_url)
+        self.assertEqual(opener.request.get_method(), "GET")
+
+    def test_every_live_identity_mismatch_fails_closed(self) -> None:
+        cases = {
+            "number": {"number": 43},
+            "closed": {"state": "closed"},
+            "merged": {"merged": True},
+            "base repo": {"base.repo": {"full_name": "other/example"}},
+            "head repo": {"head.repo": {"full_name": "other/example"}},
+            "base ref": {"base.ref": "release/stale"},
+            "base sha": {"base.sha": "c" * 40},
+            "head sha": {"head.sha": "d" * 40},
+        }
+        for name, overrides in cases.items():
+            with (
+                self.subTest(case=name),
+                self.assertRaisesRegex(live_pair.LivePRPairError, "mismatch"),
+            ):
+                live_pair.validate_live_pr_pair(
+                    _environment(), opener=_Opener(_payload(**overrides))
+                )
+
+    def test_malformed_duplicate_and_oversized_responses_fail_closed(self) -> None:
+        payloads = (
+            b"not json",
+            b'{"number":42,"number":42}',
+            b"{" + b" " * live_pair.MAX_RESPONSE_BYTES + b"}",
+            _payload()
+            .decode()
+            .replace('"merged": false', '"merged": false, "x": NaN')
+            .encode(),
+            _payload()
+            .decode()
+            .replace('"merged": false', '"merged": false, "x": Infinity')
+            .encode(),
+            _payload()
+            .decode()
+            .replace('"merged": false', '"merged": false, "x": -Infinity')
+            .encode(),
+            _payload().decode().encode("utf-16"),
+        )
+        for payload in payloads:
+            with (
+                self.subTest(size=len(payload)),
+                self.assertRaises(live_pair.LivePRPairError),
+            ):
+                live_pair.validate_live_pr_pair(_environment(), opener=_Opener(payload))
+
+    def test_false_positive_json_content_types_fail_closed(self) -> None:
+        for content_type in (
+            "application/jsonp",
+            "text/application/json",
+            "fooapplication/jsonbar",
+            "text/plain",
+        ):
+            with (
+                self.subTest(content_type=content_type),
+                self.assertRaisesRegex(
+                    live_pair.LivePRPairError, "non-JSON content type"
+                ),
+            ):
+                live_pair.validate_live_pr_pair(
+                    _environment(),
+                    opener=_Opener(_payload(), content_type=content_type),
+                )
+
+    def test_wrong_field_types_fail_closed(self) -> None:
+        for overrides in ({"number": True}, {"merged": 0}, {"state": ["open"]}):
+            with (
+                self.subTest(overrides=overrides),
+                self.assertRaisesRegex(live_pair.LivePRPairError, "wrong type"),
+            ):
+                live_pair.validate_live_pr_pair(
+                    _environment(), opener=_Opener(_payload(**overrides))
+                )
+
+    def test_http_failure_redirect_and_bad_api_origin_fail_closed(self) -> None:
+        with self.assertRaisesRegex(live_pair.LivePRPairError, "request failed"):
+            live_pair.validate_live_pr_pair(
+                _environment(),
+                opener=_Opener(
+                    b"",
+                    error=urllib.error.URLError("offline"),
+                ),
+            )
+        with self.assertRaisesRegex(live_pair.LivePRPairError, "redirect"):
+            live_pair._NoRedirect().redirect_request(None, None, 302, "", {}, "")
+        environment = _environment()
+        environment["GITHUB_API_URL"] = "http://api.github.com"
+        with self.assertRaisesRegex(live_pair.LivePRPairError, "exactly https"):
+            live_pair.validate_live_pr_pair(environment, opener=_Opener(_payload()))
+
+    def test_transport_errors_never_reflect_bearer_token(self) -> None:
+        environment = _environment()
+        token = environment["GITHUB_TOKEN"]
+        errors = (
+            urllib.error.HTTPError("https://api.github.com", 403, token, {}, None),
+            urllib.error.URLError(token),
+            http.client.BadStatusLine(token),
+            OSError(token),
+        )
+        for error in errors:
+            with self.subTest(error=type(error).__name__):
+                with self.assertRaises(live_pair.LivePRPairError) as raised:
+                    live_pair.validate_live_pr_pair(
+                        environment,
+                        opener=_Opener(b"", error=error),
+                    )
+                self.assertNotIn(token, str(raised.exception))
+
+    def test_response_diagnostics_and_main_never_reflect_bearer_token(self) -> None:
+        environment = _environment()
+        token = environment["GITHUB_TOKEN"]
+        reflected_cases = (
+            _Opener(_payload(), content_type=token),
+            _Opener(f'{{"{token}":1,"{token}":2}}'.encode()),
+            _Opener(_payload(state=token)),
+        )
+        for opener in reflected_cases:
+            with self.subTest(opener=opener):
+                with self.assertRaises(live_pair.LivePRPairError) as raised:
+                    live_pair.validate_live_pr_pair(environment, opener=opener)
+                self.assertNotIn(token, str(raised.exception))
+
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(
+                live_pair,
+                "validate_live_pr_pair",
+                side_effect=live_pair.LivePRPairError(token),
+            ),
+            mock.patch.dict(live_pair.os.environ, environment, clear=True),
+            contextlib.redirect_stderr(stderr),
+        ):
+            self.assertEqual(live_pair.main(), 1)
+        self.assertNotIn(token, stderr.getvalue())
+
+    def test_repository_dot_segments_fail_before_network(self) -> None:
+        for repository in ("../example", "owner/..", "./example", "owner/."):
+            environment = _environment()
+            environment["GITHUB_REPOSITORY"] = repository
+            environment["EXPECTED_BASE_REPO"] = repository
+            environment["EXPECTED_HEAD_REPO"] = repository
+            opener = _Opener(_payload())
+            with (
+                self.subTest(repository=repository),
+                self.assertRaisesRegex(
+                    live_pair.LivePRPairError, "canonical owner/repository"
+                ),
+            ):
+                live_pair.validate_live_pr_pair(environment, opener=opener)
+            self.assertIsNone(opener.request)
+
+    def test_invalid_environment_fails_before_network(self) -> None:
+        cases = {
+            "PR_NUMBER": "0",
+            "EXPECTED_BASE_SHA": BASE.upper(),
+            "EXPECTED_HEAD_SHA": "short",
+            "EXPECTED_HEAD_REPO": "other/example",
+        }
+        for key, value in cases.items():
+            environment = _environment()
+            environment[key] = value
+            opener = _Opener(_payload())
+            with self.subTest(field=key), self.assertRaises(live_pair.LivePRPairError):
+                live_pair.validate_live_pr_pair(environment, opener=opener)
+            self.assertIsNone(opener.request)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_hf_live_pr_pair.py
+++ b/.github/scripts/test_hf_live_pr_pair.py
@@ -9,9 +9,9 @@ import io
 import json
 import sys
 import unittest
+import unittest.mock
 import urllib.error
 from pathlib import Path
-from unittest import mock
 
 
 HERE = Path(__file__).resolve().parent
@@ -242,12 +242,12 @@ class TestLivePRPair(unittest.TestCase):
 
         stderr = io.StringIO()
         with (
-            mock.patch.object(
+            unittest.mock.patch.object(
                 live_pair,
                 "validate_live_pr_pair",
                 side_effect=live_pair.LivePRPairError(token),
             ),
-            mock.patch.dict(live_pair.os.environ, environment, clear=True),
+            unittest.mock.patch.dict(live_pair.os.environ, environment, clear=True),
             contextlib.redirect_stderr(stderr),
         ):
             self.assertEqual(live_pair.main(), 1)

--- a/.github/scripts/test_hf_source_bound_baseline.py
+++ b/.github/scripts/test_hf_source_bound_baseline.py
@@ -121,12 +121,13 @@ class SourceBoundBaselineTests(unittest.TestCase):
             else:
                 setattr(drift, key, value)
 
-    def args(self, candidate=True):
+    def args(self, candidate=True, expected_source_ref=""):
         return argparse.Namespace(
             github_repo="szl-holdings/a11oy",
             hf_repo="SZLHOLDINGS/a11oy",
             trusted_base_ref=self.BASE,
             candidate_ref=self.HEAD if candidate else "",
+            expected_source_ref=expected_source_ref,
             dockerfile_path="Dockerfile",
             source_probe_path="/api/build-info",
             ref="main",
@@ -203,8 +204,77 @@ class SourceBoundBaselineTests(unittest.TestCase):
         self.assertTrue(calls["include_dockerfile"])
         self.assertEqual(report["mode"], "source-bound-live-baseline")
         self.assertEqual(report["observed_source_sha"], self.SOURCE)
+        self.assertIsNone(report["expected_source_ref"])
+        self.assertEqual(
+            report["source_binding_policy"], "ancestor-or-exact-candidate"
+        )
+        self.assertTrue(report["source_binding_valid"])
         self.assertFalse(report["allowlist_used"])
         self.assertEqual(candidate["baseline_ref"], self.SOURCE)
+
+    def test_exact_expected_source_succeeds_without_ancestry_fallback(self):
+        calls = self.install_clean()
+        drift.github_ref_is_ancestor = lambda *_args: self.fail(
+            "exact expected-source mode must not use ancestry"
+        )
+
+        report, errors, warns, candidate = baseline.source_bound_baseline_compare(
+            self.args(expected_source_ref=self.SOURCE)
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(warns, [])
+        self.assertEqual(calls["refs"], (self.SOURCE, self.LIVE))
+        self.assertEqual(report["expected_source_ref"], self.SOURCE)
+        self.assertEqual(report["source_binding_policy"], "exact-expected-source")
+        self.assertTrue(report["source_binding_valid"])
+        self.assertEqual(
+            report["observed_source_ancestry_status"], "exact-expected-source"
+        )
+        self.assertEqual(candidate["baseline_ref"], self.SOURCE)
+
+    def test_stale_ancestor_fails_exact_mode_without_compare_or_candidate_delta(self):
+        self.install_clean()
+        drift.github_ref_is_ancestor = lambda *_args: self.fail(
+            "exact expected-source mode must not fall back to ancestry"
+        )
+        drift.compare = lambda *_args, **_kwargs: self.fail("compare must not run")
+        drift.candidate_managed_delta = lambda *_args: self.fail(
+            "candidate delta must not run for an invalid source binding"
+        )
+
+        report, errors, warns, candidate = baseline.source_bound_baseline_compare(
+            self.args(expected_source_ref=self.BASE)
+        )
+
+        self.assertEqual(warns, [])
+        self.assertIsNone(candidate)
+        self.assertEqual(report["status"], "drift")
+        self.assertEqual(report["expected_source_ref"], self.BASE)
+        self.assertFalse(report["source_binding_valid"])
+        self.assertEqual(
+            report["observed_source_ancestry_status"], "expected-source-mismatch"
+        )
+        exact_errors = [
+            item for item in errors if item["kind"] == "observed-source-not-exact"
+        ]
+        self.assertEqual(len(exact_errors), 1)
+        self.assertEqual(exact_errors[0]["observed_source_sha"], self.SOURCE)
+        self.assertEqual(exact_errors[0]["expected_source_ref"], self.BASE)
+
+    def test_malformed_expected_source_fails_before_any_network_observation(self):
+        drift.hf_space_state = lambda *_args: self.fail("HF must not be queried")
+        baseline.source_probe_state = lambda *_args: self.fail(
+            "source probe must not be queried"
+        )
+        drift.github_ref_is_ancestor = lambda *_args: self.fail(
+            "GitHub ancestry must not be queried"
+        )
+
+        with self.assertRaisesRegex(ValueError, "expected protected source GitHub SHA"):
+            baseline.source_bound_baseline_compare(
+                self.args(expected_source_ref="main")
+            )
 
     def test_exact_deployed_candidate_is_a_valid_source_bound_baseline(self):
         calls = self.install_clean()
@@ -333,10 +403,21 @@ class ReusableWorkflowTests(unittest.TestCase):
             '--source-probe-path "${SOURCE_PROBE_PATH}"',
             "TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}",
             "CANDIDATE_REF: ${{ inputs.candidate-ref }}",
+            "EXPECTED_SOURCE_REF: ${{ inputs.expected-source-ref }}",
+            '--expected-source-ref "${EXPECTED_SOURCE_REF}"',
         ):
             self.assertIn(safe, self.workflow)
         self.assertNotIn(
             '--source-probe-path "${{ inputs.source-probe-path }}"', self.workflow
+        )
+        self.assertNotIn(
+            '--expected-source-ref "${{ inputs.expected-source-ref }}"',
+            self.workflow,
+        )
+        self.assertIn("expected-source-ref:", self.workflow)
+        self.assertIn(
+            "expected-source-ref must be an exact lowercase 40-character SHA",
+            self.workflow,
         )
 
     def test_exact_reusable_revision_tools_and_reports_are_preserved(self):

--- a/.github/workflows/reusable-hf-candidate-plan.yml
+++ b/.github/workflows/reusable-hf-candidate-plan.yml
@@ -1,8 +1,10 @@
 name: Reusable - HF Candidate Deployment Plan
 
-# Base-controlled, network-free admission for a Dockerfile-backed Hugging Face
-# payload. The caller supplies exact base/head Git objects. Only the protected
-# reusable-workflow revision is executed; candidate repository code is data.
+# Base-controlled admission for a Dockerfile-backed Hugging Face payload. The
+# caller supplies exact base/head Git objects; the workflow revalidates that
+# tuple against the live PR while the planner itself remains network-free.
+# Only the protected reusable-workflow revision is executed; candidate code is
+# data and pinned checkout bytes model the production publisher exactly.
 
 on:
   workflow_call:
@@ -38,6 +40,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   hf-candidate-plan:
@@ -58,6 +61,7 @@ jobs:
           README_PATH: ${{ inputs.readme-path }}
           SOURCE_REVISION_FILE: ${{ inputs.source-revision-file }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
           EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -76,6 +80,10 @@ jobs:
           }
           [ "${EVENT_NAME}" = "pull_request_target" ] || {
             echo "::error::candidate admission requires a base-controlled pull_request_target caller"
+            exit 1
+          }
+          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::candidate admission requires a canonical pull-request number"
             exit 1
           }
           [ "${EVENT_BASE_REPO}" = "${GH_REPO}" ] && \
@@ -100,6 +108,42 @@ jobs:
                 ;;
             esac
           done
+
+      - name: Revalidate live pull-request tuple before checkout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
+          CANDIDATE_REF: ${{ inputs.candidate-ref }}
+        run: |
+          set -euo pipefail
+          live_pr="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+          jq -e \
+            --arg repo "${GH_REPO}" \
+            --arg base "${TRUSTED_BASE_REF}" \
+            --arg head "${CANDIDATE_REF}" \
+            '.state == "open" and
+             .base.repo.full_name == $repo and
+             .head.repo.full_name == $repo and
+             .base.sha == $base and
+             .head.sha == $head' \
+            <<<"${live_pr}" >/dev/null || {
+              echo "::error::live pull-request base/head/repository tuple changed"
+              exit 1
+            }
+
+      - name: Checkout exact protected baseline bytes as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.trusted-base-ref }}
+          fetch-depth: 1
+          path: baseline
+          persist-credentials: false
 
       - name: Checkout exact candidate Git objects as data
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -131,22 +175,56 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
           INCLUDE_README: ${{ inputs.include-readme }}
           README_PATH: ${{ inputs.readme-path }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          validate_live_pr() {
+            local live_pr
+            live_pr="$(gh api --method GET \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+            jq -e \
+              --arg repo "${GH_REPO}" \
+              --arg base "${TRUSTED_BASE_REF}" \
+              --arg head "${CANDIDATE_REF}" \
+              '.state == "open" and
+               .base.repo.full_name == $repo and
+               .head.repo.full_name == $repo and
+               .base.sha == $base and
+               .head.sha == $head' \
+              <<<"${live_pr}" >/dev/null || {
+                echo "::error::live pull-request base/head/repository tuple changed"
+                return 1
+              }
+          }
           observed_head="$(git -C caller rev-parse HEAD)"
           if [ "${observed_head}" != "${CANDIDATE_REF}" ]; then
             echo "::error::candidate checkout did not resolve to the exact requested head"
             exit 1
           fi
+          observed_base="$(git -C baseline rev-parse HEAD)"
+          if [ "${observed_base}" != "${TRUSTED_BASE_REF}" ]; then
+            echo "::error::baseline checkout did not resolve to the exact requested base"
+            exit 1
+          fi
+          validate_live_pr
           python3 tools/.github/scripts/hf_candidate_plan.py \
             --repo-root caller \
             --github-repo "${GH_REPO}" \
             --trusted-base-ref "${TRUSTED_BASE_REF}" \
             --candidate-ref "${CANDIDATE_REF}" \
+            --baseline-checkout-root baseline \
+            --candidate-checkout-root caller \
             --dockerfile-path "${DOCKERFILE_PATH}" \
             --include-readme "${INCLUDE_README}" \
             --readme-path "${README_PATH}" \
             --report-out hf-managed-candidate-plan.out.json
+          validate_live_pr || {
+            rm -f hf-managed-candidate-plan.out.json
+            exit 1
+          }
 
       - name: Upload immutable candidate plan
         if: always()

--- a/.github/workflows/reusable-hf-candidate-plan.yml
+++ b/.github/workflows/reusable-hf-candidate-plan.yml
@@ -1,10 +1,8 @@
 name: Reusable - HF Candidate Deployment Plan
 
-# Base-controlled admission for a Dockerfile-backed Hugging Face payload. The
-# caller supplies exact base/head Git objects; the workflow revalidates that
-# tuple against the live PR while the planner itself remains network-free.
-# Only the protected reusable-workflow revision is executed; candidate code is
-# data and pinned checkout bytes model the production publisher exactly.
+# Base-controlled, provider-free admission for a Dockerfile-backed Hugging Face
+# payload. The caller supplies exact base/head Git objects. Only the protected
+# reusable-workflow revision is executed; candidate repository code is data.
 
 on:
   workflow_call:
@@ -61,7 +59,6 @@ jobs:
           README_PATH: ${{ inputs.readme-path }}
           SOURCE_REVISION_FILE: ${{ inputs.source-revision-file }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
           EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -80,10 +77,6 @@ jobs:
           }
           [ "${EVENT_NAME}" = "pull_request_target" ] || {
             echo "::error::candidate admission requires a base-controlled pull_request_target caller"
-            exit 1
-          }
-          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] || {
-            echo "::error::candidate admission requires a canonical pull-request number"
             exit 1
           }
           [ "${EVENT_BASE_REPO}" = "${GH_REPO}" ] && \
@@ -109,42 +102,6 @@ jobs:
             esac
           done
 
-      - name: Revalidate live pull-request tuple before checkout
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
-          CANDIDATE_REF: ${{ inputs.candidate-ref }}
-        run: |
-          set -euo pipefail
-          live_pr="$(gh api --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
-          jq -e \
-            --arg repo "${GH_REPO}" \
-            --arg base "${TRUSTED_BASE_REF}" \
-            --arg head "${CANDIDATE_REF}" \
-            '.state == "open" and
-             .base.repo.full_name == $repo and
-             .head.repo.full_name == $repo and
-             .base.sha == $base and
-             .head.sha == $head' \
-            <<<"${live_pr}" >/dev/null || {
-              echo "::error::live pull-request base/head/repository tuple changed"
-              exit 1
-            }
-
-      - name: Checkout exact protected baseline bytes as data
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ inputs.trusted-base-ref }}
-          fetch-depth: 1
-          path: baseline
-          persist-credentials: false
-
       - name: Checkout exact candidate Git objects as data
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -167,6 +124,19 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Revalidate live pull-request pair before planning
+        env:
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          EXPECTED_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ inputs.trusted-base-ref }}
+          EXPECTED_HEAD_SHA: ${{ inputs.candidate-ref }}
+        run: python3 tools/.github/scripts/hf_live_pr_pair.py
+
       - name: Verify exact offline candidate deployment plan
         env:
           GH_REPO: ${{ github.repository }}
@@ -175,56 +145,22 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
           INCLUDE_README: ${{ inputs.include-readme }}
           README_PATH: ${{ inputs.readme-path }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          validate_live_pr() {
-            local live_pr
-            live_pr="$(gh api --method GET \
-              -H 'Accept: application/vnd.github+json' \
-              -H 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
-            jq -e \
-              --arg repo "${GH_REPO}" \
-              --arg base "${TRUSTED_BASE_REF}" \
-              --arg head "${CANDIDATE_REF}" \
-              '.state == "open" and
-               .base.repo.full_name == $repo and
-               .head.repo.full_name == $repo and
-               .base.sha == $base and
-               .head.sha == $head' \
-              <<<"${live_pr}" >/dev/null || {
-                echo "::error::live pull-request base/head/repository tuple changed"
-                return 1
-              }
-          }
           observed_head="$(git -C caller rev-parse HEAD)"
           if [ "${observed_head}" != "${CANDIDATE_REF}" ]; then
             echo "::error::candidate checkout did not resolve to the exact requested head"
             exit 1
           fi
-          observed_base="$(git -C baseline rev-parse HEAD)"
-          if [ "${observed_base}" != "${TRUSTED_BASE_REF}" ]; then
-            echo "::error::baseline checkout did not resolve to the exact requested base"
-            exit 1
-          fi
-          validate_live_pr
           python3 tools/.github/scripts/hf_candidate_plan.py \
             --repo-root caller \
             --github-repo "${GH_REPO}" \
             --trusted-base-ref "${TRUSTED_BASE_REF}" \
             --candidate-ref "${CANDIDATE_REF}" \
-            --baseline-checkout-root baseline \
-            --candidate-checkout-root caller \
             --dockerfile-path "${DOCKERFILE_PATH}" \
             --include-readme "${INCLUDE_README}" \
             --readme-path "${README_PATH}" \
             --report-out hf-managed-candidate-plan.out.json
-          validate_live_pr || {
-            rm -f hf-managed-candidate-plan.out.json
-            exit 1
-          }
 
       - name: Upload immutable candidate plan
         if: always()
@@ -234,3 +170,16 @@ jobs:
           path: hf-managed-candidate-plan.out.json
           if-no-files-found: error
           retention-days: 90
+
+      - name: Revalidate live pull-request pair after artifact upload
+        env:
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          EXPECTED_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ inputs.trusted-base-ref }}
+          EXPECTED_HEAD_SHA: ${{ inputs.candidate-ref }}
+        run: python3 tools/.github/scripts/hf_live_pr_pair.py

--- a/.github/workflows/reusable-hf-candidate-plan.yml
+++ b/.github/workflows/reusable-hf-candidate-plan.yml
@@ -1,0 +1,158 @@
+name: Reusable - HF Candidate Deployment Plan
+
+# Base-controlled, network-free admission for a Dockerfile-backed Hugging Face
+# payload. The caller supplies exact base/head Git objects. Only the protected
+# reusable-workflow revision is executed; candidate repository code is data.
+
+on:
+  workflow_call:
+    inputs:
+      trusted-base-ref:
+        description: "Exact lowercase 40-character protected PR base SHA."
+        required: true
+        type: string
+      candidate-ref:
+        description: "Exact lowercase 40-character candidate head SHA."
+        required: true
+        type: string
+      dockerfile-path:
+        description: "Canonical repository-relative Dockerfile path."
+        required: false
+        type: string
+        default: "Dockerfile"
+      include-readme:
+        description: "Include the Space README as a first-class payload control."
+        required: false
+        type: boolean
+        default: true
+      readme-path:
+        description: "Canonical repository-relative Space README path."
+        required: false
+        type: string
+        default: "README.md"
+      source-revision-file:
+        description: "Generated source-revision files are not yet supported by offline admission."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  hf-candidate-plan:
+    name: Immutable HF candidate deployment plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Validate immutable candidate inputs
+        env:
+          TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
+          CANDIDATE_REF: ${{ inputs.candidate-ref }}
+          DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+          README_PATH: ${{ inputs.readme-path }}
+          SOURCE_REVISION_FILE: ${{ inputs.source-revision-file }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          sha_re='^[0-9a-f]{40}$'
+          [[ "${TRUSTED_BASE_REF}" =~ ${sha_re} ]] || {
+            echo "::error::trusted-base-ref must be an exact lowercase 40-character SHA"
+            exit 1
+          }
+          [[ "${CANDIDATE_REF}" =~ ${sha_re} ]] || {
+            echo "::error::candidate-ref must be an exact lowercase 40-character SHA"
+            exit 1
+          }
+          [ "${EVENT_NAME}" = "pull_request_target" ] || {
+            echo "::error::candidate admission requires a base-controlled pull_request_target caller"
+            exit 1
+          }
+          [ "${EVENT_BASE_REPO}" = "${GH_REPO}" ] && \
+            [ "${EVENT_HEAD_REPO}" = "${GH_REPO}" ] || {
+              echo "::error::candidate admission currently requires a same-repository pull request"
+              exit 1
+            }
+          [ "${TRUSTED_BASE_REF}" = "${EVENT_BASE_SHA}" ] && \
+            [ "${CANDIDATE_REF}" = "${EVENT_HEAD_SHA}" ] || {
+              echo "::error::candidate admission inputs do not equal the current pull-request base/head"
+              exit 1
+            }
+          [ -z "${SOURCE_REVISION_FILE}" ] || {
+            echo "::error::offline candidate admission does not yet model generated source-revision files"
+            exit 1
+          }
+          for candidate_path in "${DOCKERFILE_PATH}" "${README_PATH}"; do
+            case "${candidate_path}" in
+              ""|/*|*\\*|*:*|*..*|*//*|./*|*/./*)
+                echo "::error::payload control paths must be canonical repository-relative paths"
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Checkout exact candidate Git objects as data
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.candidate-ref }}
+          fetch-depth: 0
+          path: caller
+          persist-credentials: false
+
+      - name: Checkout exact protected verifier authority
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: tools
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify exact offline candidate deployment plan
+        env:
+          GH_REPO: ${{ github.repository }}
+          TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
+          CANDIDATE_REF: ${{ inputs.candidate-ref }}
+          DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
+          INCLUDE_README: ${{ inputs.include-readme }}
+          README_PATH: ${{ inputs.readme-path }}
+        run: |
+          set -euo pipefail
+          observed_head="$(git -C caller rev-parse HEAD)"
+          if [ "${observed_head}" != "${CANDIDATE_REF}" ]; then
+            echo "::error::candidate checkout did not resolve to the exact requested head"
+            exit 1
+          fi
+          python3 tools/.github/scripts/hf_candidate_plan.py \
+            --repo-root caller \
+            --github-repo "${GH_REPO}" \
+            --trusted-base-ref "${TRUSTED_BASE_REF}" \
+            --candidate-ref "${CANDIDATE_REF}" \
+            --dockerfile-path "${DOCKERFILE_PATH}" \
+            --include-readme "${INCLUDE_README}" \
+            --readme-path "${README_PATH}" \
+            --report-out hf-managed-candidate-plan.out.json
+
+      - name: Upload immutable candidate plan
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-managed-candidate-plan
+          path: hf-managed-candidate-plan.out.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/reusable-hf-module-drift-check.yml
+++ b/.github/workflows/reusable-hf-module-drift-check.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: "/api/build-info"
+      expected-source-ref:
+        description: "Source-bound mode: optional exact protected source SHA that build-info must equal."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -98,6 +103,7 @@ jobs:
           MODE: ${{ inputs.mode }}
           TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
           CANDIDATE_REF: ${{ inputs.candidate-ref }}
+          EXPECTED_SOURCE_REF: ${{ inputs.expected-source-ref }}
           LOCK_PATH: ${{ inputs.deployment-lock-path }}
           SOURCE_PROBE_PATH: ${{ inputs.source-probe-path }}
         run: |
@@ -110,6 +116,12 @@ jobs:
           if [ -n "${CANDIDATE_REF}" ]; then
             [[ "${CANDIDATE_REF}" =~ ${sha_re} ]] || {
               echo "::error::candidate-ref must be an exact lowercase 40-character SHA"
+              exit 1
+            }
+          fi
+          if [ -n "${EXPECTED_SOURCE_REF}" ]; then
+            [[ "${EXPECTED_SOURCE_REF}" =~ ${sha_re} ]] || {
+              echo "::error::expected-source-ref must be an exact lowercase 40-character SHA"
               exit 1
             }
           fi
@@ -212,6 +224,7 @@ jobs:
           HF_REPO_IN: ${{ inputs.hf-repo }}
           TRUSTED_BASE_REF: ${{ inputs.trusted-base-ref }}
           CANDIDATE_REF: ${{ inputs.candidate-ref }}
+          EXPECTED_SOURCE_REF: ${{ inputs.expected-source-ref }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile-path }}
           SOURCE_PROBE_PATH: ${{ inputs.source-probe-path }}
         run: |
@@ -226,6 +239,7 @@ jobs:
             --hf-repo "${HF_REPO}" \
             --trusted-base-ref "${TRUSTED_BASE_REF}" \
             --candidate-ref "${CANDIDATE_REF}" \
+            --expected-source-ref "${EXPECTED_SOURCE_REF}" \
             --dockerfile-path "${DOCKERFILE_PATH}" \
             --source-probe-path "${SOURCE_PROBE_PATH}" \
             --report-out hf-module-drift-report.out.json \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,6 +175,18 @@ jobs:
       - name: HF module-drift lineage cross-check self-test
         run: python3 .github/scripts/test_hf_module_drift_check.py
 
+      # Keeps PR payload admission independent from live HF availability. The
+      # protected verifier consumes exact local Git objects and treats the
+      # candidate checkout strictly as data.
+      - name: HF candidate deployment-plan self-test
+        run: python3 .github/scripts/test_hf_candidate_plan.py
+
+      # Pins optional exact-source equality for scheduled/manual/post-deploy
+      # verification while retaining legacy ancestor diagnostics for callers
+      # that intentionally omit the exact-source input.
+      - name: HF source-bound exact identity self-test
+        run: python3 .github/scripts/test_hf_source_bound_baseline.py
+
       # Pins the SZL anatomy-map cross-surface drift guard. The single honest
       # anatomy map ships on three independently-deployed surfaces (a11oy
       # /console, killinchu /elite, the SZLHOLDINGS/anatomy HF Space); the guard

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,6 +181,9 @@ jobs:
       - name: HF candidate deployment-plan self-test
         run: python3 .github/scripts/test_hf_candidate_plan.py
 
+      - name: HF candidate live PR-pair self-test
+        run: python3 .github/scripts/test_hf_live_pr_pair.py
+
       # Pins optional exact-source equality for scheduled/manual/post-deploy
       # verification while retaining legacy ancestor diagnostics for callers
       # that intentionally omit the exact-source input.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 ## Reusable workflows
 
-Twenty-one SHA-pinned, harden-runner-protected workflows that every product repo can call:
+Twenty-two SHA-pinned, harden-runner-protected workflows that every product repo can call:
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ jobs:
 | Workflow | What it does |
 |---|---|
 | `reusable-hf-deploy.yml` | GitHub → Hugging Face Space deployer (Dockerfile-derived file set) |
-| `reusable-hf-candidate-plan.yml` | Build an exact, network-free base-to-head HF deployment plan from protected verifier code |
+| `reusable-hf-candidate-plan.yml` | Build an exact, provider-free base-to-head HF deployment plan and revalidate the live PR pair |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source and its live HF Space |
 | `reusable-anatomy-map-drift.yml` | Guard the shared SZL Anatomy map across its surfaces |
 | `reusable-bundle-ref-check.yml` | Verify UDS bundle `repository`/`ref` point at published GHCR tags |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 | [`profile/README.md`](./profile/README.md) | Org profile shown at <https://github.com/szl-holdings> |
 | [`.github/ISSUE_TEMPLATE/`](./.github/ISSUE_TEMPLATE/) | Default issue templates cascaded to every repo without its own |
 | [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md) | Default PR template |
-| [`.github/workflows/`](./.github/workflows/) | **21 reusable workflows** — see [`WORKFLOWS.md`](./WORKFLOWS.md) |
+| [`.github/workflows/`](./.github/workflows/) | **22 reusable workflows** — see [`WORKFLOWS.md`](./WORKFLOWS.md) |
 | [`.github/dependabot.yml`](./.github/dependabot.yml) | Weekly dependency updates for this repo |
 | [`.github/CODEOWNERS`](./.github/CODEOWNERS) | Org-default ownership |
 | [`templates/`](./templates/) | Copy-paste templates for product repos (`README`, `CONTRIBUTING`, `CODE_OF_CONDUCT`, `SECURITY`) |
@@ -86,6 +86,7 @@ jobs:
 | Workflow | What it does |
 |---|---|
 | `reusable-hf-deploy.yml` | GitHub → Hugging Face Space deployer (Dockerfile-derived file set) |
+| `reusable-hf-candidate-plan.yml` | Build an exact, network-free base-to-head HF deployment plan from protected verifier code |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source and its live HF Space |
 | `reusable-anatomy-map-drift.yml` | Guard the shared SZL Anatomy map across its surfaces |
 | `reusable-bundle-ref-check.yml` | Verify UDS bundle `repository`/`ref` point at published GHCR tags |

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -20,7 +20,7 @@ of redefining the same logic locally.
 | `reusable-secret-scan.yml` | TruffleHog committed-secret detection | `push`, `pull_request`, weekly cron |
 | `reusable-scorecard.yml` | OpenSSF Scorecard supply-chain hygiene | weekly cron, `branch_protection_rule` |
 | `reusable-trivy.yml` | Trivy filesystem vulnerability scan | `push`, weekly cron |
-| `reusable-hf-candidate-plan.yml` | Build a network-free exact base-to-head Dockerfile payload plan using protected verifier code | base-controlled `pull_request_target` |
+| `reusable-hf-candidate-plan.yml` | Revalidate a live PR and build an exact base-to-head Dockerfile payload plan from publisher-materialized bytes using protected verifier code | base-controlled `pull_request_target` with `contents: read` and `pull-requests: read` |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space | caller-chosen |
 
 ## Calling a reusable workflow

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -20,6 +20,7 @@ of redefining the same logic locally.
 | `reusable-secret-scan.yml` | TruffleHog committed-secret detection | `push`, `pull_request`, weekly cron |
 | `reusable-scorecard.yml` | OpenSSF Scorecard supply-chain hygiene | weekly cron, `branch_protection_rule` |
 | `reusable-trivy.yml` | Trivy filesystem vulnerability scan | `push`, weekly cron |
+| `reusable-hf-candidate-plan.yml` | Build a network-free exact base-to-head Dockerfile payload plan using protected verifier code | base-controlled `pull_request_target` |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space | caller-chosen |
 
 ## Calling a reusable workflow
@@ -64,6 +65,14 @@ layers guard this:
 
 Both honor `.github/hf-module-drift-allow.json`. They never overwrite either
 side automatically because drift can originate in GitHub or Hugging Face.
+
+Candidate admission is deliberately separate from live drift. A protected
+base-controlled workflow may call `reusable-hf-candidate-plan.yml` with the
+exact pull-request base and head SHAs. The reusable workflow executes only this
+repository's protected verifier revision, treats candidate Git objects as
+data, makes no Hugging Face or runtime request, and emits a deterministic
+Dockerfile-managed payload plan. Live source, deployment, and runtime identity
+remain distinct post-merge gates.
 
 ## Org code-security config drift (`code-security-drift.yml`)
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -20,7 +20,7 @@ of redefining the same logic locally.
 | `reusable-secret-scan.yml` | TruffleHog committed-secret detection | `push`, `pull_request`, weekly cron |
 | `reusable-scorecard.yml` | OpenSSF Scorecard supply-chain hygiene | weekly cron, `branch_protection_rule` |
 | `reusable-trivy.yml` | Trivy filesystem vulnerability scan | `push`, weekly cron |
-| `reusable-hf-candidate-plan.yml` | Revalidate a live PR and build an exact base-to-head Dockerfile payload plan from publisher-materialized bytes using protected verifier code | base-controlled `pull_request_target` with `contents: read` and `pull-requests: read` |
+| `reusable-hf-candidate-plan.yml` | Build a provider-free exact base-to-head Dockerfile payload plan and revalidate the live PR pair | base-controlled `pull_request_target` |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space | caller-chosen |
 
 ## Calling a reusable workflow
@@ -70,9 +70,10 @@ Candidate admission is deliberately separate from live drift. A protected
 base-controlled workflow may call `reusable-hf-candidate-plan.yml` with the
 exact pull-request base and head SHAs. The reusable workflow executes only this
 repository's protected verifier revision, treats candidate Git objects as
-data, makes no Hugging Face or runtime request, and emits a deterministic
-Dockerfile-managed payload plan. Live source, deployment, and runtime identity
-remain distinct post-merge gates.
+data, revalidates the live GitHub PR tuple immediately before planning and after
+artifact upload, makes no Hugging Face or runtime request, and emits a
+deterministic Dockerfile-managed payload plan. Live source, deployment, and
+runtime identity remain distinct post-merge gates.
 
 ## Org code-security config drift (`code-security-drift.yml`)
 


### PR DESCRIPTION
## Summary

- add a protected, provider-independent Hugging Face candidate deployment planner over exact base/head Git objects
- bind candidate source objects to the exact checkout bytes the production publisher will consume
- revalidate the live same-repository PR tuple immediately before planning and again after artifact upload
- require optional exact deployed-source equality for scheduled, manual, and post-deployment runtime proof
- publish the exact effective Docker build-context policy beside every remote Dockerfile

## Problem closed

PR admission was coupled to live Hugging Face availability, so provider instability could block source review before the candidate delta was evaluated. Scheduled/manual source-bound checks could also accept a stable stale ancestor of protected main. The original planner additionally missed checkout-transform drift, trusted a stored event snapshot, and could disagree with publisher target overlays.

This successor separates the lifecycle:

1. protected base-to-HF parity remains its own live proof
2. candidate base-to-head payload planning is provider-independent
3. publication and runtime readiness remain post-merge gates
4. exact deployed-source mode rejects stale ancestors

## Exact identity

- base: `5f4ffa890236eacea7d364f153087a05415ae9f5`
- exact current head: `575438e1b104f5b33a7925b64dbd958a0610020d`
- current tree: `495615db99481e23bcc8361f507cdb47f1b816c7`
- history: five GitHub-verified SSH-signed commits, each with matching DCO
- no force-push or history rewrite; the externally advanced `0f91f312...` commit is preserved
- PR was marked ready only after exact-head gates completed, all five review threads were resolved, and the final independent review returned GO

## Security contract

- reusable workflow executes only the protected called-workflow revision
- candidate source is data; no candidate script, dependency, build, or workflow executes
- current PR number, open/not-merged state, base/head repositories, base ref, and exact base/head SHAs are re-read from GitHub before planning and after artifact upload
- live PR responses require exact `https://api.github.com`, no redirects, canonical repo/PR identity, HTTP 200, exact JSON media type, strict UTF-8, duplicate-free finite JSON, bounded bytes, and exact field types
- response and transport failures use non-secret diagnostics; bearer-token reflection regressions cover malformed headers, JSON, HTTP status lines, and transport errors
- every production publisher source maps to its exact candidate Git blob and exact regular, contained, non-link checkout bytes
- revision-scoped `text`, `eol`, `crlf`, `ident`, `filter`, and `working-tree-encoding` attributes must remain unchanged for common publisher sources
- included README mappings to reserved HF-root `Dockerfile` and `Dockerfile.dockerignore` fail closed in the shared publisher/planner contract
- effective Docker ignore bytes are always published exactly, or as deterministic empty bytes
- unsupported Dockerfile grammar, newly unresolved COPY sources, ignored managed sources, managed removals, non-blob members, ancestry drift, source-revision-file synthesis, and hidden provider/network calls fail closed

## Exact A11oy fixture

The protected offline planner for `66e488cf0496b828285eb33cbc6041aee2aa374e` to `197570906cf8fd5a54742df1550f7ddea7c8cce3` reports:

- managed files: 1,187
- deltas: exactly 9 intended HTML paths
- unresolved sources: 0
- provider requests: 0

No A11oy write, CI, deployment, Hugging Face, domain, or runtime mutation was performed from this lane.

## Local validation

- candidate planner exact/grammar/ignore/transform/object/workflow matrix: **30/30 PASS**
- live PR-pair validator: **10/10 PASS**
- production publisher suite: **86/86 PASS**, 2 explicit Windows symlink-capability skips
- exact-source controller suite: **14/14 PASS**
- existing module-drift unit suite: **38/38 PASS**
- strict workflow YAML parse: **PASS**
- Ruff and Python compilation: **PASS**
- `git diff --check`: **PASS**
- two independent byte-level security/correctness reviews: **GO**, no remaining P0-P2 on the security-complete tree
- final test-import successor: syntax-only; live PR-pair tests remain **10/10 PASS**
- final README successor: observed workflow inventory is consistently **22** in table and prose

## Admission

Ready-state admission requires every exact-head hosted check to remain terminal green and every actionable thread to remain resolved. Merge only through the normal protected path; no bypass, force update, settings change, self-approval, blind rerun, Hugging Face mutation, or deployment is authorized by this source PR.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>
