### PR TITLE
ci: retire external DCO organization ruleset

### DIFF
--- a/.github/workflows/retire-external-dco-ruleset.yml
+++ b/.github/workflows/retire-external-dco-ruleset.yml
@@ -1,0 +1,126 @@
+name: Retire external DCO organization ruleset
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/retire-external-dco-ruleset.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/retire-external-dco-ruleset.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: retire-external-dco-organization-ruleset
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate immutable DCO retirement target
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate exact target identity
+        shell: bash
+        env:
+          EXPECTED_ORG: szl-holdings
+          EXPECTED_RULESET_ID: "20596488"
+          EXPECTED_RULESET_NAME: external-dco-required-workflow
+          EXPECTED_WORKFLOW_REPOSITORY_ID: "1258631185"
+          EXPECTED_WORKFLOW_PATH: .github/workflows/dco-required.yml
+          EXPECTED_WORKFLOW_REF: refs/heads/main
+        run: |
+          set -euo pipefail
+          test "$EXPECTED_ORG" = "szl-holdings"
+          test "$EXPECTED_RULESET_ID" = "20596488"
+          test "$EXPECTED_RULESET_NAME" = "external-dco-required-workflow"
+          test "$EXPECTED_WORKFLOW_REPOSITORY_ID" = "1258631185"
+          test "$EXPECTED_WORKFLOW_PATH" = ".github/workflows/dco-required.yml"
+          test "$EXPECTED_WORKFLOW_REF" = "refs/heads/main"
+          [[ "$EXPECTED_RULESET_ID" =~ ^[0-9]+$ ]]
+          [[ "$EXPECTED_WORKFLOW_REPOSITORY_ID" =~ ^[0-9]+$ ]]
+          echo "Exact legacy DCO organization ruleset target validated."
+
+  retire:
+    name: Delete exact external DCO ruleset
+    if: github.event_name != 'pull_request'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Verify, retire, and prove absence
+        shell: bash
+        env:
+          GH_ADMIN_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          ORG: szl-holdings
+          RULESET_ID: "20596488"
+          RULESET_NAME: external-dco-required-workflow
+          WORKFLOW_REPOSITORY_ID: "1258631185"
+          WORKFLOW_PATH: .github/workflows/dco-required.yml
+          WORKFLOW_REF: refs/heads/main
+        run: |
+          set -euo pipefail
+          test -n "$GH_ADMIN_TOKEN" || {
+            echo "SZL_GITHUB_TOKEN is unavailable in the central governance repository." >&2
+            exit 1
+          }
+
+          api="https://api.github.com/orgs/${ORG}/rulesets/${RULESET_ID}"
+          common_headers=(
+            --header "Accept: application/vnd.github+json"
+            --header "Authorization: Bearer ${GH_ADMIN_TOKEN}"
+            --header "X-GitHub-Api-Version: 2022-11-28"
+          )
+
+          get_status="$(curl --silent --show-error --output /tmp/ruleset-before.json --write-out '%{http_code}' "${common_headers[@]}" "$api")"
+          if [ "$get_status" = "404" ]; then
+            echo "Ruleset ${RULESET_ID} is already absent; retirement is idempotently complete."
+            exit 0
+          fi
+          test "$get_status" = "200" || {
+            echo "Unable to read exact ruleset before mutation; status=${get_status}." >&2
+            exit 1
+          }
+
+          jq -e \
+            --argjson id "$RULESET_ID" \
+            --arg name "$RULESET_NAME" \
+            --argjson repository_id "$WORKFLOW_REPOSITORY_ID" \
+            --arg path "$WORKFLOW_PATH" \
+            --arg ref "$WORKFLOW_REF" \
+            '.id == $id
+             and .name == $name
+             and .source_type == "Organization"
+             and .source == "szl-holdings"
+             and .enforcement == "active"
+             and (.rules | length) == 1
+             and .rules[0].type == "workflows"
+             and (.rules[0].parameters.workflows | length) == 1
+             and .rules[0].parameters.workflows[0].repository_id == $repository_id
+             and .rules[0].parameters.workflows[0].path == $path
+             and .rules[0].parameters.workflows[0].ref == $ref' \
+            /tmp/ruleset-before.json >/dev/null || {
+              echo "Live ruleset no longer matches the immutable DCO retirement contract; refusing mutation." >&2
+              exit 1
+            }
+
+          delete_status="$(curl --silent --show-error --output /tmp/ruleset-delete.json --write-out '%{http_code}' --request DELETE "${common_headers[@]}" "$api")"
+          test "$delete_status" = "204" || {
+            echo "Exact ruleset deletion failed; status=${delete_status}." >&2
+            exit 1
+          }
+
+          verify_status="$(curl --silent --show-error --output /tmp/ruleset-after.json --write-out '%{http_code}' "${common_headers[@]}" "$api")"
+          test "$verify_status" = "404" || {
+            echo "Ruleset still resolves after deletion; status=${verify_status}." >&2
+            exit 1
+          }
+          echo "Deleted and verified absence of organization ruleset ${RULESET_ID} (${RULESET_NAME})."


### PR DESCRIPTION
## Satisfies

Satisfies: SOLO-DCO-RETIREMENT / C-20596488

## Section reference

Section 18 of PAYLOAD FORGE-9

## Root cause

An active organization-level required-workflow ruleset still invokes `szl-doctrine/.github/workflows/dco-required.yml` on every default-branch pull request. Repository-level workflow deletions cannot remove that organization control, so DCO continued to block the declared solo-operator model.

## Labels

Labels: retire DCO trailer enforcement; preserve exact-head automation, signed-commit policy, strict status checks, squash-only merges, CodeQL, secret scanning, vulnerability scanning, doctrine, and provenance.

## Rollback

Rollback: recreate organization ruleset `20596488` from the exact pre-mutation contract recorded in this PR and re-enable `.github/workflows/dco-required.yml` on `szl-doctrine@main`.

## Risk class

Risk: D — organization-wide required-workflow retirement with immutable target validation and post-delete API readback.

Solo-Operator-Authorization: confirmed

## Tests executed

| Test | Command | Result | Evidence |
| --- | --- | --- | --- |
| Immutable target contract | PR validation job | pending | exact org, ruleset ID/name, source repository ID, workflow path, and ref |
| DCO migration commit | required organization workflow | pending | final signed-off migration commit only |
| Security and governance | protected PR checks | pending | exact-head Actions results |

## Evidence checklist

- [ ] `gate/ground-truth` green
- [ ] `gate/labels` green; no silent evidence promotion
- [ ] `gate/schema` green
- [ ] `gate/adversarial` green
- [ ] `gate/verify-all` green with declared expected failures
- [ ] `gate/provenance` green; attestation verifies
- [ ] `gate/a11y-perf` green; no UI surface changed
- [ ] `gate/lean` green; sorry count did not increase
- [x] Screenshots not applicable; no UI changes
- [x] No known product limitation introduced
- [ ] Exact-head provenance and all required build/security checks are green
- [x] No force-push, destructive rebase, or unrelated safeguard reduction

## Known limitations introduced

The one-shot workflow is intentionally temporary and must be deleted after API readback proves ruleset `20596488` is absent.

## Doctrine

- [x] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no banned vendors