### PR TITLE
feat(hf): enforce weighted model evidence

### DIFF
--- a/.github/scripts/hf_model_evidence_audit.py
+++ b/.github/scripts/hf_model_evidence_audit.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Fail-closed public model-evidence audit for the SZLHOLDINGS Hub estate.
+
+The Hugging Face Models tab can contain checkpoints, adapters, GGUF files,
+NumPy demonstrations, software kernels, documentation, and roadmap stubs. This
+checker keeps those categories distinct and never turns repository visibility,
+a README claim, or a self-authored receipt into a quality or runtime pass.
+
+The live path is read-only. It resolves every public model repository to an
+immutable Hub revision, inventories files, reads the root card at that exact
+revision, and emits JSON plus a bounded Markdown summary. ``--enforce`` can
+hold the scheduled workflow red for unsafe executable metadata, unqualified
+frontier claims without structured results, or weighted artifacts without
+Hub-standard evaluation metadata.
+
+Exit codes:
+  0 = collection completed and no enforced violation was found.
+  1 = collection completed and at least one enforced violation was found.
+  2 = collection could not be completed or its minimum coverage was not met.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable
+
+HF_API = "https://huggingface.co/api"
+HF_HOST = "https://huggingface.co"
+DEFAULT_ORG = "SZLHOLDINGS"
+SCHEMA = "szl.hf-model-evidence-audit/v1"
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+WEIGHT_SUFFIXES = (".safetensors", ".gguf", ".npz", ".onnx")
+KNOWN_WEIGHT_NAMES = {
+    "adapter_model.bin",
+    "pytorch_model.bin",
+    "tf_model.h5",
+    "flax_model.msgpack",
+}
+UNSAFE_EXECUTABLE_SUFFIXES = (".pkl", ".pickle", ".joblib")
+UNSAFE_EXECUTABLE_NAMES = {"training_args.bin"}
+STRUCTURED_RESULT_FILES = {
+    "eval_results.json",
+    "model-index.yaml",
+    "model-index.yml",
+    "results.json",
+}
+OVERCLAIM = re.compile(
+    r"(?i)(?:\bSOTA\b|state[- ]of[- ]the[- ]art|fully[- ]trained|"
+    r"frontier[- ]class|best[- ]in[- ]class)"
+)
+NEGATING_QUALIFIER = re.compile(
+    r"(?i)(?:\bno\b|\bnot\b|does not|do not|cannot|can't|unsupported|"
+    r"unproven|not established|not claimed|no claim|roadmap|target only|"
+    r"would require|without .* evidence)"
+)
+
+
+class AuditIncomplete(RuntimeError):
+    """Raised when the remote inventory cannot be proved complete enough."""
+
+
+def _token() -> str | None:
+    for name in ("HF_ORG_TOKEN", "HF_TOKEN", "HF_WRITE_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def _request(url: str, token: str | None) -> urllib.request.Request:
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/json")
+    request.add_header("User-Agent", "szl-hf-model-evidence-audit/1")
+    if token:
+        request.add_header("Authorization", "Bearer " + token)
+    return request
+
+
+def _get_json(url: str, token: str | None) -> Any:
+    with urllib.request.urlopen(_request(url, token), timeout=45) as response:
+        return json.load(response)
+
+
+def _get_text(url: str, token: str | None) -> str | None:
+    try:
+        request = _request(url, token)
+        request.headers["Accept"] = "text/plain"
+        with urllib.request.urlopen(request, timeout=45) as response:
+            return response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        raise
+
+
+def _repo_id(item: dict[str, Any]) -> str:
+    return str(item.get("id") or item.get("modelId") or "")
+
+
+def _paths(info: dict[str, Any]) -> list[str]:
+    paths = []
+    for sibling in info.get("siblings") or []:
+        if not isinstance(sibling, dict):
+            continue
+        path = sibling.get("rfilename") or sibling.get("path")
+        if path:
+            paths.append(str(path).replace("\\", "/"))
+    return sorted(set(paths))
+
+
+def weight_files(paths: Iterable[str]) -> list[str]:
+    """Return loadable-looking weight artifacts, excluding trainer metadata."""
+    result = []
+    for path in paths:
+        name = PurePosixPath(path).name.lower()
+        if name in UNSAFE_EXECUTABLE_NAMES:
+            continue
+        if name in KNOWN_WEIGHT_NAMES or name.endswith(WEIGHT_SUFFIXES):
+            result.append(path)
+    return sorted(set(result))
+
+
+def unsafe_executable_files(paths: Iterable[str]) -> list[str]:
+    result = []
+    for path in paths:
+        name = PurePosixPath(path).name.lower()
+        if name in UNSAFE_EXECUTABLE_NAMES or name.endswith(UNSAFE_EXECUTABLE_SUFFIXES):
+            result.append(path)
+    return sorted(set(result))
+
+
+def structured_evaluation(info: dict[str, Any], paths: Iterable[str], readme: str) -> dict[str, Any]:
+    card = info.get("cardData") or info.get("card_data") or {}
+    if not isinstance(card, dict):
+        card = {}
+    card_keys = [
+        key
+        for key in ("model-index", "model_index", "eval_results")
+        if card.get(key)
+    ]
+    result_files = [
+        path
+        for path in paths
+        if PurePosixPath(path).name.lower() in STRUCTURED_RESULT_FILES
+    ]
+    readme_keys = sorted(
+        set(
+            match.group(1).lower()
+            for match in re.finditer(
+                r"(?m)^\s*(model-index|eval_results)\s*:",
+                readme,
+            )
+        )
+    )
+    return {
+        "present": bool(card_keys or result_files or readme_keys),
+        "card_keys": card_keys,
+        "files": sorted(result_files),
+        "readme_keys": readme_keys,
+    }
+
+
+def unqualified_claims(readme: str) -> list[str]:
+    """Return frontier phrases that are not locally bounded by a disclaimer."""
+    claims = []
+    normalized = re.sub(r"\s+", " ", readme)
+    for match in OVERCLAIM.finditer(normalized):
+        start = max(0, match.start() - 120)
+        end = min(len(normalized), match.end() + 120)
+        window = normalized[start:end]
+        if NEGATING_QUALIFIER.search(window):
+            continue
+        claims.append(match.group(0))
+    return sorted(set(claims), key=str.lower)
+
+
+def _card_value(info: dict[str, Any], key: str) -> Any:
+    card = info.get("cardData") or info.get("card_data") or {}
+    if isinstance(card, dict) and card.get(key) not in (None, "", []):
+        return card.get(key)
+    return info.get(key)
+
+
+def artifact_kind(info: dict[str, Any], weights: list[str]) -> str:
+    library = str(info.get("library_name") or "").lower()
+    lower = [path.lower() for path in weights]
+    if not weights:
+        return "software_kernel_or_non_weight_asset" if library == "kernels" else "no_loadable_weights"
+    if any(path.endswith(".gguf") for path in lower):
+        return "gguf_quantization"
+    if any(path.endswith(".safetensors") for path in lower):
+        return "adapter_or_checkpoint"
+    if any(path.endswith(".npz") for path in lower):
+        return "numpy_artifact"
+    return "weighted_artifact"
+
+
+def evaluate_model(
+    info: dict[str, Any],
+    readme: str | None,
+    *,
+    require_structured_eval_for_weights: bool,
+) -> dict[str, Any]:
+    repo_id = _repo_id(info)
+    revision = str(info.get("sha") or "")
+    paths = _paths(info)
+    readme_text = readme or ""
+    weights = weight_files(paths)
+    unsafe = unsafe_executable_files(paths)
+    evaluation = structured_evaluation(info, paths, readme_text)
+    claims = unqualified_claims(readme_text)
+    violations: list[dict[str, str]] = []
+    warnings: list[dict[str, str]] = []
+
+    if unsafe:
+        violations.append(
+            {
+                "code": "UNSAFE_EXECUTABLE_ARTIFACT",
+                "detail": ", ".join(unsafe),
+            }
+        )
+    if claims and not evaluation["present"]:
+        violations.append(
+            {
+                "code": "UNBOUND_FRONTIER_CLAIM",
+                "detail": ", ".join(claims),
+            }
+        )
+    if weights and not evaluation["present"]:
+        finding = {
+            "code": "WEIGHTS_WITHOUT_STRUCTURED_EVALUATION",
+            "detail": "No model-index/eval_results or conventional structured results file.",
+        }
+        if require_structured_eval_for_weights:
+            violations.append(finding)
+        else:
+            warnings.append(finding)
+    if not SHA40.fullmatch(revision):
+        violations.append({"code": "MISSING_IMMUTABLE_REVISION", "detail": revision or "absent"})
+    if "README.md" not in paths:
+        warnings.append({"code": "MISSING_ROOT_CARD", "detail": "README.md absent"})
+    if not _card_value(info, "license"):
+        warnings.append({"code": "MISSING_LICENSE_METADATA", "detail": "license absent"})
+    if weights and not (info.get("pipeline_tag") or _card_value(info, "pipeline_tag")):
+        warnings.append({"code": "MISSING_PIPELINE_TAG", "detail": "weighted artifact has no pipeline tag"})
+
+    release_static = bool(
+        weights
+        and evaluation["present"]
+        and not unsafe
+        and SHA40.fullmatch(revision)
+        and "README.md" in paths
+        and _card_value(info, "license")
+    )
+    return {
+        "id": repo_id,
+        "sha": revision,
+        "private": bool(info.get("private")),
+        "library_name": info.get("library_name"),
+        "pipeline_tag": info.get("pipeline_tag"),
+        "artifact_kind": artifact_kind(info, weights),
+        "weight_files": weights,
+        "unsafe_executable_files": unsafe,
+        "structured_evaluation": evaluation,
+        "unqualified_frontier_claims": claims,
+        "release_static_evidence": "PRESENT" if release_static else "INCOMPLETE",
+        "violations": violations,
+        "warnings": warnings,
+    }
+
+
+def collect_models(
+    org: str,
+    token: str | None,
+    *,
+    require_structured_eval_for_weights: bool,
+) -> list[dict[str, Any]]:
+    page_limit = 1000
+    query = urllib.parse.urlencode({"author": org, "limit": page_limit, "full": "true"})
+    listing = _get_json(f"{HF_API}/models?{query}", token)
+    if not isinstance(listing, list):
+        raise AuditIncomplete("model listing did not return a JSON array")
+    if len(listing) >= page_limit:
+        raise AuditIncomplete(
+            f"model listing reached the {page_limit}-item safety ceiling; pagination is required"
+        )
+    results = []
+    seen: set[str] = set()
+    for listed in sorted(listing, key=_repo_id):
+        if not isinstance(listed, dict):
+            raise AuditIncomplete("model listing contained a non-object entry")
+        repo_id = _repo_id(listed)
+        if not repo_id.upper().startswith(org.upper() + "/"):
+            continue
+        if listed.get("private") is True:
+            continue
+        if repo_id in seen:
+            raise AuditIncomplete(f"model listing contained a duplicate ID: {repo_id}")
+        seen.add(repo_id)
+        encoded = urllib.parse.quote(repo_id, safe="/")
+        info = _get_json(f"{HF_API}/models/{encoded}?blobs=true", token)
+        if not isinstance(info, dict):
+            raise AuditIncomplete(f"model detail was not an object: {repo_id}")
+        if info.get("private") is True:
+            continue
+        revision = str(info.get("sha") or "")
+        raw_url = f"{HF_HOST}/{encoded}/resolve/{urllib.parse.quote(revision, safe='')}/README.md"
+        readme = _get_text(raw_url, token)
+        results.append(
+            evaluate_model(
+                info,
+                readme,
+                require_structured_eval_for_weights=require_structured_eval_for_weights,
+            )
+        )
+    return results
+
+
+def build_report(
+    org: str,
+    models: list[dict[str, Any]],
+    *,
+    require_structured_eval_for_weights: bool,
+    minimum_models: int,
+) -> dict[str, Any]:
+    if len(models) < minimum_models:
+        raise AuditIncomplete(
+            f"coverage collapse: observed {len(models)} models, required at least {minimum_models}"
+        )
+    kinds = Counter(model["artifact_kind"] for model in models)
+    violations = [
+        {"model": model["id"], **finding}
+        for model in models
+        for finding in model["violations"]
+    ]
+    warnings = [
+        {"model": model["id"], **finding}
+        for model in models
+        for finding in model["warnings"]
+    ]
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "organization": org,
+        "status": "VIOLATIONS" if violations else "COMPLETE",
+        "policy": {
+            "minimum_models": minimum_models,
+            "require_structured_eval_for_weights": require_structured_eval_for_weights,
+            "static_evidence_is_not": [
+                "independent quality certification",
+                "state-of-the-art proof",
+                "deployment evidence",
+                "runtime evidence",
+            ],
+        },
+        "counts": {
+            "repositories": len(models),
+            "weighted_repositories": sum(bool(model["weight_files"]) for model in models),
+            "structured_evaluation": sum(
+                bool(model["structured_evaluation"]["present"]) for model in models
+            ),
+            "static_evidence_present": sum(
+                model["release_static_evidence"] == "PRESENT" for model in models
+            ),
+            "violations": len(violations),
+            "warnings": len(warnings),
+            "artifact_kinds": dict(sorted(kinds.items())),
+        },
+        "violations": violations,
+        "warnings": warnings,
+        "models": models,
+    }
+
+
+def incomplete_report(org: str, error: Exception) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "organization": org,
+        "status": "INCOMPLETE",
+        "error": f"{type(error).__name__}: {error}",
+        "counts": {},
+        "violations": [],
+        "warnings": [],
+        "models": [],
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    counts = report.get("counts") or {}
+    lines = [
+        "# Hugging Face model evidence audit",
+        "",
+        f"- Organization: `{report.get('organization', 'UNKNOWN')}`",
+        f"- Generated: `{report.get('generated_at', 'UNKNOWN')}`",
+        f"- Status: **{report.get('status', 'INCOMPLETE')}**",
+    ]
+    if report.get("status") == "INCOMPLETE":
+        lines.extend(["", f"Collection error: `{report.get('error', 'unknown')}`"])
+        return "\n".join(lines) + "\n"
+    lines.extend(
+        [
+            f"- Model-type repositories: **{counts.get('repositories', 0)}**",
+            f"- Repositories with weights: **{counts.get('weighted_repositories', 0)}**",
+            f"- Repositories with structured evaluation: **{counts.get('structured_evaluation', 0)}**",
+            f"- Enforced violations: **{counts.get('violations', 0)}**",
+            "",
+            "Static metadata is not SOTA, independent quality, deployment, or runtime proof.",
+        ]
+    )
+    violations = report.get("violations") or []
+    if violations:
+        lines.extend(["", "## Enforced findings", "", "| Model | Code | Detail |", "|---|---|---|"])
+        for finding in violations[:60]:
+            detail = str(finding.get("detail") or "").replace("|", "\\|").replace("\n", " ")
+            lines.append(
+                f"| `{finding.get('model', 'UNKNOWN')}` | `{finding.get('code', 'UNKNOWN')}` | {detail[:240]} |"
+            )
+        if len(violations) > 60:
+            lines.append(f"\nOnly the first 60 of {len(violations)} findings are shown; use the JSON artifact.")
+    return "\n".join(lines) + "\n"
+
+
+def _write(path: str, text: str) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(text, encoding="utf-8", newline="\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org", default=DEFAULT_ORG)
+    parser.add_argument("--report", default="reports/hf-model-evidence-latest.json")
+    parser.add_argument("--markdown", default="reports/hf-model-evidence-latest.md")
+    parser.add_argument("--min-models", type=int, default=1)
+    parser.add_argument("--require-structured-eval-for-weights", action="store_true")
+    parser.add_argument("--enforce", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        models = collect_models(
+            args.org,
+            _token(),
+            require_structured_eval_for_weights=args.require_structured_eval_for_weights,
+        )
+        report = build_report(
+            args.org,
+            models,
+            require_structured_eval_for_weights=args.require_structured_eval_for_weights,
+            minimum_models=args.min_models,
+        )
+        code = 1 if args.enforce and report["violations"] else 0
+    except Exception as error:  # noqa: BLE001 - any collection gap must fail closed
+        report = incomplete_report(args.org, error)
+        code = 2
+    _write(args.report, json.dumps(report, indent=2, sort_keys=True) + "\n")
+    _write(args.markdown, render_markdown(report))
+    print(json.dumps(report.get("counts", {}), sort_keys=True))
+    if report.get("status") == "INCOMPLETE":
+        print(report.get("error", "collection incomplete"), file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_model_evidence_audit.py
+++ b/.github/scripts/test_hf_model_evidence_audit.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+HERE = pathlib.Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+audit = importlib.import_module("hf_model_evidence_audit")
+
+
+def model_info(*, paths: list[str], card: dict | None = None, sha: str | None = None):
+    return {
+        "id": "SZLHOLDINGS/example",
+        "sha": sha or "a" * 40,
+        "library_name": "transformers",
+        "pipeline_tag": "text-generation",
+        "cardData": {"license": "apache-2.0", **(card or {})},
+        "siblings": [{"rfilename": path} for path in paths],
+    }
+
+
+class ModelEvidenceAuditTests(unittest.TestCase):
+    def test_weights_exclude_trainer_metadata(self) -> None:
+        paths = ["adapter_model.safetensors", "training_args.bin", "weights/model.gguf"]
+        self.assertEqual(
+            audit.weight_files(paths),
+            ["adapter_model.safetensors", "weights/model.gguf"],
+        )
+        self.assertEqual(audit.unsafe_executable_files(paths), ["training_args.bin"])
+
+    def test_negated_frontier_statement_is_not_an_overclaim(self) -> None:
+        text = "This artifact is not state of the art and no SOTA claim is made."
+        self.assertEqual(audit.unqualified_claims(text), [])
+        self.assertEqual(audit.unqualified_claims("A fully trained frontier-class model."), ["frontier-class", "fully trained"])
+
+    def test_weighted_artifact_without_structured_eval_fails_when_required(self) -> None:
+        result = audit.evaluate_model(
+            model_info(paths=["README.md", "model.safetensors"]),
+            "---\nlicense: apache-2.0\n---\nA model.",
+            require_structured_eval_for_weights=True,
+        )
+        self.assertEqual(result["release_static_evidence"], "INCOMPLETE")
+        self.assertIn(
+            "WEIGHTS_WITHOUT_STRUCTURED_EVALUATION",
+            {item["code"] for item in result["violations"]},
+        )
+
+    def test_structured_eval_and_safe_weights_meet_static_evidence_only(self) -> None:
+        result = audit.evaluate_model(
+            model_info(
+                paths=["README.md", "model.safetensors"],
+                card={"model-index": [{"name": "example", "results": [{"task": {"type": "text-generation"}}]}]},
+            ),
+            "---\nlicense: apache-2.0\nmodel-index:\n- name: example\n---\nMeasured model.",
+            require_structured_eval_for_weights=True,
+        )
+        self.assertEqual(result["release_static_evidence"], "PRESENT")
+        self.assertEqual(result["violations"], [])
+
+    def test_unqualified_claim_without_results_fails(self) -> None:
+        result = audit.evaluate_model(
+            model_info(paths=["README.md"]),
+            "A state-of-the-art system.",
+            require_structured_eval_for_weights=False,
+        )
+        self.assertIn("UNBOUND_FRONTIER_CLAIM", {item["code"] for item in result["violations"]})
+
+    def test_coverage_collapse_is_incomplete(self) -> None:
+        with self.assertRaises(audit.AuditIncomplete):
+            audit.build_report(
+                "SZLHOLDINGS",
+                [],
+                require_structured_eval_for_weights=True,
+                minimum_models=40,
+            )
+
+    def test_collection_excludes_private_entries(self) -> None:
+        listing = [
+            {"id": "SZLHOLDINGS/private", "private": True},
+            {"id": "SZLHOLDINGS/public", "private": False},
+        ]
+        detail = model_info(paths=["README.md"])
+        detail["id"] = "SZLHOLDINGS/public"
+        with (
+            mock.patch.object(audit, "_get_json", side_effect=[listing, detail]),
+            mock.patch.object(audit, "_get_text", return_value="Public card."),
+        ):
+            models = audit.collect_models(
+                "SZLHOLDINGS",
+                "token",
+                require_structured_eval_for_weights=False,
+            )
+        self.assertEqual([item["id"] for item in models], ["SZLHOLDINGS/public"])
+
+    def test_collection_rejects_duplicate_ids(self) -> None:
+        listing = [
+            {"id": "SZLHOLDINGS/repeated", "private": False},
+            {"id": "SZLHOLDINGS/repeated", "private": False},
+        ]
+        detail = model_info(paths=["README.md"])
+        detail["id"] = "SZLHOLDINGS/repeated"
+        with (
+            mock.patch.object(audit, "_get_json", side_effect=[listing, detail]),
+            mock.patch.object(audit, "_get_text", return_value="Public card."),
+            self.assertRaises(audit.AuditIncomplete),
+        ):
+            audit.collect_models(
+                "SZLHOLDINGS",
+                None,
+                require_structured_eval_for_weights=False,
+            )
+
+    def test_collection_rejects_listing_ceiling(self) -> None:
+        listing = [
+            {"id": f"SZLHOLDINGS/model-{index}", "private": False}
+            for index in range(1000)
+        ]
+        with (
+            mock.patch.object(audit, "_get_json", return_value=listing),
+            self.assertRaises(audit.AuditIncomplete),
+        ):
+            audit.collect_models(
+                "SZLHOLDINGS",
+                None,
+                require_structured_eval_for_weights=False,
+            )
+
+    def test_network_failure_writes_incomplete_report_and_exits_two(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = pathlib.Path(directory) / "report.json"
+            markdown = pathlib.Path(directory) / "report.md"
+            with mock.patch.object(audit, "collect_models", side_effect=OSError("offline")):
+                code = audit.main(["--report", str(report), "--markdown", str(markdown), "--enforce"])
+            self.assertEqual(code, 2)
+            payload = json.loads(report.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "INCOMPLETE")
+            self.assertIn("offline", payload["error"])
+            self.assertIn("INCOMPLETE", markdown.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-model-evidence-audit.yml
+++ b/.github/workflows/hf-model-evidence-audit.yml
@@ -1,0 +1,145 @@
+name: HF Model Evidence Audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_model_evidence_audit.py
+      - .github/scripts/test_hf_model_evidence_audit.py
+      - .github/workflows/hf-model-evidence-audit.yml
+      - huggingface/MODEL_RELEASE_EVIDENCE.md
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/hf_model_evidence_audit.py
+      - .github/scripts/test_hf_model_evidence_audit.py
+      - .github/workflows/hf-model-evidence-audit.yml
+      - huggingface/MODEL_RELEASE_EVIDENCE.md
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-model-evidence-audit-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Safe weights and structured evaluation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    env:
+      REPORT_JSON: reports/hf-model-evidence-latest.json
+      REPORT_MD: reports/hf-model-evidence-latest.md
+      REPORT_ISSUE_TITLE: "[hf-model-evidence] weighted artifact release gate"
+      GH_TOKEN: ${{ github.token }}
+      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Run network-free policy self-tests
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            .github/scripts/hf_model_evidence_audit.py \
+            .github/scripts/test_hf_model_evidence_audit.py
+          python .github/scripts/test_hf_model_evidence_audit.py
+          git diff --check
+
+      - name: Audit exact public Hub revisions
+        if: github.event_name != 'pull_request'
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/hf_model_evidence_audit.py \
+            --org SZLHOLDINGS \
+            --min-models 40 \
+            --require-structured-eval-for-weights \
+            --enforce \
+            --report "$REPORT_JSON" \
+            --markdown "$REPORT_MD"
+          code=$?
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload immutable audit evidence
+        if: always() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hf-model-evidence-${{ github.run_id }}
+          path: |
+            ${{ env.REPORT_JSON }}
+            ${{ env.REPORT_MD }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Persist deterministic evidence issue
+        if: always() && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "$REPORT_MD"
+          {
+            echo '<!-- szl-hf-model-evidence-audit -->'
+            echo '# Hugging Face model evidence gate'
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Source revision: \`${GITHUB_SHA}\`"
+            echo
+            cat "$REPORT_MD"
+          } > /tmp/hf-model-evidence-issue.md
+
+          issue_number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+            --search "${REPORT_ISSUE_TITLE} in:title" --json number,title \
+            --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" | head -n1)"
+          if [ -n "$issue_number" ]; then
+            gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" \
+              --body-file /tmp/hf-model-evidence-issue.md
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$REPORT_ISSUE_TITLE" \
+              --body-file /tmp/hf-model-evidence-issue.md >/dev/null
+            issue_number="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+              --search "${REPORT_ISSUE_TITLE} in:title" --json number,title \
+              --jq ".[] | select(.title == env.REPORT_ISSUE_TITLE) | .number" | head -n1)"
+          fi
+
+          if [ "${{ steps.audit.outputs.exit_code }}" = "0" ]; then
+            gh issue close "$issue_number" --repo "$GITHUB_REPOSITORY" \
+              --reason completed \
+              --comment 'All public weighted artifacts expose structured evaluation metadata and no enforced unsafe or unbound-claim finding remains.' || true
+          else
+            gh issue reopen "$issue_number" --repo "$GITHUB_REPOSITORY" || true
+          fi
+
+      - name: Enforce completed evidence result
+        if: always() && github.event_name != 'pull_request'
+        env:
+          EXIT_CODE: ${{ steps.audit.outputs.exit_code }}
+        run: |
+          code="${EXIT_CODE:-2}"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::HF model evidence audit is incomplete or has enforced findings."
+            exit "$code"
+          fi
+          echo 'Weighted artifacts have structured evidence and no enforced unsafe finding.'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,13 @@ jobs:
       - name: HF license-consistency safety-net self-test
         run: python3 .github/scripts/test_hf_license_consistency.py
 
+      # Keeps model inventory semantics honest: weighted artifacts must not be
+      # promoted as evidence-complete without structured results, unsafe
+      # executable trainer metadata stays visible, and a failed/partial Hub
+      # listing can never collapse into a false green.
+      - name: HF model-evidence audit self-test
+        run: python3 .github/scripts/test_hf_model_evidence_audit.py
+
       # Pins the managed-security-configuration drift checker (task #387): the
       # auth/API-failure branch (must be exit 2, never a silent 0) and the drift
       # branches need live org-admin calls that can't run in CI, so this stubbed,

--- a/huggingface/MODEL_RELEASE_EVIDENCE.md
+++ b/huggingface/MODEL_RELEASE_EVIDENCE.md
@@ -1,0 +1,49 @@
+# Hugging Face model release evidence
+
+The `SZLHOLDINGS` Hugging Face Models tab contains several artifact classes.
+A count from that tab must not be presented as a count of fully trained models.
+Checkpoints, adapters, quantizations, NumPy demonstrations, software kernels,
+documentation, and roadmap reservations are separate categories.
+
+## Release boundary
+
+A weighted artifact is not evidence-complete until its public package binds:
+
+- an immutable Hub revision and the SHA-256 of every released binary;
+- the exact base model and base revision;
+- tokenizer, processor, chat-template, and configuration hashes;
+- versioned dataset bytes, licenses, split membership, and leakage controls;
+- source revision, recipe, dependency lock or image digest, seed, precision, and
+  hardware;
+- held-out evaluation inputs, raw outputs, scorer source, runtime, decoding
+  configuration, failures, and uncertainty where applicable;
+- Hub-standard `model-index` or `eval_results` metadata for discovery; and
+- a safe serialization policy. Pickle-style trainer metadata is not an
+  inference dependency.
+
+Alternative adapters or quantizations need unambiguous identities. Keep one
+canonical default artifact per model ID, or publish variants under separate IDs
+or immutable releases with an explicit selector.
+
+## What the automated gate proves
+
+The `HF Model Evidence Audit` workflow reads public model repositories without
+mutating them. At each exact Hub revision it records artifact type, weight
+files, structured result metadata, unsafe executable-style files, and
+unqualified frontier claims. It fails closed when collection coverage drops,
+when weighted repositories lack structured results, when executable trainer
+metadata is published, or when an unqualified frontier claim lacks structured
+results.
+
+Passing this static gate does not prove state-of-the-art quality, independent
+validation, deployment, runtime health, or production readiness. Those claims
+require the same public harness against named baselines plus separately bound
+deployment and runtime evidence.
+
+## Current migration rule
+
+Existing gaps remain visible as a red scheduled issue until remediated; they are
+not allowlisted into a false pass. Repositories that intentionally contain only
+kernels, documentation, or roadmap material are classified as non-weight
+assets and do not need fabricated training evidence. Their software contracts,
+benchmarks, packaging, and source-to-Hub parity remain separate gates.


### PR DESCRIPTION
## Purpose

Make the public SZLHOLDINGS model inventory fail closed on the evidence gaps found in the 2026-08-30 estate audit. A Hub Models-tab count is not a count of fully trained, benchmarked, or deployed models.

## Exact identity

- Base: 58743dd88f3eebe405c11833890093f8457c8224
- Head: cf6e0be8e107d7bfcf3788590bbdc1b3ac38fdaf
- Commit DCO: Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>

## Changes

- Add a read-only public Hub audit that resolves every model repository at its immutable SHA.
- Classify weighted artifacts separately from kernels, docs, and non-weight assets.
- Enforce incomplete inventory coverage, weighted artifacts without structured evaluation, unsafe executable-style trainer metadata, and unbound frontier claims.
- Add 10 network-free unit tests, including API failure, private filtering, duplicate IDs, and listing-ceiling branches.
- Add a scheduled evidence artifact plus deterministic issue that remains open and red until findings are repaired.
- Document the stronger release-evidence contract and its limits.

## Verified baseline

Read-only live execution at the pushed source found 43 public model-type repositories, 19 repositories with weights, zero with structured model-index or eval_results evidence, and 22 enforced findings: 19 missing structured evaluation and three training_args.bin artifacts.

That red baseline is intentional evidence, not a regression hidden as green.

## Local verification

- Python 3.12 compilation: pass.
- Network-free tests: 10 of 10 pass.
- git diff --check: pass.
- Live public audit: completed with exit 1 because the 22 expected findings remain.

## Evidence boundaries

Passing this static gate will not establish SOTA quality, independent validation, training completion, deployment, runtime health, or production readiness. Those require reproducible public baselines and separate source, deployment, and runtime witnesses.

No model, dataset, Space, weight, organization setting, or provider runtime is mutated by this PR.

## Rollback

Revert cf6e0be8e107d7bfcf3788590bbdc1b3ac38fdaf.
