### PR TITLE
chore(hf): relock SZLHOLDINGS organization card on push

### DIFF
--- a/huggingface/org-card/RELOCK_20260829.md
+++ b/huggingface/org-card/RELOCK_20260829.md
@@ -1,0 +1,14 @@
+# Current-main publication relock — 2026-08-29
+
+This source-bound receipt exists only to force the canonical Hugging Face organization-card publication lane to consume the latest protected `main` through a `push` event.
+
+## Measured before this receipt
+
+- last successful publisher bind: `szl-holdings/.github@65b708072e530c6bd383094ed3efed45c0a7760f` (`#481`, event `push`)
+- live `deployment.json` source revision: `65b708072e530c6bd383094ed3efed45c0a7760f`
+- Hub Space SHA: `810a4a6e62b3854ac6d070de862f3bdf8cc7a6e8`
+- protected repository main at receipt authoring: `3a9562cf7cdc7575b707afa9f02915c2374454cd`
+- later `workflow_dispatch` run `33227181824` failed the publication-authority contract (`GITHUB_EVENT_NAME` must be `push`)
+- later push run `33226512445` (`#480`) was cancelled and did not rebind
+
+It changes no organization-card claims or presentation. Completion still requires the repository-native publisher to materialize the exact merged source and independently read back the served revision and bytes.


### PR DESCRIPTION
## Outcome

Force one protected publication cycle for the current GitHub-governed Hugging Face organization front door through a **push** on a watched org-card path. `workflow_dispatch` is contract-rejected (`GITHUB_EVENT_NAME` must be `push`).

## Bound surfaces

- `huggingface/org-card/RELOCK_20260829.md` (receipt only; not in the public bundle)
- `SZLHOLDINGS/README`
- `https://huggingface.co/SZLHOLDINGS`
- public `deployment.json` source readback

## Measured before this PR

- last successful bind: GitHub `.github#481` SHA `65b708072e530c6bd383094ed3efed45c0a7760f` (event `push`)
- live `deployment.json` revision: `65b708072e530c6bd383094ed3efed45c0a7760f`
- Hub Space SHA: `810a4a6e62b3854ac6d070de862f3bdf8cc7a6e8`
- protected main at authoring: `3a9562cf7cdc7575b707afa9f02915c2374454cd`
- `workflow_dispatch` run `33227181824` failed publication authority
- push run `33226512445` (`#480`) was cancelled and did not rebind

## Acceptance

- exact-head checks and DCO must be terminal green;
- promotion must use the protected merge path;
- the canonical publisher must report the exact merged GitHub revision through public deployment metadata;
- the card must preserve the enforced word budget, lineage, and all `CUTTING`, `SIMULATED`, `HISTORICAL`, `CONJECTURE`, and `UNAVAILABLE` boundaries;
- stale, ambiguous, or mismatched source/runtime identity remains non-green.

This PR adds only a relock receipt. It changes no model weight, dataset payload, application behavior, credential, workflow permission, provider setting, or truth label. Physical killinchu effector remains **SIMULATED**. Do not stamp LIVE/PROVED.

Satisfies: C-158
Labels: ops, hf, org-card publication refresh
Rollback: Before merge, close this pull request. After merge, revert the protected squash commit through a new DCO-signed pull request. Reverting removes the publication receipt trigger; it does not mutate Hugging Face except through the existing protected publisher.
Risk: D - receipt-only refresh of the existing org-card publisher. No product, model, evaluation, capability, or authorization claim changes.
Solo-Operator-Authorization: confirmed

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>