### PR TITLE
fix(frontend): enlarge org-card navigation hit regions

### DIFF
--- a/huggingface/org-card/index.html
+++ b/huggingface/org-card/index.html
@@ -66,7 +66,7 @@
     #szl-hf-org-card .szl-hf-brand { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 11px; min-height: var(--tap); text-decoration: none; font-weight: 780; letter-spacing: .08em; }
     #szl-hf-org-card .szl-hf-brand-mark { width: 11px; height: 11px; border-radius: 50%; background: var(--teal); box-shadow: 0 0 20px rgba(71, 215, 196, .5); }
     #szl-hf-org-card nav { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 6px; }
-    #szl-hf-org-card nav a { display: inline-flex; min-height: var(--tap); align-items: center; border-radius: 999px; padding: 0 12px; color: var(--muted); text-decoration: none; font-size: 14px; white-space: nowrap; }
+    #szl-hf-org-card nav a { display: inline-flex; min-width: 48px; height: 48px; min-height: var(--tap); align-items: center; justify-content: center; border-radius: 10px; padding: 0 12px; color: var(--muted); text-decoration: none; font-size: 14px; white-space: nowrap; }
     #szl-hf-org-card nav a:hover { background: rgba(71, 215, 196, .08); color: var(--ink); }
     #szl-hf-org-card nav a.szl-hf-primary-link { border: 1px solid rgba(215, 181, 94, .48); color: var(--gold-hi); }
 

--- a/tests/test_hf_org_card_touch_targets.py
+++ b/tests/test_hf_org_card_touch_targets.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_org_card_navigation_has_full_size_hit_regions() -> None:
+    html = Path("huggingface/org-card/index.html").read_text(encoding="utf-8")
+    rule = html.split("#szl-hf-org-card nav a {", 1)[1].split("}", 1)[0]
+    assert "min-width: 48px" in rule
+    assert "height: 48px" in rule
+    assert "min-height: var(--tap)" in rule
+    assert "justify-content: center" in rule
+    assert "border-radius: 10px" in rule
+    assert "border-radius: 999px" not in rule


### PR DESCRIPTION
## Outcome

Clean current-main successor to #488. It carries only the two verified effective files and excludes the superseded bot-authored workflow history.

The universal Hugging Face frontend canary found `Start`, `Portfolio`, and `Truth` visually 44px high but without a fully hit-testable 44×44 interior because the pill clipping consumed the corners.

## Correction

- render every organization-card navigation control at 48px height and at least 48px width;
- use a 10px rounded rectangle so a complete 44×44 interior remains hit-testable;
- keep `min-height: var(--tap)` and the shared `--tap: 44px` token required by the isolated embed contract;
- preserve responsive reflow, hover treatment, keyboard focus, safe-area handling, and source binding;
- add a permanent source regression for the geometry.

## Exact identity

- current protected parent: `c598fb1618a85526bfaf99f8f00b7ad8800d1fe2`
- exact clean head: `4b87cf32055a9176f1fc507e1506a4025a672061`
- exact tree: `f74476401f861cccf373aa07e47e223b3bd179e8`
- effective paths: `huggingface/org-card/index.html`, `tests/test_hf_org_card_touch_targets.py`
- no workflow file is added, modified, or deleted.

## Acceptance

Do not merge until exact-head DCO, embed hardening, tests, security gates, and CodeQL are terminal green. After protected merge, require the organization-card publisher and universal live frontend canary to pass on the served revision.

No administrator bypass, Replit dependency, secret mutation, provider-setting change, or domain mutation is included.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>