### PR TITLE
feat(hf): publish DCO-clean universal frontend verifier v1

### DIFF
--- a/.github/workflows/hf-universal-frontend-action-v1.yml
+++ b/.github/workflows/hf-universal-frontend-action-v1.yml
@@ -1,0 +1,131 @@
+name: HF universal frontend action v1
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - actions/hf-universal-frontend-v1/**
+      - docs/HF_UNIVERSAL_FRONTEND_ACTION_V1.md
+      - tests/test_hf_universal_frontend_action_v1.py
+      - .github/workflows/hf-universal-frontend-action-v1.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - actions/hf-universal-frontend-v1/**
+      - docs/HF_UNIVERSAL_FRONTEND_ACTION_V1.md
+      - tests/test_hf_universal_frontend_action_v1.py
+      - .github/workflows/hf-universal-frontend-action-v1.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-universal-frontend-action-v1-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install exact focused-test runtime
+        run: python3 -m pip install --disable-pip-version-check 'pytest==9.0.3'
+
+      - name: Verify action implementation and adversarial controls
+        run: |
+          python3 -m py_compile actions/hf-universal-frontend-v1/check.py
+          python3 -m pytest -q tests/test_hf_universal_frontend_action_v1.py
+
+      - name: Build an exact static fixture
+        run: |
+          python3 - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+          root = Path('/tmp/hf-frontend-action-fixture')
+          (root / 'docs').mkdir(parents=True)
+          (root / 'README.md').write_text(
+              '---\n'
+              'title: Fixture\n'
+              'sdk: static\n'
+              'app_file: index.html\n'
+              'short_description: Governed fixture\n'
+              'fullWidth: true\n'
+              'header: mini\n'
+              '---\n# Fixture\n',
+              encoding='utf-8',
+          )
+          (root / 'index.html').write_text(
+              '<html><head><meta name="viewport" content="width=device-width, initial-scale=1">'
+              '<link rel="stylesheet" href="./szl-universal-frontend.css" data-szl-universal-frontend="v1">'
+              '</head><body></body></html>',
+              encoding='utf-8',
+          )
+          (root / 'szl-universal-frontend.css').write_text(
+              '--szl-touch-target: 44px;\n'
+              'overflow-wrap: anywhere;\n'
+              'overflow-x: clip;\n'
+              '@media (max-width: 560px) {}\n'
+              '@media (prefers-reduced-motion: reduce) {}\n',
+              encoding='utf-8',
+          )
+          def digest(path):
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+          manifest = {
+              'schema': 'szl.hf-universal-frontend/v1',
+              'remote_mutation': False,
+              'sdk': 'static',
+              'framework': 'static',
+              'app_file': 'index.html',
+              'css_file': 'szl-universal-frontend.css',
+              'entry_file': None,
+              'contract': {
+                  'viewport_classes': [360, 390, 768, 1024, 1440],
+                  'minimum_touch_target_px': 44,
+                  'horizontal_overflow_allowed': False,
+                  'reduced_motion_required': True,
+                  'technical_identifier_wrapping_required': True,
+              },
+              'file_sha256': {
+                  'README.md': digest(root / 'README.md'),
+                  'index.html': digest(root / 'index.html'),
+                  'szl-universal-frontend.css': digest(root / 'szl-universal-frontend.css'),
+              },
+          }
+          (root / 'docs' / 'hf-universal-frontend-v1.json').write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          PY
+
+      - name: Execute the composite action against the fixture
+        id: fixture
+        uses: ./actions/hf-universal-frontend-v1
+        with:
+          root: /tmp/hf-frontend-action-fixture
+
+      - name: Verify composite outputs
+        env:
+          STATUS: ${{ steps.fixture.outputs.status }}
+          FRAMEWORK: ${{ steps.fixture.outputs.framework }}
+          MANIFEST_SHA256: ${{ steps.fixture.outputs.manifest_sha256 }}
+        run: |
+          test "$STATUS" = PASS
+          test "$FRAMEWORK" = static
+          test "${#MANIFEST_SHA256}" -eq 64

--- a/actions/hf-universal-frontend-v1/README.md
+++ b/actions/hf-universal-frontend-v1/README.md
@@ -1,0 +1,39 @@
+# SZL Hugging Face Universal Frontend Contract v1
+
+This composite action verifies a source-native Hugging Face frontend integration without writing to the repository or Hub.
+
+```yaml
+permissions:
+  contents: read
+
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+    with:
+      persist-credentials: false
+
+  - uses: szl-holdings/.github/actions/hf-universal-frontend-v1@<PINNED_COMMIT_SHA>
+```
+
+The caller must pin the action to an immutable commit SHA.
+
+## Required repository files
+
+- `README.md` with Hugging Face YAML front matter
+- `docs/hf-universal-frontend-v1.json`
+- the manifest-declared application entry point
+- the manifest-declared universal CSS file
+
+## Verified controls
+
+- safe repository-relative managed paths
+- exact `szl.hf-universal-frontend/v1` schema
+- `remote_mutation: false`
+- Static, Gradio, Streamlit, or React framework binding
+- short description of no more than 60 characters
+- `fullWidth: true` and `header: mini`
+- 44-pixel touch-target contract
+- five canonical viewport classes
+- overflow, reduced-motion, and identifier-wrapping CSS tokens
+- exact SHA-256 digests for all managed files
+
+The action does not create branches, commits, pull requests, deployments, Space revisions, model changes, dataset changes, collection changes, secrets, signer keys, storage mounts, visibility changes, or hardware allocations.

--- a/actions/hf-universal-frontend-v1/action.yml
+++ b/actions/hf-universal-frontend-v1/action.yml
@@ -1,0 +1,49 @@
+name: SZL Hugging Face universal frontend contract v1
+description: Verify source-native Hugging Face card, responsive CSS, framework binding, and managed-file digests.
+author: SZL Holdings
+
+inputs:
+  root:
+    description: Repository root containing README.md and the frontend manifest.
+    required: false
+    default: .
+  manifest:
+    description: Repository-relative frontend manifest path.
+    required: false
+    default: docs/hf-universal-frontend-v1.json
+
+outputs:
+  status:
+    description: PASS when every contract gate succeeds.
+    value: ${{ steps.verify.outputs.status }}
+  framework:
+    description: Detected framework recorded in the manifest.
+    value: ${{ steps.verify.outputs.framework }}
+  app_file:
+    description: Canonical application entry point.
+    value: ${{ steps.verify.outputs.app_file }}
+  css_file:
+    description: Universal frontend CSS path.
+    value: ${{ steps.verify.outputs.css_file }}
+  manifest_sha256:
+    description: SHA-256 digest of the verified manifest.
+    value: ${{ steps.verify.outputs.manifest_sha256 }}
+
+runs:
+  using: composite
+  steps:
+    - id: verify
+      name: Verify universal frontend contract
+      shell: bash
+      env:
+        INPUT_ROOT: ${{ inputs.root }}
+        INPUT_MANIFEST: ${{ inputs.manifest }}
+      run: >-
+        python3 "$GITHUB_ACTION_PATH/check.py"
+        --root "$INPUT_ROOT"
+        --manifest "$INPUT_MANIFEST"
+        --github-output "$GITHUB_OUTPUT"
+
+branding:
+  icon: monitor
+  color: blue

--- a/actions/hf-universal-frontend-v1/check.py
+++ b/actions/hf-universal-frontend-v1/check.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "szl.hf-universal-frontend/v1"
+ALLOWED_FRAMEWORKS = {"static", "gradio", "streamlit", "react"}
+PYTHON_MARKER = "# SZL_HF_UNIVERSAL_FRONTEND_V1"
+HTML_MARKER = 'data-szl-universal-frontend="v1"'
+REACT_MARKER = "// SZL_HF_UNIVERSAL_FRONTEND_V1"
+REQUIRED_CSS_TOKENS = (
+    "--szl-touch-target: 44px",
+    "overflow-wrap: anywhere",
+    "overflow-x: clip",
+    "@media (max-width: 560px)",
+    "@media (prefers-reduced-motion: reduce)",
+)
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ContractError(RuntimeError):
+    pass
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def safe_path(root: Path, value: Any, label: str) -> Path:
+    if isinstance(value, Path):
+        value = str(value)
+    if not isinstance(value, str) or not value.strip():
+        raise ContractError(f"{label} is absent or not a string")
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ContractError(f"{label} must be a safe repository-relative path: {value!r}")
+    resolved_root = root.resolve()
+    unresolved = resolved_root / relative
+    cursor = resolved_root
+    for part in relative.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise ContractError(f"{label} may not contain a symlink: {value!r}")
+    path = unresolved.resolve()
+    try:
+        path.relative_to(resolved_root)
+    except ValueError as error:
+        raise ContractError(f"{label} escapes the repository root: {value!r}") from error
+    if not path.is_file():
+        raise ContractError(f"{label} does not exist: {value!r}")
+    return path
+
+
+def parse_front_matter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        raise ContractError("README.md must start with Hugging Face YAML front matter")
+    end = text.find("\n---\n", 4)
+    if end < 0:
+        raise ContractError("README.md Hugging Face front matter is not terminated")
+    values: dict[str, str] = {}
+    duplicates: set[str] = set()
+    for line in text[4:end].splitlines():
+        match = re.match(r"^([A-Za-z0-9_-]+)\s*:\s*(.*?)\s*$", line)
+        if not match:
+            continue
+        key = match.group(1)
+        value = match.group(2).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        if key in values:
+            duplicates.add(key)
+        values[key] = value.strip()
+    if duplicates:
+        raise ContractError("README.md contains duplicate front-matter keys: " + ", ".join(sorted(duplicates)))
+    return values
+
+
+def validate_front_matter(values: dict[str, str], manifest: dict[str, Any]) -> None:
+    short = values.get("short_description") or values.get("shortDescription")
+    if not short:
+        raise ContractError("short_description is absent")
+    if len(short) > 60:
+        raise ContractError(f"short_description exceeds 60 characters: {len(short)}")
+    if values.get("fullWidth", "").lower() != "true":
+        raise ContractError("fullWidth must be true")
+    if values.get("header") != "mini":
+        raise ContractError("header must be mini")
+    sdk = values.get("sdk")
+    if not sdk:
+        raise ContractError("sdk is absent from README.md front matter")
+    app_file = values.get("app_file") or values.get("appFile")
+    if app_file and app_file != manifest.get("app_file"):
+        raise ContractError(
+            f"README app_file {app_file!r} diverges from manifest app_file {manifest.get('app_file')!r}"
+        )
+
+
+def validate_css(css_text: str) -> None:
+    missing = [token for token in REQUIRED_CSS_TOKENS if token not in css_text]
+    if missing:
+        raise ContractError("universal CSS is missing required tokens: " + ", ".join(missing))
+
+
+def validate_framework_binding(framework: str, app_text: str) -> None:
+    if framework in {"gradio", "streamlit"} and PYTHON_MARKER not in app_text:
+        raise ContractError("Python frontend binding marker is absent")
+    if framework == "gradio" and "_SZL_UNIVERSAL_CSS" not in app_text:
+        raise ContractError("Gradio universal CSS binding is absent")
+    if framework == "streamlit" and "unsafe_allow_html=True" not in app_text:
+        raise ContractError("Streamlit universal CSS binding is absent")
+    if framework == "static":
+        if HTML_MARKER not in app_text:
+            raise ContractError("Static universal CSS link marker is absent")
+        if not re.search(r"<meta\s+[^>]*name=[\"']viewport[\"']", app_text, re.IGNORECASE):
+            raise ContractError("Static viewport metadata is absent")
+    if framework == "react" and REACT_MARKER not in app_text:
+        raise ContractError("React universal CSS import marker is absent")
+
+
+def validate_hashes(
+    root: Path, hashes: Any, required_paths: set[str]
+) -> dict[str, str]:
+    if not isinstance(hashes, dict) or not hashes:
+        raise ContractError("file_sha256 is absent or empty")
+    missing = sorted(required_paths - set(hashes))
+    if missing:
+        raise ContractError(
+            "file_sha256 is missing managed paths: " + ", ".join(missing)
+        )
+    verified: dict[str, str] = {}
+    for relative, expected in sorted(hashes.items()):
+        if not isinstance(expected, str) or not SHA256.fullmatch(expected):
+            raise ContractError(f"invalid SHA-256 digest for {relative!r}")
+        path = safe_path(root, relative, f"file_sha256[{relative!r}]")
+        observed = sha256(path)
+        if observed != expected:
+            raise ContractError(
+                f"file hash mismatch for {relative}: expected {expected}, observed {observed}"
+            )
+        verified[str(relative)] = observed
+    return verified
+
+
+def validate(root: Path, manifest_path: Path) -> dict[str, Any]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise ContractError(f"repository root does not exist: {root}")
+    manifest_full = safe_path(root, manifest_path, "manifest")
+    try:
+        manifest = json.loads(manifest_full.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ContractError(f"manifest is not valid JSON: {error}") from error
+    if not isinstance(manifest, dict):
+        raise ContractError("manifest root must be a JSON object")
+    if manifest.get("schema") != SCHEMA:
+        raise ContractError(f"unexpected manifest schema: {manifest.get('schema')!r}")
+    if manifest.get("remote_mutation") is not False:
+        raise ContractError("manifest remote_mutation must be false")
+    framework = manifest.get("framework")
+    if framework not in ALLOWED_FRAMEWORKS:
+        raise ContractError(f"unsupported framework: {framework!r}")
+
+    # Resolve every manifest-controlled path before comparing descriptive
+    # metadata. This keeps traversal and containment failures authoritative.
+    readme = safe_path(root, "README.md", "README.md")
+    app = safe_path(root, manifest.get("app_file"), "app_file")
+    css = safe_path(root, manifest.get("css_file"), "css_file")
+    entry = None
+    if manifest.get("entry_file"):
+        entry = safe_path(root, manifest.get("entry_file"), "entry_file")
+
+    # Authenticate managed bytes before interpreting their contents. A changed
+    # file must report hash drift rather than an incidental downstream parse or
+    # framework-binding error.
+    required_hashes = {
+        "README.md",
+        str(manifest["app_file"]),
+        str(manifest["css_file"]),
+    }
+    if manifest.get("entry_file"):
+        required_hashes.add(str(manifest["entry_file"]))
+    hashes = validate_hashes(
+        root, manifest.get("file_sha256"), required_hashes
+    )
+
+    front = parse_front_matter(readme.read_text(encoding="utf-8"))
+    validate_front_matter(front, manifest)
+    validate_css(css.read_text(encoding="utf-8"))
+    binding_path = entry or app
+    validate_framework_binding(framework, binding_path.read_text(encoding="utf-8"))
+
+    contract = manifest.get("contract")
+    if not isinstance(contract, dict):
+        raise ContractError("manifest contract is absent")
+    if contract.get("minimum_touch_target_px") != 44:
+        raise ContractError("minimum_touch_target_px must be 44")
+    if contract.get("horizontal_overflow_allowed") is not False:
+        raise ContractError("horizontal_overflow_allowed must be false")
+    if contract.get("reduced_motion_required") is not True:
+        raise ContractError("reduced_motion_required must be true")
+    if contract.get("technical_identifier_wrapping_required") is not True:
+        raise ContractError("technical_identifier_wrapping_required must be true")
+    viewports = contract.get("viewport_classes")
+    if viewports != [360, 390, 768, 1024, 1440]:
+        raise ContractError(f"unexpected viewport_classes: {viewports!r}")
+
+    return {
+        "schema": "szl.hf-universal-frontend-contract-result/v1",
+        "status": "PASS",
+        "framework": framework,
+        "sdk": manifest.get("sdk"),
+        "app_file": manifest.get("app_file"),
+        "css_file": manifest.get("css_file"),
+        "entry_file": manifest.get("entry_file"),
+        "manifest_path": str(manifest_path),
+        "manifest_sha256": sha256(manifest_full),
+        "verified_files": hashes,
+        "remote_mutation": False,
+    }
+
+
+def write_github_output(path: Path, result: dict[str, Any]) -> None:
+    lines = {
+        "status": result["status"],
+        "framework": result["framework"],
+        "app_file": result["app_file"],
+        "css_file": result["css_file"],
+        "manifest_sha256": result["manifest_sha256"],
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in lines.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("docs/hf-universal-frontend-v1.json"),
+    )
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+    try:
+        result = validate(args.root, args.manifest)
+    except (ContractError, OSError, ValueError) as error:
+        print(json.dumps({"status": "FAIL", "error": str(error)}, indent=2, sort_keys=True))
+        return 1
+    if args.github_output:
+        write_github_output(args.github_output, result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/HF_UNIVERSAL_FRONTEND_ACTION_V1.md
+++ b/docs/HF_UNIVERSAL_FRONTEND_ACTION_V1.md
@@ -1,0 +1,46 @@
+# Organization-wide Hugging Face Universal Frontend Action v1
+
+## Architecture
+
+Each Space repository owns its framework-native adapter, application source, card metadata, and canonical deployment workflow. The organization repository owns one reusable, read-only verifier:
+
+```text
+source-native adapter
++ repository manifest
++ pinned organization verifier
++ protected merge
++ existing Space writer
++ estate-wide live census
+```
+
+This prevents two failure modes:
+
+1. copying one application shell across unrelated Static, Gradio, Streamlit, React, and Docker architectures;
+2. allowing local verifier forks to drift until identical claims have different meanings.
+
+## Trust boundary
+
+The shared action verifies only committed repository state. It has no network dependency and requires no token, secret, Hub credential, or write permission.
+
+It validates:
+
+- safe repository-relative managed paths
+- exact evidence schema
+- explicit non-mutation boundary
+- framework-native CSS binding
+- Hugging Face card metadata boundaries
+- five canonical viewport classes
+- 44-pixel touch targets
+- horizontal-overflow prohibition
+- reduced-motion and technical-identifier wrapping controls
+- exact managed-file SHA-256 digests
+
+It does not prove live runtime readiness. Live readiness remains the responsibility of the estate-wide browser census and source/runtime revision readback.
+
+## Pinning policy
+
+Callers must pin the action to a full immutable commit SHA. Floating references such as `main`, tags without immutable policy, or version branches are not admissible in protected CI.
+
+## Promotion policy
+
+The action is read-only. It may not create branches, commits, pull requests, releases, deployments, Hub revisions, model updates, dataset updates, collection changes, secrets, signer keys, storage mounts, visibility changes, or hardware allocations.

--- a/tests/test_hf_universal_frontend_action_v1.py
+++ b/tests/test_hf_universal_frontend_action_v1.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "actions" / "hf-universal-frontend-v1" / "check.py"
+SPEC = importlib.util.spec_from_file_location("hf_frontend_action_v1", CHECK)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+CSS = """--szl-touch-target: 44px;
+overflow-wrap: anywhere;
+overflow-x: clip;
+@media (max-width: 560px) {}
+@media (prefers-reduced-motion: reduce) {}
+"""
+
+
+def _sha(path: Path) -> str:
+    return MODULE.sha256(path)
+
+
+def _fixture(root: Path, framework: str = "static") -> None:
+    (root / "docs").mkdir(parents=True)
+    if framework == "static":
+        app = root / "index.html"
+        app.write_text(
+            '<html><head><meta name="viewport" content="width=device-width, initial-scale=1">'
+            '<link rel="stylesheet" href="./szl-universal-frontend.css" data-szl-universal-frontend="v1">'
+            "</head><body></body></html>",
+            encoding="utf-8",
+        )
+        app_file = "index.html"
+    elif framework == "gradio":
+        app = root / "app.py"
+        app.write_text(
+            "# SZL_HF_UNIVERSAL_FRONTEND_V1\n_SZL_UNIVERSAL_CSS = 'x'\n",
+            encoding="utf-8",
+        )
+        app_file = "app.py"
+    else:
+        raise AssertionError(framework)
+    css = root / "szl-universal-frontend.css"
+    css.write_text(CSS, encoding="utf-8")
+    (root / "README.md").write_text(
+        "---\n"
+        "title: Example\n"
+        "sdk: static\n"
+        f"app_file: {app_file}\n"
+        "short_description: Governed example\n"
+        "fullWidth: true\n"
+        "header: mini\n"
+        "---\n"
+        "# Example\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "schema": "szl.hf-universal-frontend/v1",
+        "remote_mutation": False,
+        "sdk": "static",
+        "framework": framework,
+        "app_file": app_file,
+        "css_file": "szl-universal-frontend.css",
+        "entry_file": None,
+        "contract": {
+            "viewport_classes": [360, 390, 768, 1024, 1440],
+            "minimum_touch_target_px": 44,
+            "horizontal_overflow_allowed": False,
+            "reduced_motion_required": True,
+            "technical_identifier_wrapping_required": True,
+        },
+        "file_sha256": {
+            "README.md": _sha(root / "README.md"),
+            app_file: _sha(app),
+            "szl-universal-frontend.css": _sha(css),
+        },
+    }
+    (root / "docs" / "hf-universal-frontend-v1.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_static_contract_passes(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    result = MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+    assert result["status"] == "PASS"
+    assert result["framework"] == "static"
+    assert result["remote_mutation"] is False
+
+
+def test_gradio_contract_passes(tmp_path: Path) -> None:
+    _fixture(tmp_path, "gradio")
+    result = MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+    assert result["framework"] == "gradio"
+
+
+def test_hash_drift_fails_closed(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    (tmp_path / "index.html").write_text("drift", encoding="utf-8")
+    with pytest.raises(MODULE.ContractError, match="hash mismatch"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_partial_hash_manifest_is_rejected(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    manifest_path = tmp_path / "docs" / "hf-universal-frontend-v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del payload["file_sha256"]["index.html"]
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(MODULE.ContractError, match="missing managed paths: index.html"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_path_traversal_is_rejected(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    manifest_path = tmp_path / "docs" / "hf-universal-frontend-v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["app_file"] = "../outside.py"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(MODULE.ContractError, match="safe repository-relative path"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_managed_file_symlink_is_rejected(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    app = tmp_path / "index.html"
+    target = tmp_path / "index-target.html"
+    app.rename(target)
+    app.symlink_to(target.name)
+    with pytest.raises(MODULE.ContractError, match="may not contain a symlink"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_missing_css_control_is_rejected(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    css = tmp_path / "szl-universal-frontend.css"
+    css.write_text(CSS.replace("overflow-x: clip;", ""), encoding="utf-8")
+    manifest_path = tmp_path / "docs" / "hf-universal-frontend-v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["file_sha256"]["szl-universal-frontend.css"] = _sha(css)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(MODULE.ContractError, match="missing required tokens"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_identifier_wrapping_contract_is_required(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    manifest_path = tmp_path / "docs" / "hf-universal-frontend-v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["contract"]["technical_identifier_wrapping_required"] = False
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(
+        MODULE.ContractError,
+        match="technical_identifier_wrapping_required must be true",
+    ):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_overlong_short_description_is_rejected(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    readme = tmp_path / "README.md"
+    readme.write_text(readme.read_text(encoding="utf-8").replace("Governed example", "x" * 61), encoding="utf-8")
+    manifest_path = tmp_path / "docs" / "hf-universal-frontend-v1.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["file_sha256"]["README.md"] = _sha(readme)
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(MODULE.ContractError, match="exceeds 60"):
+        MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+
+
+def test_github_output_is_bounded(tmp_path: Path) -> None:
+    _fixture(tmp_path)
+    result = MODULE.validate(tmp_path, Path("docs/hf-universal-frontend-v1.json"))
+    output = tmp_path / "github-output"
+    MODULE.write_github_output(output, result)
+    lines = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
+    assert lines["status"] == "PASS"
+    assert lines["framework"] == "static"
+    assert len(lines["manifest_sha256"]) == 64


### PR DESCRIPTION
## Outcome

Clean current-main one-parent successor to #461.

Publish one organization-wide, pinned, offline/read-only Hugging Face frontend contract action while preserving source-native framework adapters and repository-specific deployment ownership.

## Closed review findings

- accepts `pathlib.Path` values produced by the action CLI;
- requires SHA-256 coverage for README, app, CSS, and any declared entry file;
- rejects file and directory symlink components before resolution;
- requires the technical-identifier wrapping contract flag;
- authenticates managed bytes before semantic interpretation.

## Exact source

- protected base: `efbd45ffa094f4e702ce3fbc470dd4a36705eb3e`;
- exact head: `bb86e5c7f18adc1cf9fba5672ab45d7b1d1169fc`;
- semantic source: #461 head `e86974ab85fa852bbbd56a6fd991696026c1af7f`;
- one DCO-trailed source commit with exact author/trailer identity;
- six changed paths.

## Evidence

- focused verifier suite: 10 passed;
- extra nested-directory symlink negative control: passed;
- Python compilation and whitespace validation: passed;
- independent review: zero remaining P0-P2 findings.

## Safety boundary

The action is offline and read-only. It creates no branches, commits, pull requests, releases, deployments, Hub revisions, model changes, dataset changes, collection changes, secrets, signer keys, storage mounts, visibility changes, or hardware allocations.

Risk: B — reusable read-only composite action, focused test contract, documentation, and exact-head CI.

Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>