### PR TITLE
fix(dco): admit exact protected squash author

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -1037,13 +1037,15 @@ def validate_github_squash_attestation(
         )
         source_author_identities.add((source_author_name, source_author_email))
     squash_identities = valid_dco_identities(message)
+    exact_squash_author = (author_name, author_email) in squash_identities
+    validated_source_author_fallback = any(
+        identity[1] == author_email and identity in source_author_identities
+        for identity in squash_identities
+    )
     require(
-        any(
-            identity[1] == author_email and identity in source_author_identities
-            for identity in squash_identities
-        ),
-        "provider squash Signed-off-by identity is not an exact validated "
-        "source-commit author identity",
+        exact_squash_author or validated_source_author_fallback,
+        "provider squash Signed-off-by identity does not exactly match the "
+        "squash author or a validated source-commit author",
     )
 
 

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -864,15 +864,15 @@ class DcoCheckTests(unittest.TestCase):
     def test_push_exact_identity_provider_squash_rejects_unsigned_source(self) -> None:
         unsigned_source = self.commit(
             "fix: unsigned provider source",
-            name="Lutar, Stephen P.",
-            email="builder@example.com",
+            name="Source Contributor",
+            email="contributor@example.com",
         )
         self.git("reset", "--hard", self.base)
         head = self.commit(
             "fix: exact-identity provider squash (#411)\n\n"
-            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
-            name="Lutar, Stephen P.",
-            email="builder@example.com",
+            "Signed-off-by: PR Creator <creator@example.com>",
+            name="PR Creator",
+            email="creator@example.com",
             committer_name="GitHub",
             committer_email="noreply@github.com",
         )
@@ -897,6 +897,55 @@ class DcoCheckTests(unittest.TestCase):
         self.assertIn(paths["commit"], calls)
         self.assertIn(paths["commits_page"], calls)
         self.assertEqual(source_fetches, [(411, unsigned_source)])
+
+    def test_push_exact_squash_author_can_differ_from_source_author(self) -> None:
+        source_head = self.commit(
+            "fix: source contribution\n\n"
+            "Signed-off-by: Source Contributor <contributor@example.com>",
+            name="Source Contributor",
+            email="contributor@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: exact squash author (#411)\n\n"
+            "Signed-off-by: PR Creator <creator@example.com>",
+            name="PR Creator",
+            email="creator@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, calls, paths = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+        )
+        source_fetches: list[tuple[int, str]] = []
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                head,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+                source_fetch=lambda number, sha: source_fetches.append((number, sha)),
+            ),
+            1,
+        )
+        self.assertEqual(source_fetches, [(411, source_head)])
+        self.assertEqual(
+            calls,
+            [
+                paths["commit"],
+                paths["pulls_page"],
+                paths["pulls_boundary"],
+                paths["metadata"],
+                paths["commits_page"],
+                paths["commits_boundary"],
+                paths["metadata"],
+            ],
+        )
 
     def test_push_exact_identity_provider_squash_validates_all_sources(self) -> None:
         source_first = self.commit(
@@ -1290,7 +1339,7 @@ class DcoCheckTests(unittest.TestCase):
             source_head,
         )
         self.assert_rejected(
-            "not an exact validated source-commit author identity",
+            "does not exactly match the squash author or a validated source-commit author",
             dco.validate_push_range,
             self.repo,
             self.base,


### PR DESCRIPTION
## Summary

- admit an exact terminal signoff matching the raw GitHub squash author after complete source-history validation
- retain the existing same-email, exact-source-author fallback only for GitHub display-name canonicalization
- add a production-path regression for a valid PR creator who did not author a source commit
- prove an exact squash-author signoff still cannot excuse an unsigned source commit

## Defect closed

The protected push controller validates every source commit behind a GitHub web-flow squash, then currently requires the squash signoff itself to be an exact source-commit author. That rejects a valid squash authored and exactly signed off by a PR creator who did not author source bytes.

## Fail-closed ordering

1. GitHub signature/account, exact parent, unique merged PR, base/head, pagination, pull ref, and local graph all bind first.
2. Every exact source commit passes the existing raw-object DCO validator.
3. Only then may the squash pass via either:
   - exact raw squash-author name and email in the terminal signoff block; or
   - the existing exact validated source-author identity with the same email as the squash author.
4. Arbitrary same-email names, unsigned sources, malformed histories, stale PR metadata, and graph drift still reject.

## Exact boundary

- base: `5f4ffa890236eacea7d364f153087a05415ae9f5`
- head: `98f115532996ea7edfe91102e87bb8fab7eed3fb`
- history: one SSH-signed commit with exact-author DCO
- scope: `.github/scripts/dco_check.py` and `.github/scripts/test_dco_events.py`

## Local validation

- raw DCO suite: 65/65 PASS
- event/controller suite: 40/40 PASS
- activation suite: 8/8 PASS
- total DCO tests: 113/113 PASS
- merge-queue controller: 7/7 PASS
- FORGE-9 bootstrap invariants: PASS
- ground-truth, labels, schema, provenance, a11y/perf, and Lean gates: PASS
- Python AST and `git diff --check`: PASS
- independent exact-diff review: CLEAN, no P0-P2

Ruff reports only the pre-existing E731 at unchanged `dco_check.py:1110`; this two-file diff adds no Ruff finding.

## Serialized admission

This PR is deliberately draft behind [#431](https://github.com/szl-holdings/.github/pull/431). The files do not overlap, but this branch must be rebased onto exact protected main after #431 settles, then receive fresh exact-head checks and independent review before any ready or merge transition.

No bypass, force update, self-approval, workflow rerun, settings mutation, or protection change is authorized.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>