### PR TITLE
fix(hf): enable manual org-card publisher recovery

### DIFF
--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -1,6 +1,7 @@
 name: Hugging Face organization front door
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Scope

Adds an input-free `workflow_dispatch` trigger to the existing canonical Hugging Face organization-card publisher so an explicitly authorized operator can publish the current protected `main` successor after cancelling the two stale August 11 runs.

No publisher logic, permissions, secrets, environment, concurrency, manifests, assets, or other workflow behavior changes.

## Exact source evidence

- Protected base: `9731db892fdf0fe59d1b635b55a74a60ba0b7d6d`
- Signed head: `c1eea275453dcce479b9e0d7cfc875e989e88f65`
- Changed path: `.github/workflows/hf-org-card-deploy.yml`
- Diff: one insertion, zero deletions
- GitHub signature verification: `verified=true`, `reason=valid`
- DCO: `Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>`

## Validation

- `actionlint` v1.7.12 on the changed workflow: 0 errors
- Independent YAML parse: all 80 workflow files parsed
- Event assertion: exactly `push` and input-free `workflow_dispatch`
- `git diff --check`: passed
- Exact parent/path/clean-worktree assertions: passed
- Exact-head CodeQL JavaScript/TypeScript and Python: passed
- Exact-head tests, pinned-action check, doctrine, gitleaks, Trivy, and FORGE gates: passed
- Independent read-only review: CLEAN

Repository-wide actionlint still reports existing `job.workflow_*` expression findings in unrelated reusable workflows; the changed workflow is clean and none of those findings are introduced or touched here.

## Safety boundary

The workflow remains bound to the ref selected at dispatch and has no user-supplied branch input. Checkout has no `ref:` override, publication uses `$GITHUB_SHA`, permissions remain `contents: read`, credentials are not persisted, production environment approval remains required, and concurrency remains `hf-org-card-main` with `cancel-in-progress: false`.

The initial Native DCO failure was the workflow's intentional fail-closed response to draft status, not a missing trailer. This PR is now ready for the normal DCO rerun and protected merge queue. Publication, stale-run cancellation, production approval, and immutable Hugging Face readback remain post-merge operations and are not claimed here.
