### PR TITLE
fix(anatomy): authenticate private Space reads

### DIFF
--- a/.github/scripts/anatomy_map_drift.py
+++ b/.github/scripts/anatomy_map_drift.py
@@ -113,6 +113,20 @@ def _gh_headers():
     return h
 
 
+def _hf_headers():
+    """Return an HF-only read credential without leaking GitHub credentials.
+
+    The anatomy Space is normally public, but organization visibility changes
+    must not turn the drift guard into a permanent HTTP 401.  Reuse the
+    established ``HF_TOKEN`` Actions secret when it is available; the header is
+    attached only to ``huggingface.co`` requests made by ``fetch_hf_file``.
+    """
+    tok = os.environ.get("HF_TOKEN")
+    if not tok:
+        return {}
+    return {"Authorization": f"Bearer {tok}"}
+
+
 def fetch_github_file(repo, path, ref="main"):
     """Raw file content via the contents API (works for PRIVATE repos w/ token)."""
     url = f"{GH_API}/repos/{repo}/contents/{urllib.parse.quote(path)}?ref={ref}"
@@ -124,9 +138,9 @@ def fetch_github_file(repo, path, ref="main"):
 
 
 def fetch_hf_file(repo, path, ref="main"):
-    """Raw file content from a (public) Hugging Face Space."""
+    """Raw file content from a public or authenticated Hugging Face Space."""
     url = f"{HF_HOST}/spaces/{repo}/raw/{ref}/{urllib.parse.quote(path)}"
-    status, body = _http(url)
+    status, body = _http(url, headers=_hf_headers())
     if status != 200:
         raise RuntimeError(f"HF space {repo}:{path}@{ref}: HTTP {status}")
     return body.decode("utf-8", "replace")

--- a/.github/scripts/test_anatomy_map_drift.py
+++ b/.github/scripts/test_anatomy_map_drift.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import unittest
+from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _MODULE_PATH = os.path.join(_HERE, "anatomy_map_drift.py")
@@ -134,6 +135,50 @@ class TestExtractors(unittest.TestCase):
         caps = amd.parse_capabilities(_block())
         keys = [k for (k, _s, _f) in caps]
         self.assertEqual(keys, ["rag", "khipu", "receipts", "math"])
+
+
+class TestFetchAuthority(unittest.TestCase):
+    def test_hf_token_is_scoped_to_hugging_face_reads(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"HF_TOKEN": "hf-read-secret", "GITHUB_TOKEN": "github-secret"},
+                clear=True,
+            ),
+            mock.patch.object(amd, "_http", return_value=(200, b"honest")) as http,
+        ):
+            self.assertEqual(
+                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "data.js"), "honest"
+            )
+
+        _url, kwargs = http.call_args
+        self.assertTrue(_url[0].startswith("https://huggingface.co/spaces/"))
+        self.assertEqual(
+            kwargs["headers"], {"Authorization": "Bearer hf-read-secret"}
+        )
+        self.assertNotIn("github-secret", repr(http.call_args))
+
+    def test_hf_read_remains_anonymous_when_token_is_absent(self):
+        with (
+            mock.patch.dict(os.environ, {"GITHUB_TOKEN": "github-secret"}, clear=True),
+            mock.patch.object(amd, "_http", return_value=(200, b"public")) as http,
+        ):
+            self.assertEqual(
+                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "index.html"), "public"
+            )
+
+        self.assertEqual(http.call_args.kwargs["headers"], {})
+        self.assertNotIn("github-secret", repr(http.call_args))
+
+    def test_hf_fetch_error_never_echoes_the_token(self):
+        with (
+            mock.patch.dict(os.environ, {"HF_TOKEN": "do-not-print"}, clear=True),
+            mock.patch.object(amd, "_http", return_value=(401, b"")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "HTTP 401") as caught:
+                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "data.js")
+
+        self.assertNotIn("do-not-print", str(caught.exception))
 
 
 class TestEvaluate(unittest.TestCase):

--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \

--- a/.github/workflows/anatomy-map-hf-drift.yml
+++ b/.github/workflows/anatomy-map-hf-drift.yml
@@ -81,6 +81,8 @@ jobs:
         run: python3 .github/scripts/test_anatomy_map_drift.py
 
       - name: Check the public anatomy surfaces (HF Space + a-11-oy.com mirror)
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \

--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -24,11 +24,11 @@ name: Reusable — Anatomy-map Drift Check
 #   jobs:
 #     anatomy-map-drift:
 #       uses: szl-holdings/.github/.github/workflows/reusable-anatomy-map-drift.yml@main
-#       secrets: inherit   # optional: passes SZL_GITHUB_TOKEN if the org defines it
+#       secrets: inherit   # optional: passes GitHub/HF read credentials if defined
 #
-# The check reads only PUBLIC same-org repos + the public HF Space, so the
-# caller's built-in github.token is sufficient; SZL_GITHUB_TOKEN is a fallback
-# for a future private surface.
+# The check reads same-org repos plus the HF Space. The caller's built-in
+# github.token covers public GitHub sources; SZL_GITHUB_TOKEN and HF_TOKEN are
+# optional fail-closed read fallbacks when a source is private.
 
 on:
   workflow_call:
@@ -41,6 +41,9 @@ on:
     secrets:
       SZL_GITHUB_TOKEN:
         description: "Optional PAT fallback for reading a (future) private surface."
+        required: false
+      HF_TOKEN:
+        description: "Optional Hugging Face token for reading a private anatomy Space."
         required: false
 
 permissions:
@@ -81,6 +84,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           EXTRA=""
@@ -121,7 +125,8 @@ jobs:
             *)
               echo "::error::Could not complete the anatomy-map drift check"
               echo "::error::(a surface failed to fetch -- network/auth). Set the"
-              echo "::error::SZL_GITHUB_TOKEN secret if a surface repo is private."
+              echo "::error::HF_TOKEN secret for a private HF Space, or"
+              echo "::error::SZL_GITHUB_TOKEN if a GitHub source is private."
               echo "::error::Failed (not passed) so coverage can never look green when"
               echo "::error::the check could not actually run."
               exit 1


### PR DESCRIPTION
## Outcome

Restore fail-closed Anatomy evidence reads when `SZLHOLDINGS/anatomy` is private, without changing the Space, publishing, or exposing a credential.

## Security properties

- use the established optional `HF_TOKEN` secret only for `huggingface.co/spaces/.../raw/...` reads
- never fall back to a GitHub token for Hugging Face
- retain anonymous reads when the Space is public
- never include token material in status/error output
- keep all drift checks read-only and fail closed on 401/unavailable evidence

## Coverage

- reusable a11oy/consumer workflow
- central full-surface sweep
- public-surface watcher
- 3 new network-free authority/redaction regressions; full anatomy self-test: 16 passed

## Qualification

Draft only. No secret, Hugging Face, deployment, ruleset, or protected-branch mutation occurred. A consuming caller must pin this exact shared commit and inherit an authorized existing `HF_TOKEN`; if the secret is absent or lacks read scope, the check remains red rather than fabricating evidence.