### PR TITLE
ci: publish operator Docker Spaces (szl-sovereign-os, szl-real-estate)

### DIFF
--- a/.github/workflows/publish-operator-spaces.yml
+++ b/.github/workflows/publish-operator-spaces.yml
@@ -1,4 +1,5 @@
 # Copyright 2026 SZL Holdings — SPDX-License-Identifier: Apache-2.0
+# Mirror GitHub canonical sources onto SZLHOLDINGS Docker Spaces.
 name: Publish operator Spaces
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-operator-spaces.yml
+++ b/.github/workflows/publish-operator-spaces.yml
@@ -1,0 +1,166 @@
+# Copyright 2026 SZL Holdings — SPDX-License-Identifier: Apache-2.0
+name: Publish operator Spaces
+on:
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: Comma-separated szl-holdings repo names to mirror as Docker Spaces
+        required: false
+        default: szl-sovereign-os,szl-real-estate
+permissions:
+  contents: read
+concurrency:
+  group: publish-operator-spaces
+  cancel-in-progress: false
+jobs:
+  publish:
+    name: Publish with repo secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      published: ${{ steps.push.outputs.published }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - run: pip install huggingface_hub
+      - name: Clone operator sources
+        env:
+          REPOS: ${{ github.event.inputs.repos }}
+        run: |
+          set -euo pipefail
+          mkdir -p siblings
+          IFS=',' read -ra RS <<< "${REPOS}"
+          for r in "${RS[@]}"; do
+            r=$(echo "$r" | xargs)
+            git clone --depth 1 "https://github.com/szl-holdings/${r}.git" "siblings/${r}"
+          done
+      - id: push
+        name: Push Docker Spaces
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+          HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+          REPOS: ${{ github.event.inputs.repos }}
+        run: |
+          python - <<'PY'
+          import os, sys
+          from pathlib import Path
+          token = (
+              os.environ.get("HF_TOKEN")
+              or os.environ.get("HF_ORG_TOKEN")
+              or os.environ.get("HF_WRITE_TOKEN")
+              or ""
+          )
+          if not token:
+              print("HF_TOKEN UNAVAILABLE on repo secrets — production job will retry. Not fabricated LIVE.")
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                  fh.write("published=false\n")
+              sys.exit(0)
+          from huggingface_hub import HfApi, create_repo, space_info
+          api = HfApi(token=token)
+          published = []
+          for name in [r.strip() for r in os.environ.get("REPOS", "").split(",") if r.strip()]:
+              folder = Path("siblings") / name
+              if not folder.exists():
+                  print(f"UNAVAILABLE source folder {folder}")
+                  sys.exit(2)
+              repo_id = f"SZLHOLDINGS/{name}"
+              create_repo(
+                  repo_id,
+                  repo_type="space",
+                  space_sdk="docker",
+                  exist_ok=True,
+                  token=token,
+                  private=False,
+              )
+              api.upload_folder(
+                  folder_path=str(folder),
+                  repo_id=repo_id,
+                  repo_type="space",
+                  ignore_patterns=[".git*", ".github/**", "tests/*", ".venv/*", "__pycache__/*"],
+              )
+              info = space_info(repo_id, token=token)
+              print(f"published {repo_id} sdk={getattr(info, 'sdk', None)}")
+              published.append(repo_id)
+          print(f"MEASURED published={published}")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write("published=true\n")
+          PY
+
+  publish-production:
+    name: Publish with production environment secrets
+    needs: publish
+    if: needs.publish.outputs.published != 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - run: pip install huggingface_hub
+      - name: Clone operator sources
+        env:
+          REPOS: ${{ github.event.inputs.repos }}
+        run: |
+          set -euo pipefail
+          mkdir -p siblings
+          IFS=',' read -ra RS <<< "${REPOS}"
+          for r in "${RS[@]}"; do
+            r=$(echo "$r" | xargs)
+            git clone --depth 1 "https://github.com/szl-holdings/${r}.git" "siblings/${r}"
+          done
+      - name: Push Docker Spaces via production
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+          HF_WRITE_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+          REPOS: ${{ github.event.inputs.repos }}
+        run: |
+          python - <<'PY'
+          import os, sys
+          from pathlib import Path
+          token = (
+              os.environ.get("HF_TOKEN")
+              or os.environ.get("HF_ORG_TOKEN")
+              or os.environ.get("HF_WRITE_TOKEN")
+              or ""
+          )
+          if not token:
+              print("HF_TOKEN UNAVAILABLE even on production environment. Not fabricated LIVE.")
+              sys.exit(2)
+          from huggingface_hub import HfApi, create_repo, space_info
+          api = HfApi(token=token)
+          published = []
+          for name in [r.strip() for r in os.environ.get("REPOS", "").split(",") if r.strip()]:
+              folder = Path("siblings") / name
+              if not folder.exists():
+                  print(f"UNAVAILABLE source folder {folder}")
+                  sys.exit(2)
+              repo_id = f"SZLHOLDINGS/{name}"
+              create_repo(
+                  repo_id,
+                  repo_type="space",
+                  space_sdk="docker",
+                  exist_ok=True,
+                  token=token,
+                  private=False,
+              )
+              api.upload_folder(
+                  folder_path=str(folder),
+                  repo_id=repo_id,
+                  repo_type="space",
+                  ignore_patterns=[".git*", ".github/**", "tests/*", ".venv/*", "__pycache__/*"],
+              )
+              info = space_info(repo_id, token=token)
+              print(f"published {repo_id} sdk={getattr(info, 'sdk', None)}")
+              published.append(repo_id)
+          print(f"MEASURED published={published}")
+          PY


### PR DESCRIPTION
New public repos do not inherit the Hub write token. This org repo is listed in `required_actions_secrets.json` as holding `HF_TOKEN`.

Adds `publish-operator-spaces.yml`:
1. Try repo secrets (`HF_TOKEN`, `HF_ORG_TOKEN`, `HF_ORG_TOKEN1`, `HF_WRITE_TOKEN`)
2. If empty, retry with the `production` environment (same as `hf-org-card-deploy.yml`)

Mirrors GitHub canonical sources to:
- `SZLHOLDINGS/szl-sovereign-os` (Docker, 7860)
- `SZLHOLDINGS/szl-real-estate` (Docker, 7860)

Fail-closed. Do not claim RUNNING without Hub readback.

Doctrine v11. Λ = Conjecture 1. Apache-2.0.