### PR TITLE
fix(app): grant qillqaq secret-name read

### DIFF
--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -304,7 +304,9 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         )
         permissions = manifest["default_permissions"]
         self.assertEqual(permissions["organization_administration"], "read")
+        self.assertEqual(permissions["organization_secrets"], "read")
         self.assertEqual(permissions["administration"], "read")
+        self.assertEqual(permissions["secrets"], "read")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -178,7 +178,9 @@ def verify_manifest() -> None:
         "contents": "read",
         "metadata": "read",
         "organization_administration": "read",
+        "organization_secrets": "read",
         "pull_requests": "write",
+        "secrets": "read",
     }
     if permissions != expected:
         fail("GitHub App permissions differ from the reviewed minimum")

--- a/.governance/github-app-manifest.json
+++ b/.governance/github-app-manifest.json
@@ -14,7 +14,9 @@
     "contents": "read",
     "metadata": "read",
     "organization_administration": "read",
-    "pull_requests": "write"
+    "organization_secrets": "read",
+    "pull_requests": "write",
+    "secrets": "read"
   },
   "default_events": []
 }


### PR DESCRIPTION
## Satisfies

Satisfies: C-158.

## Root cause

The protected `Governed Secret Health` workflow requests repository and organization secret-name read from qillqaq, but the tracked App manifest did not declare those two permissions. The preferred short-lived App reader could not be minted, leaving only the audited governed fallback path.

## Permanent repair

- add repository `secrets: read` to the qillqaq manifest;
- add organization `organization_secrets: read` to the qillqaq manifest;
- update the exact FORGE-9 minimum-permission invariant;
- extend the existing App-permission regression;
- preserve every existing permission and add no write permission.

## Signed and DCO-bound lineage

Bounded materializer run `32089522670` created one GitHub-verified signed commit from protected main `3e510792e63da1dcfcbc58272d9466f7a8bc3dd0`:

- commit: `239284e90499883b1bec71b6c032451930be0b5a`;
- signature: `verified=true`, reason `valid`;
- exact commit author and DCO identity: `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`;
- changed paths: manifest, FORGE-9 verifier, and existing App-permission regression only;
- governance, code-security, and secret-health tests: passed;
- secret value requested or recorded: false;
- artifact digest: `sha256:1e651f14e944f7fa4889c721a6c6f97b9b220ca2d4ee050261b8326ff5145e7e`.

## Activation boundary

GitHub may require an organization owner to approve the App permission increase after merge. Source merge alone is not live activation. Secret health remains fail-closed until qillqaq successfully mints the reader and the audit reports `VERIFIED`.

## Labels

Labels: PROVED signed read-only permission repair, exact DCO identity, and governance invariants; MEASURED missing App installation capability; NOT CLAIMED activated until installation approval and live secret-health verification.

## Rollback

Revert through a protected signed pull request. Do not restore the expired PAT lane.

## Risk class

Risk: D — reviewed GitHub App permission-manifest change; secret-name metadata read only.

Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>