### PR TITLE
fix(frontend): retry Holo Space rollout after canonical assets publish

### DIFF
--- a/.github/workflows/holo-space-v2-rollout.yml
+++ b/.github/workflows/holo-space-v2-rollout.yml
@@ -52,6 +52,39 @@ jobs:
           python -m py_compile .github/scripts/holo_space_rollout_v2.py
           python .github/tests/test_holo_space_rollout_v2.py
           python -m json.tool design/holographic-space-v2/space-registry.json >/dev/null
+      - name: Prove canonical Holo assets are published
+        env:
+          GITHUB_TOKEN: ${{ env.GH_ORG_TOKEN }}
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          assets = (
+              "console/assets/szl-holo-v2.css",
+              "console/assets/szl-holo-v2.js",
+              "docs/holographic-experience-v2/theme-registry.json",
+          )
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+              "User-Agent": "szl-holo-space-v2-preflight/1.0",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          witnesses = []
+          for path in assets:
+              url = f"https://api.github.com/repos/szl-holdings/a11oy/contents/{path}?ref=main"
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  payload = json.load(response)
+              sha = payload.get("sha")
+              if not sha:
+                  raise SystemExit(f"canonical asset has no immutable blob SHA: {path}")
+              witnesses.append({"path": path, "sha": sha})
+          print(json.dumps({"status": "READY", "assets": witnesses}, indent=2, sort_keys=True))
+          PY
       - name: Create guarded source pull requests
         id: apply
         shell: bash


### PR DESCRIPTION
## Purpose

Re-run the guarded Holo Space v2 estate rollout now that the three canonical A11oy Holo assets are present on protected `a11oy/main`.

The first one-shot run failed closed before any mutation because it executed before `console/assets/szl-holo-v2.css`, `console/assets/szl-holo-v2.js`, and the v2 theme registry had landed. The controller and all 17 offline adapter/safety tests passed; the only failure was the expected source-asset 404.

## Change

Add an explicit immutable preflight that resolves all three canonical assets through the GitHub Contents API and requires each to expose a blob SHA before cross-repository branches or pull requests may be created.

Merging this one-file workflow change triggers exactly one new rollout pass through the existing path-scoped `push` event.

## Safety boundary

- no direct writes to default branches;
- no force-pushes or branch-protection changes;
- no direct Hugging Face mutation;
- every compatible source change remains reviewable in its owning repository;
- report-only and unmapped Spaces remain explicitly reported rather than guessed.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>