### PR TITLE
fix(security): retire stale cross-repo deployment credential

### DIFF
--- a/.github/workflows/redeploy-a11oy-protected-main.yml
+++ b/.github/workflows/redeploy-a11oy-protected-main.yml
@@ -1,14 +1,17 @@
-name: Redeploy canonical A11oy from protected main
+name: Verify canonical A11oy recovery authority
 
-# One-shot recovery lane. It dispatches the existing a11oy/hf-sync.yml at an
-# exact protected-main revision, waits for the deployer's own parity/attestation
-# gates, and then independently verifies one public RUNNING canonical Space and
-# absence of all four retired clone IDs.
+# Read-only recovery verifier. Canonical deployment authority lives inside
+# szl-holdings/a11oy/.github/workflows/hf-sync.yml, where repository-native
+# github.token and managed Hugging Face authority are available. This workflow
+# intentionally carries no cross-repository PAT and no Hugging Face credential.
+
 on:
   push:
     branches: [main]
     paths:
-      - .github/workflows/redeploy-a11oy-protected-main.yml
+      - '.github/workflows/redeploy-a11oy-protected-main.yml'
+  schedule:
+    - cron: '43 8 * * 1'
   workflow_dispatch: {}
 
 permissions:
@@ -16,301 +19,230 @@ permissions:
   issues: write
 
 concurrency:
-  group: redeploy-a11oy-protected-main
+  group: verify-canonical-a11oy-recovery-authority
   cancel-in-progress: false
 
 jobs:
-  redeploy:
-    name: Dispatch, attest, and verify canonical A11oy
+  verify:
+    name: Verify repository-native deployment and current public parity
     runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
-      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      EXPECTED_A11OY_MAIN: 90ed8c7289efbda085d82f0dc60cf821b22f5caf
-      REPORT_ISSUE_TITLE: '[a11oy-canonical-redeploy] protected-main restoration'
+    timeout-minutes: 15
     steps:
-      - name: Checkout organization control plane
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
-          persist-credentials: false
-          fetch-depth: 1
+          egress-policy: audit
 
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Read exact protected source and public runtime
+        id: probe
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          A11OY_REPOSITORY: szl-holdings/a11oy
+          A11OY_ORIGIN: https://szlholdings-a11oy.hf.space
+          A11OY_SPACE_API: https://huggingface.co/api/spaces/SZLHOLDINGS/a11oy
+          REPORT_PATH: reports/a11oy-recovery-authority.json
         with:
-          python-version: '3.12'
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const report = {
+              schema: 'szl.a11oy-recovery-authority/v3',
+              generated_at: new Date().toISOString(),
+              canonical_deployment_workflow: 'szl-holdings/a11oy/.github/workflows/hf-sync.yml',
+              github_repository: process.env.A11OY_REPOSITORY,
+              origin: process.env.A11OY_ORIGIN,
+              source: null,
+              runtime: null,
+              huggingface: null,
+              ok: false,
+              errors: [],
+              boundaries: [
+                'No cross-repository PAT or Hugging Face token is consumed.',
+                'This workflow performs public/read-only source and runtime verification.',
+                'Deployment remains repository-native in a11oy/hf-sync.yml.',
+                'No Space, model, dataset, hardware, visibility, secret, ruleset, or branch is mutated.',
+              ],
+            };
 
