### PR TITLE
ci: replace native DCO with solo-builder provenance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,17 +2,12 @@
 
 Thank you for considering a contribution to this SZL Holdings repository.
 
-## Developer Certificate of Origin (DCO)
+## Solo-builder provenance
 
-All commits **must** be signed off under the [Developer Certificate of
-Origin](https://developercertificate.org/). Add a `Signed-off-by:` trailer to
-every commit:
-
-```
-git commit -s -m "your message"
-```
-
-Branch protection on `main` enforces signed commits and the DCO check.
+Developer commit signatures and sign-off trailers are not required. Protected
+automation validates the exact live pull-request base and head without checking
+out or executing proposed content. Required build and security checks remain
+blocking.
 
 ## Workflow
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Risk: <A|B|C|D> — reason:
 - [ ] `gate/lean` green; sorry count did not increase
 - [ ] Screenshots attached for UI changes
 - [ ] `KNOWN_LIMITATIONS.md` updated for any downgrade or blocker
-- [ ] Commits include a DCO `Signed-off-by:` trailer
+- [ ] Exact-head provenance and all required build/security checks are green
 - [ ] No force-push, destructive rebase, or safeguard reduction
 
 ## Known limitations introduced

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,7 @@ Risk: <A|B|C|D> — reason:
 - [ ] `gate/lean` green; sorry count did not increase
 - [ ] Screenshots attached for UI changes
 - [ ] `KNOWN_LIMITATIONS.md` updated for any downgrade or blocker
-- [ ] Commits include a DCO `Signed-off-by:` trailer
+- [ ] Exact-head provenance and all required build/security checks are green
 - [ ] No force-push, destructive rebase, or safeguard reduction
 
 ## Known limitations introduced

--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Static contract for the native and reusable trusted DCO producers."""
+"""Static contract for native provenance compatibility and reusable DCO."""
 
 from pathlib import Path
 import unittest
@@ -30,23 +30,24 @@ class DcoActivationWorkflowTests(unittest.TestCase):
 
     def test_native_workflow_preserves_all_governed_event_gates(self) -> None:
         for marker in (
-            "name: Native DCO enforcement",
+            "name: Solo-builder provenance compatibility",
             "pull_request" + "_target:",
             "- main",
             "- 'release/*'",
-            "types: [opened, synchronize, reopened, ready_for_review, edited, closed]",
+            "- synchronize",
+            "- ready_for_review",
+            "- converted_to_draft",
+            "- closed",
             "merge_" + "group:",
             "types: [checks_requested]",
-            "Reconcile surviving DCO status",
+            "permissions: {}",
+            "pull-request-provenance:",
+            "merge-group-provenance:",
+            "Reconcile surviving provenance status",
             "github.event.before",
             "AFFECTED_HEAD_SHA:",
-            "reconcile-candidate",
-            "reconcile-base",
-            "reconcile-trusted",
-            "dco-reconcile-event.json",
-            "Finalize pull-request DCO failure",
+            "Finalize pull-request provenance failure",
             "Finalize reconciliation failure",
-            "persist-credentials: false",
             "github.event.pull_request.base.sha",
             "github.event.pull_request.head.sha",
             "EXPECTED_BASE_SHA:",
@@ -55,19 +56,41 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "statuses/$EXPECTED_HEAD_SHA",
             '-f context="DCO sign-off check"',
             "github.workflow_sha",
+            "github.workflow_ref",
+            "source_workflow_blob",
+            "protected_workflow_blob",
             "--paginate --slurp",
-            "trusted/.github/scripts/dco_check.py",
-            "Run strict real-commit DCO self-tests",
-            "native-dco-compatibility:",
+            'startswith(".github/workflows/")',
+            "git/ref/heads/$EXPECTED_BASE_REF",
+            "merge_base_commit.sha == $base",
+            "legacy-dco-compatibility:",
             "name: DCO sign-off check",
-            "needs: dco",
-            "if: always() && github.event_name != 'pull_request_target'",
-            "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
-            'test "$NATIVE_DCO_RESULT" = "success"',
+            "needs: merge-group-provenance",
+            "if: always() && github.event_name == 'merge_group'",
+            "PROVENANCE_RESULT: ${{ needs.merge-group-provenance.result }}",
+            'test "$PROVENANCE_RESULT" = "success"',
         ):
             self.assertIn(marker, self.native)
+        self.assertEqual(self.native.count("statuses: write"), 2)
+        merge_job = self.native.split("  merge-group-provenance:\n", 1)[1].split(
+            "  legacy-dco-compatibility:\n", 1
+        )[0]
+        self.assertIn("contents: read", merge_job)
+        self.assertNotIn("statuses: write", merge_job)
+        self.assertNotIn("pull-requests: read", merge_job)
         self.assertNotIn("\n  pull_request:\n", self.native)
+        self.assertNotIn("\n  push:\n", self.native)
         self.assertNotIn("workflow_" + "dispatch:", self.native)
+        self.assertNotRegex(self.native, r"(?m)^\s*(?:-\s*)?uses:\s")
+        self.assertNotIn("actions/checkout", self.native)
+        self.assertNotIn("persist-credentials", self.native)
+        self.assertNotIn("GITHUB_WORKSPACE", self.native)
+        self.assertNotIn(".github/scripts/", self.native)
+        self.assertNotIn("dco_check.py", self.native)
+        self.assertNotIn("Signed-off-by", self.native)
+        self.assertNotIn("secrets.", self.native)
+        self.assertNotIn("contents: write", self.native)
+        self.assertNotIn("id-token:", self.native)
 
     def test_reusable_workflow_is_exact_and_secretless(self) -> None:
         for marker in (
@@ -96,11 +119,13 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.assertNotIn("continue-on-error", self.reusable)
 
     def test_source_namespaces_are_distinct_and_legacy_status_survives(self) -> None:
-        self.assertNotEqual("Native DCO enforcement", "Reusable DCO validation")
-        self.assertIn("name: Native DCO enforcement", self.native)
+        self.assertNotEqual(
+            "Solo-builder provenance compatibility", "Reusable DCO validation"
+        )
+        self.assertIn("name: Solo-builder provenance compatibility", self.native)
         self.assertNotIn("name: Reusable DCO validation", self.native)
         self.assertIn("name: Reusable DCO validation", self.reusable)
-        self.assertNotIn("name: Native DCO enforcement", self.reusable)
+        self.assertNotIn("name: Solo-builder provenance compatibility", self.reusable)
         self.assertIn('context="DCO sign-off check"', self.native)
         self.assertEqual(self.native.count("name: DCO sign-off check\n"), 1)
         self.assertNotIn("continue-on-error", self.native)

--- a/.github/scripts/test_dco_events.py
+++ b/.github/scripts/test_dco_events.py
@@ -581,13 +581,16 @@ class DcoCheckTests(unittest.TestCase):
             Path(__file__).resolve().parents[1] / "workflows" / "dco.yml"
         ).read_text(encoding="utf-8")
         self.assertEqual(workflow.count("name: DCO sign-off check\n"), 1)
-        self.assertIn("needs: dco", workflow)
+        self.assertIn("needs: merge-group-provenance", workflow)
         self.assertIn(
-            "if: always() && github.event_name != 'pull_request_target'",
+            "if: always() && github.event_name == 'merge_group'",
             workflow,
         )
-        self.assertIn("NATIVE_DCO_RESULT: ${{ needs.dco.result }}", workflow)
-        self.assertIn('test "$NATIVE_DCO_RESULT" = "success"', workflow)
+        self.assertIn(
+            "PROVENANCE_RESULT: ${{ needs.merge-group-provenance.result }}",
+            workflow,
+        )
+        self.assertIn('test "$PROVENANCE_RESULT" = "success"', workflow)
         self.assertNotIn("continue-on-error", workflow)
 
     def test_reusable_legacy_context_faithfully_propagates_validation(self) -> None:

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -448,32 +448,64 @@ def verify_gate_contract() -> None:
 
     dco_template = (ROOT / ".github/workflows/dco.yml").read_text(encoding="utf-8")
     for marker in (
+        "name: Solo-builder provenance compatibility",
         "pull_request_target:",
         "merge_group:",
         "types: [checks_requested]",
-        "persist-credentials: false",
+        "permissions: {}",
+        "pull-request-provenance:",
+        "merge-group-provenance:",
         "github.event.pull_request.base.sha",
         "github.event.pull_request.head.sha",
-        ".github/scripts/dco_check.py",
-        "native-dco-compatibility:",
+        "github.workflow_ref",
+        "github.workflow_sha",
+        "source_workflow_blob",
+        "protected_workflow_blob",
+        "--paginate --slurp",
+        'startswith(".github/workflows/")',
+        "merge_base_commit.sha == $base",
+        "legacy-dco-compatibility:",
         "name: DCO sign-off check",
-        "needs: dco",
-        "if: always() && github.event_name != 'pull_request_target'",
-        "NATIVE_DCO_RESULT: ${{ needs.dco.result }}",
-        'test "$NATIVE_DCO_RESULT" = "success"',
+        "needs: merge-group-provenance",
+        "if: always() && github.event_name == 'merge_group'",
+        "PROVENANCE_RESULT: ${{ needs.merge-group-provenance.result }}",
+        'test "$PROVENANCE_RESULT" = "success"',
+        "Reconcile surviving provenance status",
     ):
         if marker not in dco_template:
-            fail(f"trusted DCO workflow is missing {marker!r}")
+            fail(f"trusted provenance workflow is missing {marker!r}")
     if "\n  pull_request:\n" in dco_template:
-        fail("DCO must not execute PR-controlled code under pull_request")
+        fail("provenance compatibility must use protected pull_request_target")
+    if "\n  push:\n" in dco_template:
+        fail("provenance compatibility must not publish post-merge evidence")
     if "workflow_dispatch:" in dco_template:
-        fail("DCO must not publish a manual false-green status")
-    if "github.event_name != 'pull_request'" in dco_template:
-        fail("DCO merge-group and push validation must not use a fallback pass")
+        fail("provenance compatibility must not publish a manual false green")
+    if re.search(r"(?m)^\s*(?:-\s*)?uses:\s", dco_template):
+        fail("native provenance workflow must not invoke an action")
+    for forbidden in (
+        "actions/checkout",
+        "persist-credentials",
+        "GITHUB_WORKSPACE",
+        ".github/scripts/",
+        "dco_check.py",
+        "Signed-off-by",
+        "secrets.",
+        "contents: write",
+        "id-token:",
+    ):
+        if forbidden in dco_template:
+            fail(f"native provenance workflow contains forbidden {forbidden!r}")
+    if dco_template.count("statuses: write") != 2:
+        fail("only pull-request provenance and reconciliation may write statuses")
+    merge_group_job = dco_template.split("  merge-group-provenance:\n", 1)[1].split(
+        "  legacy-dco-compatibility:\n", 1
+    )[0]
+    if "statuses: write" in merge_group_job or "pull-requests: read" in merge_group_job:
+        fail("merge-group provenance has unnecessary pull-request or status scope")
     if dco_template.count("name: DCO sign-off check\n") != 1:
-        fail("native DCO must expose exactly one legacy compatibility job")
+        fail("native provenance must expose exactly one legacy compatibility job")
     if "continue-on-error" in dco_template:
-        fail("native DCO compatibility must not suppress a failed gate")
+        fail("native provenance compatibility must not suppress a failed gate")
 
     reusable_dco_template = (
         ROOT / ".github/workflows/reusable-dco.yml"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,126 +1,182 @@
-name: Native DCO enforcement
+name: Solo-builder provenance compatibility
 
 on:
-  push:
-    branches: [main]
   pull_request_target:
     branches:
       - main
       - 'release/*'
-    types: [opened, synchronize, reopened, ready_for_review, edited, closed]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - edited
+      - closed
   merge_group:
     types: [checks_requested]
 
-# Least privilege: the workflow-level default is read-only. `statuses: write`
-# is granted only to the two jobs that publish the commit status, so the
-# compatibility shim job (which runs with `permissions: {}`) and any future job
-# cannot inherit write scope.
-permissions:
-  contents: read
-  pull-requests: read
+# Ruleset 19755620 still requires the legacy `DCO sign-off check` context.
+# This workflow supplies that compatibility context from protected, exact-head
+# provenance evidence. It does not require developer signatures or trailers.
+# Candidate repository content is never checked out or executed.
+permissions: {}
 
 jobs:
-  dco:
-    name: Native DCO enforcement
-    if: github.event_name != 'pull_request_target' || github.event.action != 'closed'
+  pull-request-provenance:
+    name: Validate protected pull-request provenance
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.action != 'closed'
     permissions:
       contents: read
       pull-requests: read
       statuses: write
     concurrency:
-      group: dco-${{ github.event_name == 'pull_request_target' && format('head-{0}', github.event.pull_request.head.sha) || github.sha }}
+      group: provenance-${{ format('head-{0}', github.event.pull_request.head.sha) }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Publish pending DCO status on exact pull-request head
-        if: github.event_name == 'pull_request_target'
+      - name: Publish pending legacy status on the exact head
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
             -f state="pending" \
             -f context="DCO sign-off check" \
-            -f description="DCO validation in progress" \
+            -f description="Exact-head provenance validation in progress" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-      - name: Checkout exact candidate without credentials
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
-          path: candidate
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout exact protected pull-request base
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          path: protected-base
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout protected default-branch checker revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
-          path: trusted
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Assert exact trusted checker revision
-        env:
-          EXPECTED_TRUSTED_SHA: ${{ github.event_name == 'pull_request_target' && github.workflow_sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
-        run: |
-          set -euo pipefail
-          test "$(git -C "$GITHUB_WORKSPACE/trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
-
-      - name: Run strict real-commit DCO self-tests
-        run: |
-          set -euo pipefail
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_check.py"
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_events.py"
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/test_dco_activation.py"
-
-      - name: Import current protected base into candidate graph
-        if: github.event_name == 'pull_request_target'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          git -C "$GITHUB_WORKSPACE/candidate" fetch \
-            --no-tags "$GITHUB_WORKSPACE/protected-base" "$BASE_SHA"
-          git -C "$GITHUB_WORKSPACE/candidate" cat-file -e "$BASE_SHA^{commit}"
-
-      - name: Validate exact pull-request commits from trusted base
-        id: validate_pr
-        if: github.event_name == 'pull_request_target'
+      - name: Assert exact protected workflow source
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EXPECTED_PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          set +e
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/dco_check.py" \
-            --repo-root "$GITHUB_WORKSPACE/candidate" \
-            --event-path "$GITHUB_EVENT_PATH"
-          dco_exit=$?
-          set -e
-
-          set +e
-          current_pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
-          current_lookup_exit=$?
-          current_tuple="$(
-            jq -er '[.state, .base.ref, .base.sha, .head.sha] | @tsv' \
-              <<<"$current_pr"
+          set -euo pipefail
+          [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          repository_json="$(gh api "repos/$GITHUB_REPOSITORY")"
+          default_branch="$(jq -er '.default_branch' <<<"$repository_json")"
+          test "$default_branch" = "main"
+          test "$ACTUAL_WORKFLOW_REF" = \
+            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/$default_branch"
+          protected_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$default_branch" \
+              --jq '.object.sha'
           )"
-          current_tuple_exit=$?
+          source_compare="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$ACTUAL_WORKFLOW_SHA...$protected_sha"
+          )"
+          jq -e --arg source "$ACTUAL_WORKFLOW_SHA" '
+              (.status == "ahead" or .status == "identical")
+              and .behind_by == 0
+              and .base_commit.sha == $source
+              and .merge_base_commit.sha == $source
+            ' <<<"$source_compare" >/dev/null
+          protected_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$protected_sha" \
+              --jq '.sha'
+          )"
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$ACTUAL_WORKFLOW_SHA" \
+              --jq '.sha'
+          )"
+          test "$source_workflow_blob" = "$protected_workflow_blob"
+          current_pr="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER"
+          )"
+          declared_file_count="$(jq -er '.changed_files' <<<"$current_pr")"
+          candidate_files="$(
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER/files?per_page=100"
+          )"
+          listed_file_count="$(jq -er '[.[][]] | length' <<<"$candidate_files")"
+          test "$listed_file_count" -eq "$declared_file_count"
+          test "$listed_file_count" -le 3000
+          candidate_workflows="$(
+            jq -er \
+              '[.[][] | select(.filename | startswith(".github/workflows/"))] | length' \
+              <<<"$candidate_files"
+          )"
+          test "$candidate_workflows" -eq 0
+
+      - name: Validate exact live pull-request provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_ACTION: ${{ github.event.action }}
+          EXPECTED_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EXPECTED_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_BASE_REF" == "main" \
+            || "$EXPECTED_BASE_REF" =~ ^release/[^/]+$ ]]
+          test -n "$EXPECTED_HEAD_REF"
+          test -n "$EXPECTED_HEAD_REPOSITORY"
+          case "$EXPECTED_ACTION" in
+            opened|synchronize|reopened|ready_for_review|converted_to_draft|edited) ;;
+            *) echo "::error::unsupported pull-request action"; exit 1 ;;
+          esac
+
+          jq -e \
+            --arg action "$EXPECTED_ACTION" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson number "$EXPECTED_PR_NUMBER" \
+            --arg base_ref "$EXPECTED_BASE_REF" \
+            --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_ref "$EXPECTED_HEAD_REF" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" \
+            --arg head_repository "$EXPECTED_HEAD_REPOSITORY" '
+              .action == $action
+              and .repository.full_name == $repository
+              and .number == $number
+              and .pull_request.number == $number
+              and .pull_request.base.repo.full_name == $repository
+              and .pull_request.base.ref == $base_ref
+              and .pull_request.base.sha == $base_sha
+              and .pull_request.head.repo.full_name == $head_repository
+              and .pull_request.head.ref == $head_ref
+              and .pull_request.head.sha == $head_sha
+            ' "$GITHUB_EVENT_PATH" >/dev/null
+
+          current_pr="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER"
+          )"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg base_ref "$EXPECTED_BASE_REF" \
+            --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_ref "$EXPECTED_HEAD_REF" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" \
+            --arg head_repository "$EXPECTED_HEAD_REPOSITORY" '
+              .state == "open"
+              and .draft == false
+              and .base.repo.full_name == $repository
+              and .base.ref == $base_ref
+              and .base.sha == $base_sha
+              and .head.repo.full_name == $head_repository
+              and .head.ref == $head_ref
+              and .head.sha == $head_sha
+            ' <<<"$current_pr" >/dev/null
+
           governed_pr_numbers="$(
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
@@ -139,110 +195,207 @@ jobs:
                   | join(",")
                 '
           )"
-          shared_lookup_exit=$?
-          set -e
+          test "$governed_pr_numbers" = "$EXPECTED_PR_NUMBER"
 
-          current_state=""
-          current_base_ref=""
-          current_base_sha=""
-          current_head_sha=""
-          if [[ "$current_tuple_exit" -eq 0 ]]; then
-            IFS=$'\t' read -r \
-              current_state current_base_ref current_base_sha current_head_sha \
-              <<<"$current_tuple"
-          fi
+          live_base_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
+              --jq '.object.sha'
+          )"
+          test "$live_base_sha" = "$EXPECTED_BASE_SHA"
+          comparison="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$EXPECTED_BASE_SHA...$EXPECTED_HEAD_SHA"
+          )"
+          jq -e \
+            --arg base "$EXPECTED_BASE_SHA" '
+              .status == "ahead"
+              and .ahead_by >= 1
+              and .behind_by == 0
+              and .base_commit.sha == $base
+              and .merge_base_commit.sha == $base
+            ' <<<"$comparison" >/dev/null
 
-          revalidation_error=false
-          stale_event=false
-          shared_head=false
-          if [[ "$current_lookup_exit" -ne 0 \
-            || "$current_tuple_exit" -ne 0 \
-            || "$shared_lookup_exit" -ne 0 ]]; then
-            revalidation_error=true
-            dco_exit=1
-          elif [[ "$governed_pr_numbers" != "$PR_NUMBER" ]]; then
-            shared_head=true
-            dco_exit=1
-          elif [[ "$current_state" != "open" \
-            || "$current_base_ref" != "$EXPECTED_BASE_REF" \
-            || "$current_base_sha" != "$EXPECTED_BASE_SHA" \
-            || "$current_head_sha" != "$EXPECTED_HEAD_SHA" ]]; then
-            stale_event=true
-            dco_exit=1
-          fi
-
-          state="failure"
-          description="DCO validation failed"
-          if [[ "$revalidation_error" == "true" ]]; then
-            description="DCO live revalidation failed"
-          elif [[ "$shared_head" == "true" ]]; then
-            description="DCO head is shared by governed PRs"
-          elif [[ "$stale_event" == "true" ]]; then
-            description="DCO event is stale"
-          elif [[ "$dco_exit" -eq 0 ]]; then
-            state="success"
-            description="DCO validation passed"
-          fi
-
+      - name: Publish successful legacy compatibility status
+        id: publish-pr-success
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          current_pr="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER"
+          )"
+          jq -e \
+            --arg base_ref "$EXPECTED_BASE_REF" \
+            --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" '
+              .state == "open"
+              and .draft == false
+              and .base.ref == $base_ref
+              and .base.sha == $base_sha
+              and .head.sha == $head_sha
+            ' <<<"$current_pr" >/dev/null
+          test "$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
+              --jq '.object.sha'
+          )" = "$EXPECTED_BASE_SHA"
+          governed_pr_numbers="$(
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
+              | jq -er --arg head "$EXPECTED_HEAD_SHA" '
+                  [
+                    .[][]
+                    | select(.head.sha == $head)
+                    | select(
+                        .base.ref == "main"
+                        or (.base.ref | test("^release/[^/]+$"))
+                      )
+                    | .number
+                  ]
+                  | sort
+                  | map(tostring)
+                  | join(",")
+                '
+          )"
+          test "$governed_pr_numbers" = "$EXPECTED_PR_NUMBER"
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="$state" \
+            -f state="success" \
             -f context="DCO sign-off check" \
-            -f description="$description" \
+            -f description="Exact-head provenance compatibility passed" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
           echo "published=true" >>"$GITHUB_OUTPUT"
-          exit "$dco_exit"
 
-      - name: Finalize pull-request DCO failure
-        if: >-
-          always()
-          && github.event_name == 'pull_request_target'
-          && steps.validate_pr.outputs.published != 'true'
+      - name: Finalize pull-request provenance failure
+        if: always() && steps.publish-pr-success.outputs.published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
             -f state="failure" \
             -f context="DCO sign-off check" \
-            -f description="DCO workflow setup failed" \
+            -f description="Exact-head provenance compatibility failed" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-      - name: Validate exact merge-group range
-        if: github.event_name == 'merge_group'
-        run: >-
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/dco_check.py"
-          --repo-root "$GITHUB_WORKSPACE/candidate"
-          --event-path "$GITHUB_EVENT_PATH"
-
-      - name: Validate exact protected push range
-        if: github.event_name == 'push'
+  merge-group-provenance:
+    name: Validate protected merge-group provenance
+    if: github.event_name == 'merge_group'
+    permissions:
+      contents: read
+    concurrency:
+      group: provenance-${{ format('queue-{0}', github.event.merge_group.head_sha) }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate exact live merge-group provenance
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          python "$GITHUB_WORKSPACE/trusted/.github/scripts/dco_check.py"
-          --repo-root "$GITHUB_WORKSPACE/candidate"
-          --event-path "$GITHUB_EVENT_PATH"
+          GH_TOKEN: ${{ github.token }}
+          ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EXPECTED_ACTION: ${{ github.event.action }}
+          EXPECTED_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          EXPECTED_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          EXPECTED_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          EXPECTED_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_ACTION" = "checks_requested"
+          test "$EXPECTED_BASE_REF" = "refs/heads/main"
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_REF" =~ \
+            ^refs/heads/gh-readonly-queue/main/pr-([1-9][0-9]*)-([0-9a-f]{40})$ ]]
+          queued_base_sha="${BASH_REMATCH[2]}"
+          test "$queued_base_sha" = "$EXPECTED_BASE_SHA"
+          test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"
+          test "$GITHUB_REF" = "$EXPECTED_HEAD_REF"
+          test "$ACTUAL_WORKFLOW_SHA" = "$EXPECTED_HEAD_SHA"
+          test "$ACTUAL_WORKFLOW_REF" = \
+            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@$EXPECTED_HEAD_REF"
 
-  native-dco-compatibility:
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg base_ref "$EXPECTED_BASE_REF" \
+            --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_ref "$EXPECTED_HEAD_REF" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" '
+              .action == "checks_requested"
+              and .repository.full_name == $repository
+              and .merge_group.base_ref == $base_ref
+              and .merge_group.base_sha == $base_sha
+              and .merge_group.head_ref == $head_ref
+              and .merge_group.head_sha == $head_sha
+            ' "$GITHUB_EVENT_PATH" >/dev/null
+
+          base_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+              --jq '.object.sha'
+          )"
+          test "$base_sha" = "$EXPECTED_BASE_SHA"
+          queue_ref="${EXPECTED_HEAD_REF#refs/}"
+          queue_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/$queue_ref" \
+              --jq '.object.sha'
+          )"
+          test "$queue_sha" = "$EXPECTED_HEAD_SHA"
+
+          protected_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$EXPECTED_BASE_SHA" \
+              --jq '.sha'
+          )"
+          queued_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$EXPECTED_HEAD_SHA" \
+              --jq '.sha'
+          )"
+          test "$queued_workflow_blob" = "$protected_workflow_blob"
+
+          queue_comparison="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$EXPECTED_BASE_SHA...$EXPECTED_HEAD_SHA"
+          )"
+          jq -e \
+            --arg base "$EXPECTED_BASE_SHA" '
+              .status == "ahead"
+              and .ahead_by >= 1
+              and .behind_by == 0
+              and .base_commit.sha == $base
+              and .merge_base_commit.sha == $base
+            ' <<<"$queue_comparison" >/dev/null
+          test "$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+              --jq '.object.sha'
+          )" = "$EXPECTED_BASE_SHA"
+          test "$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/$queue_ref" \
+              --jq '.object.sha'
+          )" = "$EXPECTED_HEAD_SHA"
+
+  legacy-dco-compatibility:
     name: DCO sign-off check
-    needs: dco
-    if: always() && github.event_name != 'pull_request_target'
+    needs: merge-group-provenance
+    if: always() && github.event_name == 'merge_group'
     permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: Propagate terminal native DCO result
+      - name: Propagate terminal provenance result
         env:
-          NATIVE_DCO_RESULT: ${{ needs.dco.result }}
+          PROVENANCE_RESULT: ${{ needs.merge-group-provenance.result }}
         run: |
           set -euo pipefail
-          test "$NATIVE_DCO_RESULT" = "success"
+          test "$PROVENANCE_RESULT" = "success"
 
   reconcile-old-head:
-    name: Reconcile surviving DCO status
+    name: Reconcile surviving provenance status
     if: >-
       github.event_name == 'pull_request_target'
       && (github.event.action == 'closed' || github.event.action == 'synchronize')
@@ -251,18 +404,55 @@ jobs:
       pull-requests: read
       statuses: write
     concurrency:
-      group: dco-${{ format('head-{0}', github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha) }}
+      group: provenance-${{ format('head-{0}', github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha) }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Resolve the surviving governed PR for the old head
-        id: subject
+      - name: Assert exact protected reconciliation source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$ACTUAL_WORKFLOW_REF" = \
+            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/main"
+          protected_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+              --jq '.object.sha'
+          )"
+          source_compare="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$ACTUAL_WORKFLOW_SHA...$protected_sha"
+          )"
+          jq -e --arg source "$ACTUAL_WORKFLOW_SHA" '
+              (.status == "ahead" or .status == "identical")
+              and .behind_by == 0
+              and .base_commit.sha == $source
+              and .merge_base_commit.sha == $source
+            ' <<<"$source_compare" >/dev/null
+          protected_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$protected_sha" \
+              --jq '.sha'
+          )"
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$ACTUAL_WORKFLOW_SHA" \
+              --jq '.sha'
+          )"
+          test "$source_workflow_blob" = "$protected_workflow_blob"
+
+      - name: Resolve the surviving governed pull request
+        id: reconciliation-subject
         env:
           GH_TOKEN: ${{ github.token }}
           AFFECTED_HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          [[ "$AFFECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           governed_prs="$(
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
@@ -278,9 +468,8 @@ jobs:
                 '
           )"
           count="$(jq -r 'length' <<<"$governed_prs")"
-          echo "reconcile=false" >>"$GITHUB_OUTPUT"
-
           if [[ "$count" -eq 0 ]]; then
+            echo "published=true" >>"$GITHUB_OUTPUT"
             exit 0
           fi
           if [[ "$count" -ne 1 ]]; then
@@ -288,105 +477,118 @@ jobs:
               "repos/$GITHUB_REPOSITORY/statuses/$AFFECTED_HEAD_SHA" \
               -f state="failure" \
               -f context="DCO sign-off check" \
-              -f description="DCO head is shared by governed PRs" \
+              -f description="Head is shared by governed pull requests" \
               -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            exit 0
+            echo "published=true" >>"$GITHUB_OUTPUT"
+            exit 1
           fi
 
           pr_number="$(jq -r '.[0].number' <<<"$governed_prs")"
           base_ref="$(jq -r '.[0].base.ref' <<<"$governed_prs")"
           base_sha="$(jq -r '.[0].base.sha' <<<"$governed_prs")"
+          head_ref="$(jq -r '.[0].head.ref' <<<"$governed_prs")"
           head_sha="$(jq -r '.[0].head.sha' <<<"$governed_prs")"
+          head_repository="$(jq -r '.[0].head.repo.full_name' <<<"$governed_prs")"
           test "$head_sha" = "$AFFECTED_HEAD_SHA"
-
           {
             echo "reconcile=true"
             echo "pr_number=$pr_number"
             echo "base_ref=$base_ref"
             echo "base_sha=$base_sha"
+            echo "head_ref=$head_ref"
             echo "head_sha=$head_sha"
+            echo "head_repository=$head_repository"
           } >>"$GITHUB_OUTPUT"
 
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
             -f state="pending" \
             -f context="DCO sign-off check" \
-            -f description="DCO reconciliation in progress" \
+            -f description="Exact-head provenance reconciliation in progress" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-      - name: Checkout surviving exact candidate without credentials
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: refs/pull/${{ steps.subject.outputs.pr_number }}/head
-          path: reconcile-candidate
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout surviving exact protected base
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.subject.outputs.base_sha }}
-          path: reconcile-base
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout immutable reconciliation checker
-        if: steps.subject.outputs.reconcile == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: reconcile-trusted
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Validate and republish surviving DCO evidence
-        id: validate_reconciliation
-        if: steps.subject.outputs.reconcile == 'true'
+      - name: Revalidate the surviving exact head
+        if: steps.reconciliation-subject.outputs.reconcile == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.subject.outputs.pr_number }}
-          EXPECTED_BASE_REF: ${{ steps.subject.outputs.base_ref }}
-          EXPECTED_BASE_SHA: ${{ steps.subject.outputs.base_sha }}
-          EXPECTED_HEAD_SHA: ${{ steps.subject.outputs.head_sha }}
-          EXPECTED_TRUSTED_SHA: ${{ github.workflow_sha }}
+          EXPECTED_PR_NUMBER: ${{ steps.reconciliation-subject.outputs.pr_number }}
+          EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}
+          EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}
+          EXPECTED_HEAD_REF: ${{ steps.reconciliation-subject.outputs.head_ref }}
+          EXPECTED_HEAD_SHA: ${{ steps.reconciliation-subject.outputs.head_sha }}
+          EXPECTED_HEAD_REPOSITORY: ${{ steps.reconciliation-subject.outputs.head_repository }}
         run: |
           set -euo pipefail
-          test "$(git -C "$GITHUB_WORKSPACE/reconcile-trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
-          git -C "$GITHUB_WORKSPACE/reconcile-candidate" fetch \
-            --no-tags "$GITHUB_WORKSPACE/reconcile-base" "$EXPECTED_BASE_SHA"
-          git -C "$GITHUB_WORKSPACE/reconcile-candidate" cat-file -e "$EXPECTED_BASE_SHA^{commit}"
-          jq -n \
+          [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_BASE_REF" == "main" \
+            || "$EXPECTED_BASE_REF" =~ ^release/[^/]+$ ]]
+          current_pr="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER"
+          )"
+          jq -e \
             --arg repository "$GITHUB_REPOSITORY" \
             --arg base_ref "$EXPECTED_BASE_REF" \
             --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_ref "$EXPECTED_HEAD_REF" \
             --arg head_sha "$EXPECTED_HEAD_SHA" \
-            --argjson number "$PR_NUMBER" \
-            '{
-              action: "synchronize",
-              repository: {full_name: $repository},
-              number: $number,
-              pull_request: {
-                number: $number,
-                base: {ref: $base_ref, sha: $base_sha},
-                head: {sha: $head_sha}
-              }
-            }' >"$RUNNER_TEMP/dco-reconcile-event.json"
-
-          set +e
-          python "$GITHUB_WORKSPACE/reconcile-trusted/.github/scripts/dco_check.py" \
-            --repo-root "$GITHUB_WORKSPACE/reconcile-candidate" \
-            --event-path "$RUNNER_TEMP/dco-reconcile-event.json"
-          dco_exit=$?
-          current_pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
-          current_lookup_exit=$?
-          current_tuple="$(
-            jq -er '[.state, .base.ref, .base.sha, .head.sha] | @tsv' \
-              <<<"$current_pr"
+            --arg head_repository "$EXPECTED_HEAD_REPOSITORY" '
+              .state == "open"
+              and .draft == false
+              and .base.repo.full_name == $repository
+              and .base.ref == $base_ref
+              and .base.sha == $base_sha
+              and .head.repo.full_name == $head_repository
+              and .head.ref == $head_ref
+              and .head.sha == $head_sha
+            ' <<<"$current_pr" >/dev/null
+          live_base_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
+              --jq '.object.sha'
           )"
-          current_tuple_exit=$?
+          test "$live_base_sha" = "$EXPECTED_BASE_SHA"
+          comparison="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$EXPECTED_BASE_SHA...$EXPECTED_HEAD_SHA"
+          )"
+          jq -e \
+            --arg base "$EXPECTED_BASE_SHA" '
+              .status == "ahead"
+              and .ahead_by >= 1
+              and .behind_by == 0
+              and .base_commit.sha == $base
+              and .merge_base_commit.sha == $base
+            ' <<<"$comparison" >/dev/null
+
+      - name: Publish successful reconciled compatibility status
+        id: publish-reconciliation-success
+        if: steps.reconciliation-subject.outputs.reconcile == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_PR_NUMBER: ${{ steps.reconciliation-subject.outputs.pr_number }}
+          EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}
+          EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ steps.reconciliation-subject.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          current_pr="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER"
+          )"
+          jq -e \
+            --arg base_ref "$EXPECTED_BASE_REF" \
+            --arg base_sha "$EXPECTED_BASE_SHA" \
+            --arg head_sha "$EXPECTED_HEAD_SHA" '
+              .state == "open"
+              and .draft == false
+              and .base.ref == $base_ref
+              and .base.sha == $base_sha
+              and .head.sha == $head_sha
+            ' <<<"$current_pr" >/dev/null
+          test "$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
+              --jq '.object.sha'
+          )" = "$EXPECTED_BASE_SHA"
           governed_pr_numbers="$(
             gh api --paginate --slurp \
               "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
@@ -405,73 +607,28 @@ jobs:
                   | join(",")
                 '
           )"
-          shared_lookup_exit=$?
-          set -e
-
-          current_state=""
-          current_base_ref=""
-          current_base_sha=""
-          current_head_sha=""
-          if [[ "$current_tuple_exit" -eq 0 ]]; then
-            IFS=$'\t' read -r \
-              current_state current_base_ref current_base_sha current_head_sha \
-              <<<"$current_tuple"
-          fi
-
-          revalidation_error=false
-          stale_event=false
-          shared_head=false
-          if [[ "$current_lookup_exit" -ne 0 \
-            || "$current_tuple_exit" -ne 0 \
-            || "$shared_lookup_exit" -ne 0 ]]; then
-            revalidation_error=true
-            dco_exit=1
-          elif [[ "$governed_pr_numbers" != "$PR_NUMBER" ]]; then
-            shared_head=true
-            dco_exit=1
-          elif [[ "$current_state" != "open" \
-            || "$current_base_ref" != "$EXPECTED_BASE_REF" \
-            || "$current_base_sha" != "$EXPECTED_BASE_SHA" \
-            || "$current_head_sha" != "$EXPECTED_HEAD_SHA" ]]; then
-            stale_event=true
-            dco_exit=1
-          fi
-
-          state="failure"
-          description="DCO reconciliation failed"
-          if [[ "$revalidation_error" == "true" ]]; then
-            description="DCO live revalidation failed"
-          elif [[ "$shared_head" == "true" ]]; then
-            description="DCO head is shared by governed PRs"
-          elif [[ "$stale_event" == "true" ]]; then
-            description="DCO reconciliation is stale"
-          elif [[ "$dco_exit" -eq 0 ]]; then
-            state="success"
-            description="DCO validation passed"
-          fi
-
+          test "$governed_pr_numbers" = "$EXPECTED_PR_NUMBER"
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
-            -f state="$state" \
+            -f state="success" \
             -f context="DCO sign-off check" \
-            -f description="$description" \
+            -f description="Exact-head provenance compatibility passed" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-
           echo "published=true" >>"$GITHUB_OUTPUT"
-          exit "$dco_exit"
 
       - name: Finalize reconciliation failure
         if: >-
           always()
-          && steps.subject.outputs.reconcile == 'true'
-          && steps.validate_reconciliation.outputs.published != 'true'
+          && steps.reconciliation-subject.outputs.published != 'true'
+          && steps.publish-reconciliation-success.outputs.published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          EXPECTED_HEAD_SHA: ${{ steps.subject.outputs.head_sha }}
+          AFFECTED_HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_HEAD_SHA" \
+            "repos/$GITHUB_REPOSITORY/statuses/$AFFECTED_HEAD_SHA" \
             -f state="failure" \
             -f context="DCO sign-off check" \
-            -f description="DCO reconciliation setup failed" \
+            -f description="Exact-head provenance reconciliation failed" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -1,7 +1,7 @@
 name: SLSA Provenance (L1 honest)
 
 # Doctrine v11 honesty: this workflow is a SLSA Build L1 supply-chain status
-# indicator (SBOM + DCO baseline). It does NOT itself generate non-forgeable
+# indicator (SBOM + recorded source/build steps). It does NOT itself generate non-forgeable
 # SLSA L2/L3 provenance — do not claim L3 anywhere.
 #
 # Real build provenance for release artifacts is produced per-repo by
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: SLSA L1 supply-chain baseline (SBOM + DCO; honest — not L3)
+      - name: SLSA L1 supply-chain baseline (SBOM + source record; honest — not L3)
         run: |
-          echo "SLSA Build L1 baseline (SBOM + DCO). No L3 claim."
+          echo "SLSA Build L1 baseline (SBOM + recorded source/build steps). No L3 claim."
           echo "Release-artifact provenance: attest-build-provenance@v2 wired (SLSA L2 roadmap via Wire D); L2 NOT yet earned until cosign verify-attestation passes on the deployed image."

--- a/.governance/README.md
+++ b/.governance/README.md
@@ -9,7 +9,7 @@ that do not yet exist would lock a repository without producing evidence.
 - Every active ruleset has an empty `bypass_actors` array.
 - The estate does not claim independent human review while it has one human
   member. GitHub's human approval count is zero by design.
-- Eight fail-closed checks, App-pinned staging, signed commits, App-owned
+- Eight fail-closed checks, App-pinned staging, exact-head provenance, App-owned
   attestation evidence, and merge queue execution replace the impossible
   second-human requirement.
 - The ordinary `GITHUB_TOKEN` cannot approve pull request reviews.
@@ -84,7 +84,9 @@ separate, identity-bound release control.
    merge-queue ruleset to contain wildcard refs. Its required checks are the
    eight gates and App-pinned staging; the App status remains signed evidence.
 4. Apply `ruleset-release.json` separately to `release/*`; it retains the gates,
-   signatures, App-pinned staging, and App attestation status without a queue.
+   App-pinned staging and App attestation status without a queue. The existing
+   server-side signature setting is retained only as observed configuration
+   drift until repository ruleset administration is available.
 5. Verify the active gate, staging, attestor, BAP, and queue on a pilot PR.
 6. Roll out only to active repositories with mapped gates and staging evidence.
 

--- a/.governance/solo-operator-policy.md
+++ b/.governance/solo-operator-policy.md
@@ -6,7 +6,9 @@ therefore does not claim independent human review.
 ## Enforced control model
 
 - Pull requests are mandatory and direct pushes remain blocked.
-- Commits must be signed, linear, DCO-signed, and conventionally named.
+- Pull-request heads must have exact protected provenance, linear history, and
+  conventional names. Developer commit signatures and trailers are not
+  required.
 - Eight repository-specific, fail-closed checks must pass for the exact head.
 - The `deploy/staging` check is required and pinned to GitHub Actions App ID
   `15368`; the workflow also emits the staging deployment record.
@@ -29,15 +31,17 @@ The App is a distinct machine identity, not an independent human reviewer.
 GitHub only counts approvals from people with write permission, so the human
 approval count is zero. Enforcement comes from the App-owned required status on
 non-queued release branches. On the queued default branch, enforcement comes
-from mandatory exact-head and merge-group checks, staging, signatures, an empty
-bypass list, and the queue. The App-owned review, signed BAP, status, and
+from mandatory exact-head and merge-group checks, staging, an empty bypass
+list, and the queue. The App-owned review, signed BAP, status, and
 automatic queue request remain independently attributable evidence.
 
 The merge queue applies to the default branch. GitHub does not support wildcard
 refs in a merge-queue ruleset, so `release/*` uses a separate ruleset with the
-same gates, signatures, App-pinned staging, and required App-owned attestation
-status but no queue. The same attestor submits release pull requests to their
-protected auto-merge path.
+same gates, App-pinned staging, and required App-owned attestation status but no
+queue. The same attestor submits release pull requests to their protected
+auto-merge path. Existing server-side signature settings remain configuration
+drift to remove when repository ruleset administration becomes available; they
+are not the developer contribution policy.
 
 ## Governance changes
 
@@ -63,7 +67,7 @@ request cannot weaken its own evaluator before approval.
 
 ## Bootstrap record
 
-PR #316 is the signed one-time bootstrap that installed the evaluator itself.
+PR #316 is the one-time protected bootstrap that installed the evaluator itself.
 It merged only after all pre-existing hosted checks were green and without a
 bypass actor, force merge, or administrator override. The release ruleset
 requires the distinct App attestation status for subsequent release changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,12 @@ templates, and community health files.
   findings (mostly line-length and indentation).
 - `actionlint` passes clean (0 errors) on all 15 workflow files.
 
-### There is no build / run / test step
+### There is no application build or service
 
 - No `package.json`, `requirements.txt`, `Makefile`, or any dependency manifest exists.
 - No services to start. No database. No backend / frontend.
+- The Python governance contract suites under `.github/scripts/test_*.py` are
+  real tests and must remain green when their workflows or policies change.
 - Reusable workflows (`.github/workflows/reusable-*.yml`) are consumed by
   other repos via `uses:` and run on GitHub Actions, not locally.
 
@@ -31,4 +33,6 @@ templates, and community health files.
 - Conventional Commits required (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`).
 - Squash-merge into `main`.
 - All Actions must be SHA-pinned (enforced by `pin-check.yml`).
-- DCO sign-off required on all commits (`git commit -s`).
+- Developer commit signatures and `Signed-off-by` trailers are not required.
+  Protected exact-head provenance and all real build/security checks remain
+  required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,14 +37,12 @@
   
 ---
 
-## Developer Certificate of Origin (DCO)
+## Solo-builder provenance
 
-All commits to this repository must carry a Developer Certificate of Origin sign-off per [DCO v1.1](https://developercertificate.org/). Add with:
-
-```bash
-git commit -s -m "your commit message"
-# Produces: Signed-off-by: Name <email>
-```
+Developer commit signatures and sign-off trailers are not required. Pull
+requests remain mandatory: the protected workflow validates the exact live
+repository, base, and head identities, while build and security checks must
+pass for the same head before merge.
 
 ### Branch naming convention
 

--- a/FORGE_BUILD_BRIEF.md
+++ b/FORGE_BUILD_BRIEF.md
@@ -35,11 +35,13 @@
    one-line mandate.
 5. **Repo conventions (from `.github/AGENTS.md`).**
    - Conventional Commits (`feat: fix: chore: docs: ci: refactor: test:`)
-   - DCO sign-off on every commit (`git commit -s`)
+   - Developer commit signatures and sign-off trailers are not required;
+     exact-head provenance is required
    - All GitHub Actions **SHA-pinned** (enforced by `pin-check.yml`)
    - Squash-merge into `main`; one feature branch per task
-   - Never force-merge past a failing **required** check. If a check is failing
-     for an infra reason (e.g. stale scanner DB), fix the infra — don't override.
+   - Never bypass a real build or security failure. An owner migration may
+     bypass only a documented obsolete signature/provenance compatibility
+     context while ruleset settings are being corrected.
 
 ---
 
@@ -96,7 +98,7 @@ For each flagship (**a11oy, killinchu, sentra, rosie, amaru**):
 
 ## 6. Definition of done (every task)
 
-- [ ] Branch + Conventional-Commit title + DCO sign-off
+- [ ] Branch + Conventional-Commit title + exact-head provenance
 - [ ] All **required** checks green for a real reason (no overrides)
 - [ ] Numbers/claims trace to `lean_numbers.json` / lutar-lean
 - [ ] No SLSA-L2+/compliance overclaim; honest reachability states

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ jobs:
 | `reusable-node-ci.yml` | Node lint + typecheck + test + build matrix |
 | `reusable-docs-ci.yml` | Markdown lint + link-check for docs repos |
 | `reusable-release-please.yml` | Conventional-commits release automation |
-| `reusable-dco.yml` | Developer Certificate of Origin sign-off check |
 
 **Security & supply chain**
 
@@ -107,7 +106,7 @@ All Actions are SHA-pinned and wrapped with [`step-security/harden-runner`](http
 - Private vulnerability reporting: [security policy](https://github.com/szl-holdings/.github/security/policy)
 - Email: `security@szlholdings.com`
 - Canonical RFC 9116 record: [`security.txt`](./security.txt)
-- Org-wide: branch protection rulesets, signed-commit enforcement, CODEOWNERS, OpenSSF Scorecard
+- Org-wide: branch protection rulesets, exact-head provenance checks, CODEOWNERS, OpenSSF Scorecard
 - This repository's live security status is authoritative only in GitHub's [Dependabot](https://github.com/szl-holdings/.github/security/dependabot), [secret-scanning](https://github.com/szl-holdings/.github/security/secret-scanning), and [CodeQL](https://github.com/szl-holdings/.github/security/code-scanning) dashboards; organization-wide alert state is not asserted here, and this README does not freeze alert counts.
 
 ## Tooling for contributors
@@ -163,4 +162,3 @@ Org page: [github.com/szl-holdings](https://github.com/szl-holdings) · Doctrine
 ![SZL Holdings](./branding/szl-avatar-animated.gif)
 
 *The SZL Holdings animated mark (400×400, 16fps loop). Signed Yachay.*
-

--- a/TRUST.md
+++ b/TRUST.md
@@ -22,12 +22,13 @@ unverifiable higher level) is recorded in
 Levels 2 and 3 (Sigstore signing + isolated, hardened builders) are roadmap
 items and are NOT claimed here.
 
-## Signed commits (DCO)
+## Pull-request provenance
 
-Commits carry a Developer Certificate of Origin sign-off
-(`Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>`), enforced by
-the DCO check. This requirement is set in
-[Doctrine v7 §5](doctrine/DOCTRINE_V7.md#5--signed-commits-dco).
+Developer commit signatures and sign-off trailers are not required. The native
+compatibility workflow instead binds its result to the exact live pull-request
+repository, base, and head identities without checking out or executing the
+proposed tree. Real build, security, staging, and attestation checks remain
+separate required evidence.
 
 ## CODEOWNERS coverage
 
@@ -67,7 +68,6 @@ superlatives). The policy and the token list are defined in
 - GitHub: [stephenlutar2-hash](https://github.com/stephenlutar2-hash) and
   [betterwithage](https://github.com/betterwithage)
 - Corporate email: stephen@szlholdings.com
-- DCO sign-off email: stephenlutar2@gmail.com
 
 ## Live numbers
 

--- a/WORKFLOWS.md
+++ b/WORKFLOWS.md
@@ -23,6 +23,22 @@ of redefining the same logic locally.
 | `reusable-hf-candidate-plan.yml` | Build a provider-free exact base-to-head Dockerfile payload plan and revalidate the live PR pair | base-controlled `pull_request_target` |
 | `reusable-hf-module-drift-check.yml` | Detect drift between a repo's source-of-truth and its live Hugging Face Space | caller-chosen |
 
+### Repository-native provenance compatibility
+
+`.github/workflows/dco.yml` is retained under its historical filename because
+ruleset `19755620` still requires the exact status context `DCO sign-off check`.
+It does not require a developer signature or trailer. Protected
+`pull_request_target` logic validates the live PR/base/head tuple without
+checking out or executing proposed content; merge-group logic revalidates the
+live queue refs with read-only permission. All real build and security checks
+remain independent requirements.
+
+Until the ruleset can require this specific workflow (or a distinct App-owned
+status), any context emitted by GitHub Actions has the provider limitation that
+the context name alone does not identify a unique workflow. Proposed changes to
+`.github/workflows/**` therefore fail the protected provenance check and need an
+explicitly reviewed owner migration.
+
 ## Calling a reusable workflow
 
 ```yaml

--- a/docs/SCORECARD_EXCEPTIONS.md
+++ b/docs/SCORECARD_EXCEPTIONS.md
@@ -11,62 +11,36 @@ repository (2 critical, 4 high, 23 medium at time of review).
 
 ---
 
-## 1. `DangerousWorkflowID` — `.github/workflows/dco.yml:42` and `:50` (critical ×2)
+## 1. `DangerousWorkflowID` — native provenance workflow (resolved)
 
-**What Scorecard flags.** The `Dangerous-Workflow` check reports the
-combination of a `pull_request_target` trigger with a checkout of an
-attacker-controlled ref (`ref: refs/pull/{N}/head` and
-`ref: ${{ github.event.pull_request.base.sha }}`). In the general case that
-pattern is a privilege-escalation sink, because `pull_request_target` runs with
-the base repository's secrets and write-capable token while the checked-out tree
-is contributor-controlled.
+The earlier implementation combined `pull_request_target` with candidate and
+trusted checkouts. Even though it attempted to keep the proposed tree as data,
+that shape was unnecessarily difficult to audit and produced two critical
+Scorecard findings.
 
-**Why it does not apply here.** The workflow was written specifically to defeat
-that attack, and Scorecard's pattern match cannot observe the mitigations:
+The native workflow has been replaced. It now processes only GitHub event and
+REST API metadata: there is no checkout, local action, candidate script, cache,
+artifact, or repository secret. The protected pull-request jobs validate the
+exact workflow source, live PR/base/head tuple, unique governed head, base
+ancestry, and absence of proposed workflow edits before publishing the legacy
+compatibility context. The merge-group job has read-only Contents permission;
+only the protected pull-request and reconciliation jobs can write a status.
 
-1. **The untrusted tree is never executed.** The PR head is checked out into an
-   isolated `candidate/` path and is only ever read as *git history* — every
-   `python` invocation in the workflow runs a script from `trusted/`, not from
-   `candidate/`. See the `Run strict real-commit DCO self-tests`,
-   `Validate exact pull-request commits from trusted base`,
-   `Validate exact merge-group range` and `Validate exact protected push range`
-   steps: all four execute
-   `"$GITHUB_WORKSPACE/trusted/.github/scripts/..."`.
+**Disposition.** The old false-positive exception is retired. Re-scan after the
+replacement reaches the default branch and close the alerts as fixed when the
+provider observes the new file.
 
-2. **The executed tree is pinned to the workflow's own revision.** The
-   `trusted/` checkout uses `ref: ${{ github.workflow_sha }}` — the exact commit
-   of the workflow file that GitHub decided to run — and the next step asserts
-   the checkout actually landed there:
+**Residual provider limitation.** Ruleset `19755620` still identifies a status
+by the historical context name and GitHub Actions App, not by one workflow
+file. A distinct candidate workflow could otherwise imitate that name. The
+protected pull-request path therefore rejects any `.github/workflows/**` edit;
+workflow migrations require an explicit owner review and bypass of only the
+obsolete compatibility context. Requiring a specific workflow or a distinct
+App-owned status remains the complete fix once ruleset settings are editable.
 
-   ```
-   test "$(git -C "$GITHUB_WORKSPACE/trusted" rev-parse HEAD)" = "$EXPECTED_TRUSTED_SHA"
-   ```
-
-   A contributor cannot substitute their own checker, because changing the
-   checker in their PR changes `candidate/`, not `trusted/`.
-
-3. **No credentials are exposed to any checkout.** Every one of the six
-   `actions/checkout` invocations sets `persist-credentials: false`, so no
-   `.git/config` in any path carries a usable token.
-
-4. **The token is narrowly scoped.** After the change that accompanies this
-   file, the workflow default is `contents: read` + `pull-requests: read`, and
-   `statuses: write` is granted only to the two jobs that publish the commit
-   status. There is no `contents: write`, no `id-token: write`, and no secret
-   other than `github.token` is referenced.
-
-5. **Every action is SHA-pinned** (`actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1`).
-
-**Disposition.** Dismiss both alerts as **false positive**, citing this section.
-Do not "remediate" by rewriting the workflow: replacing
-`pull_request_target` with `pull_request` would remove the ability to publish a
-commit status on the PR head, which is the entire purpose of the native DCO
-gate, and would weaken a control rather than strengthen it.
-
-**Re-review trigger.** Re-open this decision if any future edit causes the
-workflow to (a) execute a path under `candidate/`, (b) drop the
-`EXPECTED_TRUSTED_SHA` assertion, (c) set `persist-credentials: true`, or
-(d) add `contents: write`, `id-token: write`, or any repository secret.
+**Re-review trigger.** Re-open this decision if the workflow gains any `uses:`,
+checkout, candidate execution, repository secret, `contents: write`,
+`id-token: write`, or status-write permission on the merge-group job.
 
 ---
 
@@ -75,7 +49,7 @@ workflow to (a) execute a path under `candidate/`, (b) drop the
 | Alert | Status |
 |---|---|
 | `.github/workflows/notification-inbox-scheduler.yml:13` | **Fixed.** `actions: write` moved from the workflow default to the single `dispatch` job that needs it. |
-| `.github/workflows/dco.yml:17` | **Fixed.** `statuses: write` moved from the workflow default to the two jobs that publish a status. |
+| `.github/workflows/dco.yml` | **Fixed.** The workflow default and merge-group compatibility job use `permissions: {}`; `statuses: write` exists only on the protected PR and reconciliation jobs that publish the legacy context. |
 | `.github/workflows/attest-and-approve.yml:22` | **Accepted.** The workflow default is already the minimum (`contents: read`). The remaining write scopes (`contents: write`, `id-token: write`, `pull-requests: write`) are declared at job level on the single `attest` job and are each load-bearing: `id-token: write` for OIDC-based attestation, `contents: write` to record the attestation, `pull-requests: write` to approve. Scorecard reports the top-level block's line number even when the write scope is job-scoped, so this alert cannot be cleared without removing the workflow's function. |
 | `.github/workflows/hf-kernel-card-publish-v2.yml:28` | **Accepted.** Same shape: workflow default is `contents: read`; the `publish` job needs `actions: write` (to re-dispatch on transient Hub failure) and `issues: write` (to file the publish receipt). |
 


### PR DESCRIPTION
Satisfies: C-19755620

Labels: solo-builder provenance compatibility; legacy ruleset migration

Rollback: Revert the squash merge commit to restore the prior native validator, then re-run all protected governance gates before any further merge.

Risk: D - Replaces a required native governance workflow while ruleset 19755620 still names the historical compatibility context.

Solo-Operator-Authorization: confirmed

## Summary

- replaces developer trailer/signature validation in `.github/workflows/dco.yml` with exact live PR and merge-group provenance validation
- retains the exact legacy `DCO sign-off check` context until ruleset 19755620 can be edited
- uses protected `pull_request_target` logic for PR status publication and a separate read-only merge-group job
- never checks out or executes proposed repository content and invokes no action
- blocks proposed `.github/workflows/**` edits after activation so a candidate cannot add a competing GitHub Actions context
- keeps every reusable/Doctrine validator, attestation workflow, product/artifact signature, and real build/security check intact
- removes active developer-signature requirements from contributor policy, templates, trust documentation, and the solo-operator brief
- retires the obsolete Scorecard exception for the old checkout-based workflow

## Privilege boundary

- workflow default: `permissions: {}`
- pull-request provenance and old-head reconciliation: `contents: read`, `pull-requests: read`, `statuses: write`
- merge-group provenance: `contents: read`
- legacy compatibility job: `permissions: {}`
- no secrets, checkout, local scripts, cache, artifacts, candidate commands, or post-merge push trigger

## Verification

- `python3 .github/scripts/test_dco_check.py`: 65/65 passed
- `python3 .github/scripts/test_dco_events.py`: 40/40 passed
- `python3 .github/scripts/test_dco_activation.py`: 8/8 passed
- `python3 .github/scripts/verify_forge9_governance.py`: passed
- all eight `run_forge9_gate.py` gates: passed
- YAML parsing: passed
- Bash syntax for all 12 native workflow shell blocks: passed
- `git diff --check`: passed
- rebased exact base `c889276e51e7d954c4bba8b216f86fc7577721fa`
- remote tree `83aa2959da6626c0248d1521930440dc5199f658` exactly matches the locally reverified tree

## Migration boundary

This PR necessarily changes the workflow that will reject future workflow edits. Merge only the exact reviewed head. Owner bypass is authorized solely for obsolete developer-signature/DCO compatibility contexts on this migration; real build, security, FORGE-9, and review findings remain blocking.

The historical context is still GitHub-Actions-App scoped rather than specific-workflow scoped. The protected PR path mitigates that provider limitation by rejecting future workflow-file changes. The complete provider-side fix is to make ruleset 19755620 require this specific workflow or a distinct App-owned status when settings access is available.