### PR TITLE
chore(hf): relock SZLHOLDINGS organization card

### DIFF
--- a/audit/HF_ORG_CARD_RELOCK_20260828.md
+++ b/audit/HF_ORG_CARD_RELOCK_20260828.md
@@ -1,0 +1,26 @@
+# Hugging Face organization-card relock — 2026-08-28
+
+This receipt forces one protected-main publication cycle for the current SZLHOLDINGS organization-card source.
+
+## Source of truth
+
+- GitHub repository: `szl-holdings/.github`
+- governed card source: `huggingface/org-card/README.md`
+- public organization: `https://huggingface.co/SZLHOLDINGS`
+- served source/readback: `https://szlholdings-readme.static.hf.space/deployment.json`
+
+The resulting protected `main` revision is the only admitted source revision for this relock. A successful workflow start, reachable Space, or cached organization page does not establish convergence.
+
+## Acceptance
+
+1. Exact-head GitHub checks and DCO are terminal green.
+2. Promotion occurs through the protected merge path.
+3. The repository-native org-card publisher materializes the current source and publishes it through the canonical SZLHOLDINGS README surface.
+4. Public deployment metadata independently reports the exact merged GitHub revision and expected source repository.
+5. The organization card remains below its enforced word budget and preserves the `CUTTING`, `SIMULATED`, `HISTORICAL`, `CONJECTURE`, `UNAVAILABLE`, and other evidence boundaries.
+6. Models, datasets, Spaces, kernels, and collections remain linked to their original repositories and lineage; no third-party artifact is relabeled as SZL-owned.
+7. Any stale, ambiguous, unavailable, or mismatched source/runtime identity remains non-green.
+
+This receipt changes no model weight, dataset payload, application behavior, credential, workflow permission, provider setting, or truth label.
+
+Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>


### PR DESCRIPTION
Force one protected publication cycle for the current GitHub-governed Hugging Face organization front door.

## Bound surfaces

- `huggingface/org-card/README.md`
- `SZLHOLDINGS/README`
- `https://huggingface.co/SZLHOLDINGS`
- public deployment/source readback

## Acceptance

- exact-head checks and DCO must be terminal green;
- promotion must use the protected merge path;
- the canonical publisher must report the exact merged GitHub revision through public deployment metadata;
- the card must preserve the enforced word budget, lineage, and all `CUTTING`, `SIMULATED`, `HISTORICAL`, `CONJECTURE`, and `UNAVAILABLE` boundaries;
- stale, ambiguous, or mismatched source/runtime identity remains non-green.

This PR adds only a relock receipt. It changes no model weight, dataset payload, application behavior, credential, workflow permission, provider setting, or truth label.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>