### PR TITLE
ci(notifications): schedule protected inbox-zero sweeps

### DIFF
--- a/.github/workflows/notification-inbox-scheduler.yml
+++ b/.github/workflows/notification-inbox-scheduler.yml
@@ -1,0 +1,45 @@
+name: GitHub Notification Inbox Scheduler
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/notification-inbox-scheduler.yml
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: github-personal-notification-scheduler
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch protected inbox-zero controller
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Dispatch the protected notification clearer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run clear-personal-notifications.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
+
+          echo 'The protected inbox-zero workflow was accepted for dispatch.'
+          echo 'That workflow owns the classic Notifications-scoped credential,'
+          echo 'moves read and unread Inbox threads to Done, publishes a count-only'
+          echo 'receipt, clears its receipt-generated thread, and fails unless both'
+          echo 'Inbox and Unread are exactly zero.'


### PR DESCRIPTION
## Outcome

Current-main linear successor to #449 after the protected DCO repair merged as #456.

- schedules the existing protected notification clearer at minute 17 each hour;
- permits owner dispatch without exposing notification content;
- receives no personal notification credential;
- delegates inventory, clearing, count-only receipts, and zero-count proof to the existing protected workflow;
- uses a concurrency lock and a bounded scheduler timeout;
- changes one workflow only.

## Contract metadata

Satisfies: C-160

Labels: PROVED current-main one-parent scheduler delegation and zero-content boundary; MEASURED by exact-head FORGE-9, DCO, doctrine, security, and test checks; NOT CLAIMED Inbox zero until the protected clearer reports exact zero Inbox and Unread counts.

Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a new DCO-compliant pull request. Reverting disables the recurring dispatch loop but does not alter notification content.

Risk: B — Actions dispatch only. No notification content, token value, source outside this workflow, ruleset, deployment, model, dataset, or Hugging Face resource is modified.

Solo-Operator-Authorization: confirmed

## Exact source

- protected base: `efbd45ffa094f4e702ce3fbc470dd4a36705eb3e`
- exact head: `ce467aa530bc245afe926af70046098ec2a25766`
- predecessor: #449 head `ad1a7b1c065256af00c4edee938bceda0f833de8`
- one DCO-trailed source commit
- one changed workflow

## Truth boundary

This installs the dispatch loop. It does not claim Inbox zero until the protected clearer publishes a fresh count-only receipt showing exact zero Inbox and Unread counts.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>