### PR TITLE
chore(governance): build exact A11oy token-ingress promotion controller

### DIFF
--- a/.github/workflows/a11oy-token-ingress-promotion-signed-builder.yml
+++ b/.github/workflows/a11oy-token-ingress-promotion-signed-builder.yml
@@ -1,0 +1,243 @@
+name: A11oy token-ingress promotion signed builder
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/a11oy-token-ingress-promotion-signed-builder.yml'
+      - '.github/workflows/a11oy-token-ingress-promotion.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: a11oy-token-ingress-promotion-signed-builder
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build GitHub-verified one-shot token-ingress controller
+    if: >-
+      github.event.pull_request.user.login == 'stephenlutar2-hash' &&
+      github.event.pull_request.head.repo.full_name == 'szl-holdings/.github' &&
+      github.event.pull_request.head.ref == 'chore/a11oy-token-ingress-promotion-builder-20260818' &&
+      github.event.pull_request.draft == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      TARGET_BRANCH: feat/a11oy-token-ingress-promotion-20260818
+      TARGET_PATH: .github/workflows/a11oy-token-ingress-promotion.yml
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Verify exact protected-base context
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_sha='${{ github.event.pull_request.base.sha }}'
+          test "$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')" = "$base_sha"
+          test "$base_sha" = 'a9be95991efc5c20afd2379af63adcbf67408fc7'
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact carrier head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: carrier
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Validate exact controller contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import pathlib
+          import re
+
+          path = pathlib.Path('carrier/.github/workflows/a11oy-token-ingress-promotion.yml')
+          text = path.read_text(encoding='utf-8')
+          if '\t' in text:
+              raise SystemExit('controller contains tab indentation')
+          if 'pull_request_target' in text or 'set -x' in text:
+              raise SystemExit('unsafe controller construct')
+          required = (
+              'TARGET_PR: \'1340\'',
+              'EXPECTED_BASE_SHA: e9f18874076ab9977651e793bfd083021b79756d',
+              'EXPECTED_HEAD_SHA: 6bd2b60ff3b472725212d6019cd74ec875217671',
+              'EXPECTED_TITLE: \'feat(ingress): converge semantic token routing into budget control\'',
+              'secrets.QILLQAQ_PRIVATE_KEY',
+              'create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1',
+              'secret_values_emitted:false',
+          )
+          missing = [marker for marker in required if marker not in text]
+          if missing:
+              raise SystemExit(f'controller missing exact bindings: {missing}')
+          for line in text.splitlines():
+              if line.strip().startswith('uses:') and not re.search(r'@[0-9a-f]{40}(?:\s|$)', line):
+                  raise SystemExit(f'unpinned action: {line.strip()}')
+          forbidden = ('echo $GH_TOKEN', 'printenv', 'env |', 'set +x')
+          if any(marker in text for marker in forbidden):
+              raise SystemExit('secret-output construct detected')
+          PY
+
+      - name: Create or verify the GitHub-signed target commit
+        id: publish
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.context.outputs.base_sha }}
+          CARRIER_PATH: ${{ github.workspace }}/carrier/.github/workflows/a11oy-token-ingress-promotion.yml
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          export GH_TOKEN REPOSITORY TARGET_BRANCH TARGET_PATH BASE_SHA CARRIER_PATH
+          python - <<'PY'
+          import base64
+          import json
+          import os
+          import pathlib
+          import urllib.error
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repository = os.environ['REPOSITORY']
+          branch = os.environ['TARGET_BRANCH']
+          target_path = os.environ['TARGET_PATH']
+          base_sha = os.environ['BASE_SHA']
+          carrier = pathlib.Path(os.environ['CARRIER_PATH'])
+
+          def api(method, url, payload=None, allow_missing=False):
+              data = None if payload is None else json.dumps(payload, separators=(',', ':')).encode()
+              request = urllib.request.Request(
+                  url,
+                  data=data,
+                  method=method,
+                  headers={
+                      'Authorization': f'Bearer {token}',
+                      'Accept': 'application/vnd.github+json',
+                      'Content-Type': 'application/json',
+                      'User-Agent': 'szl-a11oy-token-ingress-promotion-builder',
+                      'X-GitHub-Api-Version': '2022-11-28',
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      return json.load(response)
+              except urllib.error.HTTPError as exc:
+                  if allow_missing and exc.code == 404:
+                      return None
+                  raise SystemExit(f'GitHub API HTTP {exc.code}') from exc
+
+          ref_url = f'https://api.github.com/repos/{repository}/git/ref/heads/{branch}'
+          ref = api('GET', ref_url, allow_missing=True)
+          if ref is None:
+              api('POST', f'https://api.github.com/repos/{repository}/git/refs', {'ref': f'refs/heads/{branch}', 'sha': base_sha})
+              head = base_sha
+          else:
+              head = str(((ref.get('object') or {}).get('sha') or ''))
+
+          if head == base_sha:
+              mutation = '''
+              mutation Build($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid url } }
+              }
+              '''
+              variables = {
+                  'input': {
+                      'branch': {'repositoryNameWithOwner': repository, 'branchName': branch},
+                      'expectedHeadOid': base_sha,
+                      'message': {
+                          'headline': 'feat(governance): promote exact A11oy token-ingress head',
+                          'body': (
+                              'Install a one-shot protected-main controller that uses the independent '
+                              'Qillqaq GitHub App to revalidate and promote only A11oy PR 1340 at exact '
+                              'base e9f18874076ab9977651e793bfd083021b79756d and exact head '
+                              '6bd2b60ff3b472725212d6019cd74ec875217671.\n\n'
+                              'Signed-off-by: github-actions[bot] '
+                              '<41898282+github-actions[bot]@users.noreply.github.com>\n'
+                              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>'
+                          ),
+                      },
+                      'fileChanges': {
+                          'additions': [{
+                              'path': target_path,
+                              'contents': base64.b64encode(carrier.read_bytes()).decode('ascii'),
+                          }],
+                      },
+                  }
+              }
+              payload = api('POST', 'https://api.github.com/graphql', {'query': mutation, 'variables': variables})
+              if payload.get('errors'):
+                  raise SystemExit('createCommitOnBranch rejected the exact controller')
+              head = str(payload['data']['createCommitOnBranch']['commit']['oid'])
+
+          if len(head) != 40 or any(ch not in '0123456789abcdef' for ch in head):
+              raise SystemExit('invalid target commit OID')
+          commit = api('GET', f'https://api.github.com/repos/{repository}/commits/{head}')
+          verification = (commit.get('commit') or {}).get('verification') or {}
+          if verification.get('verified') is not True or verification.get('reason') != 'valid':
+              raise SystemExit('target commit signature is not verified')
+          parents = commit.get('parents') or []
+          if len(parents) != 1 or parents[0].get('sha') != base_sha:
+              raise SystemExit('target commit parent mismatch')
+          files = commit.get('files') or []
+          if len(files) != 1 or files[0].get('filename') != target_path:
+              raise SystemExit('target changed-path mismatch')
+          message = str((commit.get('commit') or {}).get('message') or '')
+          required = (
+              'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>',
+              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>',
+          )
+          for trailer in required:
+              if trailer not in message:
+                  raise SystemExit(f'missing DCO trailer: {trailer}')
+          ref = api('GET', ref_url)
+          if ((ref.get('object') or {}).get('sha')) != head:
+              raise SystemExit('target branch readback mismatch')
+          pathlib.Path('builder-result.json').write_text(
+              json.dumps(
+                  {
+                      'schema': 'szl.a11oy-token-ingress-promotion-builder/v1',
+                      'base_sha': base_sha,
+                      'branch': branch,
+                      'commit_sha': head,
+                      'path': target_path,
+                      'signature_verified': True,
+                      'dco_verified': True,
+                      'secret_values_emitted': False,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              ) + '\n',
+              encoding='utf-8',
+          )
+          PY
+          commit_sha="$(jq -er '.commit_sha' builder-result.json)"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload builder evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: a11oy-token-ingress-promotion-signed-builder
+          path: builder-result.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Report target identity
+        shell: bash
+        run: |
+          {
+            echo '### GitHub-signed A11oy token-ingress promotion controller'
+            echo "- base: \`${{ steps.context.outputs.base_sha }}\`"
+            echo "- branch: \`${TARGET_BRANCH}\`"
+            echo "- head: \`${{ steps.publish.outputs.commit_sha }}\`"
+            echo '- signature: verified'
+            echo '- DCO: verified'
+            echo '- secret values emitted: false'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/a11oy-token-ingress-promotion.yml
+++ b/.github/workflows/a11oy-token-ingress-promotion.yml
@@ -1,0 +1,308 @@
+name: A11oy exact token-ingress promotion
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/a11oy-token-ingress-promotion.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a11oy-token-ingress-promotion-1340
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Independently review and promote A11oy PR 1340
+    if: github.repository == 'szl-holdings/.github' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      TARGET_REPOSITORY: szl-holdings/a11oy
+      TARGET_PR: '1340'
+      EXPECTED_AUTHOR: stephenlutar2-hash
+      EXPECTED_TITLE: 'feat(ingress): converge semantic token routing into budget control'
+      EXPECTED_BASE_REF: main
+      EXPECTED_BASE_SHA: e9f18874076ab9977651e793bfd083021b79756d
+      EXPECTED_HEAD_SHA: 6bd2b60ff3b472725212d6019cd74ec875217671
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Mint independent Qillqaq App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
+          private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: a11oy
+
+      - name: Verify, independently approve, and exact-head promote
+        id: promote
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          evidence=reports/a11oy-token-ingress-promotion
+          mkdir -p "$evidence"
+          pr_json="$RUNNER_TEMP/target-pr.json"
+          commit_json="$RUNNER_TEMP/target-commit.json"
+          reviews_json="$RUNNER_TEMP/target-reviews.json"
+          workflows_before="$evidence/workflows-before.json"
+          workflows_after="$evidence/workflows-after.json"
+          report="$evidence/report.json"
+
+          capture_workflows() {
+            local output="$1" raw="$RUNNER_TEMP/workflow-runs.json"
+            gh api "repos/${TARGET_REPOSITORY}/actions/runs?event=pull_request&head_sha=${EXPECTED_HEAD_SHA}&per_page=100" > "$raw"
+            python - "$raw" "$output" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          source = pathlib.Path(sys.argv[1])
+          output = pathlib.Path(sys.argv[2])
+          payload = json.loads(source.read_text(encoding='utf-8'))
+          rows = payload.get('workflow_runs')
+          if not isinstance(rows, list) or not rows:
+              raise SystemExit('no exact-head pull-request workflow runs')
+          latest = {}
+          for row in rows:
+              if not isinstance(row, dict):
+                  raise SystemExit('invalid workflow run row')
+              name = row.get('name')
+              run_id = row.get('id')
+              if not isinstance(name, str) or isinstance(run_id, bool) or not isinstance(run_id, int):
+                  raise SystemExit('invalid workflow identity')
+              if name not in latest or int(latest[name]['id']) < run_id:
+                  latest[name] = row
+          safe = {'success', 'neutral', 'skipped'}
+          blocked = []
+          for name, row in sorted(latest.items()):
+              if row.get('status') != 'completed' or row.get('conclusion') not in safe:
+                  blocked.append((name, row.get('status'), row.get('conclusion')))
+          if blocked:
+              raise SystemExit(f'non-green exact-head workflows: {blocked}')
+          required = {
+              'Action-contract promotion guard',
+              'Budget and token ingress contracts',
+              'CodeQL',
+              'Container build + GHCR push',
+              'DCO',
+              'Docs CI',
+              'Doctrine',
+              'Doctrine Overclaim Guard',
+              'HF Space module-drift guard',
+              'Lockfile Registry Check',
+              'Secret Scanning (Gitleaks)',
+              'Tests',
+              'Trivy + Grype container vulnerability scan',
+          }
+          missing = sorted(required - set(latest))
+          if missing:
+              raise SystemExit(f'missing required exact-head workflows: {missing}')
+          normalized = {
+              name: {
+                  'id': latest[name]['id'],
+                  'status': latest[name]['status'],
+                  'conclusion': latest[name]['conclusion'],
+              }
+              for name in sorted(latest)
+          }
+          output.write_text(json.dumps(normalized, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+          }
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          test "$(jq -er '.number' "$pr_json")" = "$TARGET_PR"
+          test "$(jq -er '.state' "$pr_json")" = 'open'
+          test "$(jq -er '.draft' "$pr_json")" = 'false'
+          test "$(jq -er '.user.login' "$pr_json")" = "$EXPECTED_AUTHOR"
+          test "$(jq -er '.title' "$pr_json")" = "$EXPECTED_TITLE"
+          test "$(jq -er '.head.repo.full_name' "$pr_json")" = "$TARGET_REPOSITORY"
+          test "$(jq -er '.head.sha' "$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -er '.base.repo.full_name' "$pr_json")" = "$TARGET_REPOSITORY"
+          test "$(jq -er '.base.ref' "$pr_json")" = "$EXPECTED_BASE_REF"
+          test "$(jq -er '.base.sha' "$pr_json")" = "$EXPECTED_BASE_SHA"
+          test "$(jq -er '.commits' "$pr_json")" = '1'
+          current_main="$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')"
+          test "$current_main" = "$EXPECTED_BASE_SHA" \
+            || { echo '::error::protected main advanced; refusing stale promotion'; exit 1; }
+
+          body_digest="$(python - "$pr_json" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+          payload = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))
+          body = payload.get('body')
+          if not isinstance(body, str):
+              raise SystemExit('pull request body is not a string')
+          required = (
+              'Satisfies: C-BUDGET-TOKEN-INGRESS-CURRENT-MAIN',
+              'Solo-Operator-Authorization: confirmed',
+              'Risk: B',
+              'No live benchmark',
+              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>',
+          )
+          missing = [marker for marker in required if marker not in body]
+          if missing:
+              raise SystemExit(f'pull request body missing required markers: {missing}')
+          print(hashlib.sha256(body.encode('utf-8')).hexdigest())
+          PY
+          )"
+
+          gh api "repos/${TARGET_REPOSITORY}/commits/${EXPECTED_HEAD_SHA}" > "$commit_json"
+          jq -e '.commit.verification.verified == true and .commit.verification.reason == "valid"' "$commit_json" >/dev/null
+          test "$(jq -er '.parents | length' "$commit_json")" = '1'
+          test "$(jq -er '.parents[0].sha' "$commit_json")" = "$EXPECTED_BASE_SHA"
+          message="$(jq -er '.commit.message' "$commit_json")"
+          grep -Fq 'Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' <<<"$message"
+          grep -Fq 'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>' <<<"$message"
+
+          mapfile -t changed_paths < <(
+            gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/files?per_page=100" --paginate --jq '.[].filename' | sort
+          )
+          expected_paths=(
+            .github/workflows/budget-token-ingress.yml
+            artifacts/proof-packets/20260818-budget-token-ingress.md
+            szl_budget_router.py
+            tests/test_budget_token_ingress.py
+            tests/test_budget_token_ingress_assembled.py
+          )
+          test "${changed_paths[*]}" = "${expected_paths[*]}" \
+            || { echo '::error::changed-path set drifted'; exit 1; }
+
+          capture_workflows "$workflows_before"
+          workflows_digest="$(sha256sum "$workflows_before" | awk '{print $1}')"
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/reviews?per_page=100" --paginate --slurp > "$reviews_json"
+          jq -e '[.[][] | select(.state == "CHANGES_REQUESTED")] | length == 0' "$reviews_json" >/dev/null
+
+          owner="${TARGET_REPOSITORY%%/*}"
+          name="${TARGET_REPOSITORY#*/}"
+          gh api graphql \
+            -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}' \
+            -F owner="$owner" -F name="$name" -F number="$TARGET_PR" \
+            > "$RUNNER_TEMP/review-threads.json"
+          jq -e --arg head "$EXPECTED_HEAD_SHA" '
+            .data.repository.pullRequest.headRefOid == $head
+            and .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false
+            and ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved != true)] | length == 0)
+          ' "$RUNNER_TEMP/review-threads.json" >/dev/null
+
+          review_body="$(cat <<EOF
+          Independent exact-head promotion review.
+
+          Head: ${EXPECTED_HEAD_SHA}
+          Base: ${EXPECTED_BASE_REF}@${EXPECTED_BASE_SHA}
+          PR body sha256: ${body_digest}
+          Workflow-set sha256: ${workflows_digest}
+          Controller: ${GITHUB_REPOSITORY}@${GITHUB_SHA}
+          Result: APPROVED after signature, DCO, exact-path, workflow, and review-thread validation.
+          EOF
+          )"
+          existing_approval="$(jq --arg head "$EXPECTED_HEAD_SHA" --arg body "$review_body" '[.[][] | select(.user.type == "Bot" and .state == "APPROVED" and .commit_id == $head and (.body // "") == $body)] | length' "$reviews_json")"
+          if [ "$existing_approval" -eq 0 ]; then
+            jq -n --arg commit_id "$EXPECTED_HEAD_SHA" --arg body "$review_body" '{commit_id:$commit_id,body:$body,event:"APPROVE"}' > "$RUNNER_TEMP/review-request.json"
+            gh api --method POST "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/reviews" --input "$RUNNER_TEMP/review-request.json" > "$RUNNER_TEMP/review-result.json"
+            jq -e --arg head "$EXPECTED_HEAD_SHA" '.user.type == "Bot" and .state == "APPROVED" and .commit_id == $head' "$RUNNER_TEMP/review-result.json" >/dev/null
+          fi
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          test "$(jq -er '.state' "$pr_json")" = 'open'
+          test "$(jq -er '.draft' "$pr_json")" = 'false'
+          test "$(jq -er '.head.sha' "$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$(jq -er '.base.sha' "$pr_json")" = "$EXPECTED_BASE_SHA"
+          test "$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')" = "$EXPECTED_BASE_SHA"
+          final_body_digest="$(python - "$pr_json" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
+          body = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')).get('body')
+          if not isinstance(body, str):
+              raise SystemExit('pull request body is not a string')
+          print(hashlib.sha256(body.encode('utf-8')).hexdigest())
+          PY
+          )"
+          test "$final_body_digest" = "$body_digest"
+          capture_workflows "$workflows_after"
+          cmp -s "$workflows_before" "$workflows_after" \
+            || { echo '::error::exact-head workflow generation changed after review'; exit 1; }
+
+          jq -n \
+            --arg sha "$EXPECTED_HEAD_SHA" \
+            --arg title "feat(ingress): converge semantic token routing into budget control (#${TARGET_PR})" \
+            --arg message $'Independent exact-head promotion after verified App review.\n\nSigned-off-by: qillqaq-attestor[bot] <qillqaq-attestor[bot]@users.noreply.github.com>\nSigned-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>' \
+            '{sha:$sha,merge_method:"squash",commit_title:$title,commit_message:$message}' \
+            > "$RUNNER_TEMP/merge-request.json"
+          gh api --method PUT "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}/merge" --input "$RUNNER_TEMP/merge-request.json" > "$RUNNER_TEMP/merge-result.json"
+          jq -e '.merged == true' "$RUNNER_TEMP/merge-result.json" >/dev/null
+          merge_sha="$(jq -er '.sha' "$RUNNER_TEMP/merge-result.json")"
+          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]
+
+          gh api "repos/${TARGET_REPOSITORY}/pulls/${TARGET_PR}" > "$pr_json"
+          jq -e --arg merge "$merge_sha" '.state == "closed" and .merged == true and .merge_commit_sha == $merge and .merged_by.type == "Bot"' "$pr_json" >/dev/null
+          test "$(gh api "repos/${TARGET_REPOSITORY}/git/ref/heads/${EXPECTED_BASE_REF}" --jq '.object.sha')" = "$merge_sha"
+          gh api "repos/${TARGET_REPOSITORY}/commits/${merge_sha}" > "$RUNNER_TEMP/merge-commit.json"
+          jq -e '.commit.verification.verified == true' "$RUNNER_TEMP/merge-commit.json" >/dev/null
+
+          jq -n \
+            --arg repository "$TARGET_REPOSITORY" \
+            --argjson pull_request "$TARGET_PR" \
+            --arg expected_base_sha "$EXPECTED_BASE_SHA" \
+            --arg expected_head_sha "$EXPECTED_HEAD_SHA" \
+            --arg pr_body_sha256 "$body_digest" \
+            --arg workflow_set_sha256 "$workflows_digest" \
+            --arg merge_commit_sha "$merge_sha" \
+            --arg controller_sha "$GITHUB_SHA" \
+            '{
+              schema:"szl.a11oy-token-ingress-promotion/v1",
+              result:"PROMOTED",
+              repository:$repository,
+              pull_request:$pull_request,
+              expected_base_sha:$expected_base_sha,
+              expected_head_sha:$expected_head_sha,
+              pr_body_sha256:$pr_body_sha256,
+              workflow_set_sha256:$workflow_set_sha256,
+              merge_commit_sha:$merge_commit_sha,
+              controller_sha:$controller_sha,
+              independent_app_review:true,
+              github_signature_verified:true,
+              dco_verified:true,
+              exact_paths_verified:true,
+              secret_values_emitted:false
+            }' > "$report"
+          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable promotion evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: a11oy-token-ingress-promotion-1340
+          path: reports/a11oy-token-ingress-promotion
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Report promotion identity
+        if: success()
+        shell: bash
+        run: |
+          {
+            echo '### A11oy exact token-ingress promotion'
+            echo "- PR: \`${TARGET_REPOSITORY}#${TARGET_PR}\`"
+            echo "- exact head: \`${EXPECTED_HEAD_SHA}\`"
+            echo "- merge commit: \`${{ steps.promote.outputs.merge_sha }}\`"
+            echo '- independent App review: verified'
+            echo '- protected-main readback: verified'
+            echo '- secret values emitted: false'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Purpose

Temporary carrier for a GitHub-native signed builder. It validates and republishes only the exact one-shot controller onto `feat/a11oy-token-ingress-promotion-20260818` using `createCommitOnBranch`, then verifies the resulting GitHub signature, DCO, exact parent, branch readback, and single changed path.

## Exact target

- A11oy PR: #1340
- target base: `e9f18874076ab9977651e793bfd083021b79756d`
- target head: `6bd2b60ff3b472725212d6019cd74ec875217671`
- target title: `feat(ingress): converge semantic token routing into budget control`

## Boundaries

- carrier remains draft and will not merge
- no project or organization secret is consumed by the carrier builder
- no direct write to protected `main`
- no force update, ruleset mutation, review submission, or target merge from this carrier
- signed target controller uses the independent Qillqaq App only after its own protected merge
- controller fails closed on any base, head, title, author, body, path, workflow, thread, signature, or DCO drift

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>