### PR TITLE
chore(hf): refresh exact organization-card publication

### DIFF
--- a/huggingface/org-card/PUBLICATION_REFRESH_20260829.md
+++ b/huggingface/org-card/PUBLICATION_REFRESH_20260829.md
@@ -1,0 +1,14 @@
+# Organization-card publication refresh — 2026-08-29
+
+## Observed state
+
+- protected source before this refresh: `szl-holdings/.github@219a1f7bd4702beecfdeeb198873b285d2ebb4fa`
+- live `deployment.json` source revision: `fba2755a14bed4d48befce97e0acc96f3b58f0f5`
+- target: `SZLHOLDINGS/README`
+- live base URL: `https://szlholdings-readme.static.hf.space`
+
+## Purpose
+
+This source-bound receipt intentionally touches the organization-card publication path so the existing protected-main workflow republishes the already reviewed Series A card and verifies the exact resulting protected revision.
+
+It changes no model, dataset, kernel, evaluation, capability, authorization, deployment-quality, or investment claim. The production workflow and its immutable readback remain the authority for completion.

--- a/huggingface/org-card/PUBLICATION_REFRESH_20260829.md
+++ b/huggingface/org-card/PUBLICATION_REFRESH_20260829.md
@@ -2,13 +2,16 @@
 
 ## Observed state
 
-- protected source before this refresh: `szl-holdings/.github@219a1f7bd4702beecfdeeb198873b285d2ebb4fa`
+- last organization-card content revision: `szl-holdings/.github@219a1f7bd4702beecfdeeb198873b285d2ebb4fa`
+- protected repository main before this refresh: `szl-holdings/.github@efa0485e53cad22cc2b21de5e5bb6949f4249638`
 - live `deployment.json` source revision: `fba2755a14bed4d48befce97e0acc96f3b58f0f5`
 - target: `SZLHOLDINGS/README`
 - live base URL: `https://szlholdings-readme.static.hf.space`
 
 ## Purpose
 
-This source-bound receipt intentionally touches the organization-card publication path so the existing protected-main workflow republishes the already reviewed Series A card and verifies the exact resulting protected revision.
+This source-bound receipt intentionally touches the organization-card publication path so the existing protected-main workflow republishes the already reviewed Series A card from the exact resulting repository revision and verifies that revision through the live deployment readback.
+
+The profile-only commit after the card-content revision did not alter the card manifest or public bundle, but it advanced protected repository `main`; the publication contract must therefore bind the exact new signed squash revision produced by this refresh PR.
 
 It changes no model, dataset, kernel, evaluation, capability, authorization, deployment-quality, or investment claim. The production workflow and its immutable readback remain the authority for completion.


### PR DESCRIPTION
∩┐╜∩┐╜## Outcome

Trigger the existing protected-main `Hugging Face organization front door` publisher for the already reviewed Series A card and require exact live revision readback.

## Observed drift

- last organization-card content revision: `219a1f7bd4702beecfdeeb198873b285d2ebb4fa`
- protected repository main before this refresh: `efa0485e53cad22cc2b21de5e5bb6949f4249638`
- live organization-card `deployment.json`: `fba2755a14bed4d48befce97e0acc96f3b58f0f5`
- target: `SZLHOLDINGS/README`
- live base: `https://szlholdings-readme.static.hf.space`

## Bounded change

Adds and corrects one source-bound publication receipt under `huggingface/org-card/`, which is a declared workflow trigger path but is not part of the materialized public bundle. The profile-only commit after the card-content revision did not alter the org-card manifest or bundle, but it advanced protected repository `main`; publication must therefore bind the exact new signed squash revision produced by this PR.

No org-card copy, model, dataset, kernel, evaluation, capability, authorization, deployment-quality, or investment claim changes.

After signed squash merge, completion requires the production workflow to publish and verify the exact resulting protected-main revision through live `deployment.json`.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>

Satisfies: C-158
Labels: ops, hf, org-card publication refresh
Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a new DCO-signed pull request. Reverting removes the publication receipt trigger; it does not mutate Hugging Face except through the existing protected publisher.
Risk: D - receipt-only refresh of the existing org-card publisher. No product, model, evaluation, capability, or authorization claim changes.
Solo-Operator-Authorization: confirmed

