### PR TITLE
ci(notifications): schedule protected inbox-zero sweeps

### DIFF
--- a/.github/workflows/notification-inbox-scheduler.yml
+++ b/.github/workflows/notification-inbox-scheduler.yml
@@ -1,0 +1,45 @@
+name: GitHub Notification Inbox Scheduler
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/notification-inbox-scheduler.yml
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: github-personal-notification-scheduler
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch protected inbox-zero controller
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Dispatch the protected notification clearer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run clear-personal-notifications.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
+
+          echo 'The protected inbox-zero workflow was accepted for dispatch.'
+          echo 'That workflow owns the classic Notifications-scoped credential,'
+          echo 'moves read and unread Inbox threads to Done, publishes a count-only'
+          echo 'receipt, clears its receipt-generated thread, and fails unless both'
+          echo 'Inbox and Unread are exactly zero.'


### PR DESCRIPTION
## Outcome

Clean current-main successor to #446.

- schedules the existing protected notification clearer at minute 17 each hour;
- permits owner dispatch without exposing notification content;
- receives no personal notification credential;
- delegates all inventory, clearing, count-only receipt, and zero-count proof to the existing protected workflow;
- uses a concurrency lock and bounded scheduler timeout;
- changes one workflow only.

## Contract metadata

Satisfies: C-160

Labels: PROVED protected scheduler delegation and zero-content boundary; MEASURED exact-head checks and post-merge count-only clearance; NOT CLAIMED Inbox zero until the protected clearer reports exact zero Inbox and Unread counts.

Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a new DCO-compliant pull request; reverting disables the recurring clearance loop but does not alter notification content.

Risk: B — Actions dispatch only; no notification content, token value, repository source outside this workflow, branch protection, deployment, model, dataset, or Hugging Face resource is modified.

Solo-Operator-Authorization: confirmed

## Exact source

- protected base: `0e1ae51c0c88fe56f388f8d143d7119ed73e0795`
- exact head: `ad1a7b1c065256af00c4edee938bceda0f833de8`
- predecessor: #446 head `41b751e29d547bc8980b2b121caebbf3e5c61a53`
- one DCO-signed source commit

## Truth boundary

This PR installs the dispatch loop. It does not claim Inbox zero until the protected clearer publishes a new count-only receipt showing exact zero Inbox and Unread counts.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>