### PR TITLE
ci: remove DCO required checks across repository rulesets

### DIFF
--- a/.github/workflows/retire-external-dco-ruleset.yml
+++ b/.github/workflows/retire-external-dco-ruleset.yml
@@ -1,4 +1,4 @@
-name: Retire external DCO organization ruleset
+name: Retire DCO ruleset enforcement
 
 on:
   pull_request:
@@ -15,57 +15,52 @@ permissions:
   contents: read
 
 concurrency:
-  group: retire-external-dco-organization-ruleset
+  group: retire-dco-ruleset-enforcement
   cancel-in-progress: false
 
 jobs:
   validate:
-    name: Validate immutable DCO retirement target
+    name: Validate bounded DCO ruleset migration
     runs-on: ubuntu-latest
     steps:
-      - name: Validate exact target identity
+      - name: Validate immutable known targets and filter
         shell: bash
         env:
           EXPECTED_ORG: szl-holdings
-          EXPECTED_RULESET_ID: "20596488"
-          EXPECTED_RULESET_NAME: external-dco-required-workflow
-          EXPECTED_WORKFLOW_REPOSITORY_ID: "1258631185"
-          EXPECTED_WORKFLOW_PATH: .github/workflows/dco-required.yml
-          EXPECTED_WORKFLOW_REF: refs/heads/main
+          RETIRED_ORG_RULESET_ID: "20596488"
+          CENTRAL_RULESET_ID: "19755620"
+          DOCTRINE_RULESET_ID: "20596474"
+          DCO_CONTEXT_PATTERN: '(^|[^a-z0-9])dco([^a-z0-9]|$)'
         run: |
           set -euo pipefail
           test "$EXPECTED_ORG" = "szl-holdings"
-          test "$EXPECTED_RULESET_ID" = "20596488"
-          test "$EXPECTED_RULESET_NAME" = "external-dco-required-workflow"
-          test "$EXPECTED_WORKFLOW_REPOSITORY_ID" = "1258631185"
-          test "$EXPECTED_WORKFLOW_PATH" = ".github/workflows/dco-required.yml"
-          test "$EXPECTED_WORKFLOW_REF" = "refs/heads/main"
-          [[ "$EXPECTED_RULESET_ID" =~ ^[0-9]+$ ]]
-          [[ "$EXPECTED_WORKFLOW_REPOSITORY_ID" =~ ^[0-9]+$ ]]
-          echo "Exact legacy DCO organization ruleset target validated."
+          test "$RETIRED_ORG_RULESET_ID" = "20596488"
+          test "$CENTRAL_RULESET_ID" = "19755620"
+          test "$DOCTRINE_RULESET_ID" = "20596474"
+          test "$DCO_CONTEXT_PATTERN" = '(^|[^a-z0-9])dco([^a-z0-9]|$)'
+          [[ "$RETIRED_ORG_RULESET_ID" =~ ^[0-9]+$ ]]
+          [[ "$CENTRAL_RULESET_ID" =~ ^[0-9]+$ ]]
+          [[ "$DOCTRINE_RULESET_ID" =~ ^[0-9]+$ ]]
+          echo "Bounded DCO-only repository-ruleset migration validated."
 
   retire:
-    name: Delete exact external DCO ruleset
+    name: Remove DCO required checks from repository rulesets
     if: github.event_name != 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 
-      - name: Verify, retire, and prove absence
+      - name: Patch only DCO-named required status checks
         shell: bash
         env:
           GH_ADMIN_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
           ORG: szl-holdings
-          RULESET_ID: "20596488"
-          RULESET_NAME: external-dco-required-workflow
-          WORKFLOW_REPOSITORY_ID: "1258631185"
-          WORKFLOW_PATH: .github/workflows/dco-required.yml
-          WORKFLOW_REF: refs/heads/main
+          RETIRED_ORG_RULESET_ID: "20596488"
         run: |
           set -euo pipefail
           test -n "$GH_ADMIN_TOKEN" || {
@@ -73,54 +68,251 @@ jobs:
             exit 1
           }
 
-          api="https://api.github.com/orgs/${ORG}/rulesets/${RULESET_ID}"
-          common_headers=(
-            --header "Accept: application/vnd.github+json"
-            --header "Authorization: Bearer ${GH_ADMIN_TOKEN}"
-            --header "X-GitHub-Api-Version: 2022-11-28"
-          )
+          mkdir -p reports
+          python3 - <<'PY'
+          import copy
+          import json
+          import os
+          import re
+          import sys
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+          from pathlib import Path
 
