### PR TITLE
fix(ci): make notification clearance rate-limit safe

### DIFF
--- a/.github/scripts/clear_personal_notifications.py
+++ b/.github/scripts/clear_personal_notifications.py
@@ -11,16 +11,24 @@ Inbox clearance is stronger than marking notifications read: every thread still
 returned by ``GET /notifications?all=true`` is deleted through the documented
 "Mark a thread as done" endpoint. The final readback must show both zero inbox
 threads and zero unread threads.
+
+Large inboxes are deliberately drained serially. Mutating requests are paced,
+and primary/secondary rate-limit responses honor ``Retry-After`` or
+``X-RateLimit-Reset`` before retrying. A count-only RUNNING receipt is updated
+during long drains so an interrupted runner never leaves an evidence vacuum.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
+import sys
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -30,7 +38,17 @@ API_VERSION = "2022-11-28"
 PER_PAGE = 50
 MAX_PAGES = 200
 MAX_ROUNDS = 8
-SETTLE_SECONDS = 2
+SETTLE_SECONDS = 2.0
+
+# GitHub's REST best practices recommend serial mutation and at least one second
+# between POST/PATCH/PUT/DELETE requests. Keep these constants patchable for
+# deterministic, network-free tests.
+MUTATION_DELAY_SECONDS = 1.0
+RATE_LIMIT_RETRIES = 8
+RATE_LIMIT_FALLBACK_SECONDS = 60.0
+RATE_LIMIT_MAX_SLEEP_SECONDS = 3700.0
+RATE_LIMIT_SAFETY_SECONDS = 5.0
+PROGRESS_INTERVAL = 100
 
 
 class NotificationError(RuntimeError):
@@ -41,52 +59,133 @@ def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _safe_path(path: str) -> str:
+    """Return a diagnostic path that cannot disclose a notification thread id."""
+    parsed = urllib.parse.urlsplit(path)
+    if parsed.path.startswith("/notifications/threads/"):
+        return "/notifications/threads/{thread_id}"
+    return parsed.path
+
+
+def _header(headers: Mapping[str, str] | None, name: str) -> str:
+    if headers is None:
+        return ""
+    value = headers.get(name)
+    return "" if value is None else str(value).strip()
+
+
+def _positive_number(value: str) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
+
+
+def rate_limit_delay(
+    *,
+    status: int,
+    detail: str,
+    headers: Mapping[str, str] | None,
+    attempt: int,
+    now_epoch: float | None = None,
+) -> float | None:
+    """Return a compliant retry delay, or ``None`` for a non-rate-limit error."""
+    retry_after = _positive_number(_header(headers, "Retry-After"))
+    remaining = _header(headers, "X-RateLimit-Remaining")
+    reset_epoch = _positive_number(_header(headers, "X-RateLimit-Reset"))
+    lower_detail = detail.lower()
+
+    is_rate_limited = (
+        status == 429
+        or "rate limit" in lower_detail
+        or retry_after is not None
+        or remaining == "0"
+    )
+    if not is_rate_limited:
+        return None
+
+    if retry_after is not None:
+        delay = retry_after
+    elif remaining == "0" and reset_epoch is not None:
+        now = time.time() if now_epoch is None else now_epoch
+        delay = max(0.0, reset_epoch - now) + RATE_LIMIT_SAFETY_SECONDS
+    else:
+        delay = RATE_LIMIT_FALLBACK_SECONDS * (2**attempt)
+
+    return max(1.0, min(delay, RATE_LIMIT_MAX_SLEEP_SECONDS))
+
+
 def request(
     token: str,
     method: str,
     path: str,
     payload: dict[str, Any] | None = None,
 ) -> tuple[int, Any]:
+    """Issue one REST request, retrying only documented rate-limit failures."""
     body = None if payload is None else json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        API + path,
-        data=body,
-        method=method,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": API_VERSION,
-            "User-Agent": "szl-clear-personal-notifications/2.0",
-            **({"Content-Type": "application/json"} if body is not None else {}),
-        },
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=45) as response:
-            raw = response.read()
-            status = response.status
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", "replace")[:2000]
-        raise NotificationError(
-            f"GitHub API {method} {path} failed HTTP {exc.code}: {detail}"
-        ) from exc
-    except Exception as exc:  # noqa: BLE001
-        raise NotificationError(
-            f"GitHub API {method} {path} failed: {type(exc).__name__}: {exc}"
-        ) from exc
 
