### PR TITLE
ci(hf): unpin Khipu Loom so holographic can pin

### DIFF
--- a/.github/scripts/hf_pinset.py
+++ b/.github/scripts/hf_pinset.py
@@ -22,6 +22,8 @@ UNPIN = [
     "SZLHOLDINGS/SZL-Cosmos",
     "SZLHOLDINGS/SZL-KHIPU",
     "SZLHOLDINGS/szl-khipu",
+    "SZLHOLDINGS/Khipu-Loom",
+    "SZLHOLDINGS/szl-estate-live",
 ]
 FACTORY = "SZLHOLDINGS/a11oy-factory"
 

--- a/huggingface/PINSET.md
+++ b/huggingface/PINSET.md
@@ -1,7 +1,7 @@
 # Hub pin set
 
 **Pin:** `a11oy`, `killinchu`, `immune`, `szl-atelier`, `holographic`
-**Unpin:** `cosmos` (and `SZL-KHIPU` as an org-front pin if Hub’s cap is 4)
+**Unpin:** `cosmos`, `szl-khipu` / `SZL-KHIPU`, `Khipu-Loom`, `szl-estate-live` (org-front fifth slot was Loom, not holographic)
 **Factory:** RUNNING, unpinned, BIND_AS_A11OY_PACKAGE — not a second flagship
 **Warhacker:** must not be a Space
 


### PR DESCRIPTION
Org-front strip still showed Khipu Loom after the first pinset. Unpin `Khipu-Loom` and `szl-estate-live`. Pin five remains a11oy, killinchu, immune, szl-atelier, holographic. Factory unpinned. Warhacker is not a Space.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>