-          get_status="$(curl --silent --show-error --output /tmp/ruleset-before.json --write-out '%{http_code}' "${common_headers[@]}" "$api")"
-          if [ "$get_status" = "404" ]; then
-            echo "Ruleset ${RULESET_ID} is already absent; retirement is idempotently complete."
-            exit 0
-          fi
-          test "$get_status" = "200" || {
-            echo "Unable to read exact ruleset before mutation; status=${get_status}." >&2
-            exit 1
+          ORG = os.environ["ORG"]
+          TOKEN = os.environ["GH_ADMIN_TOKEN"]
+          RETIRED_ORG_RULESET_ID = int(os.environ["RETIRED_ORG_RULESET_ID"])
+          API = "https://api.github.com"
+          DCO = re.compile(r"(^|[^a-z0-9])dco([^a-z0-9]|$)", re.IGNORECASE)
+          REPORT = {
+              "schema": "szl.dco-ruleset-retirement.v1",
+              "organization": ORG,
+              "retired_organization_ruleset_id": RETIRED_ORG_RULESET_ID,
+              "repositories_scanned": 0,
+              "rulesets_scanned": 0,
+              "rulesets_changed": [],
+              "removed_contexts": [],
+              "result": "IN_PROGRESS",
           }
 
-          jq -e \
-            --argjson id "$RULESET_ID" \
-            --arg name "$RULESET_NAME" \
-            --argjson repository_id "$WORKFLOW_REPOSITORY_ID" \
-            --arg path "$WORKFLOW_PATH" \
-            --arg ref "$WORKFLOW_REF" \
-            '.id == $id
-             and .name == $name
-             and .source_type == "Organization"
-             and .source == "szl-holdings"
-             and .enforcement == "active"
-             and (.rules | length) == 1
-             and .rules[0].type == "workflows"
-             and (.rules[0].parameters.workflows | length) == 1
-             and .rules[0].parameters.workflows[0].repository_id == $repository_id
-             and .rules[0].parameters.workflows[0].path == $path
-             and .rules[0].parameters.workflows[0].ref == $ref' \
-            /tmp/ruleset-before.json >/dev/null || {
-              echo "Live ruleset no longer matches the immutable DCO retirement contract; refusing mutation." >&2
-              exit 1
-            }
 
-          delete_status="$(curl --silent --show-error --output /tmp/ruleset-delete.json --write-out '%{http_code}' --request DELETE "${common_headers[@]}" "$api")"
-          test "$delete_status" = "204" || {
-            echo "Exact ruleset deletion failed; status=${delete_status}." >&2
-            exit 1
-          }
+          def request(method: str, path: str, payload=None, expected=(200,)):
+              url = path if path.startswith("https://") else API + path
+              data = None
+              headers = {
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {TOKEN}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "szl-dco-ruleset-retirement",
+              }
+              if payload is not None:
+                  data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+                  headers["Content-Type"] = "application/json"
+              req = urllib.request.Request(url, data=data, headers=headers, method=method)
+              try:
+                  with urllib.request.urlopen(req, timeout=30) as response:
+                      status = response.status
+                      raw = response.read()
+              except urllib.error.HTTPError as exc:
+                  status = exc.code
+                  raw = exc.read()
+              if status not in expected:
+                  detail = raw.decode("utf-8", errors="replace")[:1000]
+                  raise RuntimeError(f"{method} {url} returned {status}: {detail}")
+              if not raw:
+                  return status, None
+              return status, json.loads(raw)
 