-      - name: Install pinned Hub client
-        run: |
-          python -m pip install --disable-pip-version-check \
-            'huggingface_hub>=1.3,<2'
-
-      - name: Dispatch exact protected-main deploy and verify live singleton
-        id: recovery
-        shell: bash
-        run: |
-          set +e
-          mkdir -p reports
-          python - <<'PY'
-          from __future__ import annotations
-
-          import json
-          import os
-          import time
-          import urllib.error
-          import urllib.parse
-          import urllib.request
-          from datetime import datetime, timezone
-          from pathlib import Path
-          from typing import Any
-
-          from huggingface_hub import HfApi
-
-          GH_API = 'https://api.github.com'
-          GH_REPO = 'szl-holdings/a11oy'
-          WORKFLOW = 'hf-sync.yml'
-          HF_SPACE = 'SZLHOLDINGS/a11oy'
-          CLONES = [f'SZLHOLDINGS/a11oy-clone-{index}' for index in range(1, 5)]
-          EXPECTED = os.environ['EXPECTED_A11OY_MAIN']
-          REPORT = Path('reports/a11oy-protected-main-redeploy.json')
-          report: dict[str, Any] = {
-              'schema': 'szl.a11oy-protected-main-redeploy/v1',
-              'generated_at': datetime.now(timezone.utc).isoformat(),
-              'expected_github_source_sha': EXPECTED,
-              'github_repository': GH_REPO,
-              'huggingface_space': HF_SPACE,
-              'clone_ids': CLONES,
-              'dispatch': None,
-              'live': None,
-              'ok': False,
-              'errors': [],
-          }
-
-          def gh(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
-              token = os.environ.get('SZL_GITHUB_TOKEN', '').strip()
-              if not token:
-                  raise RuntimeError('SZL_GITHUB_TOKEN is not configured')
-              body = None if payload is None else json.dumps(payload).encode('utf-8')
-              request = urllib.request.Request(
-                  GH_API + path,
-                  data=body,
-                  method=method,
-                  headers={
-                      'Accept': 'application/vnd.github+json',
-                      'Authorization': f'Bearer {token}',
-                      'X-GitHub-Api-Version': '2022-11-28',
-                      'User-Agent': 'szl-a11oy-protected-main-redeploy/1.0',
-                      **({'Content-Type': 'application/json'} if body is not None else {}),
-                  },
-              )
-              try:
-                  with urllib.request.urlopen(request, timeout=45) as response:
-                      raw = response.read()
-              except urllib.error.HTTPError as exc:
-                  detail = exc.read().decode('utf-8', 'replace')[:4000]
-                  raise RuntimeError(
-                      f'GitHub API {method} {path} failed HTTP {exc.code}: {detail}'
-                  ) from exc
-              return json.loads(raw.decode('utf-8')) if raw else None
-
-          try:
-              if len(EXPECTED) != 40:
-                  raise RuntimeError('EXPECTED_A11OY_MAIN is not a full SHA')
-              int(EXPECTED, 16)
-
-              branch = gh('GET', f'/repos/{GH_REPO}/branches/main')
-              observed_main = str(((branch.get('commit') or {}).get('sha')) or '')
-              if observed_main != EXPECTED:
-                  raise RuntimeError(
-                      f'a11oy/main moved: expected {EXPECTED}, observed {observed_main}'
-                  )
-
-              dispatched_at = datetime.now(timezone.utc)
-              gh(
-                  'POST',
-                  f'/repos/{GH_REPO}/actions/workflows/{WORKFLOW}/dispatches',
-                  {'ref': 'main'},
-              )
-
-              run: dict[str, Any] | None = None
-              discovery_deadline = time.monotonic() + 180
-              while time.monotonic() < discovery_deadline:
-                  time.sleep(5)
-                  payload = gh(
-                      'GET',
-                      f'/repos/{GH_REPO}/actions/workflows/{WORKFLOW}/runs'
-                      '?event=workflow_dispatch&branch=main&per_page=20',
-                  )
-                  for candidate in payload.get('workflow_runs') or []:
-                      created_raw = str(candidate.get('created_at') or '')
-                      try:
-                          created = datetime.fromisoformat(created_raw.replace('Z', '+00:00'))
-                      except ValueError:
-                          continue
-                      if (
-                          candidate.get('head_sha') == EXPECTED
-                          and created >= dispatched_at
-                      ):
-                          run = candidate
-                          break
-                  if run:
-                      break
-              if not run:
-                  raise RuntimeError('dispatched hf-sync run was not discovered')
-
-              run_id = int(run['id'])
-              run_url = str(run.get('html_url') or '')
-              completion_deadline = time.monotonic() + 6600
-              while time.monotonic() < completion_deadline:
-                  current = gh('GET', f'/repos/{GH_REPO}/actions/runs/{run_id}')
-                  if current.get('status') == 'completed':
-                      run = current
-                      break
-                  time.sleep(15)
-              if run.get('status') != 'completed':
-                  raise RuntimeError(f'hf-sync run {run_id} did not complete in time')
-              if run.get('conclusion') != 'success':
-                  raise RuntimeError(
-                      f'hf-sync run {run_id} concluded {run.get("conclusion")}'
-                  )
-
-              report['dispatch'] = {
-                  'workflow': WORKFLOW,
-                  'run_id': run_id,
-                  'run_url': run_url,
-                  'head_sha': run.get('head_sha'),
-                  'status': run.get('status'),
-                  'conclusion': run.get('conclusion'),
+            async function readJson(url) {
+              const response = await fetch(url, {
+                headers: {
+                  accept: 'application/json',
+                  'user-agent': 'szl-a11oy-recovery-authority/3.0',
+                },
+                signal: AbortSignal.timeout(30000),
+              });
+              if (!response.ok) {
+                throw new Error(`GET ${new URL(url).pathname} returned HTTP ${response.status}`);
               }
+              return response.json();
+            }
 
-              hf_token = (
-                  os.environ.get('HF_ORG_TOKEN')
-                  or os.environ.get('HF_TOKEN')
-                  or ''
-              ).strip()
-              if not hf_token:
-                  raise RuntimeError('HF_ORG_TOKEN/HF_TOKEN is not configured')
-              api = HfApi(token=hf_token)
+            function immutableSha(value) {
+              const text = String(value || '').toLowerCase();
+              return /^[0-9a-f]{40}$/.test(text) ? text : '';
+            }
 
-              live_deadline = time.monotonic() + 1800
-              info = None
-              while time.monotonic() < live_deadline:
-                  info = api.space_info(HF_SPACE)
-                  runtime = getattr(info, 'runtime', None)
-                  stage_value = getattr(runtime, 'stage', None)
-                  stage_value = getattr(stage_value, 'value', stage_value)
-                  stage = str(stage_value or 'UNKNOWN').split('.')[-1].upper()
-                  sha = str(getattr(info, 'sha', '') or '')
-                  if stage == 'RUNNING' and len(sha) == 40:
-                      break
-                  time.sleep(15)
-              if info is None:
-                  raise RuntimeError('canonical Space metadata was not returned')
-
-              runtime = getattr(info, 'runtime', None)
-              stage_value = getattr(runtime, 'stage', None)
-              stage_value = getattr(stage_value, 'value', stage_value)
-              stage = str(stage_value or 'UNKNOWN').split('.')[-1].upper()
-              sha = str(getattr(info, 'sha', '') or '')
-              private = getattr(info, 'private', None)
-              files = set(api.list_repo_files(HF_SPACE, repo_type='space'))
-              clone_existence = {
-                  clone: bool(api.repo_exists(clone, repo_type='space'))
-                  for clone in CLONES
+            function runtimeRevision(runtime) {
+              for (const candidate of [runtime.sha, runtime.revision]) {
+                if (candidate && typeof candidate === 'object') {
+                  for (const nested of [candidate.sha, candidate.value, candidate.revision]) {
+                    const normalized = immutableSha(nested);
+                    if (normalized) {
+                      return normalized;
+                    }
+                  }
+                  continue;
+                }
+                const normalized = immutableSha(candidate);
+                if (normalized) {
+                  return normalized;
+                }
               }
-              if stage != 'RUNNING':
-                  raise RuntimeError(f'canonical Space stage is {stage}, not RUNNING')
-              if len(sha) != 40:
-                  raise RuntimeError(f'canonical Space SHA is not immutable: {sha!r}')
-              int(sha, 16)
-              if private is True:
-                  raise RuntimeError('canonical Space is private')
-              if 'Dockerfile' not in files:
-                  raise RuntimeError('canonical Space is missing Dockerfile')
-              remaining = [clone for clone, exists in clone_existence.items() if exists]
-              if remaining:
-                  raise RuntimeError(f'retired clone repositories still exist: {remaining}')
+              return '';
+            }
 
-              report['live'] = {
-                  'repo_id': HF_SPACE,
-                  'sha': sha,
-                  'stage': stage,
-                  'private': private,
-                  'dockerfile_present': True,
-                  'file_count': len(files),
-                  'clone_existence': clone_existence,
+            try {
+              const [owner, repo] = process.env.A11OY_REPOSITORY.split('/');
+              const commit = await github.rest.repos.getCommit({owner, repo, ref: 'main'});
+              const mainSha = immutableSha(commit.data.sha);
+              if (!mainSha) {
+                throw new Error('Protected main did not return a full immutable SHA.');
               }
-              report['ok'] = True
-          except Exception as exc:  # noqa: BLE001
-              report['errors'].append(f'{type(exc).__name__}: {exc}')
-          finally:
-              REPORT.write_text(
-                  json.dumps(report, indent=2, sort_keys=True) + '\n',
-                  encoding='utf-8',
-              )
+              report.source = {branch: 'main', sha: mainSha};
 
-          print(json.dumps(report, indent=2, sort_keys=True))
-          raise SystemExit(0 if report['ok'] else 1)
-          PY
-          code=$?
-          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
-          exit 0
+              const [buildInfo, livez, space] = await Promise.all([
+                readJson(`${process.env.A11OY_ORIGIN}/api/build-info`),
+                readJson(`${process.env.A11OY_ORIGIN}/api/livez`),
+                readJson(process.env.A11OY_SPACE_API),
+              ]);
 
-      - name: Upload immutable recovery receipt
+              const build = buildInfo && typeof buildInfo.build === 'object' ? buildInfo.build : {};
+              const deployed = immutableSha(build.revision);
+              const buildState = String(build.state || 'UNKNOWN').toUpperCase();
+              const receiptMinted = buildInfo?.receipt_minted;
+              const liveStatus = String(livez.status || 'UNKNOWN').toUpperCase();
+              const runtime = space && typeof space.runtime === 'object' ? space.runtime : {};
+              const stageRaw = runtime.stage && typeof runtime.stage === 'object'
+                ? runtime.stage.value
+                : runtime.stage;
+              const stage = String(stageRaw || 'UNKNOWN').split('.').pop().toUpperCase();
+              const repositorySha = immutableSha(space.sha);
+              const servedRuntimeSha = runtimeRevision(runtime);
+
+              report.runtime = {
+                deployed_git_sha: deployed || null,
+                build_state: buildState,
+                receipt_minted: receiptMinted,
+                livez_status: liveStatus,
+                source_matches_main: deployed === mainSha,
+              };
+              report.huggingface = {
+                repo_id: 'SZLHOLDINGS/a11oy',
+                repository_sha: repositorySha || null,
+                runtime_sha: servedRuntimeSha || null,
+                stage,
+                public: space.private !== true,
+                repository_sha_immutable: Boolean(repositorySha),
+                runtime_sha_immutable: Boolean(servedRuntimeSha),
+                runtime_matches_repository: Boolean(
+                  repositorySha && servedRuntimeSha && servedRuntimeSha === repositorySha
+                ),
+              };
+
+              if (deployed !== mainSha) {
+                report.errors.push(`Runtime revision ${deployed || 'UNKNOWN'} does not match protected main ${mainSha}.`);
+              }
+              if (buildState !== 'OBSERVED') {
+                report.errors.push(`Build identity state is ${buildState}, not OBSERVED.`);
+              }
+              if (receiptMinted !== false) {
+                report.errors.push(`Build identity receipt_minted is ${String(receiptMinted)}, not false.`);
+              }
+              if (liveStatus !== 'LIVE') {
+                report.errors.push(`Liveness status is ${liveStatus}.`);
+              }
+              if (stage !== 'RUNNING') {
+                report.errors.push(`Hugging Face runtime stage is ${stage}.`);
+              }
+              if (!repositorySha) {
+                report.errors.push('Hugging Face immutable repository head SHA was not observed.');
+              }
+              if (!servedRuntimeSha) {
+                report.errors.push('Hugging Face immutable served runtime SHA was not observed.');
+              }
+              if (repositorySha && servedRuntimeSha && servedRuntimeSha !== repositorySha) {
+                report.errors.push(
+                  `Hugging Face served runtime ${servedRuntimeSha} does not match repository head ${repositorySha}.`
+                );
+              }
+              if (space.private === true) {
+                report.errors.push('Canonical A11oy Space is private.');
+              }
+              report.ok = report.errors.length === 0;
+            } catch (error) {
+              report.errors.push(`${error.name || 'Error'}: ${error.message || String(error)}`);
+            }
+
+            fs.mkdirSync(path.dirname(process.env.REPORT_PATH), {recursive: true});
+            fs.writeFileSync(process.env.REPORT_PATH, JSON.stringify(report, null, 2) + '\n');
+            core.setOutput('ok', String(report.ok));
+            core.setOutput('source_sha', String(report.source?.sha || ''));
+            core.setOutput('deployed_sha', String(report.runtime?.deployed_git_sha || ''));
+            console.log(JSON.stringify({ok: report.ok, errors: report.errors}, null, 2));
+
+      - name: Persist deterministic recovery authority issue
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPORT_PATH: reports/a11oy-recovery-authority.json
+          REPORT_ISSUE: '252'
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, 'utf8'));
+            const body = [
+              '<!-- szl-a11oy-recovery-authority -->',
+              '# A11oy repository-native recovery authority',
+              '',
+              `- Control run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `- Control revision: \`${context.sha}\``,
+              `- Canonical deployer: \`${report.canonical_deployment_workflow}\``,
+              '',
+              '```json',
+              JSON.stringify(report, null, 2),
+              '```',
+              '',
+              'When red, execute or repair the canonical workflow inside `szl-holdings/a11oy`.',
+              'Do not restore a long-lived cross-repository deployment PAT.',
+            ].join('\n');
+            const issue_number = Number(process.env.REPORT_ISSUE);
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body,
+              state: report.ok ? 'closed' : 'open',
+              state_reason: report.ok ? 'completed' : undefined,
+            });
+
+      - name: Upload immutable recovery verification
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: a11oy-protected-main-redeploy-${{ github.run_id }}
-          path: reports/a11oy-protected-main-redeploy.json
+          name: a11oy-recovery-authority-${{ github.run_id }}-${{ github.run_attempt }}
+          path: reports/a11oy-recovery-authority.json
           if-no-files-found: error
           retention-days: 90
 
