### PR TITLE
Add five-verticals map to the org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -63,6 +63,20 @@ Receipts, provenance, evaluation, and formal sources make claims inspectable.
 [Verify a receipt](https://a-11-oy.com/verify) or follow the
 [research lineage](https://github.com/szl-holdings/szl-papers).
 
+## Five verticals
+
+One governed core, applied to five markets. Stage is a **REPORTED** product
+state, never adoption, authorization, or revenue. The vertical map lives at
+[a11oy.net](https://a11oy.net).
+
+| Vertical | Surface | Stage (REPORTED) |
+| --- | --- | --- |
+| Governed inference | [a11oy](https://github.com/szl-holdings/a11oy) | Live console and receipt ledger |
+| Defense — counter-UAS + SDA | [killinchu](https://github.com/szl-holdings/killinchu) · [khipu-sda-core](https://github.com/szl-holdings/khipu-sda-core) | Live demonstration; effectors **SIMULATED** |
+| Insurance | [David Leads](https://github.com/szl-holdings/david-leads) | Live public-readonly workspace |
+| Finance | [szl-quant](https://github.com/szl-holdings/szl-quant) · [Space](https://huggingface.co/spaces/SZLHOLDINGS/szl-quant-live) | Paper-only research; not financial advice |
+| Real estate | governed workflows | **ROADMAP** — no surface exists yet |
+
 ## Investor path
 
 [Company front door](https://huggingface.co/spaces/SZLHOLDINGS/README) ·


### PR DESCRIPTION
## What

Adds a **Five verticals** section to `profile/README.md`, between "Four ways in" and "Investor path": a small table mapping each vertical (governed inference, defense, insurance, finance, real estate) to its canonical surface and an honestly-labeled REPORTED stage. Links the vertical map at a11oy.net and the new finance Space (SZLHOLDINGS/szl-quant-live).

## Why

Aligns the GitHub org front door with the Hugging Face estate and the revamped a11oy.net verticals showcase, so all three read identically: one governed core, five verticals.

## Doctrine compliance

- Stage column is explicitly REPORTED; no adoption, authorization, or revenue is claimed.
- Killinchu effectors remain labeled SIMULATED.
- Finance is labeled paper-only / not financial advice.
- Real estate is labeled ROADMAP with "no surface exists yet".
- No change to the huggingface/org-card manifest or the attested-sync machinery.

CI doctrine gates should validate the wording; happy to adjust if a guard flags a token.