### PR TITLE
docs(estate): publish live second-brain fold on existing surface

### DIFF
--- a/docs/SECOND_BRAIN_LIVE.md
+++ b/docs/SECOND_BRAIN_LIVE.md
@@ -1,0 +1,45 @@
+# Second brain live — derived handles, folded estate
+
+Captured: 2026-08-29T09:35:00-04:00
+Actor: founder@szl-holdings
+Kind: estate.sign ALLOW · estate.admit DENY
+Terminal: GREEN_LIGHT
+Surface: this Estate OS `/brain`
+certified_production_ready: false
+
+## What is live
+
+The second brain is live as a **derived, handles-only** navigator on the existing Estate OS.
+
+- Six organs. Ten folds. Not eighty-eight equal products.
+- Search returns handles. A miss abstains. Nothing is fabricated LIVE.
+- GitHub remains protected source. Hugging Face remains the artifact mirror.
+- Existing maps stay existing: `SZLHOLDINGS/anatomy`, `SZLHOLDINGS/Khipu-Loom`, `SZLHOLDINGS/holographic`.
+
+## What is not live
+
+- 9000-node graph: UNAVAILABLE (cytoscape `nodeRepulsion:9000`, not a knowledge graph).
+- Private 9464-node graph: unpublished, not admitted to gradients.
+- New Hugging Face Space `SZLHOLDINGS/second-brain`: not minted.
+- New Hub Spaces `szl-sovereign-os` / `szl-real-estate`: not minted.
+- Packet 6 factory as a product: not admitted.
+- Production ATO, paid pilot, ROI, live BFT.
+
+## DCO
+
+DCO is not bypassed. Commits that land on protected heads are GitHub-signed with `Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>`. A red required check is still a red required check.
+
+## Recapture
+
+| Surface | Count |
+| --- | ---: |
+| GitHub authenticated search | 88 |
+| Packet registry | 76 |
+| Hub models / datasets / Spaces | 40 / 28 / 35 |
+| Open org PRs held | 3 |
+
+Held, not merged: `.github#496` (new Hub brands), `a11oy-factory#1` (new public repo), `a11oy-net#41` (catalog HOLD).
+
+Classified new public GitHub, not front doors: `a11oy-factory`, `szl-second-brain`, `puriq-live`, `szl-sovereign-os`, `szl-real-estate`.
+
+Packet 4 freeze still binds.

--- a/docs/second_brain_live.json
+++ b/docs/second_brain_live.json
@@ -1,0 +1,15 @@
+{
+  "capturedAt": "2026-08-29T09:35:00-04:00",
+  "actor": "founder@szl-holdings",
+  "terminal": "GREEN_LIGHT",
+  "surface": "/brain",
+  "liveClass": "DERIVED_HANDLES",
+  "claimed9000": "UNAVAILABLE",
+  "private9464": "UNPUBLISHED",
+  "newHubSpace": false,
+  "productionCertified": false,
+  "dco": "GitHub-signed commits with Signed-off-by. Required checks not overridden.",
+  "githubSearch": 88,
+  "hub": { "models": 40, "datasets": 28, "spaces": 35 },
+  "heldPrs": [".github#496", "a11oy-factory#1", "a11oy-net#41"]
+}


### PR DESCRIPTION
## Why this PR exists

Founder full green light. The Estate OS `/brain` is the live derived second brain. This publishes the snapshot on the existing org surface.

## What this is

- Handles-only retrieval over folded families
- GitHub-signed commit so DCO passes (not bypassed)
- 9000 remains UNAVAILABLE. No new Hub Space.

## What this is not

- Not a new public repository or Hugging Face Space
- Not production ATO
- Does not merge `.github#496`, `a11oy-factory#1`, or mint operator Spaces

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>
