### PR TITLE
fix(ci): close provenance reconciliation gaps

### DIFF
--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -44,6 +44,8 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "pull-request-provenance:",
             "merge-group-provenance:",
             "Reconcile surviving provenance status",
+            "EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}",
+            "EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}",
             "github.event.before",
             "AFFECTED_HEAD_SHA:",
             "Finalize pull-request provenance failure",
@@ -59,6 +61,7 @@ class DcoActivationWorkflowTests(unittest.TestCase):
             "github.workflow_ref",
             "source_workflow_blob",
             "protected_workflow_blob",
+            ".github/workflows/dco.yml@refs/heads/$EXPECTED_BASE_REF",
             "--paginate --slurp",
             'startswith(".github/workflows/")',
             "git/ref/heads/$EXPECTED_BASE_REF",
@@ -72,6 +75,14 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(marker, self.native)
         self.assertEqual(self.native.count("statuses: write"), 2)
+        self.assertGreaterEqual(self.native.count("candidate_workflows"), 2)
+        self.assertNotIn(
+            '.github/workflows/dco.yml@refs/heads/main"', self.native
+        )
+        self.assertLess(
+            self.native.index("Resolve the surviving governed pull request"),
+            self.native.index("Assert exact protected reconciliation source"),
+        )
         merge_job = self.native.split("  merge-group-provenance:\n", 1)[1].split(
             "  legacy-dco-compatibility:\n", 1
         )[0]

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -461,6 +461,7 @@ def verify_gate_contract() -> None:
         "github.workflow_sha",
         "source_workflow_blob",
         "protected_workflow_blob",
+        ".github/workflows/dco.yml@refs/heads/$EXPECTED_BASE_REF",
         "--paginate --slurp",
         'startswith(".github/workflows/")',
         "merge_base_commit.sha == $base",
@@ -471,6 +472,8 @@ def verify_gate_contract() -> None:
         "PROVENANCE_RESULT: ${{ needs.merge-group-provenance.result }}",
         'test "$PROVENANCE_RESULT" = "success"',
         "Reconcile surviving provenance status",
+        "EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}",
+        "EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}",
     ):
         if marker not in dco_template:
             fail(f"trusted provenance workflow is missing {marker!r}")
@@ -497,6 +500,14 @@ def verify_gate_contract() -> None:
             fail(f"native provenance workflow contains forbidden {forbidden!r}")
     if dco_template.count("statuses: write") != 2:
         fail("only pull-request provenance and reconciliation may write statuses")
+    if dco_template.count("candidate_workflows") < 2:
+        fail("initial and reconciled PR evidence must both reject workflow edits")
+    if '.github/workflows/dco.yml@refs/heads/main"' in dco_template:
+        fail("protected PR provenance must bind workflow source to the target base")
+    if dco_template.index("Resolve the surviving governed pull request") > dco_template.index(
+        "Assert exact protected reconciliation source"
+    ):
+        fail("reconciliation must resolve its survivor before binding workflow source")
     merge_group_job = dco_template.split("  merge-group-provenance:\n", 1)[1].split(
         "  legacy-dco-compatibility:\n", 1
     )[0]

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -58,21 +58,27 @@ jobs:
           ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
           ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
           EXPECTED_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXPECTED_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$EXPECTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_BASE_REF" == "main" \
+            || "$EXPECTED_BASE_REF" =~ ^release/[^/]+$ ]]
           repository_json="$(gh api "repos/$GITHUB_REPOSITORY")"
           default_branch="$(jq -er '.default_branch' <<<"$repository_json")"
           test "$default_branch" = "main"
           test "$ACTUAL_WORKFLOW_REF" = \
-            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/$default_branch"
+            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/$EXPECTED_BASE_REF"
           protected_sha="$(
-            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$default_branch" \
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
               --jq '.object.sha'
           )"
+          test "$protected_sha" = "$EXPECTED_BASE_SHA"
           source_compare="$(
             gh api \
               "repos/$GITHUB_REPOSITORY/compare/$ACTUAL_WORKFLOW_SHA...$protected_sha"
@@ -409,42 +415,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Assert exact protected reconciliation source
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
-          ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
-          test "$ACTUAL_WORKFLOW_REF" = \
-            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/main"
-          protected_sha="$(
-            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
-              --jq '.object.sha'
-          )"
-          source_compare="$(
-            gh api \
-              "repos/$GITHUB_REPOSITORY/compare/$ACTUAL_WORKFLOW_SHA...$protected_sha"
-          )"
-          jq -e --arg source "$ACTUAL_WORKFLOW_SHA" '
-              (.status == "ahead" or .status == "identical")
-              and .behind_by == 0
-              and .base_commit.sha == $source
-              and .merge_base_commit.sha == $source
-            ' <<<"$source_compare" >/dev/null
-          protected_workflow_blob="$(
-            gh api \
-              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$protected_sha" \
-              --jq '.sha'
-          )"
-          source_workflow_blob="$(
-            gh api \
-              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$ACTUAL_WORKFLOW_SHA" \
-              --jq '.sha'
-          )"
-          test "$source_workflow_blob" = "$protected_workflow_blob"
-
       - name: Resolve the surviving governed pull request
         id: reconciliation-subject
         env:
