### PR TITLE
test(ci): lock survivor-bound reconciliation

### DIFF
--- a/.github/scripts/test_dco_activation.py
+++ b/.github/scripts/test_dco_activation.py
@@ -103,6 +103,27 @@ class DcoActivationWorkflowTests(unittest.TestCase):
         self.assertNotIn("contents: write", self.native)
         self.assertNotIn("id-token:", self.native)
 
+    def test_cross_base_reconciliation_uses_surviving_pr_base(self) -> None:
+        reconciliation = self.native.split("  reconcile-old-head:\n", 1)[1]
+        source_step = reconciliation.split(
+            "      - name: Assert exact protected reconciliation source\n", 1
+        )[1].split("      - name: Revalidate the surviving exact head\n", 1)[0]
+
+        self.assertLess(
+            reconciliation.index("Resolve the surviving governed pull request"),
+            reconciliation.index("Assert exact protected reconciliation source"),
+        )
+        self.assertIn(
+            "EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}",
+            source_step,
+        )
+        self.assertIn(
+            "EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}",
+            source_step,
+        )
+        self.assertNotIn("github.event.pull_request.base.ref", source_step)
+        self.assertNotIn("github.event.pull_request.base.sha", source_step)
+
     def test_reusable_workflow_is_exact_and_secretless(self) -> None:
         for marker in (
             "name: Reusable DCO validation",

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -508,6 +508,18 @@ def verify_gate_contract() -> None:
         "Assert exact protected reconciliation source"
     ):
         fail("reconciliation must resolve its survivor before binding workflow source")
+    reconciliation_job = dco_template.split("  reconcile-old-head:\n", 1)[1]
+    reconciliation_source = reconciliation_job.split(
+        "      - name: Assert exact protected reconciliation source\n", 1
+    )[1].split("      - name: Revalidate the surviving exact head\n", 1)[0]
+    for marker in (
+        "EXPECTED_BASE_REF: ${{ steps.reconciliation-subject.outputs.base_ref }}",
+        "EXPECTED_BASE_SHA: ${{ steps.reconciliation-subject.outputs.base_sha }}",
+    ):
+        if marker not in reconciliation_source:
+            fail("reconciliation source must bind to the surviving PR base")
+    if "github.event.pull_request.base." in reconciliation_source:
+        fail("reconciliation source must not inherit the triggering PR base")
     merge_group_job = dco_template.split("  merge-group-provenance:\n", 1)[1].split(
         "  legacy-dco-compatibility:\n", 1
     )[0]


### PR DESCRIPTION
Satisfies: C-19755620

Labels: provenance regression; solo-builder governance

Rollback: Revert this test-only commit; production workflow behavior is unchanged, but the main↔release survivor-base regression becomes weaker.

Risk: C - Adds a fail-closed regression contract for the already-live provenance reconciliation repair without changing any workflow or runtime code.

Solo-Operator-Authorization: confirmed

## Scope

This is the strict two-file follow-up to #535:

- adds a dedicated main↔release adversarial regression that slices the reconciliation source step itself
- proves that protected-source validation consumes the surviving PR's exact base ref/SHA outputs
- proves that the reconciliation source step cannot consume the triggering event's base
- mirrors the same invariant in the full FORGE governance verifier

No workflow, permission, product-signing, attestation, merge-queue, or runtime file changes.

## Exact evidence

- parent: `62a83e989aad57d6ee9aa1856cc7dc2168ec08c1`
- head: `00219f0a96c5f38258a359e4c83a534d5bba49af`
- tree: `af62a0b34ffb42ac1e61dd7d23fe07271ce16a3a`
- changed files: exactly 2
- `test_dco_check.py`: 65/65 passed
- `test_dco_events.py`: 40/40 passed
- `test_dco_activation.py`: 9/9 passed
- `verify_forge9_governance.py`: passed
- all eight FORGE-9 gates: passed
- `git diff --check`: passed

All real hosted build, security, provenance, and review gates remain blocking.