### PR TITLE
revert(security): remove unsafe generic HF token forwarding

### DIFF
--- a/.github/scripts/anatomy_map_drift.py
+++ b/.github/scripts/anatomy_map_drift.py
@@ -113,20 +113,6 @@ def _gh_headers():
     return h
 
 
-def _hf_headers():
-    """Return an HF-only read credential without leaking GitHub credentials.
-
-    The anatomy Space is normally public, but organization visibility changes
-    must not turn the drift guard into a permanent HTTP 401.  Reuse the
-    established ``HF_TOKEN`` Actions secret when it is available; the header is
-    attached only to ``huggingface.co`` requests made by ``fetch_hf_file``.
-    """
-    tok = os.environ.get("HF_TOKEN")
-    if not tok:
-        return {}
-    return {"Authorization": f"Bearer {tok}"}
-
-
 def fetch_github_file(repo, path, ref="main"):
     """Raw file content via the contents API (works for PRIVATE repos w/ token)."""
     url = f"{GH_API}/repos/{repo}/contents/{urllib.parse.quote(path)}?ref={ref}"
@@ -138,9 +124,9 @@ def fetch_github_file(repo, path, ref="main"):
 
 
 def fetch_hf_file(repo, path, ref="main"):
-    """Raw file content from a public or authenticated Hugging Face Space."""
+    """Raw file content from a (public) Hugging Face Space."""
     url = f"{HF_HOST}/spaces/{repo}/raw/{ref}/{urllib.parse.quote(path)}"
-    status, body = _http(url, headers=_hf_headers())
+    status, body = _http(url)
     if status != 200:
         raise RuntimeError(f"HF space {repo}:{path}@{ref}: HTTP {status}")
     return body.decode("utf-8", "replace")

--- a/.github/scripts/test_anatomy_map_drift.py
+++ b/.github/scripts/test_anatomy_map_drift.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import importlib.util
 import os
 import unittest
-from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _MODULE_PATH = os.path.join(_HERE, "anatomy_map_drift.py")
@@ -135,50 +134,6 @@ class TestExtractors(unittest.TestCase):
         caps = amd.parse_capabilities(_block())
         keys = [k for (k, _s, _f) in caps]
         self.assertEqual(keys, ["rag", "khipu", "receipts", "math"])
-
-
-class TestFetchAuthority(unittest.TestCase):
-    def test_hf_token_is_scoped_to_hugging_face_reads(self):
-        with (
-            mock.patch.dict(
-                os.environ,
-                {"HF_TOKEN": "hf-read-secret", "GITHUB_TOKEN": "github-secret"},
-                clear=True,
-            ),
-            mock.patch.object(amd, "_http", return_value=(200, b"honest")) as http,
-        ):
-            self.assertEqual(
-                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "data.js"), "honest"
-            )
-
-        _url, kwargs = http.call_args
-        self.assertTrue(_url[0].startswith("https://huggingface.co/spaces/"))
-        self.assertEqual(
-            kwargs["headers"], {"Authorization": "Bearer hf-read-secret"}
-        )
-        self.assertNotIn("github-secret", repr(http.call_args))
-
-    def test_hf_read_remains_anonymous_when_token_is_absent(self):
-        with (
-            mock.patch.dict(os.environ, {"GITHUB_TOKEN": "github-secret"}, clear=True),
-            mock.patch.object(amd, "_http", return_value=(200, b"public")) as http,
-        ):
-            self.assertEqual(
-                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "index.html"), "public"
-            )
-
-        self.assertEqual(http.call_args.kwargs["headers"], {})
-        self.assertNotIn("github-secret", repr(http.call_args))
-
-    def test_hf_fetch_error_never_echoes_the_token(self):
-        with (
-            mock.patch.dict(os.environ, {"HF_TOKEN": "do-not-print"}, clear=True),
-            mock.patch.object(amd, "_http", return_value=(401, b"")),
-        ):
-            with self.assertRaisesRegex(RuntimeError, "HTTP 401") as caught:
-                amd.fetch_hf_file("SZLHOLDINGS/anatomy", "data.js")
-
-        self.assertNotIn("do-not-print", str(caught.exception))
 
 
 class TestEvaluate(unittest.TestCase):

