### PR TITLE
ci(hf): bind protected A11oy factory Space from org token

### DIFF
--- a/.github/workflows/bind-a11oy-factory-space.yml
+++ b/.github/workflows/bind-a11oy-factory-space.yml
@@ -8,8 +8,9 @@ jobs:
     name: Create private Docker Space SZLHOLDINGS/a11oy-factory
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: production
     env:
-      HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN }}
+      HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
       HF_HUB_DISABLE_PROGRESS_BARS: "1"
     steps:
       - name: Checkout factory source

--- a/.github/workflows/bind-a11oy-factory-space.yml
+++ b/.github/workflows/bind-a11oy-factory-space.yml
@@ -1,0 +1,34 @@
+name: Bind protected A11oy factory Space
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  bind:
+    name: Create private Docker Space SZLHOLDINGS/a11oy-factory
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN }}
+      HF_HUB_DISABLE_PROGRESS_BARS: "1"
+    steps:
+      - name: Checkout factory source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: szl-holdings/a11oy-factory
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hugging Face client
+        run: >-
+          python -m pip install --disable-pip-version-check
+          "huggingface_hub==1.23.0"
+
+      - name: Create protected factory Space
+        run: python .github/scripts/publish_factory_space.py


### PR DESCRIPTION
Owner order AO-2026-08-29-001.

`szl-holdings/a11oy-factory` cannot read `HF_ORG_TOKEN` (secret not granted).
This repo already has `HF_TOKEN` per `.github/data/required_actions_secrets.json`.

This dispatcher checks out factory `main` and creates **private** Docker Space `SZLHOLDINGS/a11oy-factory`.
Not a second flagship. Not a seventh public Space. Not a production certificate of a-11-oy.com.