### PR TITLE
ci(app): materialize qillqaq secrets-read permission

### DIFF
--- a/.github/scripts/materialize_qillqaq_secrets_permission.py
+++ b/.github/scripts/materialize_qillqaq_secrets_permission.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Publish one signed qillqaq Secrets-read permission repair.
+
+Temporary controller: it patches the reviewed GitHub App manifest, the exact
+FORGE-9 permission invariant, and the existing permission regression. It writes
+only those three files to a clean branch rooted at protected main.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+REPOSITORY = os.environ["REPOSITORY"]
+TARGET_BRANCH = os.environ["TARGET_BRANCH"]
+EXPECTED_PARENT = os.environ["EXPECTED_PARENT"]
+TOKEN = os.environ["GITHUB_TOKEN"]
+MANIFEST_PATH = ROOT / ".governance/github-app-manifest.json"
+VERIFIER_PATH = ROOT / ".github/scripts/verify_forge9_governance.py"
+DRIFT_TEST_PATH = ROOT / ".github/scripts/test_code_security_drift.py"
+
+OLD_EXPECTED = '''    expected = {
+        "actions": "read",
+        "administration": "read",
+        "checks": "read",
+        "commit_statuses": "write",
+        "contents": "read",
+        "metadata": "read",
+        "organization_administration": "read",
+        "pull_requests": "write",
+    }
+'''
+NEW_EXPECTED = '''    expected = {
+        "actions": "read",
+        "administration": "read",
+        "checks": "read",
+        "commit_statuses": "write",
+        "contents": "read",
+        "metadata": "read",
+        "organization_administration": "read",
+        "organization_secrets": "read",
+        "pull_requests": "write",
+        "secrets": "read",
+    }
+'''
+OLD_TEST = '''        self.assertEqual(permissions["organization_administration"], "read")
+        self.assertEqual(permissions["administration"], "read")
+'''
+NEW_TEST = '''        self.assertEqual(permissions["organization_administration"], "read")
+        self.assertEqual(permissions["organization_secrets"], "read")
+        self.assertEqual(permissions["administration"], "read")
+        self.assertEqual(permissions["secrets"], "read")
+'''
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, cwd=ROOT, check=True)
+
+
+def request(url: str, *, data: dict[str, Any] | None = None) -> Any:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(data).encode("utf-8") if data is not None else None,
+        method="POST" if data is not None else "GET",
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "szl-qillqaq-secrets-permission-materializer/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=90) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:4000]
+        raise SystemExit(f"GitHub HTTP {exc.code}: {body}") from exc
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    permissions = manifest.get("default_permissions")
+    if not isinstance(permissions, dict):
+        raise SystemExit("GitHub App manifest permissions are missing")
+    if "secrets" in permissions or "organization_secrets" in permissions:
+        raise SystemExit("Secrets permissions already exist; controller is stale")
+    permissions["organization_secrets"] = "read"
+    permissions["secrets"] = "read"
+    manifest["default_permissions"] = dict(sorted(permissions.items()))
+    MANIFEST_PATH.write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+    verifier = VERIFIER_PATH.read_text(encoding="utf-8")
+    if verifier.count(OLD_EXPECTED) != 1:
+        raise SystemExit("FORGE-9 expected-permission block changed")
+    VERIFIER_PATH.write_text(
+        verifier.replace(OLD_EXPECTED, NEW_EXPECTED, 1), encoding="utf-8"
+    )
+
+    drift_test = DRIFT_TEST_PATH.read_text(encoding="utf-8")
+    if drift_test.count(OLD_TEST) != 1:
+        raise SystemExit("code-security App-permission regression changed")
+    DRIFT_TEST_PATH.write_text(
+        drift_test.replace(OLD_TEST, NEW_TEST, 1), encoding="utf-8"
+    )
+
+    run(
+        "python",
+        "-m",
+        "py_compile",
+        str(VERIFIER_PATH),
+        str(DRIFT_TEST_PATH),
+    )
+    run("python", str(VERIFIER_PATH))
+    run("python", str(DRIFT_TEST_PATH))
+    run("python", ".github/scripts/test_secret_health.py")
+    run("git", "diff", "--check")
+
+    paths = [
+        ".github/scripts/test_code_security_drift.py",
+        ".github/scripts/verify_forge9_governance.py",
+        ".governance/github-app-manifest.json",
+    ]
+    changed = subprocess.check_output(
+        ["git", "diff", "--name-only"], cwd=ROOT, text=True
+    ).splitlines()
+    if sorted(changed) != sorted(paths):
+        raise SystemExit(f"unexpected changed paths: {changed}")
+
+    mutation = """
+    mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) { commit { oid url } }
+    }
+    """
+    variables = {
+        "input": {
+            "branch": {
+                "repositoryNameWithOwner": REPOSITORY,
+                "branchName": TARGET_BRANCH,
+            },
+            "message": {
+                "headline": "fix(app): grant qillqaq secret-name read",
+                "body": "Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>",
+            },
+            "expectedHeadOid": EXPECTED_PARENT,
+            "fileChanges": {
+                "additions": [
+                    {
+                        "path": path,
+                        "contents": base64.b64encode((ROOT / path).read_bytes()).decode(
+                            "ascii"
+                        ),
+                    }
+                    for path in paths
+                ]
+            },
+        }
+    }
+    payload = request(
+        "https://api.github.com/graphql",
+        data={"query": mutation, "variables": variables},
+    )
+    if payload.get("errors"):
+        raise SystemExit(json.dumps(payload["errors"], indent=2))
+    commit = payload["data"]["createCommitOnBranch"]["commit"]
+    sha = commit["oid"]
+    verification = request(
+        f"https://api.github.com/repos/{REPOSITORY}/commits/{sha}"
+    )["commit"]["verification"]
+    if verification.get("verified") is not True or verification.get("reason") != "valid":
+        raise SystemExit(f"target commit is not GitHub-verified: {verification}")
+
+    receipt = {
+        "schema": "szl.qillqaq-secrets-permission-materialization/v1",
+        "expected_parent": EXPECTED_PARENT,
+        "target_branch": TARGET_BRANCH,
+        "commit": commit,
+        "verification": {
+            "verified": verification.get("verified"),
+            "reason": verification.get("reason"),
+        },
+        "permissions_added": {
+            "repository.secrets": "read",
+            "organization.organization_secrets": "read",
+        },
+        "changed_paths": paths,
+        "secret_value_requested": False,
+        "secret_value_recorded": False,
+        "diagnostic_controller_included": False,
+    }
+    (ROOT / "qillqaq-secrets-permission-materialization.json").write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/materialize_qillqaq_secrets_permission.py
+++ b/.github/scripts/materialize_qillqaq_secrets_permission.py
@@ -57,6 +57,10 @@ NEW_TEST = '''        self.assertEqual(permissions["organization_administration"
         self.assertEqual(permissions["administration"], "read")
         self.assertEqual(permissions["secrets"], "read")
 '''
