### PR TITLE
ci(notifications): schedule protected inbox-zero sweeps

### DIFF
--- a/.github/workflows/notification-inbox-scheduler.yml
+++ b/.github/workflows/notification-inbox-scheduler.yml
@@ -1,0 +1,45 @@
+name: GitHub Notification Inbox Scheduler
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/notification-inbox-scheduler.yml
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: github-personal-notification-scheduler
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch protected inbox-zero controller
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Dispatch the protected notification clearer
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run clear-personal-notifications.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main
+
+          echo 'The protected inbox-zero workflow was accepted for dispatch.'
+          echo 'That workflow owns the classic Notifications-scoped credential,'
+          echo 'moves read and unread Inbox threads to Done, publishes a count-only'
+          echo 'receipt, clears its receipt-generated thread, and fails unless both'
+          echo 'Inbox and Unread are exactly zero.'


### PR DESCRIPTION
## Outcome

Current-main successor to #449 after the DCO controller repair merged.

- schedules the existing protected notification clearer at minute 17 each hour;
- permits owner dispatch without exposing notification content;
- receives no personal notification credential;
- delegates inventory, mark-Done clearance, count-only receipts, and exact-zero proof to the existing protected workflow;
- uses a concurrency lock and bounded scheduler timeout;
- changes one workflow only.

## Exact source

- protected base: `efbd45ffa094f4e702ce3fbc470dd4a36705eb3e`;
- exact head: `6be6f195989c86df56ad34ecb54197f8cbad43f2`;
- semantic source: #449 head `ad1a7b1c065256af00c4edee938bceda0f833de8`;
- current-main integration is additive and does not force-update predecessor history.

## Truth boundary

This installs the dispatch loop. It does not claim Inbox zero until the authenticated clearer publishes a receipt showing exact zero Inbox and Unread counts.

Satisfies: C-160

Risk: B — Actions dispatch only; no token value, notification content, branch protection, deployment, model, dataset, or Hugging Face resource is modified.

Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>