### PR TITLE
fix(org-card): 44px hittable floor for Start/Portfolio/Truth

### DIFF
--- a/huggingface/org-card/hit-targets.css
+++ b/huggingface/org-card/hit-targets.css
@@ -1,0 +1,27 @@
+/* 44px hittable floor for SZLHOLDINGS/README org-card.
+   Linked from index.html. Do not allowlist PRIMARY_TARGET_UNDERSIZED. */
+#szl-hf-org-card header {
+  position: relative;
+  z-index: 30;
+  isolation: isolate;
+}
+#szl-hf-org-card nav a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  height: auto;
+  padding: 12px 16px;
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
+  touch-action: manipulation;
+}
+@media (max-width: 760px) {
+  #szl-hf-org-card nav a {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 12px 10px;
+  }
+}


### PR DESCRIPTION
## Why

[a11oy#1359](https://github.com/szl-holdings/a11oy/issues/1359) canary recorded `PRIMARY_TARGET_UNDERSIZED` on the Hugging Face organization card:

- Start / Portfolio / Truth
- height 44, width 53–75, **`hit_testable_44: false`**

Source already claimed `height:48px`. The live scan failed because a fixed height plus `padding:7px` at the 760px breakpoint, and hero overlays, collapse the 44×44 hit sample.

## What

Adds `huggingface/org-card/hit-targets.css`:

- header `z-index:30; isolation:isolate` so the hero cannot steal taps
- nav links `min-width/min-height:44px; height:auto; padding:12px 16px`
- 760px breakpoint keeps the 44px padding floor

A follow-up commit on this branch will link the sheet from `index.html` (same-specificity override after the inline block).

Does not mutate Hugging Face runtime, visibility, secrets, or hardware.
Does not stamp RUNNING. Does not close #1359 until the live canary is green.

Linear, squash only. Λ = Conjecture 1.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>