@@ -507,6 +477,49 @@ jobs:
             -f description="Exact-head provenance reconciliation in progress" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
+      - name: Assert exact protected reconciliation source
+        if: steps.reconciliation-subject.outputs.reconcile == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTUAL_WORKFLOW_REF: ${{ github.workflow_ref }}
+          ACTUAL_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}
+          EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_BASE_REF" == "main" \
+            || "$EXPECTED_BASE_REF" =~ ^release/[^/]+$ ]]
+          test "$ACTUAL_WORKFLOW_REF" = \
+            "$GITHUB_REPOSITORY/.github/workflows/dco.yml@refs/heads/$EXPECTED_BASE_REF"
+          protected_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
+              --jq '.object.sha'
+          )"
+          test "$protected_sha" = "$EXPECTED_BASE_SHA"
+          source_compare="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/compare/$ACTUAL_WORKFLOW_SHA...$protected_sha"
+          )"
+          jq -e --arg source "$ACTUAL_WORKFLOW_SHA" '
+              (.status == "ahead" or .status == "identical")
+              and .behind_by == 0
+              and .base_commit.sha == $source
+              and .merge_base_commit.sha == $source
+            ' <<<"$source_compare" >/dev/null
+          protected_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$protected_sha" \
+              --jq '.sha'
+          )"
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/dco.yml?ref=$ACTUAL_WORKFLOW_SHA" \
+              --jq '.sha'
+          )"
+          test "$source_workflow_blob" = "$protected_workflow_blob"
+
       - name: Revalidate the surviving exact head
         if: steps.reconciliation-subject.outputs.reconcile == 'true'
         env:
@@ -543,6 +556,20 @@ jobs:
               and .head.ref == $head_ref
               and .head.sha == $head_sha
             ' <<<"$current_pr" >/dev/null
+          declared_file_count="$(jq -er '.changed_files' <<<"$current_pr")"
+          candidate_files="$(
+            gh api --paginate --slurp \
+              "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR_NUMBER/files?per_page=100"
+          )"
+          listed_file_count="$(jq -er '[.[][]] | length' <<<"$candidate_files")"
+          test "$listed_file_count" -eq "$declared_file_count"
+          test "$listed_file_count" -le 3000
+          candidate_workflows="$(
+            jq -er \
+              '[.[][] | select(.filename | startswith(".github/workflows/"))] | length' \
+              <<<"$candidate_files"
+          )"
+          test "$candidate_workflows" -eq 0
           live_base_sha="$(
             gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$EXPECTED_BASE_REF" \
               --jq '.object.sha'


### PR DESCRIPTION
Satisfies: C-19755620

Labels: provenance P1 repair; solo-builder governance

Rollback: Revert the corrective squash commit; this restores the merged #534 behavior but also restores all three documented P1 gaps.

Risk: D - Repairs the protected provenance workflow immediately after #534 merged before its exact review findings were addressed.

Solo-Operator-Authorization: confirmed

## Root cause

PR #534 was merged at `61d38c3138460e72d2b118196fa626506e598a62` while its opening-head Codex review was completing. Exact-head review then reported three real P1 defects in the merged workflow.

## Fixes

1. Bind initial `pull_request_target` workflow source validation to the exact governed target base (`main` or bounded `release/*`) instead of hard-coding `main`. Validate the base ref/SHA before using it and require the live protected ref to equal the event base.
2. Apply the same complete candidate-file enumeration and `.github/workflows/**` rejection during old-head reconciliation that initial admission uses. A shared-head close/synchronize event can no longer convert a workflow-changing head from failure to success.
3. Resolve the single surviving governed PR before validating the reconciliation workflow source, then bind the source to that survivor's exact base ref/SHA. A shared head spanning different governed bases now fails closed rather than borrowing trust from the trigger PR's base.

The activation tests and full FORGE verifier require all three invariants.

## Verification

- exact parent: `61d38c3138460e72d2b118196fa626506e598a62`
- exact head: `bf95e456fb6151c56daa4dea97f648e02c550ebe`
- exact tree: `d43682f473441359a92e189e52389159745c261c`
- `test_dco_check.py`: 65/65 passed
- `test_dco_events.py`: 40/40 passed
- `test_dco_activation.py`: 8/8 passed
- `verify_forge9_governance.py`: passed
- all eight FORGE-9 gates: passed
- all 12 native shell blocks: Bash syntax passed
- YAML parsing and `git diff --check`: passed

## Migration boundary

This corrective PR necessarily edits `.github/workflows/dco.yml`, which #534 intentionally made owner-migration-only until ruleset 19755620 can require a specific workflow. Owner bypass is authorized only for the obsolete legacy compatibility/signature context. Every real build, security, FORGE-9, exact-source, and review finding remains blocking.