### PR TITLE
chore(governance): build signed stale token-ingress controller cleanup

### DIFF
--- a/.github/workflows/remove-stale-a11oy-token-ingress-controller-signed-builder.yml
+++ b/.github/workflows/remove-stale-a11oy-token-ingress-controller-signed-builder.yml
@@ -1,0 +1,224 @@
+name: Stale A11oy token-ingress controller cleanup builder
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/remove-stale-a11oy-token-ingress-controller-signed-builder.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stale-a11oy-token-ingress-controller-cleanup-builder
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build GitHub-verified token-ingress controller cleanup
+    if: >-
+      github.event.pull_request.user.login == 'stephenlutar2-hash' &&
+      github.event.pull_request.head.repo.full_name == 'szl-holdings/.github' &&
+      github.event.pull_request.head.ref == 'chore/remove-stale-a11oy-token-ingress-controller-builder-20260818' &&
+      github.event.pull_request.draft == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      TARGET_BRANCH: chore/remove-stale-a11oy-token-ingress-controller-20260818
+      TARGET_PATH: .github/workflows/a11oy-token-ingress-promotion.yml
+      EXPECTED_BASE_SHA: df399c5ece4c507a8cf52c6845f2c286fc842ac2
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Verify exact protected-base context
+        id: context
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          base_sha='${{ github.event.pull_request.base.sha }}'
+          current_main="$(gh api "repos/${REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$base_sha" = "$EXPECTED_BASE_SHA"
+          test "$current_main" = "$EXPECTED_BASE_SHA"
+          gh api "repos/${REPOSITORY}/contents/${TARGET_PATH}?ref=${EXPECTED_BASE_SHA}" >/dev/null
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Create or verify the GitHub-signed deletion commit
+        id: publish
+        shell: bash
+        env:
+          BASE_SHA: ${{ steps.context.outputs.base_sha }}
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          export GH_TOKEN REPOSITORY TARGET_BRANCH TARGET_PATH BASE_SHA
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          token = os.environ['GH_TOKEN']
+          repository = os.environ['REPOSITORY']
+          branch = os.environ['TARGET_BRANCH']
+          target_path = os.environ['TARGET_PATH']
+          base_sha = os.environ['BASE_SHA']
+
+          def api(method, url, payload=None, *, allow_missing=False):
+              data = None if payload is None else json.dumps(payload, separators=(',', ':')).encode()
+              request = urllib.request.Request(
+                  url,
+                  data=data,
+                  method=method,
+                  headers={
+                      'Authorization': f'Bearer {token}',
+                      'Accept': 'application/vnd.github+json',
+                      'Content-Type': 'application/json',
+                      'User-Agent': 'szl-stale-token-ingress-controller-cleanup-builder',
+                      'X-GitHub-Api-Version': '2022-11-28',
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      return json.load(response)
+              except urllib.error.HTTPError as exc:
+                  if allow_missing and exc.code == 404:
+                      return None
+                  raise SystemExit(f'GitHub API HTTP {exc.code}') from exc
+
+          ref_url = f'https://api.github.com/repos/{repository}/git/ref/heads/{branch}'
+          ref = api('GET', ref_url, allow_missing=True)
+          if ref is None:
+              api(
+                  'POST',
+                  f'https://api.github.com/repos/{repository}/git/refs',
+                  {'ref': f'refs/heads/{branch}', 'sha': base_sha},
+              )
+              head = base_sha
+          else:
+              head = str(((ref.get('object') or {}).get('sha') or ''))
+
+          if head == base_sha:
+              mutation = '''
+              mutation BuildCleanup($input: CreateCommitOnBranchInput!) {
+                createCommitOnBranch(input: $input) { commit { oid url } }
+              }
+              '''
+              variables = {
+                  'input': {
+                      'branch': {
+                          'repositoryNameWithOwner': repository,
+                          'branchName': branch,
+                      },
+                      'expectedHeadOid': base_sha,
+                      'message': {
+                          'headline': 'chore(governance): remove stale A11oy token-ingress promotion controller',
+                          'body': (
+                              'Remove the exact-bound one-shot controller after A11oy PR 1340 '
+                              'was already promoted through the protected repository path. Retaining '
+                              'a dormant write-capable controller for a closed target adds no release '
+                              'value and unnecessarily expands governance surface.\n\n'
+                              'Signed-off-by: github-actions[bot] '
+                              '<41898282+github-actions[bot]@users.noreply.github.com>\n'
+                              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>'
+                          ),
+                      },
+                      'fileChanges': {
+                          'deletions': [{'path': target_path}],
+                      },
+                  }
+              }
+              payload = api(
+                  'POST',
+                  'https://api.github.com/graphql',
+                  {'query': mutation, 'variables': variables},
+              )
+              if payload.get('errors'):
+                  raise SystemExit('createCommitOnBranch rejected the exact deletion')
+              head = str(payload['data']['createCommitOnBranch']['commit']['oid'])
+
+          if len(head) != 40 or any(ch not in '0123456789abcdef' for ch in head):
+              raise SystemExit('invalid cleanup commit OID')
+          commit = api('GET', f'https://api.github.com/repos/{repository}/commits/{head}')
+          verification = (commit.get('commit') or {}).get('verification') or {}
+          if verification.get('verified') is not True or verification.get('reason') != 'valid':
+              raise SystemExit('cleanup commit signature is not verified')
+          parents = commit.get('parents') or []
+          if len(parents) != 1 or parents[0].get('sha') != base_sha:
+              raise SystemExit('cleanup commit parent mismatch')
+          files = commit.get('files') or []
+          if len(files) != 1:
+              raise SystemExit('cleanup commit must change exactly one path')
+          row = files[0]
+          if row.get('filename') != target_path or row.get('status') != 'removed':
+              raise SystemExit('cleanup changed-path contract mismatch')
+          message = str((commit.get('commit') or {}).get('message') or '')
+          required = (
+              'Signed-off-by: github-actions[bot] '
+              '<41898282+github-actions[bot]@users.noreply.github.com>',
+              'Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>',
+          )
+          for trailer in required:
+              if trailer not in message:
+                  raise SystemExit(f'missing DCO trailer: {trailer}')
+          ref = api('GET', ref_url)
+          if ((ref.get('object') or {}).get('sha')) != head:
+              raise SystemExit('cleanup branch readback mismatch')
+          encoded_path = urllib.parse.quote(target_path, safe='')
+          missing = api(
+              'GET',
+              f'https://api.github.com/repos/{repository}/contents/{encoded_path}?ref={head}',
+              allow_missing=True,
+          )
+          if missing is not None:
+              raise SystemExit('stale controller still exists at cleanup head')
+          pathlib.Path('cleanup-builder-result.json').write_text(
+              json.dumps(
+                  {
+                      'schema': 'szl.stale-token-ingress-controller-cleanup-builder/v1',
+                      'base_sha': base_sha,
+                      'branch': branch,
+                      'commit_sha': head,
+                      'deleted_path': target_path,
+                      'signature_verified': True,
+                      'dco_verified': True,
+                      'file_absence_verified': True,
+                      'secret_values_emitted': False,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              ) + '\n',
+              encoding='utf-8',
+          )
+          PY
+          commit_sha="$(jq -er '.commit_sha' cleanup-builder-result.json)"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload builder evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stale-a11oy-token-ingress-controller-cleanup-builder
+          path: cleanup-builder-result.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Report cleanup identity
+        shell: bash
+        run: |
+          {
+            echo '### GitHub-signed stale token-ingress controller cleanup'
+            echo "- base: \`${{ steps.context.outputs.base_sha }}\`"
+            echo "- branch: \`${TARGET_BRANCH}\`"
+            echo "- head: \`${{ steps.publish.outputs.commit_sha }}\`"
+            echo "- deleted path: \`${TARGET_PATH}\`"
+            echo '- signature: verified'
+            echo '- DCO: verified'
+            echo '- post-commit file absence: verified'
+            echo '- secret values emitted: false'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Purpose

Temporary carrier for a GitHub-native signed deletion commit. The builder removes only `.github/workflows/a11oy-token-ingress-promotion.yml` from an exact child of protected `main@df399c5ece4c507a8cf52c6845f2c286fc842ac2`.

## Why cleanup is required

The controller was exact-bound to A11oy PR #1340, but #1340 was already merged through the protected A11oy path before this controller entered `.github/main`. Its target is closed and fulfilled, so retaining the dormant write-capable one-shot workflow adds no release value and unnecessarily expands the governance surface.

## Boundaries

- carrier stays draft and will not merge
- no project or organization secret is consumed
- no direct protected-main write
- no force update, ruleset mutation, approval, or merge
- target commit is created with GitHub `createCommitOnBranch`
- target commit must be GitHub-verified, one-parent, DCO-compliant, and delete exactly one path
- target cleanup is promoted only through a separate protected PR and independent Qillqaq review

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>