### PR TITLE
fix: authenticate private HF anatomy reads

### DIFF
--- a/.github/scripts/anatomy_map_drift.py
+++ b/.github/scripts/anatomy_map_drift.py
@@ -113,6 +113,14 @@ def _gh_headers():
     return h
 
 
+def _hf_headers():
+    """Return a bearer header only when the workflow supplied an HF token."""
+    tok = os.environ.get("HF_TOKEN")
+    h = {}
+    if tok:
+        h["Authorization"] = f"Bearer {tok}"
+    return h
+
 def fetch_github_file(repo, path, ref="main"):
     """Raw file content via the contents API (works for PRIVATE repos w/ token)."""
     url = f"{GH_API}/repos/{repo}/contents/{urllib.parse.quote(path)}?ref={ref}"
@@ -124,9 +132,9 @@ def fetch_github_file(repo, path, ref="main"):
 
 
 def fetch_hf_file(repo, path, ref="main"):
-    """Raw file content from a (public) Hugging Face Space."""
+    """Raw file content from a Hugging Face Space, authenticated when needed."""
     url = f"{HF_HOST}/spaces/{repo}/raw/{ref}/{urllib.parse.quote(path)}"
-    status, body = _http(url)
+    status, body = _http(url, headers=_hf_headers())
     if status != 200:
         raise RuntimeError(f"HF space {repo}:{path}@{ref}: HTTP {status}")
     return body.decode("utf-8", "replace")

--- a/.github/scripts/test_anatomy_map_drift.py
+++ b/.github/scripts/test_anatomy_map_drift.py
@@ -15,6 +15,7 @@ text trimmed from the actual surfaces, and pin that the guard:
   3. FAILS when one surface drops the Λ=Conjecture-1 label          (exit 1)
   4. FAILS when the capability ladder is edited on ONE side only    (exit 1)
   5. FAILS when the marker block is missing entirely                (exit 1)
+  6. Sends HF bearer auth only when a token is configured
 
 It also pins the pure extractors so a future refactor can't quietly stop
 matching the locked ladder, the Λ label, the capability list, or the markers
@@ -25,6 +26,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import unittest
+from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _MODULE_PATH = os.path.join(_HERE, "anatomy_map_drift.py")
@@ -102,6 +104,15 @@ def _surfaces(a11oy=None, killinchu=None, hf=None):
 
 
 class TestExtractors(unittest.TestCase):
+    def test_hf_headers_are_optional_and_bearer_scoped(self):
+        with mock.patch.dict(os.environ, {"HF_TOKEN": ""}):
+            self.assertNotIn("Authorization", amd._hf_headers())
+        with mock.patch.dict(os.environ, {"HF_TOKEN": "hf_test_secret"}):
+            self.assertEqual(
+                amd._hf_headers()["Authorization"],
+                "Bearer hf_test_secret",
+            )
+
     def test_marker_block_found_and_bounded(self):
         b = amd.extract_marker_block("noise\n" + _block() + "\ntrailing")
         self.assertIsNotNone(b)

--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -15,7 +15,9 @@ name: Anatomy-map cross-surface drift
 #
 # Reading the a11oy / killinchu sources needs repo read access; the built-in
 # Actions token covers same-org repos, with SZL_GITHUB_TOKEN as a fallback. The
-# HF Space is public. On real drift (exit 1) an ntfy alert is pushed through the
+# HF Space may require authentication; the established HF secret fallback is
+# exported to the checker without placing credentials in URLs or logs. On real
+# drift (exit 1) an ntfy alert is pushed through the
 # team's shared relay (SLACK_WEBHOOK_URL -> a-11-oy.com/relay -> a11oy-uptime).
 # A fetch/auth failure is exit 2 (ERROR), never a silent pass.
 
@@ -70,6 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \
@@ -136,7 +139,9 @@ jobs:
               echo "::error::Could not complete the anatomy-map drift check"
               echo "::error::(a surface failed to fetch -- network/auth). Set the"
               echo "::error::SZL_GITHUB_TOKEN secret if the a11oy/killinchu repos are"
-              echo "::error::private. Failed (not passed) so coverage can never look"
+              echo "::error::private, and configure HF_ORG_TOKEN (or the established"
+              echo "::error::HF token fallback) if the anatomy Space requires auth."
+              echo "::error::Failed (not passed) so coverage can never look"
               echo "::error::green when the check could not actually run."
               exit 1
               ;;

