### PR TITLE
fix(dco): admit exact protected squash author

### DIFF
--- a/.github/scripts/dco_check.py
+++ b/.github/scripts/dco_check.py
@@ -1037,13 +1037,15 @@ def validate_github_squash_attestation(
         )
         source_author_identities.add((source_author_name, source_author_email))
     squash_identities = valid_dco_identities(message)
+    exact_squash_author = (author_name, author_email) in squash_identities
+    validated_source_author_fallback = any(
+        identity[1] == author_email and identity in source_author_identities
+        for identity in squash_identities
+    )
     require(
-        any(
-            identity[1] == author_email and identity in source_author_identities
-            for identity in squash_identities
-        ),
-        "provider squash Signed-off-by identity is not an exact validated "
-        "source-commit author identity",
+        exact_squash_author or validated_source_author_fallback,
+        "provider squash Signed-off-by identity does not exactly match the "
+        "squash author or a validated source-commit author",
     )
 
 

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -864,15 +864,15 @@ class DcoCheckTests(unittest.TestCase):
     def test_push_exact_identity_provider_squash_rejects_unsigned_source(self) -> None:
         unsigned_source = self.commit(
             "fix: unsigned provider source",
-            name="Lutar, Stephen P.",
-            email="builder@example.com",
+            name="Source Contributor",
+            email="contributor@example.com",
         )
         self.git("reset", "--hard", self.base)
         head = self.commit(
             "fix: exact-identity provider squash (#411)\n\n"
-            "Signed-off-by: Lutar, Stephen P. <builder@example.com>",
-            name="Lutar, Stephen P.",
-            email="builder@example.com",
+            "Signed-off-by: PR Creator <creator@example.com>",
+            name="PR Creator",
+            email="creator@example.com",
             committer_name="GitHub",
             committer_email="noreply@github.com",
         )
@@ -897,6 +897,55 @@ class DcoCheckTests(unittest.TestCase):
         self.assertIn(paths["commit"], calls)
         self.assertIn(paths["commits_page"], calls)
         self.assertEqual(source_fetches, [(411, unsigned_source)])
+
+    def test_push_exact_squash_author_can_differ_from_source_author(self) -> None:
+        source_head = self.commit(
+            "fix: source contribution\n\n"
+            "Signed-off-by: Source Contributor <contributor@example.com>",
+            name="Source Contributor",
+            email="contributor@example.com",
+        )
+        self.git("reset", "--hard", self.base)
+        head = self.commit(
+            "fix: exact squash author (#411)\n\n"
+            "Signed-off-by: PR Creator <creator@example.com>",
+            name="PR Creator",
+            email="creator@example.com",
+            committer_name="GitHub",
+            committer_email="noreply@github.com",
+        )
+        api_get, _, calls, paths = self.provider_api(
+            head,
+            [source_head],
+            source_head,
+        )
+        source_fetches: list[tuple[int, str]] = []
+
+        self.assertEqual(
+            dco.validate_push_range(
+                self.repo,
+                self.base,
+                head,
+                "szl-holdings/.github",
+                "",
+                api_get=api_get,
+                source_fetch=lambda number, sha: source_fetches.append((number, sha)),
+            ),
+            1,
+        )
+        self.assertEqual(source_fetches, [(411, source_head)])
+        self.assertEqual(
+            calls,
+            [
+                paths["commit"],
+                paths["pulls_page"],
+                paths["pulls_boundary"],
+                paths["metadata"],
+                paths["commits_page"],
+                paths["commits_boundary"],
+                paths["metadata"],
+            ],
+        )
 
     def test_push_exact_identity_provider_squash_validates_all_sources(self) -> None:
         source_first = self.commit(
@@ -1290,7 +1339,7 @@ class DcoCheckTests(unittest.TestCase):
             source_head,
         )
         self.assert_rejected(
-            "not an exact validated source-commit author identity",
+            "does not exactly match the squash author or a validated source-commit author",
             dco.validate_push_range,
             self.repo,
             self.base,


### PR DESCRIPTION
## Summary

Clean current-main successor to #432.

- admits an exact terminal signoff matching the raw GitHub squash author only after complete source-history validation;
- retains the existing exact validated source-author fallback for GitHub display-name canonicalization;
- proves a PR creator who did not author source bytes can still produce a valid protected squash;
- proves an exact squash-author signoff cannot excuse an unsigned source commit;
- changes only the DCO validator and its event/controller tests.

## Governance metadata

Satisfies: AT-22

Labels: PROVED fail-closed source-history and exact squash-author admission; MEASURED exact-head DCO, FORGE-9, security, doctrine, test, and CodeQL gates; NOT CLAIMED ruleset, bypass, deployment, review, or product-runtime mutation.

Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a new DCO-compliant governance pull request; reverting restores the known false rejection of valid squash authors but does not weaken source-commit validation.

Risk: D — changes the protected DCO admission predicate and production-path regressions. It does not change a ruleset, add a bypass actor, expose a secret, approve a review, enter the queue outside normal policy, or mutate product runtime.

Solo-Operator-Authorization: confirmed

## Fail-closed ordering

1. GitHub signature/account, exact parent, unique merged PR, base/head, pagination, pull ref, and graph bind first.
2. Every exact source commit passes the raw-object DCO validator.
3. Only then may the squash pass by exact raw squash-author signoff or the existing exact validated source-author identity with the same email.
4. Arbitrary same-email names, unsigned sources, malformed histories, stale metadata, and graph drift remain rejected.

## Exact source

- protected base: `0e1ae51c0c88fe56f388f8d143d7119ed73e0795`
- exact head: `9f630dc5ff2d50b3c9af536b497cf3fa65dcd102`
- predecessor reviewed implementation: #432 head `be752ab5a7d9c2820441f08cc057530d4687ab44`
- one DCO-signed source commit
- two changed files

## Review note

The Codex review request reached the configured usage limit rather than returning a review. No independent-review result is claimed. Exact-head hosted governance and security checks remain authoritative for this source transition.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>