-      - name: Persist recovery receipt
+      - name: Enforce current repository-native parity
         if: always()
         env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
+          OK: ${{ steps.probe.outputs.ok }}
         run: |
           set -euo pipefail
-          test -f reports/a11oy-protected-main-redeploy.json
-          {
-            echo '<!-- szl-a11oy-protected-main-redeploy -->'
-            echo '# A11oy protected-main restoration'
-            echo
-            echo "- Control run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "- Control revision: \`${GITHUB_SHA}\`"
-            echo
-            echo '```json'
-            cat reports/a11oy-protected-main-redeploy.json
-            echo '```'
-          } > /tmp/a11oy-redeploy.md
-          issue_number="$(gh issue list \
-            --repo "$GITHUB_REPOSITORY" \
-            --state all \
-            --search "${REPORT_ISSUE_TITLE} in:title" \
-            --json number,title \
-            --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" \
-            | head -n1)"
-          if [ -n "$issue_number" ]; then
-            gh issue edit "$issue_number" \
-              --repo "$GITHUB_REPOSITORY" \
-              --body-file /tmp/a11oy-redeploy.md
-          else
-            gh issue create \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "$REPORT_ISSUE_TITLE" \
-              --body-file /tmp/a11oy-redeploy.md
+          if [ "${OK:-false}" != 'true' ]; then
+            echo '::error::A11oy is not proven current through its repository-native deployment authority.'
+            exit 1
           fi
