### PR TITLE
fix(app): grant qillqaq secret-name read

### DIFF
--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -11,9 +11,10 @@ import importlib.util
 import io
 import json
 import os
-from pathlib import Path
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _MODULE_PATH = os.path.join(_HERE, "code_security_drift.py")
@@ -23,6 +24,15 @@ _spec = importlib.util.spec_from_file_location("code_security_drift", _MODULE_PA
 assert _spec and _spec.loader
 csd = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(csd)
+
+_FORGE9_PATH = os.path.join(_HERE, "verify_forge9_governance.py")
+_forge9_spec = importlib.util.spec_from_file_location(
+    "verify_forge9_governance",
+    _FORGE9_PATH,
+)
+assert _forge9_spec and _forge9_spec.loader
+forge9 = importlib.util.module_from_spec(_forge9_spec)
+_forge9_spec.loader.exec_module(forge9)
 
 ORG = "szl-holdings"
 CFG = csd.CANONICAL_CONFIG_ID
@@ -305,6 +315,135 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
         permissions = manifest["default_permissions"]
         self.assertEqual(permissions["organization_administration"], "read")
         self.assertEqual(permissions["administration"], "read")
+        self.assertEqual(permissions["secrets"], "read")
+        self.assertNotIn("organization_secrets", permissions)
+
+    def test_every_app_token_mint_has_exact_permission_contract(self):
+        self.assertEqual(
+            forge9.APP_TOKEN_PERMISSION_CONTRACTS,
+            {
+                ".github/workflows/attest-and-approve.yml": (
+                    {
+                        "permission-administration": "read",
+                        "permission-checks": "read",
+                        "permission-contents": "read",
+                        "permission-metadata": "read",
+                        "permission-pull-requests": "write",
+                        "permission-statuses": "write",
+                    },
+                ),
+                ".github/workflows/ci-health-digest.yml": (
+                    {
+                        "permission-actions": "read",
+                        "permission-contents": "read",
+                        "permission-organization-administration": "read",
+                    },
+                ),
+                ".github/workflows/code-security-drift.yml": (
+                    {
+                        "permission-organization-administration": "read",
+                    },
+                ),
+                ".github/workflows/organization-control-sweep.yml": (
+                    {
+                        "permission-actions": "read",
+                        "permission-contents": "read",
+                        "permission-organization-administration": "read",
+                    },
+                ),
+                ".github/workflows/secret-health.yml": (
+                    {
+                        "permission-metadata": "read",
+                        "permission-secrets": "read",
+                    },
+                ),
+            },
+        )
+        forge9.verify_app_token_permissions()
+
+    def app_token_blocks_for(self, workflow: str) -> list[dict[str, str]]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = ".github/workflows/adversarial.yml"
+            path = root / relative
+            path.parent.mkdir(parents=True)
+            path.write_text(workflow, encoding="utf-8")
+            saved_root = forge9.ROOT
+            forge9.ROOT = root
+            try:
+                return forge9.app_token_permission_blocks(relative)
+            finally:
+                forge9.ROOT = saved_root
+
+    def assert_app_token_alias_rejected(self, workflow: str) -> None:
+        with (
+            contextlib.redirect_stderr(io.StringIO()) as stderr,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            self.app_token_blocks_for(workflow)
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("uses a YAML alias", stderr.getvalue())
+
+    def test_scalar_alias_cannot_hide_app_token_mint(self):
+        self.assert_app_token_alias_rejected(
+            "name: &mint "
+            + forge9.APP_TOKEN_ACTION
+            + "\njobs:\n  verify:\n    steps:\n      - uses: *mint\n"
+        )
+
+    def test_mapping_and_flow_aliases_cannot_duplicate_token_mints(self):
+        cases = (
+            (
+                "template: &mint\n"
+                f"  uses: {forge9.APP_TOKEN_ACTION}\n"
+                "jobs:\n  verify:\n    steps:\n      - *mint\n"
+            ),
+            (
+                "name: &mint reviewed\n"
+                "jobs:\n  verify:\n    steps: [*mint]\n"
+            ),
+            (
+                "name: &mínt reviewed\n"
+                "jobs:\n  verify:\n    steps:\n      - uses: *mínt\n"
+            ),
+        )
+        for workflow in cases:
+            with self.subTest(workflow=workflow):
+                self.assert_app_token_alias_rejected(workflow)
+
+    def test_quoted_alias_text_and_shell_globs_are_not_yaml_aliases(self):
+        workflow = (
+            'name: "*mint" # *comment_only\n'
+            "jobs:\n  verify:\n    steps:\n"
+            "      - run: echo *mint\n"
+            "      - run: |\n"
+            "          uses: *script_text_only\n"
+            "          case value in\n"
+            "            *) exit 0 ;;\n"
+            "          esac\n"
+            f"      - uses: {forge9.APP_TOKEN_ACTION}\n"
+            "        with:\n          permission-actions: read\n"
+        )
+        self.assertEqual(
+            self.app_token_blocks_for(workflow),
+            [{"permission-actions": "read"}],
+        )
+
+    def test_secret_permissions_are_isolated_to_secret_health(self):
+        secret_workflow = ".github/workflows/secret-health.yml"
+        for relative, blocks in forge9.APP_TOKEN_PERMISSION_CONTRACTS.items():
+            for permissions in blocks:
+                self.assertNotIn("permission-organization-secrets", permissions)
+                if relative == secret_workflow:
+                    self.assertEqual(
+                        permissions,
+                        {
+                            "permission-metadata": "read",
+                            "permission-secrets": "read",
+                        },
+                    )
+                else:
+                    self.assertNotIn("permission-secrets", permissions)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -11,6 +11,57 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 GOVERNANCE = ROOT / ".governance"
+APP_TOKEN_ACTION_PREFIX = "actions/create-github-app-token@"
+APP_TOKEN_ACTION = (
+    APP_TOKEN_ACTION_PREFIX + "bcd2ba49218906704ab6c1aa796996da409d3eb1"
+)
+APP_TOKEN_USES_LINE = re.compile(
+    r"^(?P<dash>-\s+)?uses\s*:\s*(?P<value>.*)$"
+)
+YAML_ALIAS_NODE = re.compile(
+    r"(?:^\s*(?:-\s+)?|:\s+|[\[\{,]\s*)"
+    r"\*[^\s\[\]\{\},]+(?=\s*(?:$|[,\]\}]))"
+)
+YAML_BLOCK_SCALAR_LINE = re.compile(
+    r"^(?:-\s+)?[^:#]+:\s*[>|][0-9+-]*\s*$"
+)
+APP_TOKEN_PERMISSION_CONTRACTS = {
+    ".github/workflows/attest-and-approve.yml": (
+        {
+            "permission-administration": "read",
+            "permission-checks": "read",
+            "permission-contents": "read",
+            "permission-metadata": "read",
+            "permission-pull-requests": "write",
+            "permission-statuses": "write",
+        },
+    ),
+    ".github/workflows/ci-health-digest.yml": (
+        {
+            "permission-actions": "read",
+            "permission-contents": "read",
+            "permission-organization-administration": "read",
+        },
+    ),
+    ".github/workflows/code-security-drift.yml": (
+        {
+            "permission-organization-administration": "read",
+        },
+    ),
+    ".github/workflows/organization-control-sweep.yml": (
+        {
+            "permission-actions": "read",
+            "permission-contents": "read",
+            "permission-organization-administration": "read",
+        },
+    ),
+    ".github/workflows/secret-health.yml": (
+        {
+            "permission-metadata": "read",
+            "permission-secrets": "read",
+        },
+    ),
+}
 
 GATES = [
     "gate/ground-truth",
@@ -83,6 +134,179 @@ def load_json(path: Path) -> object:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         fail(f"{path.relative_to(ROOT)} is not valid JSON: {exc}")
+
+
+def yaml_unquoted_syntax(line: str) -> str:
+    """Return YAML syntax outside quoted scalars and comments.
+
+    The App-token inventory is intentionally dependency-free, so it cannot
+    rely on a YAML loader to expand aliases.  Preserving only unquoted syntax
+    lets the inventory reject structural alias nodes without mistaking quoted
+    documentation, comments, or ordinary shell globs for YAML aliases.
+    """
+
+    syntax: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote == "'":
+            if char == "'":
+                if index + 1 < len(line) and line[index + 1] == "'":
+                    syntax.extend((" ", " "))
+                    index += 2
+                    continue
+                quote = None
+            syntax.append(" ")
+        elif quote == '"':
+            if char == "\\" and index + 1 < len(line):
+                syntax.extend((" ", " "))
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+            syntax.append(" ")
+        elif char in {"'", '"'}:
+            quote = char
+            syntax.append(" ")
+        elif char == "#" and (index == 0 or line[index - 1].isspace()):
+            break
+        else:
+            syntax.append(char)
+        index += 1
+    return "".join(syntax)
+
+
+def yaml_alias_line(lines: list[str]) -> int | None:
+    """Return the first structural alias line, excluding block-scalar text."""
+
+    block_scalar_indent: int | None = None
+    for line_number, line in enumerate(lines, start=1):
+        syntax = yaml_unquoted_syntax(line)
+        stripped = syntax.strip()
+        indent = len(syntax) - len(syntax.lstrip())
+        if block_scalar_indent is not None:
+            if not stripped or indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
+        if YAML_BLOCK_SCALAR_LINE.fullmatch(stripped):
+            block_scalar_indent = indent
+            continue
+        if YAML_ALIAS_NODE.search(syntax):
+            return line_number
+    return None
+
+
+def app_token_permission_blocks(relative: str) -> list[dict[str, str]]:
+    path = ROOT / relative
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        fail(f"cannot read App-token workflow {relative}: {exc}")
+
+    alias_line = yaml_alias_line(lines)
+    if alias_line is not None:
+        fail(
+            f"{relative}:{alias_line} uses a YAML alias; App-token "
+            "workflow inventory requires literal nodes"
+        )
+
+    # Count every structural action reference before parsing block-style steps.
+    # Unsupported flow mappings and folded scalars must fail closed instead of
+    # silently disappearing from the exact permission inventory.
+    structural_action_mentions = sum(
+        APP_TOKEN_ACTION_PREFIX in yaml_unquoted_syntax(line) for line in lines
+    )
+
+    blocks: list[dict[str, str]] = []
+    permission_line = re.compile(r"^(permission-[a-z0-9-]+):\s*(.*)$")
+    for action_index, line in enumerate(lines):
+        action_match = APP_TOKEN_USES_LINE.fullmatch(line.lstrip())
+        if (
+            action_match is None
+            or APP_TOKEN_ACTION_PREFIX not in action_match.group("value")
+        ):
+            continue
+        action_value = action_match.group("value").split(" #", 1)[0].rstrip()
+        if (
+            len(action_value) >= 2
+            and action_value[0] == action_value[-1]
+            and action_value[0] in {"'", '"'}
+        ):
+            action_value = action_value[1:-1]
+        if action_value != APP_TOKEN_ACTION:
+            fail(
+                f"{relative} App-token action is not pinned to the reviewed source"
+            )
+        action_indent = len(line) - len(line.lstrip()) + len(
+            action_match.group("dash") or ""
+        )
+        with_index = None
+        for index in range(action_index + 1, len(lines)):
+            candidate = lines[index]
+            stripped = candidate.strip()
+            indent = len(candidate) - len(candidate.lstrip())
+            if stripped == "with:" and indent == action_indent:
+                with_index = index
+                break
+            if stripped and indent < action_indent:
+                break
+        if with_index is None:
+            fail(f"{relative} App-token step has no literal with block")
+
+        with_indent = len(lines[with_index]) - len(lines[with_index].lstrip())
+        permissions: dict[str, str] = {}
+        for candidate in lines[with_index + 1 :]:
+            stripped = candidate.strip()
+            indent = len(candidate) - len(candidate.lstrip())
+            if stripped and indent <= with_indent:
+                break
+            match = permission_line.fullmatch(stripped)
+            if not match:
+                if "permission-" in stripped and not stripped.startswith("#"):
+                    fail(
+                        f"{relative} App-token permission input must be a literal key/value"
+                    )
+                continue
+            key, value = match.groups()
+            value = value.split(" #", 1)[0].rstrip()
+            if key in permissions:
+                fail(f"{relative} App-token step repeats {key}")
+            permissions[key] = value
+        blocks.append(permissions)
+
+    if len(blocks) != structural_action_mentions:
+        fail(
+            f"{relative} contains an App-token action in an unsupported YAML "
+            "representation; use one literal block-style step"
+        )
+    return blocks
+
+
+def verify_app_token_permissions() -> None:
+    workflow_root = ROOT / ".github" / "workflows"
+    discovered: dict[str, list[dict[str, str]]] = {}
+    for path in workflow_root.iterdir():
+        if not path.is_file() or path.suffix.lower() not in {".yml", ".yaml"}:
+            continue
+        relative = str(path.relative_to(ROOT))
+        blocks = app_token_permission_blocks(relative)
+        if blocks:
+            discovered[relative] = blocks
+    expected_paths = set(APP_TOKEN_PERMISSION_CONTRACTS)
+    if set(discovered) != expected_paths:
+        fail(
+            "App-token workflow inventory drifted: expected "
+            f"{sorted(expected_paths)!r}, observed {sorted(discovered)!r}"
+        )
+
+    for relative, expected_blocks in APP_TOKEN_PERMISSION_CONTRACTS.items():
+        observed = discovered[relative]
+        if observed != list(expected_blocks):
+            fail(
+                f"{relative} App-token permissions differ from the exact minimum: "
+                f"expected {list(expected_blocks)!r}, observed {observed!r}"
+            )
 
 
 def rule(rules: list[dict[str, object]], kind: str) -> dict[str, object]:
@@ -179,6 +403,7 @@ def verify_manifest() -> None:
         "metadata": "read",
         "organization_administration": "read",
         "pull_requests": "write",
+        "secrets": "read",
     }
     if permissions != expected:
         fail("GitHub App permissions differ from the reviewed minimum")
@@ -565,6 +790,7 @@ def verify_legacy_paths_removed() -> None:
 def main() -> int:
     verify_ruleset()
     verify_manifest()
+    verify_app_token_permissions()
     verify_gate_contract()
     verify_legacy_paths_removed()
     print("FORGE-9 bootstrap invariants verified")

--- a/.github/workflows/attest-and-approve.yml
+++ b/.github/workflows/attest-and-approve.yml
@@ -32,6 +32,12 @@ jobs:
           private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-administration: read
+          permission-checks: read
+          permission-contents: read
+          permission-metadata: read
+          permission-pull-requests: write
+          permission-statuses: write
 
       - name: Resolve the attestation subject
         id: subject

--- a/.github/workflows/secret-health.yml
+++ b/.github/workflows/secret-health.yml
@@ -1,9 +1,9 @@
 # Organization-wide required GitHub Actions secret-name audit.
 #
 # Authentication is App-first and fail-closed. qillqaq is requested with only
-# repository/organization Secrets read. Until that installation permission is
-# approved, the existing governed SZL_GITHUB_TOKEN is used read-only. The retired
-# SECRET_HEALTH_TOKEN PAT is never consumed.
+# repository Secrets read plus repository metadata. Until that installation
+# permission is approved, the existing governed SZL_GITHUB_TOKEN is used
+# read-only. The retired SECRET_HEALTH_TOKEN PAT is never consumed.
 
 name: Governed Secret Health
 
@@ -74,7 +74,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-metadata: read
           permission-secrets: read
-          permission-organization-secrets: read
 
       - name: Select governed machine identity without serializing it
         id: auth

--- a/.governance/github-app-manifest.json
+++ b/.governance/github-app-manifest.json
@@ -14,7 +14,8 @@
     "contents": "read",
     "metadata": "read",
     "organization_administration": "read",
-    "pull_requests": "write"
+    "pull_requests": "write",
+    "secrets": "read"
   },
   "default_events": []
 }


### PR DESCRIPTION
## Outcome

Current-main signed successor to #465. It preserves the reviewed five-file tree while removing the stale unsigned / behind-main history.

Live MEASURED: qillqaq-attestor installation 149072489 now has repository Secrets: read (accepted 2026-08-28). App registration and org install both list secrets:read.

This PR still has to prove exact-head secret-health exits 0 without governed-fallback.

- grants qillqaq repository Secrets: read for secret-name metadata only
- removes organization-wide secret metadata from the workflow contract
- constrains every GitHub App token mint to a literal minimum-permission set
- rejects structural YAML aliases that could evade token-mint inventory
- grants no secret-value access and no secret write authority

## Exact source

- protected base: current main
- source predecessor: #465 head 442e990080e55c5497d058e71ade52e58c266fca
- one DCO-trailed SSH-signed commit
- five changed files

## Acceptance

Do not merge until the live qillqaq-attestor installation has repository Secrets: read, the exact-head secret-health job exits 0 without governed-fallback, all strict checks are terminal green, and no secret value is emitted or preserved.

After protected squash merge, require a fresh protected-main secret-health run to report verified coverage.

Satisfies: C-158

Risk: D - GitHub App repository secret-name metadata read only.

Solo-Operator-Authorization: confirmed
