### PR TITLE
fix(hf): bind exact target write authority

### DIFF
--- a/.github/data/hf-space-lifecycle-policy.json
+++ b/.github/data/hf-space-lifecycle-policy.json
@@ -17,10 +17,8 @@
   "token_authority": {
     "namespace": "SZLHOLDINGS",
     "required_org_role": "admin",
-    "allowed_access_token_roles": [
-      "fineGrained",
-      "write"
-    ]
+    "reported_access_token_role_is_authority": false,
+    "required_target_write_preflight": "HfApi.auth_check(repo_id=target, repo_type=\"space\", write=True)"
   },
   "targets": [
     {"repo_id": "SZLHOLDINGS/README", "desired_visibility": "public", "desired_runtime_stage": "RUNNING", "role": "organization-profile"},

--- a/.github/scripts/hf_space_lifecycle_reconcile.py
+++ b/.github/scripts/hf_space_lifecycle_reconcile.py
@@ -41,7 +41,7 @@ AUTHORITY_ARTIFACT_DIGEST = (
 )
 EXACT_REVISION = re.compile(r"[0-9a-f]{40}")
 EXACT_SHA256 = re.compile(r"[0-9a-f]{64}")
-ALLOWED_ACCESS_TOKEN_ROLES = frozenset({"fineGrained", "write"})
+HUGGING_FACE_ENDPOINT = "https://huggingface.co"
 ALLOWED_REPO_IDS = frozenset(
     {
         "SZLHOLDINGS/README",
@@ -223,7 +223,10 @@ def load_policy(path: Path) -> tuple[dict[str, Any], dict[str, DesiredState]]:
     expected_token_authority = {
         "namespace": ORGANIZATION,
         "required_org_role": "admin",
-        "allowed_access_token_roles": ["fineGrained", "write"],
+        "reported_access_token_role_is_authority": False,
+        "required_target_write_preflight": (
+            'HfApi.auth_check(repo_id=target, repo_type="space", write=True)'
+        ),
     }
     if token_authority != expected_token_authority:
         raise LifecycleError("lifecycle token authority changed")
@@ -288,27 +291,50 @@ class HubSpaceClient:
     def __init__(self, api: Any) -> None:
         self.api = api
 
-    def verify_operator(self) -> dict[str, str]:
+    def verify_operator(self, repo_id: str) -> dict[str, Any]:
+        if repo_id not in ALLOWED_REPO_IDS:
+            raise LifecycleError("target write preflight requires one exact policy Space")
         info = self.api.whoami(cache=False)
         if not isinstance(info, dict) or info.get("type") != "user":
             raise LifecycleError("Hugging Face credential is not a user token")
-        auth = info.get("auth") or {}
+        auth = info.get("auth")
         access = auth.get("accessToken") if isinstance(auth, dict) else None
         token_role = access.get("role") if isinstance(access, dict) else None
-        if token_role not in ALLOWED_ACCESS_TOKEN_ROLES:
-            raise LifecycleError("Hugging Face credential is not an approved write token")
-        org_role = None
-        for org in info.get("orgs") or []:
-            if isinstance(org, dict) and org.get("name") == ORGANIZATION:
-                org_role = org.get("roleInOrg")
-                break
-        if org_role != "admin":
-            raise LifecycleError("Hugging Face credential is not SZLHOLDINGS admin")
+        if not isinstance(token_role, str) or not token_role.strip():
+            raise LifecycleError("Hugging Face credential omitted token role metadata")
+        orgs = info.get("orgs")
+        if not isinstance(orgs, list):
+            raise LifecycleError("Hugging Face credential omitted organization metadata")
+        org_roles = [
+            org.get("roleInOrg")
+            for org in orgs
+            if isinstance(org, dict) and org.get("name") == ORGANIZATION
+        ]
+        if org_roles != ["admin"]:
+            raise LifecycleError("Hugging Face credential is not unambiguously SZLHOLDINGS admin")
+        try:
+            auth_result = self.api.auth_check(
+                repo_id=repo_id,
+                repo_type="space",
+                write=True,
+            )
+        except Exception as exc:
+            raise LifecycleError(
+                "Hugging Face credential lacks verified write authority "
+                f"for exact target {repo_id}"
+            ) from exc
+        if auth_result is not None:
+            raise LifecycleError(
+                "Hugging Face target write preflight returned an ambiguous response"
+            )
         return {
             "credential_type": "user",
-            "access_token_role": str(token_role),
+            "access_token_role_reported": token_role.strip(),
+            "access_token_role_is_authority": False,
             "organization": ORGANIZATION,
             "organization_role": "admin",
+            "target_write_authority": "VERIFIED",
+            "target_write_repository": repo_id,
         }
 
     def read(self, repo_id: str) -> SpaceState:
@@ -580,7 +606,7 @@ def reconcile(
 
         desired = targets[target]
         receipt["desired"] = asdict(desired)
-        receipt["operator"] = client.verify_operator()
+        receipt["operator"] = client.verify_operator(target)
         before = client.read(target)
         receipt["before"] = asdict(before)
         compare_expected(
@@ -761,10 +787,16 @@ def main(argv: list[str] | None = None) -> int:
         try:
             # Do not expose the provider credential to a feature-branch copy.
             require_current_protected_main(os.environ)
-            from huggingface_hub import HfApi
+            import httpx
+            from huggingface_hub import HfApi, set_client_factory
 
+            set_client_factory(
+                lambda: httpx.Client(follow_redirects=False, timeout=30.0)
+            )
             report, exit_code = reconcile(
-                client=HubSpaceClient(HfApi(token=token)),
+                client=HubSpaceClient(
+                    HfApi(endpoint=HUGGING_FACE_ENDPOINT, token=token)
+                ),
                 policy_path=args.policy,
                 target=args.target,
                 mode=args.mode,

--- a/.github/scripts/test_hf_space_lifecycle_reconcile.py
+++ b/.github/scripts/test_hf_space_lifecycle_reconcile.py
@@ -50,11 +50,26 @@ class FakeApi:
             "auth": {"accessToken": {"role": "write"}},
             "orgs": [{"name": "SZLHOLDINGS", "roleInOrg": "admin"}],
         }
+        self.write_authorized_targets = set(states)
+        self.auth_checks: list[dict[str, object]] = []
+        self.auth_check_error: Exception | None = None
+        self.auth_check_result: object | None = None
 
     def whoami(self, *, cache: bool) -> dict:
         if cache:
             raise AssertionError("credential preflight must not use cached identity")
         return copy.deepcopy(self.identity)
+
+    def auth_check(self, *, repo_id: str, repo_type: str, write: bool) -> object:
+        call = {"repo_id": repo_id, "repo_type": repo_type, "write": write}
+        self.auth_checks.append(call)
+        if repo_type != "space" or write is not True:
+            raise AssertionError("credential preflight escaped exact Space write check")
+        if self.auth_check_error is not None:
+            raise self.auth_check_error
+        if repo_id not in self.write_authorized_targets:
+            raise PermissionError("target-specific write access denied")
+        return self.auth_check_result
 
     def space_info(self, *, repo_id: str, expand: list[str]) -> SimpleNamespace:
         if expand != ["private", "runtime", "sdk", "sha"]:
@@ -140,6 +155,13 @@ class LifecycleTests(unittest.TestCase):
             module.AUTHORITY_ARTIFACT_DIGEST,
         )
         self.assertEqual(policy["token_authority"]["required_org_role"], "admin")
+        self.assertFalse(
+            policy["token_authority"]["reported_access_token_role_is_authority"]
+        )
+        self.assertEqual(
+            policy["token_authority"]["required_target_write_preflight"],
+            'HfApi.auth_check(repo_id=target, repo_type="space", write=True)',
+        )
         self.assertTrue(all(target.visibility == "public" for target in targets.values()))
         self.assertTrue(
             all(target.runtime_stage == "RUNNING" for target in targets.values())
@@ -162,6 +184,11 @@ class LifecycleTests(unittest.TestCase):
         weakened = copy.deepcopy(self.policy)
         weakened["boundaries"]["archive"] = True
         mutations.append(weakened)
+        role_authority = copy.deepcopy(self.policy)
+        role_authority["token_authority"][
+            "reported_access_token_role_is_authority"
+        ] = True
+        mutations.append(role_authority)
         repointed = copy.deepcopy(self.policy)
         repointed["authority"]["artifact_digest"] = "sha256:" + "f" * 64
         mutations.append(repointed)
@@ -174,7 +201,7 @@ class LifecycleTests(unittest.TestCase):
 
     def test_arbitrary_target_rejected_before_identity_or_provider_read(self) -> None:
         class ExplodingClient:
-            def verify_operator(self) -> dict:
+            def verify_operator(self, _repo_id: str) -> dict:
                 raise AssertionError("provider must not be called")
 
         report, code = module.reconcile(
@@ -194,18 +221,47 @@ class LifecycleTests(unittest.TestCase):
         self.assertEqual(code, 2)
         self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
 
-    def test_token_preflight_requires_write_and_org_admin(self) -> None:
+    def test_target_write_preflight_is_exact_and_role_is_informational(self) -> None:
         repo_id = "SZLHOLDINGS/a11oy"
         api = FakeApi({repo_id: state(repo_id, "public")})
-        safe = module.HubSpaceClient(api).verify_operator()
-        self.assertEqual(safe["access_token_role"], "write")
+        safe = module.HubSpaceClient(api).verify_operator(repo_id)
+        self.assertEqual(safe["access_token_role_reported"], "write")
+        self.assertFalse(safe["access_token_role_is_authority"])
         self.assertEqual(safe["organization_role"], "admin")
+        self.assertEqual(safe["target_write_authority"], "VERIFIED")
+        self.assertEqual(safe["target_write_repository"], repo_id)
+        self.assertEqual(
+            api.auth_checks,
+            [{"repo_id": repo_id, "repo_type": "space", "write": True}],
+        )
+
+        # A fine-grained label alone proves nothing when this target is read-only.
+        api.identity["auth"]["accessToken"]["role"] = "fineGrained"
+        api.write_authorized_targets.clear()
+        with self.assertRaises(module.LifecycleError):
+            module.HubSpaceClient(api).verify_operator(repo_id)
+        self.assertEqual(api.mutations, [])
+
+        # A token with write authority elsewhere must still fail this exact target.
+        api.identity["auth"]["accessToken"]["role"] = "write"
+        api.write_authorized_targets = {"SZLHOLDINGS/killinchu"}
+        with self.assertRaises(module.LifecycleError):
+            module.HubSpaceClient(api).verify_operator(repo_id)
+        self.assertEqual(api.mutations, [])
+
+    def test_target_write_preflight_rejects_identity_transport_and_malformed_results(self) -> None:
+        repo_id = "SZLHOLDINGS/a11oy"
+        api = FakeApi({repo_id: state(repo_id, "public")})
         for identity in (
             {"type": "org", "auth": {}, "orgs": []},
+            {"type": "user", "orgs": [{"name": "SZLHOLDINGS", "roleInOrg": "admin"}]},
             {
                 "type": "user",
-                "auth": {"accessToken": {"role": "read"}},
-                "orgs": [{"name": "SZLHOLDINGS", "roleInOrg": "admin"}],
+                "auth": {"accessToken": {"role": "write"}},
+                "orgs": [
+                    {"name": "SZLHOLDINGS", "roleInOrg": "admin"},
+                    {"name": "SZLHOLDINGS", "roleInOrg": "admin"},
+                ],
             },
             {
                 "type": "user",
@@ -215,7 +271,30 @@ class LifecycleTests(unittest.TestCase):
         ):
             api.identity = identity
             with self.assertRaises(module.LifecycleError):
-                module.HubSpaceClient(api).verify_operator()
+                module.HubSpaceClient(api).verify_operator(repo_id)
+
+        api.identity = {
+            "type": "user",
+            "auth": {"accessToken": {"role": "fineGrained"}},
+            "orgs": [{"name": "SZLHOLDINGS", "roleInOrg": "admin"}],
+        }
+        for provider_error in (
+            RuntimeError("unexpected redirect with hf_fake_token"),
+            TimeoutError("transport failed with hf_fake_token"),
+            ValueError("malformed provider response with hf_fake_token"),
+        ):
+            api.auth_check_error = provider_error
+            with self.assertRaises(module.LifecycleError) as caught:
+                module.HubSpaceClient(api).verify_operator(repo_id)
+            self.assertNotIn("hf_fake_token", str(caught.exception))
+            self.assertEqual(api.mutations, [])
+
+        api.auth_check_error = None
+        for ambiguous_result in (False, True, {}):
+            api.auth_check_result = ambiguous_result
+            with self.assertRaises(module.LifecycleError):
+                module.HubSpaceClient(api).verify_operator(repo_id)
+            self.assertEqual(api.mutations, [])
 
     def test_unknown_private_state_and_provider_denial_never_mutate(self) -> None:
         repo_id = "SZLHOLDINGS/anatomy"
@@ -484,7 +563,25 @@ class LifecycleTests(unittest.TestCase):
         self.assertNotIn("  push:\n", workflow)
         self.assertIn("group: hf-provider-mutation-szlholdings", workflow)
         self.assertIn("environment: production", workflow)
-        self.assertIn("HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}", workflow)
+        secret_binding = "HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}"
+        secret_lines = [
+            line for line in workflow.splitlines() if "HF_ORG_TOKEN" in line
+        ]
+        self.assertEqual(secret_lines, [f"          {secret_binding}"])
+        self.assertEqual(workflow.count(secret_binding), 1)
+        step_blocks = re.split(r"(?=^      - name:)", workflow, flags=re.MULTILINE)
+        controller_steps = [
+            block
+            for block in step_blocks
+            if block.startswith(
+                "      - name: Plan or apply one expected-state publication"
+            )
+        ]
+        self.assertEqual(len(controller_steps), 1)
+        self.assertIn(secret_binding, controller_steps[0])
+        for block in step_blocks:
+            if block is not controller_steps[0]:
+                self.assertNotIn("HF_ORG_TOKEN", block)
         self.assertIn("--expected-policy-sha256", workflow)
         self.assertIn("--require-hashes", workflow)
         self.assertIn("persist-credentials: false", workflow)
@@ -493,6 +590,12 @@ class LifecycleTests(unittest.TestCase):
         self.assertTrue(all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in uses))
 
         source = SCRIPT.read_text(encoding="utf-8")
+        self.assertEqual(source.count("self.api.auth_check("), 1)
+        self.assertIn('repo_type="space"', source)
+        self.assertIn("write=True", source)
+        self.assertIn("if auth_result is not None:", source)
+        self.assertIn("follow_redirects=False", source)
+        self.assertIn("endpoint=HUGGING_FACE_ENDPOINT", source)
         self.assertEqual(source.count("self.api.update_repo_settings("), 1)
         self.assertIn("private=False", source)
         for forbidden in (
@@ -509,6 +612,11 @@ class LifecycleTests(unittest.TestCase):
             "create_commit(",
             "upload_file(",
             "upload_folder(",
+            "duplicate_space(",
+            "request_space_storage(",
+            "set_space_sleep_time(",
+            "delete_space_secret(",
+            "delete_space_variable(",
         ):
             self.assertNotIn(forbidden, source)
         self.assertIn(

--- a/.github/workflows/hf-space-lifecycle-reconcile.yml
+++ b/.github/workflows/hf-space-lifecycle-reconcile.yml
@@ -109,7 +109,6 @@ jobs:
     timeout-minutes: 15
     environment: production
     env:
-      HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}
       GITHUB_TOKEN: ${{ github.token }}
       HF_HUB_DISABLE_PROGRESS_BARS: "1"
       INPUT_REPO_ID: ${{ inputs.repo_id }}
@@ -182,6 +181,8 @@ jobs:
           echo "safe_target=$SAFE_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Plan or apply one expected-state publication
+        env:
+          HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail

--- a/huggingface/SPACE_LIFECYCLE.md
+++ b/huggingface/SPACE_LIFECYCLE.md
@@ -61,9 +61,12 @@ and source/runtime identity checks. A blanket restart is not encoded here.
 
 `HF Space Lifecycle Reconcile` is manual, protected-main-only, serialized on
 `hf-provider-mutation-szlholdings`, and gated by the GitHub `production`
-environment. It accepts the fixed `HF_ORG_TOKEN` secret and verifies, without
-logging identity or token material, that the credential is a write-capable user
-token with SZLHOLDINGS admin role.
+environment. Only the controller step receives the fixed `HF_ORG_TOKEN`
+secret. Without logging identity or token material, it verifies user identity
+and an unambiguous SZLHOLDINGS admin role, then performs a separate,
+non-mutating `HfApi.auth_check(..., repo_type="space", write=True)` against the
+one exact selected Space. The reported access-token role is informational and
+is never accepted as proof of target write authority.
 
 Its only possible provider write is:
 


### PR DESCRIPTION
Corrects the two security defects that were merged unchanged in #531.

## Security fixes

- scopes `HF_ORG_TOKEN` to the controller step only; setup, tests, checkout,
  dependency installation, evidence upload, and every third-party action receive
  no provider credential
- treats the reported access-token role as informational only
- requires a non-mutating, exact-target
  `HfApi.auth_check(repo_id=target, repo_type="space", write=True)`
- pins the Hub endpoint and disables redirect following
- rejects missing/ambiguous identity, duplicate org authority, transport errors,
  redirects, malformed preflight results, read-only fine-grained tokens, and
  tokens with write authority only for another resource

## Verification

- exact head `e24f30939a064192795fc814e666013cf17480f0`
- sole parent is current main
  `464069d945b10e51893fc749f5530b7643f23ad4`
- GitHub verification is `verified=true`, `reason=valid`
- exact five-file tree `d920c5a2437df9b22203efac63adad5e13e7a772`
- 18/18 network-free adversarial lifecycle tests pass
- staging PR #532 completed all eight pull-request workflows successfully
- policy JSON, Python compilation, and `git diff --check` pass
- no Hugging Face lifecycle workflow was dispatched and no provider mutation
  occurred during repair

## Independent mutator audit

The lifecycle controller still contains exactly one provider mutator:
`update_repo_settings(..., repo_type="space", private=False)`. Static tests
exclude archive, private, create, delete, rename, upload, restart, pause,
hardware, storage, variable, and secret mutation methods.

Repository-wide search also identified separately governed legacy HF writers:
the pinset, operator-Space publisher, factory binder, org-card deployer, and
collection-truth reconciler. None was dispatched for this repair, and this
five-file change does not match the org-card push publication paths. Those
writers must remain idle during any lifecycle apply.

The workflow remains manual-only and production-gated. Do not dispatch it as
part of review or merge.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>