-
-      - name: Enforce fail-closed result
-        if: always()
-        run: |
-          code="${{ steps.recovery.outputs.exit_code }}"
-          if [ -z "$code" ]; then code=2; fi
-          if [ "$code" -ne 0 ]; then
-            echo "::error::A11oy protected-main redeploy failed with exit ${code}"
-            exit "$code"
-          fi
-          echo 'A11oy protected-main redeploy verified.'
+          echo 'A11oy repository-native deployment authority and public parity are current.'


### PR DESCRIPTION
## Outcome

Clean current-protected-main successor to #458 and #473. Replace the obsolete organization-level A11oy deployment mutator with a read-only verifier. Canonical deployment authority remains repository-native in `szl-holdings/a11oy/.github/workflows/hf-sync.yml`.

## Exact source

- protected base: `1c013c0ceb96ce7edc628b3d88264abbc90851c1`;
- exact head: `d095b28799212a40f1a353984e171cb2de3d469c`;
- exact tree: `35bd14c2fe02f3db357775c2a99739a021b78968`;
- one DCO-trailed commit;
- one changed workflow;
- no merge commit, force update, PAT restoration, secret readback, deployment mutation, ruleset mutation, or direct-main write.

## Permanent correction

- consumes no cross-repository PAT and no Hugging Face credential;
- reads protected `a11oy/main`, public build/liveness endpoints, and public Space metadata;
- requires the established build identity contract and immutable source agreement;
- captures repository head and served runtime revision independently and requires equality;
- accepts the first valid nonempty runtime SHA across supported Hugging Face response fields;
- updates control issue #252 only with a secret-free receipt;
- directs any recovery to the repository-native deployer.

## Boundary

This source change does not claim current production parity. Only the protected post-merge verifier may publish that result.

Supersedes #458 and #473.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>