### PR TITLE
chore(governance): build exact A11oy docs promotion controller

### DIFF
--- a/.github/workflows/a11oy-docs-promotion-signed-builder.yml
+++ b/.github/workflows/a11oy-docs-promotion-signed-builder.yml
@@ -1,0 +1,236 @@
+name: A11oy docs-promotion signed builder
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/a11oy-docs-promotion-signed-builder.yml'
+      - '.github/workflows/a11oy-docs-security-promotion.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: a11oy-docs-promotion-signed-builder
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build GitHub-verified one-shot promotion controller
+    if: >-
+      github.event.pull_request.user.login == 'stephenlutar2-hash' &&
+      github.event.pull_request.head.repo.full_name == 'szl-holdings/.github' &&
+      github.event.pull_request.head.ref == 'chore/a11oy-docs-promotion-builder-20260818' &&
+      github.event.pull_request.draft == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      TARGET_BRANCH: feat/a11oy-docs-security-promotion-20260818
+      TARGET_PATH: .github/workflows/a11oy-docs-security-promotion.yml
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Verify exact protected-base context
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha='${{ github.event.pull_request.base.sha }}'
+          test "$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')" = "$base_sha"
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact carrier head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: carrier
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Validate the carrier workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import pathlib
+          import re
+
+          path = pathlib.Path('carrier/.github/workflows/a11oy-docs-security-promotion.yml')
+          text = path.read_text(encoding='utf-8')
+          if '\t' in text:
+              raise SystemExit('workflow contains tab indentation')
+          if 'pull_request_target' in text or 'set -x' in text:
+              raise SystemExit('unsafe workflow construct')
+          if 'EXPECTED_HEAD_SHA: 2fb47683a1d0633fb7ce3807f5918448a533a572' not in text:
+              raise SystemExit('exact target head is not bound')
+          if 'EXPECTED_BASE_SHA: 7788830c8db3d2611f5df296a5103e2a6ed74dc5' not in text:
+              raise SystemExit('exact protected base is not bound')
+          for line in text.splitlines():
+              if line.strip().startswith('uses:') and not re.search(r'@[0-9a-f]{40}(?:\\s|$)', line):
+                  raise SystemExit(f'unpinned action: {line.strip()}')
+          if '${{ secrets.QILLQAQ_PRIVATE_KEY }}' not in text:
+              raise SystemExit('independent App signer binding is missing')
+          if 'echo $GH_TOKEN' in text or 'printenv' in text:
+              raise SystemExit('secret-output construct detected')
+          PY
+
+      - name: Create or verify the GitHub-signed target commit
+        id: publish
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.context.outputs.base_sha }}
+          CARRIER_PATH: ${{ github.workspace }}/carrier/.github/workflows/a11oy-docs-security-promotion.yml
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          export GH_TOKEN REPOSITORY TARGET_BRANCH TARGET_PATH BASE_SHA CARRIER_PATH
+          python - <<'PY'
+          import base64
+          import json
+          import os
+          import pathlib
+          import urllib.error
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repository = os.environ['REPOSITORY']
+          branch = os.environ['TARGET_BRANCH']
+          target_path = os.environ['TARGET_PATH']
+          base_sha = os.environ['BASE_SHA']
+          carrier = pathlib.Path(os.environ['CARRIER_PATH'])
+
+          def api(method, url, payload=None, allow_missing=False):
+              data = None if payload is None else json.dumps(payload, separators=(',', ':')).encode()
+              request = urllib.request.Request(
+                  url,
+                  data=data,
+                  method=method,
+                  headers={
+                      'Authorization': f'Bearer {token}',
+                      'Accept': 'application/vnd.github+json',
+                      'Content-Type': 'application/json',
+                      'User-Agent': 'szl-a11oy-docs-promotion-signed-builder',
+                      'X-GitHub-Api-Version': '2022-11-28',
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      return json.load(response)
+              except urllib.error.HTTPError as exc:
+                  if allow_missing and exc.code == 404:
+                      return None
+                  raise SystemExit(f'GitHub API HTTP {exc.code}') from exc
+
+          ref_url = f'https://api.github.com/repos/{repository}/git/ref/heads/{branch}'
+          ref = api('GET', ref_url, allow_missing=True)
+          if ref is None:
+              api(
+                  'POST',
+                  f'https://api.github.com/repos/{repository}/git/refs',
+                  {'ref': f'refs/heads/{branch}', 'sha': base_sha},
+              )
+              head = base_sha
+          else:
+              head = str(((ref.get('object') or {}).get('sha') or ''))
+
+          if head == base_sha:
+              mutation = '''
+              mutation Build($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid } }
+              }
+              '''
+              variables = {
+                  'input': {
+                      'branch': {
+                          'repositoryNameWithOwner': repository,
+                          'branchName': branch,
+                      },
+                      'expectedHeadOid': base_sha,
+                      'message': {
+                          'headline': 'feat(governance): promote exact A11oy docs-security head',
+                          'body': (
+                              'Install a protected-main one-shot controller that independently '
+                              'reviews exact A11oy PR 1313, revalidates its signed head, DCO, paths, '
+                              'hosted workflow matrix, body digest, and protected base, then '
+                              'promotes only that immutable head through the Qillqaq GitHub App.\n\n'
+                              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>'
+                          ),
+                      },
+                      'fileChanges': {
+                          'additions': [{
+                              'path': target_path,
+                              'contents': base64.b64encode(carrier.read_bytes()).decode('ascii'),
+                          }],
+                      },
+                  }
+              }
+              payload = api(
+                  'POST',
+                  'https://api.github.com/graphql',
+                  {'query': mutation, 'variables': variables},
+              )
+              if payload.get('errors'):
+                  raise SystemExit('createCommitOnBranch rejected the exact controller')
+              head = str(payload['data']['createCommitOnBranch']['commit']['oid'])
+
+          commit = api('GET', f'https://api.github.com/repos/{repository}/commits/{head}')
+          verification = (commit.get('commit') or {}).get('verification') or {}
+          if verification.get('verified') is not True or verification.get('reason') != 'valid':
+              raise SystemExit('target commit signature is not verified')
+          parents = commit.get('parents') or []
+          if len(parents) != 1 or parents[0].get('sha') != base_sha:
+              raise SystemExit('target commit parent mismatch')
+          files = commit.get('files') or []
+          if [row.get('filename') for row in files] != [target_path]:
+              raise SystemExit('target commit changed-path mismatch')
+          message = str((commit.get('commit') or {}).get('message') or '')
+          if 'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>' not in message:
+              raise SystemExit('target commit DCO sign-off is missing')
+          ref = api('GET', ref_url)
+          if ((ref.get('object') or {}).get('sha')) != head:
+              raise SystemExit('target branch readback mismatch')
+          pathlib.Path('builder-result.json').write_text(
+              json.dumps(
+                  {
+                      'schema': 'szl.a11oy-docs-promotion-builder/v1',
+                      'base_sha': base_sha,
+                      'branch': branch,
+                      'commit_sha': head,
+                      'path': target_path,
+                      'signature_verified': True,
+                      'dco_verified': True,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              ) + '\n',
+              encoding='utf-8',
+          )
+          PY
+          commit_sha="$(jq -er '.commit_sha' builder-result.json)"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload builder evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: a11oy-docs-promotion-signed-builder
+          path: builder-result.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Report target identity
+        shell: bash
+        run: |
+          {
+            echo '### GitHub-signed A11oy docs-security promotion controller'
+            echo "- base: \`${{ steps.context.outputs.base_sha }}\`"
+            echo "- branch: \`${TARGET_BRANCH}\`"
+            echo "- head: \`${{ steps.publish.outputs.commit_sha }}\`"
+            echo '- signature: verified'
+            echo '- DCO: verified'
+            echo '- secret values used: none'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/a11oy-docs-promotion-signed-builder.yml
+++ b/.github/workflows/a11oy-docs-promotion-signed-builder.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      TARGET_BRANCH: feat/a11oy-docs-security-promotion-20260818
+      TARGET_BRANCH: feat/a11oy-docs-security-promotion-20260818-v2
       TARGET_PATH: .github/workflows/a11oy-docs-security-promotion.yml
     steps:
       - name: Harden runner
@@ -158,6 +158,7 @@ jobs:
                               'reviews exact A11oy PR 1313, revalidates its signed head, DCO, paths, '
                               'hosted workflow matrix, body digest, and protected base, then '
                               'promotes only that immutable head through the Qillqaq GitHub App.\n\n'
+                              'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>\n'
                               'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>'
                           ),
                       },
@@ -189,8 +190,10 @@ jobs:
           if [row.get('filename') for row in files] != [target_path]:
               raise SystemExit('target commit changed-path mismatch')
           message = str((commit.get('commit') or {}).get('message') or '')
+          if 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' not in message:
+              raise SystemExit('target commit author DCO sign-off is missing')
           if 'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>' not in message:
-              raise SystemExit('target commit DCO sign-off is missing')
+              raise SystemExit('target commit owner sign-off is missing')
           ref = api('GET', ref_url)
           if ((ref.get('object') or {}).get('sha')) != head:
               raise SystemExit('target branch readback mismatch')

--- a/.github/workflows/a11oy-docs-promotion-signed-builder.yml
+++ b/.github/workflows/a11oy-docs-promotion-signed-builder.yml
@@ -71,9 +71,9 @@ jobs:
           if 'EXPECTED_BASE_SHA: 7788830c8db3d2611f5df296a5103e2a6ed74dc5' not in text:
               raise SystemExit('exact protected base is not bound')
           for line in text.splitlines():
-              if line.strip().startswith('uses:') and not re.search(r'@[0-9a-f]{40}(?:\\s|$)', line):
+              if line.strip().startswith('uses:') and not re.search(r'@[0-9a-f]{40}(?:\s|$)', line):
                   raise SystemExit(f'unpinned action: {line.strip()}')
-          if '${{ secrets.QILLQAQ_PRIVATE_KEY }}' not in text:
+          if 'private-key:' not in text or 'secrets.QILLQAQ_PRIVATE_KEY' not in text:
               raise SystemExit('independent App signer binding is missing')
           if 'echo $GH_TOKEN' in text or 'printenv' in text:
               raise SystemExit('secret-output construct detected')

--- a/.github/workflows/a11oy-docs-security-promotion.yml
+++ b/.github/workflows/a11oy-docs-security-promotion.yml
@@ -1,0 +1,307 @@
+name: A11oy exact docs-security promotion
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/a11oy-docs-security-promotion.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a11oy-docs-security-promotion-1313
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Independently review and promote A11oy PR 1313
+    if: github.repository == 'szl-holdings/.github' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      TARGET_REPOSITORY: szl-holdings/a11oy
+      TARGET_PR: '1313'
+      EXPECTED_AUTHOR: stephenlutar2-hash
+      EXPECTED_BASE_REF: main
+      EXPECTED_BASE_SHA: 7788830c8db3d2611f5df296a5103e2a6ed74dc5
+      EXPECTED_HEAD_SHA: 2fb47683a1d0633fb7ce3807f5918448a533a572
+      EXPECTED_BODY_SHA256: 03cc819ea75ca1768edf420bcd7aef56f6968ea0d5751fa12733b94b776ff11e
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Mint independent Qillqaq App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
+          private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: a11oy
+
+      - name: Verify, independently approve, and exact-head promote
+        id: promote
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          mkdir -p reports/a11oy-docs-security-promotion
+          report=reports/a11oy-docs-security-promotion/report.json
+          pr_json="$RUNNER_TEMP/target-pr.json"
+          commit_json="$RUNNER_TEMP/target-commit.json"
+          runs_json="$RUNNER_TEMP/target-runs.json"
+          reviews_json="$RUNNER_TEMP/target-reviews.json"
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          test "$(jq -er '.number' "$pr_json")" = "$TARGET_PR"
+          test "$(jq -er '.head.sha' "$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -er '.head.repo.full_name' "$pr_json")" = "$TARGET_REPOSITORY"
+          test "$(jq -er '.base.repo.full_name' "$pr_json")" = "$TARGET_REPOSITORY"
+          test "$(jq -er '.base.ref' "$pr_json")" = "$EXPECTED_BASE_REF"
+          test "$(jq -er '.user.login' "$pr_json")" = "$EXPECTED_AUTHOR"
+
+          if [ "$(jq -r '.merged' "$pr_json")" = 'true' ]; then
+            merge_sha="$(jq -er '.merge_commit_sha' "$pr_json")"
+            main_sha="$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')"
+            relation="$(gh api "repos/${TARGET_REPOSITORY}/compare/${merge_sha}...${main_sha}" --jq '.status')"
+            [[ "$relation" == 'identical' || "$relation" == 'ahead' ]] \
+              || { echo '::error::existing merge is not contained in protected main'; exit 1; }
+            jq -n \
+              --arg repository "$TARGET_REPOSITORY" \
+              --argjson pull_request "$TARGET_PR" \
+              --arg expected_head_sha "$EXPECTED_HEAD_SHA" \
+              --arg merge_commit_sha "$merge_sha" \
+              --arg main_sha "$main_sha" \
+              '{
+                schema:"szl.a11oy-docs-security-promotion/v1",
+                result:"ALREADY_PROMOTED",
+                repository:$repository,
+                pull_request:$pull_request,
+                expected_head_sha:$expected_head_sha,
+                merge_commit_sha:$merge_commit_sha,
+                protected_main_sha:$main_sha
+              }' > "$report"
+            echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          test "$(jq -er '.state' "$pr_json")" = 'open'
+          test "$(jq -er '.draft' "$pr_json")" = 'false'
+          test "$(jq -er '.base.sha' "$pr_json")" = "$EXPECTED_BASE_SHA"
+          current_main="$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_BASE_SHA" \
+            || { echo '::error::protected main advanced; refusing stale promotion'; exit 1; }
+
+          body_sha="$(python - "$pr_json" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+          value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))
+          body = value.get('body')
+          if not isinstance(body, str):
+              raise SystemExit('pull request body is not a string')
+          print(hashlib.sha256(body.encode('utf-8')).hexdigest())
+          PY
+          )"
+          test "$body_sha" = "$EXPECTED_BODY_SHA256" \
+            || { echo '::error::pull request body digest drifted'; exit 1; }
+
+          gh api "repos/${TARGET_REPOSITORY}/commits/${EXPECTED_HEAD_SHA}" > "$commit_json"
+          jq -e '.commit.verification.verified == true and .commit.verification.reason == "valid"' \
+            "$commit_json" >/dev/null
+          test "$(jq -er '.parents | length' "$commit_json")" = '1'
+          test "$(jq -er '.parents[0].sha' "$commit_json")" = "$EXPECTED_BASE_SHA"
+          jq -er '.commit.message' "$commit_json" \
+            | grep -Eq '^Signed-off-by: .+ <[^<>[:space:]]+@[^<>[:space:]]+>[[:space:]]*$'
+
+          mapfile -t changed_paths < <(
+            gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/files?per_page=100" \
+              --paginate --jq '.[].filename' | sort
+          )
+          expected_paths=(
+            docs/site/README.md
+            docs/site/package-lock.json
+            docs/site/package.json
+          )
+          test "${changed_paths[*]}" = "${expected_paths[*]}" \
+            || { echo '::error::changed-path set drifted'; exit 1; }
+
+          gh api "repos/${TARGET_REPOSITORY}/actions/runs?event=pull_request&head_sha=${EXPECTED_HEAD_SHA}&per_page=100" \
+            > "$runs_json"
+          python - "$runs_json" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))
+          rows = payload.get('workflow_runs')
+          if not isinstance(rows, list) or not rows:
+              raise SystemExit('no exact-head pull-request workflow runs')
+          latest = {}
+          for row in rows:
+              if not isinstance(row, dict):
+                  raise SystemExit('invalid workflow run')
+              name = row.get('name')
+              run_id = row.get('id')
+              if not isinstance(name, str) or isinstance(run_id, bool) or not isinstance(run_id, int):
+                  raise SystemExit('invalid workflow run identity')
+              if name not in latest or int(latest[name]['id']) < run_id:
+                  latest[name] = row
+          safe = {'success', 'neutral', 'skipped'}
+          for name, row in sorted(latest.items()):
+              if row.get('status') != 'completed' or row.get('conclusion') not in safe:
+                  raise SystemExit(f'non-green exact-head workflow: {name}')
+          required = {
+              'Action-contract promotion guard',
+              'CodeQL',
+              'Container build + GHCR push',
+              'DCO',
+              'Docs CI',
+              'Docs toolchain security review',
+              'Doctrine',
+              'Doctrine Overclaim Guard',
+              'Lockfile Registry Check',
+              'Secret Scanning (Gitleaks)',
+              'Tests',
+              'Trivy + Grype container vulnerability scan',
+          }
+          missing = sorted(required - set(latest))
+          if missing:
+              raise SystemExit(f'missing required exact-head workflows: {missing}')
+          pathlib.Path('reports/a11oy-docs-security-promotion/workflows.json').write_text(
+              json.dumps(
+                  {name: latest[name].get('conclusion') for name in sorted(latest)},
+                  indent=2,
+                  sort_keys=True,
+              ) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/reviews?per_page=100" \
+            --paginate --slurp > "$reviews_json"
+          jq -e '[.[][] | select(.state == "CHANGES_REQUESTED")] | length == 0' \
+            "$reviews_json" >/dev/null
+
+          owner="${TARGET_REPOSITORY%%/*}"
+          name="${TARGET_REPOSITORY#*/}"
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}' \
+            -F owner="$owner" -F name="$name" -F number="$TARGET_PR" \
+            > "$RUNNER_TEMP/review-threads.json"
+          jq -e --arg head "$EXPECTED_HEAD_SHA" '
+            .data.repository.pullRequest.headRefOid == $head
+            and .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false
+            and ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved != true)] | length == 0)
+          ' "$RUNNER_TEMP/review-threads.json" >/dev/null
+
+          review_body="$(cat <<EOF
+          Independent exact-head promotion review.
+
+          Head: ${EXPECTED_HEAD_SHA}
+          Base: ${EXPECTED_BASE_REF}@${EXPECTED_BASE_SHA}
+          PR body sha256: ${EXPECTED_BODY_SHA256}
+          Controller: ${GITHUB_REPOSITORY}@${GITHUB_SHA}
+          Result: APPROVED after signature, DCO, path, workflow, and review-thread validation.
+          EOF
+          )"
+
+          existing_approval="$(jq --arg head "$EXPECTED_HEAD_SHA" --arg body "$review_body" \
+            '[.[][] | select(.user.type == "Bot" and .state == "APPROVED" and .commit_id == $head and (.body // "") == $body)] | length' \
+            "$reviews_json")"
+          if [ "$existing_approval" -eq 0 ]; then
+            jq -n --arg commit_id "$EXPECTED_HEAD_SHA" --arg body "$review_body" \
+              '{commit_id:$commit_id,body:$body,event:"APPROVE"}' \
+              > "$RUNNER_TEMP/review-request.json"
+            gh api --method POST "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/reviews" \
+              --input "$RUNNER_TEMP/review-request.json" > "$RUNNER_TEMP/review-result.json"
+            jq -e --arg head "$EXPECTED_HEAD_SHA" '
+              .user.type == "Bot" and .state == "APPROVED" and .commit_id == $head
+            ' "$RUNNER_TEMP/review-result.json" >/dev/null
+          fi
+
+          # Final exact-tuple revalidation immediately before the independent App merge.
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          test "$(jq -er '.state' "$pr_json")" = 'open'
+          test "$(jq -er '.draft' "$pr_json")" = 'false'
+          test "$(jq -er '.head.sha' "$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -er '.base.sha' "$pr_json")" = "$EXPECTED_BASE_SHA"
+          test "$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')" = "$EXPECTED_BASE_SHA"
+
+          jq -n \
+            --arg sha "$EXPECTED_HEAD_SHA" \
+            --arg title "fix(docs): patch transitive nanoid audit finding (#${TARGET_PR})" \
+            --arg message $'Independent exact-head promotion after verified App review.\n\nSigned-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>' \
+            '{sha:$sha,merge_method:"squash",commit_title:$title,commit_message:$message}' \
+            > "$RUNNER_TEMP/merge-request.json"
+          gh api --method PUT "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/merge" \
+            --input "$RUNNER_TEMP/merge-request.json" > "$RUNNER_TEMP/merge-result.json"
+          jq -e '.merged == true' "$RUNNER_TEMP/merge-result.json" >/dev/null
+          merge_sha="$(jq -er '.sha' "$RUNNER_TEMP/merge-result.json")"
+          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          jq -e --arg merge "$merge_sha" '
+            .state == "closed" and .merged == true and .merge_commit_sha == $merge and .merged_by.type == "Bot"
+          ' "$pr_json" >/dev/null
+          test "$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')" = "$merge_sha"
+          gh api "repos/${TARGET_REPOSITORY}/commits/${merge_sha}" > "$RUNNER_TEMP/merge-commit.json"
+          jq -e '.commit.verification.verified == true' "$RUNNER_TEMP/merge-commit.json" >/dev/null
+
+          jq -n \
+            --arg repository "$TARGET_REPOSITORY" \
+            --argjson pull_request "$TARGET_PR" \
+            --arg expected_base_sha "$EXPECTED_BASE_SHA" \
+            --arg expected_head_sha "$EXPECTED_HEAD_SHA" \
+            --arg pr_body_sha256 "$EXPECTED_BODY_SHA256" \
+            --arg merge_commit_sha "$merge_sha" \
+            --arg controller_sha "$GITHUB_SHA" \
+            --slurpfile workflows reports/a11oy-docs-security-promotion/workflows.json \
+            '{
+              schema:"szl.a11oy-docs-security-promotion/v1",
+              result:"PROMOTED",
+              repository:$repository,
+              pull_request:$pull_request,
+              expected_base_sha:$expected_base_sha,
+              expected_head_sha:$expected_head_sha,
+              pr_body_sha256:$pr_body_sha256,
+              merge_commit_sha:$merge_commit_sha,
+              controller_sha:$controller_sha,
+              independent_app_review:true,
+              github_signature_verified:true,
+              dco_verified:true,
+              exact_paths_verified:true,
+              workflows:$workflows[0],
+              secret_values_emitted:false
+            }' > "$report"
+          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable promotion evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: a11oy-docs-security-promotion-1313
+          path: reports/a11oy-docs-security-promotion
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Report promotion identity
+        if: success()
+        shell: bash
+        run: |
+          {
+            echo '### A11oy exact docs-security promotion'
+            echo "- PR: \`${TARGET_REPOSITORY}#${TARGET_PR}\`"
+            echo "- exact head: \`${EXPECTED_HEAD_SHA}\`"
+            echo "- merge commit: \`${{ steps.promote.outputs.merge_sha }}\`"
+            echo '- independent App review: verified'
+            echo '- protected-main readback: verified'
+            echo '- secret values emitted: false'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Purpose

Temporary carrier for a GitHub-native signed builder. The draft workflow validates and republishes only the exact one-shot promotion controller onto `feat/a11oy-docs-security-promotion-20260818` using `createCommitOnBranch`, then verifies the resulting GitHub signature, DCO, parent, branch readback, and single changed path.

## Boundaries

- carrier remains draft and is not intended to merge
- no project secret is read by the carrier builder
- no direct write to protected `main`
- no force update, settings mutation, review submission, or target merge from this carrier
- signed target controller is exact-bound to A11oy PR #1313 head `2fb47683a1d0633fb7ce3807f5918448a533a572` and base `7788830c8db3d2611f5df296a5103e2a6ed74dc5`
- target controller uses the independent Qillqaq App only after its own protected merge

This PR will be closed unmerged after the signed target branch is verified.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>