### PR TITLE
fix(hf): scan all eager statement expressions

### DIFF
--- a/actions/hf-universal-frontend-v1/check.py
+++ b/actions/hf-universal-frontend-v1/check.py
@@ -1702,6 +1702,15 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                 and _literal_truth_value(statement.test) is False
             ):
                 return False
+            if isinstance(statement, (ast.With, ast.AsyncWith)):
+                for item in statement.items:
+                    if _expression_has_eager_lambda_barrier(item.context_expr):
+                        return False
+                    if isinstance(item.context_expr, ast.Call):
+                        calls.append(item.context_expr)
+                if not collect(statement.body):
+                    return False
+                continue
             if any(
                 _expression_has_eager_lambda_barrier(expression)
                 for expression in _statement_eager_expressions(statement)
@@ -1726,15 +1735,7 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                     return False
                 calls.append(expression)
                 continue
-            if isinstance(statement, (ast.With, ast.AsyncWith)):
-                calls.extend(
-                    item.context_expr
-                    for item in statement.items
-                    if isinstance(item.context_expr, ast.Call)
-                )
-                if not collect(statement.body):
-                    return False
-                continue
+
             if isinstance(
                 statement,
                 (ast.If,) + TRY_STATEMENT_TYPES,

--- a/actions/hf-universal-frontend-v1/check.py
+++ b/actions/hf-universal-frontend-v1/check.py
@@ -1582,6 +1582,14 @@ def _statement_eager_expressions(statement: ast.stmt) -> list[ast.expr]:
     type_alias = getattr(ast, "TypeAlias", None)
     if type_alias is not None and isinstance(statement, type_alias):
         return []
+    if isinstance(statement, ast.Assert):
+        expressions = [statement.test]
+        if (
+            statement.msg is not None
+            and _literal_truth_value(statement.test) is not True
+        ):
+            expressions.append(statement.msg)
+        return expressions
 
     expressions: list[ast.expr] = []
 
@@ -1694,6 +1702,11 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                 and _literal_truth_value(statement.test) is False
             ):
                 return False
+            if any(
+                _expression_has_eager_lambda_barrier(expression)
+                for expression in _statement_eager_expressions(statement)
+            ):
+                return False
             expression: ast.AST | None = None
             if isinstance(statement, ast.Expr):
                 expression = statement.value
@@ -1701,8 +1714,6 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                 expression = statement.value
             elif isinstance(statement, ast.AnnAssign):
                 expression = statement.value
-            if _expression_has_eager_lambda_barrier(expression):
-                return False
             if isinstance(expression, ast.Lambda):
                 continue
             if isinstance(expression, ast.Call):

--- a/actions/hf-universal-frontend-v1/check.py
+++ b/actions/hf-universal-frontend-v1/check.py
@@ -1711,6 +1711,37 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                 if not collect(statement.body):
                     return False
                 continue
+            if isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                expression = statement.value
+                if _expression_has_eager_lambda_barrier(expression):
+                    return False
+                if isinstance(expression, ast.Call):
+                    if isinstance(expression.func, ast.Lambda):
+                        return False
+                    if (
+                        isinstance(expression.func, ast.Name)
+                        and expression.func.id in local_sync_function_names
+                    ):
+                        return False
+                    calls.append(expression)
+                targets = (
+                    statement.targets
+                    if isinstance(statement, ast.Assign)
+                    else [statement.target]
+                )
+                if any(
+                    _expression_has_eager_lambda_barrier(target)
+                    for target in targets
+                ):
+                    return False
+                if (
+                    isinstance(statement, ast.AnnAssign)
+                    and _expression_has_eager_lambda_barrier(
+                        statement.annotation
+                    )
+                ):
+                    return False
+                continue
             if any(
                 _expression_has_eager_lambda_barrier(expression)
                 for expression in _statement_eager_expressions(statement)
@@ -1718,10 +1749,6 @@ def _direct_top_level_calls(tree: ast.Module) -> list[ast.Call]:
                 return False
             expression: ast.AST | None = None
             if isinstance(statement, ast.Expr):
-                expression = statement.value
-            elif isinstance(statement, ast.Assign):
-                expression = statement.value
-            elif isinstance(statement, ast.AnnAssign):
                 expression = statement.value
             if isinstance(expression, ast.Lambda):
                 continue

--- a/tests/test_hf_universal_frontend_action_v1_review_regressions.py
+++ b/tests/test_hf_universal_frontend_action_v1_review_regressions.py
@@ -876,6 +876,85 @@ st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
     )
 
 
+@pytest.mark.parametrize(
+    ("framework", "framework_import", "binding_context"),
+    [
+        (
+            "streamlit",
+            "import streamlit as st",
+            'st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)',
+        ),
+        (
+            "gradio",
+            "import gradio as ui",
+            "ui.Blocks(css=css)",
+        ),
+    ],
+)
+def test_with_binding_before_later_barrier_preserves_guaranteed_call(
+    framework: str,
+    framework_import: str,
+    binding_context: str,
+) -> None:
+    app_text = f"""\
+# SZL_HF_UNIVERSAL_FRONTEND_V1
+from pathlib import Path
+{framework_import}
+
+css = Path("assets/universal.css").read_text(encoding="utf-8")
+
+with {binding_context}, (lambda value=explode(): value):
+    pass
+"""
+
+    CHECKER.validate_framework_binding(
+        framework,
+        app_text,
+        app_file="app.py",
+        css_file="assets/universal.css",
+    )
+
+
+@pytest.mark.parametrize(
+    ("framework", "framework_import", "binding_context"),
+    [
+        (
+            "streamlit",
+            "import streamlit as st",
+            'st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)',
+        ),
+        (
+            "gradio",
+            "import gradio as ui",
+            "ui.Blocks(css=css)",
+        ),
+    ],
+)
+def test_with_barrier_before_binding_rejects_unreachable_call(
+    framework: str,
+    framework_import: str,
+    binding_context: str,
+) -> None:
+    app_text = f"""\
+# SZL_HF_UNIVERSAL_FRONTEND_V1
+from pathlib import Path
+{framework_import}
+
+css = Path("assets/universal.css").read_text(encoding="utf-8")
+
+with (lambda value=explode(): value), {binding_context}:
+    pass
+"""
+
+    with pytest.raises(CHECKER.ContractError):
+        CHECKER.validate_framework_binding(
+            framework,
+            app_text,
+            app_file="app.py",
+            css_file="assets/universal.css",
+        )
+
+
 def test_lazy_generic_bound_before_binding_is_inert() -> None:
     app_text = """\
 # SZL_HF_UNIVERSAL_FRONTEND_V1

--- a/tests/test_hf_universal_frontend_action_v1_review_regressions.py
+++ b/tests/test_hf_universal_frontend_action_v1_review_regressions.py
@@ -955,6 +955,95 @@ with (lambda value=explode(): value), {binding_context}:
         )
 
 
+@pytest.mark.parametrize(
+    ("framework", "framework_import", "binding_expression"),
+    [
+        (
+            "streamlit",
+            "import streamlit as st",
+            'st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)',
+        ),
+        (
+            "gradio",
+            "import gradio as ui",
+            "ui.Blocks(css=css)",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "assignment_template",
+    [
+        "targets[(lambda value=explode(): value)] = {binding}",
+        "bound: (lambda value=explode(): value) = {binding}",
+    ],
+    ids=["subscript-target", "annotation-after-rhs"],
+)
+def test_assignment_rhs_binding_before_later_barrier_is_preserved(
+    framework: str,
+    framework_import: str,
+    binding_expression: str,
+    assignment_template: str,
+) -> None:
+    assignment = assignment_template.format(binding=binding_expression)
+    app_text = f"""\
+# SZL_HF_UNIVERSAL_FRONTEND_V1
+from pathlib import Path
+{framework_import}
+
+css = Path("assets/universal.css").read_text(encoding="utf-8")
+targets = {{}}
+
+{assignment}
+"""
+
+    CHECKER.validate_framework_binding(
+        framework,
+        app_text,
+        app_file="app.py",
+        css_file="assets/universal.css",
+    )
+
+
+@pytest.mark.parametrize(
+    ("framework", "framework_import", "binding_expression"),
+    [
+        (
+            "streamlit",
+            "import streamlit as st",
+            'st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)',
+        ),
+        (
+            "gradio",
+            "import gradio as ui",
+            "ui.Blocks(css=css)",
+        ),
+    ],
+)
+def test_augmented_assignment_target_barrier_blocks_rhs_binding(
+    framework: str,
+    framework_import: str,
+    binding_expression: str,
+) -> None:
+    app_text = f"""\
+# SZL_HF_UNIVERSAL_FRONTEND_V1
+from pathlib import Path
+{framework_import}
+
+css = Path("assets/universal.css").read_text(encoding="utf-8")
+targets = {{0: 1}}
+
+targets[(lambda value=explode(): value)] += {binding_expression}
+"""
+
+    with pytest.raises(CHECKER.ContractError):
+        CHECKER.validate_framework_binding(
+            framework,
+            app_text,
+            app_file="app.py",
+            css_file="assets/universal.css",
+        )
+
+
 def test_lazy_generic_bound_before_binding_is_inert() -> None:
     app_text = """\
 # SZL_HF_UNIVERSAL_FRONTEND_V1

--- a/tests/test_hf_universal_frontend_action_v1_review_regressions.py
+++ b/tests/test_hf_universal_frontend_action_v1_review_regressions.py
@@ -690,6 +690,15 @@ async def helper():
     pass""",
         """class Helper:
     raise RuntimeError("stop")""",
+        "assert (lambda value=explode(): value)",
+        """value = 0
+value += (lambda value=explode(): value)""",
+        """values = {}
+del values[(lambda value=explode(): value)]""",
+        """with (lambda value=explode(): value):
+    pass""",
+        """runtime_condition = False
+assert runtime_condition, (lambda value=explode(): value)""",
         "helper = lambda value=explode(): value",
         "helper = (lambda value=explode(): value,)",
         "helper = [lambda value=explode(): value]",
@@ -722,6 +731,11 @@ pending = helper(lambda value=explode(): value)""",
         "async-parameter-annotation",
         "async-return-annotation",
         "class-body",
+        "assert-test-lambda-default",
+        "augassign-lambda-default",
+        "delete-lambda-default",
+        "with-context-lambda-default",
+        "assert-unknown-message-lambda-default",
         "lambda-default",
         "tuple-lambda-default",
         "list-lambda-default",
@@ -791,6 +805,9 @@ css = Path("assets/universal.css").read_text(encoding="utf-8")
     (lambda: explode())""",
         """if False:
     (lambda value=explode(): value)""",
+        "assert True, (lambda value=explode(): value)",
+        """if True:
+    assert True, (lambda value=explode(): value)""",
         "helper = (lambda value=explode(): value) if False else None",
         "helper = False and (lambda value=explode(): value)",
         "helper = True or (lambda value=explode(): value)",
@@ -803,6 +820,8 @@ pending = helper()""",
         "lazy-generator-element-default",
         "branch-lazy-lambda-body",
         "untaken-branch-lambda-default",
+        "assert-true-skips-message",
+        "branch-assert-true-skips-message",
         "untaken-conditional-lambda-default",
         "false-and-lambda-default",
         "true-or-lambda-default",


### PR DESCRIPTION
## Why

PR #513 merged 75 seconds after its exact-head Codex review posted two unresolved execution-model findings. This protected successor closes those gaps and the evaluation-order findings discovered by exact-head successor reviews:

- [P1: scan eager expressions in every top-level statement](https://github.com/szl-holdings/.github/pull/513#discussion_r3889317461)
- [P2: skip assertion messages when the test is true](https://github.com/szl-holdings/.github/pull/513#discussion_r3889317464)
- [P2: preserve earlier context calls before later barriers](https://github.com/szl-holdings/.github/pull/514#discussion_r3889429307)
- [P2: preserve RHS bindings before scanning assignment targets](https://github.com/szl-holdings/.github/pull/514#discussion_r3889449677)

## Changes

- Route every statement's directly evaluated expressions through the shared eager-lambda barrier instead of a three-statement whitelist.
- Model `assert` precisely: always inspect its test and inspect its message only when the test is not provably true.
- Process `with` and `async with` context expressions left-to-right so earlier guaranteed bindings survive later barriers.
- Process plain and annotated assignment RHS values before targets and annotations, while preserving target-first augmented-assignment behavior.
- Add negative and positive cross-framework regressions for all of the above ordering and short-circuit paths.

## Validation

- Exact head: `6f106dbdc28ba8a9dd3ae2c567a529777e0887cd`
- Three local commits, all DCO-authored and independently verified by GitHub with valid ED25519 SSH signatures
- Local HF universal frontend family: `334 passed, 1 deselected in 27.86s`
- Sole deselection: unchanged Windows symlink privilege case (`WinError 1314`); hosted Linux CI is authoritative for that platform path.

## Evidence boundary

This PR establishes pushed source and local validation only. Merge, downstream publication, deployment, Hugging Face state, domain propagation, and witnessed runtime behavior remain unclaimed until independently observed.