### PR TITLE
fix(app): grant qillqaq secret-name read

### DIFF
--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -304,7 +304,9 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         )
         permissions = manifest["default_permissions"]
         self.assertEqual(permissions["organization_administration"], "read")
+        self.assertEqual(permissions["organization_secrets"], "read")
         self.assertEqual(permissions["administration"], "read")
+        self.assertEqual(permissions["secrets"], "read")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -178,7 +178,9 @@ def verify_manifest() -> None:
         "contents": "read",
         "metadata": "read",
         "organization_administration": "read",
+        "organization_secrets": "read",
         "pull_requests": "write",
+        "secrets": "read",
     }
     if permissions != expected:
         fail("GitHub App permissions differ from the reviewed minimum")

--- a/.governance/github-app-manifest.json
+++ b/.governance/github-app-manifest.json
@@ -14,7 +14,9 @@
     "contents": "read",
     "metadata": "read",
     "organization_administration": "read",
-    "pull_requests": "write"
+    "organization_secrets": "read",
+    "pull_requests": "write",
+    "secrets": "read"
   },
   "default_events": []
 }


### PR DESCRIPTION
## Satisfies

Satisfies: C-158.

## Root cause

The protected `Governed Secret Health` workflow requests repository and organization secret-name read from qillqaq, but the tracked App manifest did not declare those two permissions. GitHub therefore could not mint the preferred short-lived reader, forcing the audited governed fallback path.

## Permanent repair

- add repository `secrets: read` to the qillqaq manifest;
- add organization `organization_secrets: read` to the qillqaq manifest;
- update the exact FORGE-9 minimum-permission invariant;
- extend the existing code-security App-permission regression;
- preserve every existing qillqaq permission and add no write permission.

## Signed lineage

Bounded materializer run `32088883873` created one GitHub-verified signed commit from protected main `3e510792e63da1dcfcbc58272d9466f7a8bc3dd0`:

- commit: `6f7d8c5fb700cb8252a8fabc235e507789e0a505`;
- signature: `verified=true`, reason `valid`;
- changed paths: manifest, FORGE-9 verifier, existing App-permission regression only;
- governance verifier: passed;
- code-security tests: passed;
- secret-health tests: passed;
- secret value requested or recorded: false;
- artifact digest: `sha256:854683ddf5bf11a36ac4a792e368bb7e9667d81972134a7fb970827886e1c22a`.

## Activation boundary

GitHub may require an organization owner to approve the App permission increase after merge. Source merge alone is not treated as live activation. The secret-health lane remains fail-closed until qillqaq successfully mints the reader and the audit reports `VERIFIED`.

## Labels

Labels: PROVED signed read-only permission repair and exact governance invariants; MEASURED missing App installation capability; NOT CLAIMED activated until installation approval and live secret-health verification.

## Rollback

Revert through a protected signed pull request. Do not restore the expired PAT lane.

## Risk class

Risk: D — reviewed GitHub App permission-manifest change; secret-name metadata read only.

Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>