--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -70,7 +70,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \

--- a/.github/workflows/anatomy-map-hf-drift.yml
+++ b/.github/workflows/anatomy-map-hf-drift.yml
@@ -81,8 +81,6 @@ jobs:
         run: python3 .github/scripts/test_anatomy_map_drift.py
 
       - name: Check the public anatomy surfaces (HF Space + a-11-oy.com mirror)
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           python3 .github/scripts/anatomy_map_drift.py \

--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -24,11 +24,11 @@ name: Reusable — Anatomy-map Drift Check
 #   jobs:
 #     anatomy-map-drift:
 #       uses: szl-holdings/.github/.github/workflows/reusable-anatomy-map-drift.yml@main
-#       secrets: inherit   # optional: passes GitHub/HF read credentials if defined
+#       secrets: inherit   # optional: passes SZL_GITHUB_TOKEN if the org defines it
 #
-# The check reads same-org repos plus the HF Space. The caller's built-in
-# github.token covers public GitHub sources; SZL_GITHUB_TOKEN and HF_TOKEN are
-# optional fail-closed read fallbacks when a source is private.
+# The check reads only PUBLIC same-org repos + the public HF Space, so the
+# caller's built-in github.token is sufficient; SZL_GITHUB_TOKEN is a fallback
+# for a future private surface.
 
 on:
   workflow_call:
@@ -41,9 +41,6 @@ on:
     secrets:
       SZL_GITHUB_TOKEN:
         description: "Optional PAT fallback for reading a (future) private surface."
-        required: false
-      HF_TOKEN:
-        description: "Optional Hugging Face token for reading a private anatomy Space."
         required: false
 
 permissions:
@@ -84,7 +81,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set +e
           EXTRA=""
@@ -125,8 +121,7 @@ jobs:
             *)
               echo "::error::Could not complete the anatomy-map drift check"
               echo "::error::(a surface failed to fetch -- network/auth). Set the"
-              echo "::error::HF_TOKEN secret for a private HF Space, or"
-              echo "::error::SZL_GITHUB_TOKEN if a GitHub source is private."
+              echo "::error::SZL_GITHUB_TOKEN secret if a surface repo is private."
               echo "::error::Failed (not passed) so coverage can never look green when"
               echo "::error::the check could not actually run."
               exit 1


### PR DESCRIPTION
## Security containment

Revert #517 before any consumer pins it.

The merged reader attaches the repository's generic `HF_TOKEN` through `urllib.request.Request(..., headers=...)` and follows default redirects. That boundary is insufficient because redirected requests may cross from `huggingface.co` to a storage/CDN authority while retaining `Authorization`; the implementation also does not reject HTTPS-to-HTTP redirects or malformed/control-character token material.

## Exact change

- restore the complete protected tree from pre-#517 main `58743dd88f3eebe405c11833890093f8457c8224`
- remove generic `HF_TOKEN` forwarding from the central and reusable Anatomy workflows
- return private-Space reads to honest fail-closed HTTP 401 rather than risk credential propagation

## Follow-on contract

A separate successor may restore private reads only with:

- dedicated least-privilege `HF_READ_TOKEN`
- explicit secret mapping, never `secrets: inherit`
- strict validation and fully redacted errors
- HTTP(S)-only parsing; no HTTPS downgrade
- credential stripping or fail-closed behavior on every authority change in a redirect chain
- adversarial network-free tests
- immutable shared-workflow pinning by consumers

## Integrity

Candidate `0e4b0f113c2a956166982dbb99242a69af132722` is one DCO-bearing parent of current protected main. Merge only after the exact-head `.github` workflow matrix is terminal green; squash merge is required so protected main receives a GitHub-verified commit.