### PR TITLE
docs(estate): publish GitHub ↔ Hugging Face source-mirror registry

### DIFF
--- a/docs/GITHUB_HF_ALIGNMENT.md
+++ b/docs/GITHUB_HF_ALIGNMENT.md
@@ -1,0 +1,94 @@
+# GitHub ↔ Hugging Face alignment
+
+**Status:** `SOURCE_MIRROR_REGISTRY_PUBLISHED`  
+**Captured:** 2026-08-29T00:31:00-04:00  
+**Evidence class:** REPORTED  
+**Runtime:** DEMO
+
+GitHub `szl-holdings` is protected source. Hugging Face `SZLHOLDINGS` is the
+artifact, evaluation, and demonstration mirror — not customer production SaaS.
+
+This registry classifies **existing** cards against **existing** repositories.
+It does not mint a new public GitHub repository or Hugging Face Space.
+
+## Live recapture
+
+| Surface | Count | Source |
+| --- | ---: | --- |
+| GitHub authenticated search | 82 | `user:szl-holdings` |
+| GitHub org page shown | 69 | github.com/szl-holdings |
+| GitHub private observed | 5 | same search |
+| GitHub archived observed | 7 | same search |
+| Hub model cards | 40 | `/api/models?author=SZLHOLDINGS` |
+| Hub datasets | 28 | `/api/datasets?author=SZLHOLDINGS` |
+| Hub Spaces (API) | 31 | `/api/spaces?author=SZLHOLDINGS` |
+| Hub Spaces (org card) | 30 | huggingface.co/SZLHOLDINGS |
+| Hub collections | 13 | org card |
+| Kernel-tagged model cards | 15 | Hub tags `kernels` |
+
+Packet 4 snapshot remains 76 GitHub rows / 17 dedicated model cards / 27 Spaces.
+Delta is sprawl to classify, not a new product line.
+
+Remaining open PR: [`szl-holdings/.github#465`](https://github.com/szl-holdings/.github/pull/465)
+(external GitHub App permission — not closed by this map).
+
+## Rule
+
+1. Exact-name Kernel Hub packages already have GitHub twins. Hub is the publish mirror.
+2. Weight and adapter cards bind to [`szl-forge`](https://github.com/szl-holdings/szl-forge). GGUF children bind to [`szl-serve`](https://github.com/szl-holdings/szl-serve).
+3. Numpy silhouettes bind to [`szl-khipu`](https://github.com/szl-holdings/szl-khipu). Atlas stays [`SZLHOLDINGS/anatomy`](https://huggingface.co/spaces/SZLHOLDINGS/anatomy).
+4. Roadmap names (`qantu`, `waman`, `chakana`, `tinku`, `KILLINCHU-EYE`, org stub) stay Hub cards. Do not mint GitHub products for them.
+5. Spaces without a dedicated repo fold into anatomy, Forge, kernels, or Evidence Studio. Do not mint `cosmos` or `holographic` repositories.
+6. Wave 0 still **DENY**s new public repositories, Spaces, and product names.
+
+## Exact kernel / software twins
+
+| Hub | GitHub |
+| --- | --- |
+| SZLHOLDINGS/szl-kernels | szl-holdings/szl-kernels |
+| SZLHOLDINGS/szl-invariants | szl-holdings/szl-invariants |
+| SZLHOLDINGS/szl-blocked | szl-holdings/szl-blocked |
+| SZLHOLDINGS/szl-govsign | szl-holdings/szl-govsign |
+| SZLHOLDINGS/szl-provctl | szl-holdings/szl-provctl |
+| SZLHOLDINGS/szl-ouroboros | szl-holdings/szl-ouroboros |
+| SZLHOLDINGS/szl-formulas | szl-holdings/szl-formulas |
+| SZLHOLDINGS/szl-lambda-gate | szl-holdings/szl-lambda-gate |
+| SZLHOLDINGS/szl-governed-norm | szl-holdings/szl-governed-norm |
+| SZLHOLDINGS/governed-inference-meter | szl-holdings/governed-inference-meter |
+| SZLHOLDINGS/szl-receipt-attn | szl-holdings/szl-receipt-attn |
+| SZLHOLDINGS/szl-maskmod | szl-holdings/szl-maskmod |
+| SZLHOLDINGS/szl-block-kv | szl-holdings/szl-block-kv |
+| SZLHOLDINGS/YARQA-ATTN | szl-holdings/YARQA-ATTN |
+| SZLHOLDINGS/szl-nemo | szl-holdings/szl-nemo |
+| SZLHOLDINGS/szl-khipu | szl-holdings/szl-khipu |
+| SZLHOLDINGS/szl-lake | szl-holdings/szl-lake |
+
+## Weight lineage (Forge)
+
+SZL-Khipu-1.5B, SZL-Forge-1.5B-ReceiptAgent, szl-receiptagent-qwen35-0.8b-v2,
+SZL-Khipu-1.5B-abstain, KHIPU-R2, WILLAY, chaski, chaski-5050, chaski-r2,
+szl-training-scripts → `szl-holdings/szl-forge`.
+
+SZL-Khipu-1.5B-GGUF → `szl-holdings/szl-serve`.
+A11OY-MINI → `szl-holdings/a11oy`.
+TinyKhipu-Nano / ReceiptAgent-Nano / Moons-Nano → `szl-holdings/szl-khipu`.
+MiniEmbed-Nano / szl-khipu-kernels → `szl-holdings/szl-kernels`.
+
+## Flagship Spaces (paired)
+
+a11oy, killinchu, anatomy, yarqa, hatun-mcp, sda, immune, david-leads,
+szl-khipu, ayllu, nexus, plus the hologram twins
+(governed-norm-holo, lambda-gate-holo, energy-attest-holo, receipt-chain-live,
+szl-provctl-live, szl-kernels-live).
+
+`SZLHOLDINGS/cosmos` has no GitHub twin — fold into anatomy. Do not mint.
+
+## What this is not
+
+- Not ATO, paid pilot, ROI, or live BFT.
+- Not 9000 invented live nodes. Second-brain count remains UNAVAILABLE.
+- Not a Hugging Face mutation. This OS cannot write the Hub.
+- Not a pin change. Front-door pin target remains
+  `.github`, `a11oy`, `platform`, `docs-site`, `a11oy-net`, `killinchu`.
+
+Λ uniqueness remains **Conjecture 1**. Khipu BFT remains **Conjecture 2**.

--- a/docs/github_hf_alignment.json
+++ b/docs/github_hf_alignment.json
@@ -1,0 +1,36 @@
+{
+  "schema": "szl.github-hf-alignment/v1",
+  "status": "SOURCE_MIRROR_REGISTRY_PUBLISHED",
+  "capturedAt": "2026-08-29T00:31:00-04:00",
+  "evidenceClass": "REPORTED",
+  "runtimeState": "DEMO",
+  "rule": "GitHub is protected source. Hugging Face is the artifact mirror, not customer production.",
+  "github": {
+    "org": "szl-holdings",
+    "searchTotal": 82,
+    "orgPageShown": 69,
+    "privateObserved": 5,
+    "archivedObserved": 7,
+    "remainingOpenPr": "szl-holdings/.github#465"
+  },
+  "huggingface": {
+    "org": "SZLHOLDINGS",
+    "models": 40,
+    "datasets": 28,
+    "spacesApi": 31,
+    "spacesOrgCard": 30,
+    "collections": 13,
+    "kernelTaggedModels": 15
+  },
+  "packet": {
+    "githubAuthenticated": 76,
+    "hfModelsDedicated": 17,
+    "hfSpaces": 27
+  },
+  "denies": [
+    "No new public GitHub repository",
+    "No new Hugging Face Space or model-brand",
+    "No ATO, paid pilot, ROI, or live BFT",
+    "No 9000-node second-brain invention"
+  ]
+}

--- a/profile/README.md
+++ b/profile/README.md
@@ -91,10 +91,8 @@ universal safety, customer adoption, or an investment outcome.
 [Hatun MCP](https://github.com/szl-holdings/hatun-mcp) ·
 [Runtime substrate](https://github.com/szl-holdings/szl-substrate)
 
-Read each artifact's license and limits before use.
-The [public experience standard](https://github.com/szl-holdings/.github/blob/main/docs/PUBLIC_EXPERIENCE_STANDARD.md)
-and [estate lifecycle map](https://github.com/szl-holdings/.github/blob/main/docs/ESTATE_LIFECYCLE.md)
-define the shared contract.
+[Public experience](https://github.com/szl-holdings/.github/blob/main/docs/PUBLIC_EXPERIENCE_STANDARD.md)
+and [lifecycle](https://github.com/szl-holdings/.github/blob/main/docs/ESTATE_LIFECYCLE.md).
 
 ## Current state
 
@@ -106,6 +104,12 @@ define the shared contract.
 
 The dataset [`SZLHOLDINGS/SZLHOLDINGS`](https://huggingface.co/datasets/SZLHOLDINGS/SZLHOLDINGS)
 is a **HISTORICAL** mirror, not a current card or runtime source.
+
+
+## GitHub ↔ Hugging Face
+
+GitHub is protected source. Hugging Face is the artifact mirror.
+[Alignment registry](https://github.com/szl-holdings/.github/blob/main/docs/GITHUB_HF_ALIGNMENT.md).
 
 ## Truth language
 


### PR DESCRIPTION
## Why this PR exists

Founder asked to approve and publish GitHub alignment with Hugging Face `SZLHOLDINGS`.

GitHub is protected source. Hub is the artifact mirror. This PR publishes the live pairing on the existing org front door.

## Recapture 2026-08-29 (REPORTED)

- GitHub `szl-holdings`: 82 authenticated repositories
- Hub `SZLHOLDINGS`: 40 model cards, 28 datasets, 31 Spaces (API) / 30 (org card), 13 collections

## What this is

- Classification of existing Hub cards against existing GitHub authorities
- Kernel Hub packages keep exact GitHub twins
- Weight cards bind to `szl-forge`; GGUF to `szl-serve`; silhouettes to `szl-khipu`
- Roadmap names stay Hub cards

## What this is not

- Not a new public repository or Hugging Face Space
- Not ATO, paid pilot, ROI, or live BFT
- Not a pin change
- Not a Hub mutation (this OS cannot write Hugging Face)
- Wave 0 still denies minting

Remaining open: `.github#465` (GitHub App permission).