### PR TITLE
ci(notifications): schedule protected inbox-zero sweeps

### DIFF
--- a/.github/workflows/notification-inbox-scheduler.yml
+++ b/.github/workflows/notification-inbox-scheduler.yml
@@ -1,0 +1,45 @@
+name: GitHub Notification Inbox Scheduler
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/notification-inbox-scheduler.yml
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: github-personal-notification-scheduler
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch protected inbox-zero controller
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Dispatch the protected notification clearer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run clear-personal-notifications.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
+
+          echo 'The protected inbox-zero workflow was accepted for dispatch.'
+          echo 'That workflow owns the classic Notifications-scoped credential,'
+          echo 'moves read and unread Inbox threads to Done, publishes a count-only'
+          echo 'receipt, clears its receipt-generated thread, and fails unless both'
+          echo 'Inbox and Unread are exactly zero.'


### PR DESCRIPTION
## Outcome

Install an hourly and owner-dispatchable trigger for the existing protected GitHub notification clearer. A push of this scheduler to protected `main` also dispatches the clearer immediately, so the current historical Inbox backlog is processed without waiting for the next cron window.

## Solo-operator loop

- dispatches only `.github/workflows/clear-personal-notifications.yml` from protected `main`;
- receives no personal notification credential and cannot read notification content;
- relies on the existing clearer to inventory read and unread Inbox threads, move them to Done, publish a count-only receipt, clear the receipt-generated thread, and prove Inbox and Unread are both zero;
- runs at minute 17 of every hour to avoid top-of-hour congestion;
- uses a concurrency lock and a five-minute scheduler timeout;
- pins the runner-hardening action by full commit SHA.

## Changed path

- `.github/workflows/notification-inbox-scheduler.yml`

## Truth boundary

This PR installs the dispatch loop. It does not claim the current Inbox is zero until the protected clearer publishes a new count-only receipt with exact zero Inbox and Unread counts.

Risk: B — Actions dispatch only. No branch protection, repository source outside this workflow, notification content, token value, Hugging Face resource, or deployment is modified.

Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>