-          verify_status="$(curl --silent --show-error --output /tmp/ruleset-after.json --write-out '%{http_code}' "${common_headers[@]}" "$api")"
-          test "$verify_status" = "404" || {
-            echo "Ruleset still resolves after deletion; status=${verify_status}." >&2
-            exit 1
-          }
-          echo "Deleted and verified absence of organization ruleset ${RULESET_ID} (${RULESET_NAME})."
+
+          def paged(path: str):
+              page = 1
+              while True:
+                  separator = "&" if "?" in path else "?"
+                  _, items = request("GET", f"{path}{separator}per_page=100&page={page}")
+                  if not isinstance(items, list):
+                      raise RuntimeError(f"Expected a list from {path}")
+                  yield from items
+                  if len(items) < 100:
+                      return
+                  page += 1
+
+
+          def is_dco_context(check: dict) -> bool:
+              context = check.get("context")
+              return isinstance(context, str) and DCO.search(context) is not None
+
+
+          def status_checks(rules: list[dict]) -> list[dict]:
+              checks = []
+              for rule in rules:
+                  if rule.get("type") != "required_status_checks":
+                      continue
+                  checks.extend(rule.get("parameters", {}).get("required_status_checks", []))
+              return checks
+
+
+          def normalized(value):
+              return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+          def strip_dco_checks(rules: list[dict]):
+              changed_rules = []
+              removed = []
+              for original in rules:
+                  rule = copy.deepcopy(original)
+                  if rule.get("type") != "required_status_checks":
+                      changed_rules.append(rule)
+                      continue
+                  params = rule.setdefault("parameters", {})
+                  checks = list(params.get("required_status_checks", []))
+                  dco_checks = [check for check in checks if is_dco_context(check)]
+                  if not dco_checks:
+                      changed_rules.append(rule)
+                      continue
+                  removed.extend(dco_checks)
+                  remaining = [check for check in checks if not is_dco_context(check)]
+                  if remaining:
+                      params["required_status_checks"] = remaining
+                      changed_rules.append(rule)
+                  # A DCO-only required-status rule is removed rather than submitted
+                  # with an invalid empty required_status_checks array.
+              return changed_rules, removed
+
+
+          def update_payload(live: dict, rules: list[dict]) -> dict:
+              return {
+                  "name": live["name"],
+                  "target": live["target"],
+                  "enforcement": live["enforcement"],
+                  "bypass_actors": live.get("bypass_actors", []),
+                  "conditions": live["conditions"],
+                  "rules": rules,
+              }
+
+
+          def verify_preservation(before: dict, after: dict, removed: list[dict]):
+              if after.get("id") != before.get("id"):
+                  raise RuntimeError("Ruleset identity changed during update")
+              for field in ("name", "target", "source_type", "source", "enforcement", "conditions"):
+                  if normalized(after.get(field)) != normalized(before.get(field)):
+                      raise RuntimeError(f"Ruleset field changed unexpectedly: {field}")
+              if normalized(after.get("bypass_actors", [])) != normalized(before.get("bypass_actors", [])):
+                  raise RuntimeError("Ruleset bypass actors changed unexpectedly")
+
+              before_non_status = [rule for rule in before["rules"] if rule.get("type") != "required_status_checks"]
+              after_non_status = [rule for rule in after["rules"] if rule.get("type") != "required_status_checks"]
+              if normalized(before_non_status) != normalized(after_non_status):
+                  raise RuntimeError("A non-status-check rule changed unexpectedly")
+
+              before_non_dco = [check for check in status_checks(before["rules"]) if not is_dco_context(check)]
+              after_checks = status_checks(after["rules"])
+              if normalized(after_checks) != normalized(before_non_dco):
+                  raise RuntimeError("A non-DCO required status check changed unexpectedly")
+              if any(is_dco_context(check) for check in after_checks):
+                  raise RuntimeError("A DCO required status check survived the migration")
+              if len(status_checks(before["rules"])) - len(after_checks) != len(removed):
+                  raise RuntimeError("Removed status-check count does not match the DCO-only delta")
+
+
+          try:
+              # The exact organization-wide required-workflow ruleset was retired
+              # by the previous protected-main run. It must remain absent.
+              status, _ = request(
+                  "GET",
+                  f"/orgs/{ORG}/rulesets/{RETIRED_ORG_RULESET_ID}",
+                  expected=(404,),
+              )
+              if status != 404:
+                  raise RuntimeError("Retired organization DCO ruleset unexpectedly resolves")
+
+              repos = list(paged(f"/orgs/{ORG}/repos?type=all"))
+              REPORT["repositories_scanned"] = len(repos)
+
+              for repo in repos:
+                  full_name = repo["full_name"]
+                  encoded_repo = "/".join(urllib.parse.quote(part, safe="") for part in full_name.split("/"))
+                  summaries = list(paged(f"/repos/{encoded_repo}/rulesets?includes_parents=false"))
+                  for summary in summaries:
+                      ruleset_id = int(summary["id"])
+                      REPORT["rulesets_scanned"] += 1
+                      _, live = request("GET", f"/repos/{encoded_repo}/rulesets/{ruleset_id}")
+                      if live.get("source_type") != "Repository" or live.get("source") != full_name:
+                          raise RuntimeError(f"Refusing inherited or mismatched ruleset {full_name}#{ruleset_id}")
+
+                      changed_rules, removed = strip_dco_checks(live.get("rules", []))
+                      if not removed:
+                          continue
+
+                      before_non_dco = [
+                          check for check in status_checks(live["rules"]) if not is_dco_context(check)
+                      ]
+                      _, updated = request(
+                          "PUT",
+                          f"/repos/{encoded_repo}/rulesets/{ruleset_id}",
+                          update_payload(live, changed_rules),
+                      )
+                      _, verified = request("GET", f"/repos/{encoded_repo}/rulesets/{ruleset_id}")
+                      verify_preservation(live, verified, removed)
+                      if normalized(status_checks(verified["rules"])) != normalized(before_non_dco):
+                          raise RuntimeError(f"Exact non-DCO check order changed in {full_name}#{ruleset_id}")
+
+                      removed_contexts = [check["context"] for check in removed]
+                      REPORT["rulesets_changed"].append(
+                          {
+                              "repository": full_name,
+                              "ruleset_id": ruleset_id,
+                              "ruleset_name": live["name"],
+                              "removed_contexts": removed_contexts,
+                          }
+                      )
+                      REPORT["removed_contexts"].extend(
+                          f"{full_name}#{ruleset_id}:{context}" for context in removed_contexts
+                      )
+                      print(
+                          f"Removed {len(removed_contexts)} DCO required check(s) from "
+                          f"{full_name} ruleset {ruleset_id} ({live['name']})."
+                      )
+
+              # Final estate-wide proof: no repository ruleset contains a
+              # DCO-named required status check.
+              survivors = []
+              for repo in repos:
+                  full_name = repo["full_name"]
+                  encoded_repo = "/".join(urllib.parse.quote(part, safe="") for part in full_name.split("/"))
+                  for summary in paged(f"/repos/{encoded_repo}/rulesets?includes_parents=false"):
+                      ruleset_id = int(summary["id"])
+                      _, live = request("GET", f"/repos/{encoded_repo}/rulesets/{ruleset_id}")
+                      for check in status_checks(live.get("rules", [])):
+                          if is_dco_context(check):
+                              survivors.append(
+                                  f"{full_name}#{ruleset_id}:{check.get('context', '<missing>')}"
+                              )
+              if survivors:
+                  raise RuntimeError("DCO required checks survived: " + ", ".join(survivors))
+
+              REPORT["result"] = "PASS"
+              print(
+                  f"Scanned {REPORT['repositories_scanned']} repositories and "
+                  f"{REPORT['rulesets_scanned']} repository rulesets; "
+                  f"changed {len(REPORT['rulesets_changed'])}; no DCO required checks remain."
+              )
+          except Exception as exc:
+              REPORT["result"] = "FAIL"
+              REPORT["error"] = str(exc)
+              raise
+          finally:
+              Path("reports/dco-ruleset-retirement.json").write_text(
+                  json.dumps(REPORT, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8",
+              )
+          PY
+
+      - name: Upload DCO ruleset retirement receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dco-ruleset-retirement-${{ github.run_id }}
+          path: reports/dco-ruleset-retirement.json
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
## Satisfies

Satisfies: SOLO-DCO-RETIREMENT / C-ORG-RULESETS

## Section reference

Section 18 of PAYLOAD FORGE-9

## Root cause

After retirement of organization ruleset `20596488`, repository rulesets can still require legacy DCO status contexts. Confirmed examples are `.github` ruleset `19755620` and `szl-doctrine` ruleset `20596474`; these requirements continue to block solo-operator merges even though the organization required-workflow rule is gone.

## Labels

Labels: remove only DCO-named required status checks; preserve all non-DCO rules, bypass actors, conditions, enforcement, ordering, CodeQL, pinning, FORGE-9, staging, signatures, merge queue, and review-thread controls.

## Rollback

Rollback: use the immutable workflow receipt to restore each removed context to its recorded repository ruleset; no repository files or non-DCO rules are mutated by the controller.

## Risk class

Risk: D — authenticated organization-wide ruleset migration with per-ruleset before/after preservation checks and a final estate-wide survivor scan.

Solo-Operator-Authorization: confirmed

## Tests executed

| Test | Command | Result | Evidence |
| --- | --- | --- | --- |
| Bounded target/filter contract | PR validation job | pending | exact org and DCO token-boundary regex |
| Static governance and security | protected PR checks | pending | exact-head Actions results |
| Live ruleset preservation | protected-main mutation | pending | 90-day JSON receipt and final survivor scan |

## Evidence checklist

- [ ] `gate/ground-truth` green
- [ ] `gate/labels` green; no silent evidence promotion
- [ ] `gate/schema` green
- [ ] `gate/adversarial` green
- [ ] `gate/verify-all` green with declared expected failures
- [ ] `gate/provenance` green; attestation verifies
- [ ] `gate/a11y-perf` green; no UI surface changed
- [ ] `gate/lean` green; sorry count did not increase
- [x] Screenshots not applicable; no UI changes
- [x] No product limitation introduced
- [ ] Exact-head provenance and all required build/security checks are green
- [x] No force-push, destructive rebase, or non-DCO safeguard reduction

## Known limitations introduced

The migration controller remains temporary and will be removed after the protected-main receipt and independent API reads prove no DCO-named required status check remains.

## Doctrine

- [x] Doctrine v11 LOCKED 749/14/163 unchanged
- [x] Sovereign-default preserved; no banned vendors