-    if not raw:
-        return status, None
-    try:
-        return status, json.loads(raw.decode("utf-8"))
-    except json.JSONDecodeError as exc:
-        raise NotificationError(
-            f"GitHub API {method} {path} returned non-JSON content"
-        ) from exc
+    for attempt in range(RATE_LIMIT_RETRIES + 1):
+        req = urllib.request.Request(
+            API + path,
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": API_VERSION,
+                "User-Agent": "szl-clear-personal-notifications/2.1",
+                **({"Content-Type": "application/json"} if body is not None else {}),
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=45) as response:
+                raw = response.read()
+                status = response.status
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:2000]
+            delay = rate_limit_delay(
+                status=exc.code,
+                detail=detail,
+                headers=exc.headers,
+                attempt=attempt,
+            )
+            if delay is not None and attempt < RATE_LIMIT_RETRIES:
+                print(
+                    "GitHub rate limit encountered; "
+                    f"retrying after {math.ceil(delay)} second(s) "
+                    f"(attempt {attempt + 1}/{RATE_LIMIT_RETRIES}).",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(delay)
+                continue
+            raise NotificationError(
+                f"GitHub API {method} {_safe_path(path)} failed "
+                f"HTTP {exc.code}: {detail}"
+            ) from exc
+        except Exception as exc:  # noqa: BLE001
+            raise NotificationError(
+                f"GitHub API {method} {_safe_path(path)} failed: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+        if not raw:
+            return status, None
+        try:
+            return status, json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise NotificationError(
+                f"GitHub API {method} {_safe_path(path)} returned non-JSON content"
+            ) from exc
+
+    raise AssertionError("rate-limit retry loop exhausted without returning")
 
 
 def notification_thread_ids(token: str, *, include_read: bool) -> list[str]:
     """Return current inbox thread IDs without recording notification content."""
-
     ids: list[str] = []
     seen: set[str] = set()
     for page in range(1, MAX_PAGES + 1):
@@ -113,7 +212,7 @@ def notification_thread_ids(token: str, *, include_read: bool) -> list[str]:
         if len(payload) < PER_PAGE:
             return ids
     raise NotificationError(
-        f"Inbox inventory exceeded the fail-closed limit of "
+        "Inbox inventory exceeded the fail-closed limit of "
         f"{MAX_PAGES * PER_PAGE} threads"
     )
 
@@ -127,7 +226,40 @@ def mark_thread_done(token: str, thread_id: str) -> None:
         )
 
 
-def clear_inbox(token: str) -> dict[str, Any]:
+def _running_report(
+    *,
+    identity: str,
+    before_inbox_count: int,
+    before_unread_count: int,
+    cleared_count: int,
+    clearance_rounds: int,
+    delete_attempts: int,
+    remaining_count: int | None,
+) -> dict[str, Any]:
+    return {
+        "schema": "szl.github-notification-clearance/v2",
+        "generated_at": utc_now(),
+        "identity": identity,
+        "before_inbox_count": before_inbox_count,
+        "before_unread_count": before_unread_count,
+        "after_inbox_count": remaining_count,
+        "after_unread_count": None,
+        "cleared_count": cleared_count,
+        "clearance_rounds": clearance_rounds,
+        "delete_attempts": delete_attempts,
+        "mutation_delay_seconds": MUTATION_DELAY_SECONDS,
+        "rate_limit_retries": RATE_LIMIT_RETRIES,
+        "notification_content_recorded": False,
+        "thread_ids_recorded": False,
+        "status": "RUNNING",
+    }
+
+
+def clear_inbox(
+    token: str,
+    *,
+    progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
     _, user = request(token, "GET", "/user")
     identity = str((user or {}).get("login") or "")
     if not identity:
@@ -141,27 +273,74 @@ def clear_inbox(token: str) -> dict[str, Any]:
     rounds = 0
     remaining = before_inbox
 
+    if progress is not None:
+        progress(
+            _running_report(
+                identity=identity,
+                before_inbox_count=len(before_inbox),
+                before_unread_count=len(before_unread),
+                cleared_count=0,
+                clearance_rounds=0,
+                delete_attempts=0,
+                remaining_count=len(remaining),
+            )
+        )
+
     for round_number in range(1, MAX_ROUNDS + 1):
         rounds = round_number
         if not remaining:
             break
+
         for thread_id in remaining:
+            if delete_attempts:
+                time.sleep(MUTATION_DELAY_SECONDS)
             mark_thread_done(token, thread_id)
             delete_attempts += 1
             cleared_ids.add(thread_id)
+
+            if delete_attempts % PROGRESS_INTERVAL == 0:
+                print(
+                    f"notification clearance progress: cleared={len(cleared_ids)}",
+                    flush=True,
+                )
+                if progress is not None:
+                    progress(
+                        _running_report(
+                            identity=identity,
+                            before_inbox_count=len(before_inbox),
+                            before_unread_count=len(before_unread),
+                            cleared_count=len(cleared_ids),
+                            clearance_rounds=rounds,
+                            delete_attempts=delete_attempts,
+                            remaining_count=None,
+                        )
+                    )
+
         time.sleep(SETTLE_SECONDS)
         remaining = notification_thread_ids(token, include_read=True)
+        if progress is not None:
+            progress(
+                _running_report(
+                    identity=identity,
+                    before_inbox_count=len(before_inbox),
+                    before_unread_count=len(before_unread),
+                    cleared_count=len(cleared_ids),
+                    clearance_rounds=rounds,
+                    delete_attempts=delete_attempts,
+                    remaining_count=len(remaining),
+                )
+            )
 
     if remaining:
         raise NotificationError(
-            f"Notification inbox did not converge to zero; "
+            "Notification inbox did not converge to zero; "
             f"remaining_count={len(remaining)}"
         )
 
     final_unread = notification_thread_ids(token, include_read=False)
     if final_unread:
         raise NotificationError(
-            f"Unread notifications remained after inbox clearance; "
+            "Unread notifications remained after inbox clearance; "
             f"remaining_count={len(final_unread)}"
         )
 
@@ -176,10 +355,22 @@ def clear_inbox(token: str) -> dict[str, Any]:
         "cleared_count": len(cleared_ids),
         "clearance_rounds": rounds,
         "delete_attempts": delete_attempts,
+        "mutation_delay_seconds": MUTATION_DELAY_SECONDS,
+        "rate_limit_retries": RATE_LIMIT_RETRIES,
         "notification_content_recorded": False,
         "thread_ids_recorded": False,
         "status": "CLEARED",
     }
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
 
 
 def main() -> int:
@@ -188,23 +379,31 @@ def main() -> int:
     args = parser.parse_args()
 
     report: dict[str, Any]
+    last_snapshot: dict[str, Any] = {}
     code = 1
     token = (
         os.environ.get("GH_NOTIFICATIONS_TOKEN", "").strip()
         or os.environ.get("SZL_GITHUB_TOKEN", "").strip()
     )
+
+    def record_progress(snapshot: dict[str, Any]) -> None:
+        last_snapshot.clear()
+        last_snapshot.update(snapshot)
+        _write_report(args.report, snapshot)
+
     try:
         if not token:
             raise NotificationError(
                 "GH_NOTIFICATIONS_TOKEN/SZL_GITHUB_TOKEN is not configured"
             )
-        report = clear_inbox(token)
+        report = clear_inbox(token, progress=record_progress)
         code = 0
     except Exception as exc:  # noqa: BLE001
         report = {
+            **last_snapshot,
             "schema": "szl.github-notification-clearance/v2",
             "generated_at": utc_now(),
-            "after_inbox_count": None,
+            "after_inbox_count": last_snapshot.get("after_inbox_count"),
             "after_unread_count": None,
             "notification_content_recorded": False,
             "thread_ids_recorded": False,
@@ -212,11 +411,7 @@ def main() -> int:
             "errors": [f"{type(exc).__name__}: {exc}"],
         }
     finally:
-        args.report.parent.mkdir(parents=True, exist_ok=True)
-        args.report.write_text(
-            json.dumps(report, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        _write_report(args.report, report)
 
     print(json.dumps(report, indent=2, sort_keys=True))
     return code

--- a/.github/scripts/test_clear_personal_notifications.py
+++ b/.github/scripts/test_clear_personal_notifications.py
@@ -2,12 +2,15 @@
 """Network-free regressions for personal GitHub notification inbox clearance."""
 from __future__ import annotations
 
+import email.message
 import importlib.util
+import io
 import sys
 import unittest
+import urllib.error
 import urllib.parse
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 MODULE_PATH = Path(__file__).with_name("clear_personal_notifications.py")
 SPEC = importlib.util.spec_from_file_location("clear_personal_notifications", MODULE_PATH)
@@ -67,6 +70,45 @@ class FakeGitHub:
             raise AssertionError("wrong token")
 
 
+class FakeResponse:
+    def __init__(self, status: int, body: bytes = b"") -> None:
+        self.status = status
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return self.body
+
+
+def http_error(
+    *,
+    status: int = 403,
+    detail: bytes = b'{"message":"API rate limit exceeded"}',
+    retry_after: str | None = None,
+    remaining: str | None = None,
+    reset: str | None = None,
+) -> urllib.error.HTTPError:
+    headers = email.message.Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    if remaining is not None:
+        headers["X-RateLimit-Remaining"] = remaining
+    if reset is not None:
+        headers["X-RateLimit-Reset"] = reset
+    return urllib.error.HTTPError(
+        url="https://api.github.com/notifications/threads/secret-id",
+        code=status,
+        msg="Forbidden",
+        hdrs=headers,
+        fp=io.BytesIO(detail),
+    )
+
+
 class NotificationClearanceTests(unittest.TestCase):
     def test_inventory_includes_read_threads_and_paginates_at_api_maximum(self):
         api = FakeGitHub(53)
@@ -90,11 +132,15 @@ class NotificationClearanceTests(unittest.TestCase):
 
     def test_clear_inbox_moves_read_and_unread_threads_to_done(self):
         api = FakeGitHub(4)
+        snapshots = []
         with (
             patch.object(clearer, "request", api.request),
             patch.object(clearer.time, "sleep", return_value=None),
         ):
-            report = clearer.clear_inbox("classic-token")
+            report = clearer.clear_inbox(
+                "classic-token",
+                progress=snapshots.append,
+            )
         self.assertEqual(report["before_inbox_count"], 4)
         self.assertEqual(report["before_unread_count"], 2)
         self.assertEqual(report["after_inbox_count"], 0)
@@ -104,6 +150,8 @@ class NotificationClearanceTests(unittest.TestCase):
         self.assertFalse(report["notification_content_recorded"])
         self.assertFalse(report["thread_ids_recorded"])
         self.assertTrue(all(state["done"] for state in api.threads.values()))
+        self.assertTrue(snapshots)
+        self.assertTrue(all(snapshot["status"] == "RUNNING" for snapshot in snapshots))
 
     def test_clear_inbox_catches_notification_arriving_during_clearance(self):
         api = FakeGitHub(2, inject_concurrent=True)
@@ -116,6 +164,85 @@ class NotificationClearanceTests(unittest.TestCase):
         self.assertEqual(report["cleared_count"], 3)
         self.assertGreaterEqual(report["clearance_rounds"], 2)
         self.assertTrue(api.threads["999"]["done"])
+
+    def test_clear_inbox_paces_mutating_requests_serially(self):
+        api = FakeGitHub(3)
+        with (
+            patch.object(clearer, "request", api.request),
+            patch.object(clearer.time, "sleep", return_value=None) as sleeper,
+        ):
+            clearer.clear_inbox("classic-token")
+        self.assertEqual(
+            sleeper.call_args_list.count(call(clearer.MUTATION_DELAY_SECONDS)),
+            2,
+        )
+
+    def test_rate_limit_delay_honors_retry_after(self):
+        self.assertEqual(
+            clearer.rate_limit_delay(
+                status=429,
+                detail="",
+                headers={"Retry-After": "7"},
+                attempt=0,
+                now_epoch=100,
+            ),
+            7,
+        )
+
+    def test_rate_limit_delay_honors_primary_reset_with_safety_margin(self):
+        self.assertEqual(
+            clearer.rate_limit_delay(
+                status=403,
+                detail="API rate limit exceeded",
+                headers={
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": "110",
+                },
+                attempt=0,
+                now_epoch=100,
+            ),
+            15,
+        )
+
+    def test_request_retries_rate_limit_then_returns(self):
+        error = http_error(retry_after="1")
+        response = FakeResponse(204)
+        with (
+            patch.object(
+                clearer.urllib.request,
+                "urlopen",
+                side_effect=[error, response],
+            ),
+            patch.object(clearer.time, "sleep", return_value=None) as sleeper,
+        ):
+            status, payload = clearer.request(
+                "classic-token",
+                "DELETE",
+                "/notifications/threads/secret-id",
+            )
+        self.assertEqual(status, 204)
+        self.assertIsNone(payload)
+        sleeper.assert_called_once_with(1.0)
+
+    def test_non_rate_limit_error_redacts_thread_identifier(self):
+        error = http_error(
+            detail=b'{"message":"Forbidden"}',
+            remaining="10",
+        )
+        with patch.object(
+            clearer.urllib.request,
+            "urlopen",
+            side_effect=error,
+        ):
+            with self.assertRaises(clearer.NotificationError) as raised:
+                clearer.request(
+                    "classic-token",
+                    "DELETE",
+                    "/notifications/threads/secret-id",
+                )
+        message = str(raised.exception)
+        self.assertIn("/notifications/threads/{thread_id}", message)
+        self.assertNotIn("secret-id", message)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/clear-personal-notifications.yml
+++ b/.github/workflows/clear-personal-notifications.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
     paths:
       - .github/scripts/clear_personal_notifications.py
+      - .github/scripts/test_clear_personal_notifications.py
+      - .github/workflows/clear-personal-notifications.yml
+  pull_request:
+    paths:
+      - .github/scripts/clear_personal_notifications.py
+      - .github/scripts/test_clear_personal_notifications.py
       - .github/workflows/clear-personal-notifications.yml
   workflow_dispatch:
 
@@ -12,18 +18,10 @@ permissions:
   contents: read
   issues: write
 
-concurrency:
-  group: github-personal-notification-clearance
-  cancel-in-progress: false
-
 jobs:
-  clear:
-    name: Count, clear, publish receipt, and reverify zero unread
+  validate:
+    name: Validate rate-limit-safe notification clearer
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      GH_NOTIFICATIONS_TOKEN: ${{ secrets.GH_NOTIFICATIONS_TOKEN || secrets.SZL_GITHUB_TOKEN }}
-      RECEIPT_TITLE: '[notification-clearance] personal GitHub inbox zero'
     steps:
       - name: Checkout control plane
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -33,10 +31,37 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Validate notification clearer
+      - name: Compile and run network-free regressions
         run: |
           set -euo pipefail
           python -m py_compile .github/scripts/clear_personal_notifications.py
+          python .github/scripts/test_clear_personal_notifications.py
+
+  clear:
+    name: Count, clear, publish receipt, and reverify zero unread
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    concurrency:
+      group: github-personal-notification-clearance
+      cancel-in-progress: false
+    env:
+      GH_NOTIFICATIONS_TOKEN: ${{ secrets.GH_NOTIFICATIONS_TOKEN || secrets.SZL_GITHUB_TOKEN }}
+      RECEIPT_TITLE: '[notification-clearance] personal GitHub inbox zero'
+      PYTHONUNBUFFERED: '1'
+    steps:
+      - name: Checkout control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Require classic notification token
+        run: |
+          set -euo pipefail
           test -n "${GH_NOTIFICATIONS_TOKEN:-}" || {
             echo '::error::No user token is configured. Add GH_NOTIFICATIONS_TOKEN with Notifications: read/write, or grant that permission to SZL_GITHUB_TOKEN.'
             exit 2


### PR DESCRIPTION
## Incident

`GitHub Notification Inbox Zero` failed once on a primary GitHub API rate limit, then its retry was cancelled at the existing 15-minute job ceiling while still issuing one `DELETE /notifications/threads/{id}` call at a time. The retry produced no usable final receipt because the process was terminated mid-drain.

## Fix

- Keep the exact-zero contract: every read and unread inbox thread still must reach Done, followed by a zero-inbox/zero-unread readback.
- Pace mutating requests serially at one-second intervals.
- Honor `Retry-After`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`; use bounded exponential fallback for secondary limits.
- Redact notification thread identifiers from all error paths.
- Atomically persist count-only `RUNNING` receipts during long drains so cancellation cannot erase progress evidence.
- Raise the mutating job ceiling from 15 minutes to the GitHub Actions maximum of 360 minutes, sufficient for the script's fail-closed 10,000-thread inventory bound plus rate-limit resets.
- Add a PR-only validation job; the mutating job is explicitly skipped for pull-request events.

## Verification

- `python -m py_compile .github/scripts/clear_personal_notifications.py`
- `python .github/scripts/test_clear_personal_notifications.py`
- 9 network-free regressions pass, covering pagination, read+unread deletion, concurrent arrival, mutation pacing, `Retry-After`, primary reset handling, retry recovery, and thread-ID redaction.
- Atomic diff: 3 files, 1 commit, branch is 1 ahead / 0 behind `main`.

## Merge rule

Merge only after the PR validation and repository checks are green. The post-merge push will start the long-running, rate-limit-safe clearance worker; do not bypass its final exact-zero assertion.