### PR TITLE
feat(hf): attest second-brain operator routes

### DIFF
--- a/.github/workflows/publish-operator-spaces.yml
+++ b/.github/workflows/publish-operator-spaces.yml
@@ -121,7 +121,7 @@ jobs:
               {
                   'repo': 'szl-real-estate',
                   'hf_repo': 'SZLHOLDINGS/szl-real-estate',
-                  'smoke_paths': '["/"]',
+                  'smoke_paths': '["/","/healthz","/api/second-brain","/api/formulas"]',
               },
               {
                   'repo': 'szl-command-lab',
@@ -131,7 +131,7 @@ jobs:
               {
                   'repo': 'lyte-lattice',
                   'hf_repo': 'SZLHOLDINGS/lyte-lattice',
-                  'smoke_paths': '["/"]',
+                  'smoke_paths': '["/","/healthz","/api/second-brain","/api/formulas"]',
               },
           ]
           matrix = publish.get('strategy', {}).get('matrix', {}).get('include')
@@ -203,13 +203,13 @@ jobs:
         include:
           - repo: szl-real-estate
             hf_repo: SZLHOLDINGS/szl-real-estate
-            smoke_paths: '["/"]'
+            smoke_paths: '["/","/healthz","/api/second-brain","/api/formulas"]'
           - repo: szl-command-lab
             hf_repo: SZLHOLDINGS/szl-command-lab
             smoke_paths: '["/","/healthz"]'
           - repo: lyte-lattice
             hf_repo: SZLHOLDINGS/lyte-lattice
-            smoke_paths: '["/"]'
+            smoke_paths: '["/","/healthz","/api/second-brain","/api/formulas"]'
     concurrency:
       group: hf-central-publish-${{ matrix.repo }}
       cancel-in-progress: false


### PR DESCRIPTION
Extends the single-writer central Hugging Face publisher's smoke/attestation contract to the newly installed governed second-brain routes on the exact-source operator Spaces.

- `szl-real-estate`: `/`, `/healthz`, `/api/second-brain`, `/api/formulas`
- `lyte-lattice`: `/`, `/healthz`, `/api/second-brain`, `/api/formulas`
- `szl-command-lab`: existing `/`, `/healthz`

The validation contract and runtime matrix remain lockstep. No alternate provider writer is introduced. Merging this workflow change triggers the central publisher against the current protected source tips.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>