+BOT_SIGNOFF = (
+    "Signed-off-by: github-actions[bot] "
+    "<41898282+github-actions[bot]@users.noreply.github.com>"
+)
 
 
 def run(*args: str) -> None:
@@ -73,7 +77,7 @@ def request(url: str, *, data: dict[str, Any] | None = None) -> Any:
             "Accept": "application/vnd.github+json",
             "Content-Type": "application/json",
             "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "szl-qillqaq-secrets-permission-materializer/1",
+            "User-Agent": "szl-qillqaq-secrets-permission-materializer/2",
         },
     )
     try:
@@ -149,7 +153,7 @@ def main() -> int:
             },
             "message": {
                 "headline": "fix(app): grant qillqaq secret-name read",
-                "body": "Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>",
+                "body": BOT_SIGNOFF,
             },
             "expectedHeadOid": EXPECTED_PARENT,
             "fileChanges": {
@@ -173,14 +177,22 @@ def main() -> int:
         raise SystemExit(json.dumps(payload["errors"], indent=2))
     commit = payload["data"]["createCommitOnBranch"]["commit"]
     sha = commit["oid"]
-    verification = request(
-        f"https://api.github.com/repos/{REPOSITORY}/commits/{sha}"
-    )["commit"]["verification"]
+    commit_payload = request(f"https://api.github.com/repos/{REPOSITORY}/commits/{sha}")
+    verification = commit_payload["commit"]["verification"]
+    author = commit_payload["commit"]["author"]
     if verification.get("verified") is not True or verification.get("reason") != "valid":
         raise SystemExit(f"target commit is not GitHub-verified: {verification}")
+    if author != {
+        "name": "github-actions[bot]",
+        "email": "41898282+github-actions[bot]@users.noreply.github.com",
+        "date": author.get("date"),
+    }:
+        raise SystemExit(f"unexpected signed commit author: {author}")
+    if BOT_SIGNOFF not in commit_payload["commit"]["message"]:
+        raise SystemExit("signed commit does not carry its exact author DCO identity")
 
     receipt = {
-        "schema": "szl.qillqaq-secrets-permission-materialization/v1",
+        "schema": "szl.qillqaq-secrets-permission-materialization/v2",
         "expected_parent": EXPECTED_PARENT,
         "target_branch": TARGET_BRANCH,
         "commit": commit,
@@ -188,6 +200,7 @@ def main() -> int:
             "verified": verification.get("verified"),
             "reason": verification.get("reason"),
         },
+        "dco_identity": BOT_SIGNOFF,
         "permissions_added": {
             "repository.secrets": "read",
             "organization.organization_secrets": "read",

--- a/.github/workflows/materialize-qillqaq-secrets-permission.yml
+++ b/.github/workflows/materialize-qillqaq-secrets-permission.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: materialize-qillqaq-secrets-read
+  group: materialize-qillqaq-secrets-read-v2
   cancel-in-progress: false
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      TARGET_BRANCH: fix/qillqaq-secrets-read-v1
+      TARGET_BRANCH: fix/qillqaq-secrets-read-v2
       EXPECTED_PARENT: 3e510792e63da1dcfcbc58272d9466f7a8bc3dd0
     steps:
       - name: Checkout exact controller source

--- a/.github/workflows/materialize-qillqaq-secrets-permission.yml
+++ b/.github/workflows/materialize-qillqaq-secrets-permission.yml
@@ -1,0 +1,54 @@
+name: Materialize Signed qillqaq Secrets Permission
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/materialize_qillqaq_secrets_permission.py
+      - .github/workflows/materialize-qillqaq-secrets-permission.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: materialize-qillqaq-secrets-read
+  cancel-in-progress: false
+
+jobs:
+  materialize:
+    name: Publish exact signed App permission repair
+    if: >-
+      github.repository == 'szl-holdings/.github' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == 'diag/qillqaq-secrets-permission-v1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      TARGET_BRANCH: fix/qillqaq-secrets-read-v1
+      EXPECTED_PARENT: 3e510792e63da1dcfcbc58272d9466f7a8bc3dd0
+    steps:
+      - name: Checkout exact controller source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Build, test, and publish signed permission repair
+        run: python .github/scripts/materialize_qillqaq_secrets_permission.py
+
+      - name: Upload immutable materialization receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: qillqaq-secrets-permission-${{ github.run_id }}
+          path: qillqaq-secrets-permission-materialization.json
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
## Satisfies

Satisfies: C-158.

## Purpose

Bounded one-use materializer for the exact GitHub App permission repair required by the protected `Governed Secret Health` workflow.

GitHub's current REST contract requires repository `Secrets: read` to list repository secret names and organization `Secrets: read` to list organization secret names. The existing workflow already requests `permission-secrets: read` and `permission-organization-secrets: read`, but the tracked qillqaq App manifest does not yet declare those permissions.

This draft:

- adds `secrets: read` and `organization_secrets: read` to the reviewed App manifest;
- updates the exact FORGE-9 minimum-permission invariant;
- expands the existing App-permission regression;
- runs the governance verifier, code-security tests, secret-health tests, compilation, and patch hygiene;
- creates one GitHub-verified signed commit on clean branch `fix/qillqaq-secrets-read-v1`;
- writes only the manifest, verifier, and existing permission test.

## Boundaries

Temporary diagnostic/materialization controller. Close without merge after the permanent signed successor exists. No secret value is requested, read, serialized, hashed, or logged. No App installation setting is silently approved by source code; GitHub may require an organization owner to approve the permission increase after merge.

## Labels

Labels: PROVED exact permission-name mapping and bounded signed materialization; MEASURED missing qillqaq Secrets-read installation scope; NOT CLAIMED activated until the installation owner approves the increase and the live audit returns VERIFIED.

## Rollback

Close this draft without merge. Revert the permanent successor through a protected signed pull request if the permission is no longer required.

## Risk class

Risk: D — reviewed GitHub App permission-manifest change; read-only secret-name metadata only.

Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>