--- a/.github/workflows/anatomy-map-hf-drift.yml
+++ b/.github/workflows/anatomy-map-hf-drift.yml
@@ -81,6 +81,8 @@ jobs:
         run: python3 .github/scripts/test_anatomy_map_drift.py
 
       - name: Check the public anatomy surfaces (HF Space + a-11-oy.com mirror)
+        env:
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \
@@ -139,8 +141,10 @@ jobs:
               ;;
             *)
               echo "::error::Could not complete the public anatomy-map drift check"
-              echo "::error::(a public surface failed to fetch -- HF Space or"
-              echo "::error::a-11-oy.com unreachable). Failed (not passed) so coverage"
+              echo "::error::(a public surface failed to fetch -- HF Space auth/access"
+              echo "::error::or a-11-oy.com reachability). Configure HF_ORG_TOKEN (or"
+              echo "::error::the established HF token fallback) when the Space requires"
+              echo "::error::authentication. Failed (not passed) so coverage"
               echo "::error::can never look green when the check could not actually run;"
               echo "::error::a public surface being down is itself an alignment problem."
               exit 1

--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -24,11 +24,11 @@ name: Reusable — Anatomy-map Drift Check
 #   jobs:
 #     anatomy-map-drift:
 #       uses: szl-holdings/.github/.github/workflows/reusable-anatomy-map-drift.yml@main
-#       secrets: inherit   # optional: passes SZL_GITHUB_TOKEN if the org defines it
+#       secrets: inherit   # passes optional GitHub and Hugging Face read tokens
 #
-# The check reads only PUBLIC same-org repos + the public HF Space, so the
-# caller's built-in github.token is sufficient; SZL_GITHUB_TOKEN is a fallback
-# for a future private surface.
+# The caller's built-in github.token covers public same-org repositories.
+# SZL_GITHUB_TOKEN remains an optional fallback for private GitHub surfaces;
+# the HF token fallback chain supports the anatomy Space whether public or private.
 
 on:
   workflow_call:
@@ -41,6 +41,18 @@ on:
     secrets:
       SZL_GITHUB_TOKEN:
         description: "Optional PAT fallback for reading a (future) private surface."
+        required: false
+      HF_ORG_TOKEN:
+        description: "Preferred organization token for reading a private HF Space."
+        required: false
+      HF_ORG_TOKEN1:
+        description: "Legacy organization token fallback for HF reads."
+        required: false
+      HF_TOKEN:
+        description: "Standard Hugging Face token fallback."
+        required: false
+      HF_WRITE_TOKEN:
+        description: "Legacy final fallback; only read access is used by this job."
         required: false
 
 permissions:
@@ -81,6 +93,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
         run: |
           set +e
           EXTRA=""
@@ -120,8 +133,9 @@ jobs:
               ;;
             *)
               echo "::error::Could not complete the anatomy-map drift check"
-              echo "::error::(a surface failed to fetch -- network/auth). Set the"
-              echo "::error::SZL_GITHUB_TOKEN secret if a surface repo is private."
+              echo "::error::(a surface failed to fetch -- network/auth). Set"
+              echo "::error::SZL_GITHUB_TOKEN for private GitHub sources or an"
+              echo "::error::HF_ORG_TOKEN/HF_TOKEN secret for a private HF Space."
               echo "::error::Failed (not passed) so coverage can never look green when"
               echo "::error::the check could not actually run."
               exit 1


### PR DESCRIPTION
## Summary

- authenticate Hugging Face raw-file reads when an estate token is configured
- use the established `HF_ORG_TOKEN` / `HF_ORG_TOKEN1` / `HF_TOKEN` / `HF_WRITE_TOKEN` fallback order
- preserve anonymous reads when no token exists and never place credentials in URLs or logs
- declare reusable-workflow secrets and correct fail-closed remediation guidance
- add a network-free regression for optional bearer-header behavior

## Root cause

The anatomy drift guard described `SZLHOLDINGS/anatomy` as public and called the raw endpoint without Hugging Face authentication. The Space currently returns HTTP 401, so protected callers fail closed before comparing doctrine bytes.

## Exact identity

- base: `984c59e9f1c2e0a8c7e15842e311caaf4a6e6609`
- head: `11dc639eb5856085a82f5df03e5ddf1b6bce15df`
- one ED25519 SSH-signed commit with matching `Signed-off-by`

## Evidence boundary

Source repair is pushed. CI and a consuming exact-head rerun are required before claiming the cross-estate drift gate operational.