### PR TITLE
fix(hf): preserve canonical runtime source probe URLs

### DIFF
--- a/.github/scripts/hf_space_source_binding.py
+++ b/.github/scripts/hf_space_source_binding.py
@@ -10,6 +10,11 @@ adds the missing runtime identity plane:
 3. after deployment, GET a same-host standard build-info endpoint and require
    ``build.state=OBSERVED`` plus ``build.revision=<exact Git SHA>``.
 
+Runtime probes always use the caller's canonical path verbatim. Retry identity and
+cache-control signals travel in request headers, never in synthetic query
+parameters. This avoids changing application routing while preserving bounded,
+independently attributable convergence attempts.
+
 It never changes Space hardware, visibility, sleep policy, secrets, models, or data.
 """
 from __future__ import annotations
@@ -31,6 +36,8 @@ SHA40 = re.compile(r"^[0-9a-f]{40}$")
 VARIABLE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
 REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 REPORT_SCHEMA = "szl.hf-space-source-binding/v1"
+PROBE_SOURCE_HEADER = "X-SZL-Source-Revision"
+PROBE_ATTEMPT_HEADER = "X-SZL-Probe-Attempt"
 
 
 class SourceBindingError(RuntimeError):
@@ -116,6 +123,18 @@ def bind_variable(api: HfApi, binding: Mapping[str, str]) -> dict[str, Any]:
     return verify_variable(api, binding)
 
 
+def _probe_headers(binding: Mapping[str, str], attempt: int) -> dict[str, str]:
+    """Return per-attempt transport identity without changing application routing."""
+    return {
+        "Accept": "application/json",
+        "Cache-Control": "no-cache, no-store, max-age=0",
+        "Pragma": "no-cache",
+        "User-Agent": "szl-hf-space-source-binding/1",
+        PROBE_SOURCE_HEADER: binding["revision"],
+        PROBE_ATTEMPT_HEADER: str(attempt),
+    }
+
+
 def _runtime_probe_observation(
     binding: Mapping[str, str],
     *,
@@ -124,23 +143,20 @@ def _runtime_probe_observation(
     request_timeout_seconds: float,
 ) -> dict[str, Any]:
     canonical_url = live_origin(binding["repo_id"]) + binding["probe_path"]
-    separator = "&" if "?" in canonical_url else "?"
-    request_url = (
-        f"{canonical_url}{separator}__szl_source_revision={binding['revision']}"
-        f"&__szl_probe_attempt={attempt}"
-    )
     observation: dict[str, Any] = {
         "attempt": attempt,
         "observed_at": datetime.now(timezone.utc).isoformat(),
-        "url": request_url,
+        "url": canonical_url,
         "expected_revision": binding["revision"],
+        "request_identity": "headers",
         "matched": False,
     }
     try:
         response = session.get(
-            request_url,
+            canonical_url,
             allow_redirects=False,
             timeout=request_timeout_seconds,
+            headers=_probe_headers(binding, attempt),
         )
     except Exception as exc:  # noqa: BLE001 - preserve a bounded transport observation
         observation.update(
@@ -208,14 +224,6 @@ def verify_runtime_probe(
     if not 0 < interval_seconds <= 60:
         raise SourceBindingError("runtime probe interval must be greater than 0 and at most 60 seconds")
     session = session or requests.Session()
-    session.headers.update(
-        {
-            "Accept": "application/json",
-            "Cache-Control": "no-cache, no-store, max-age=0",
-            "Pragma": "no-cache",
-            "User-Agent": "szl-hf-space-source-binding/1",
-        }
-    )
     started = monotonic()
     deadline = started + timeout_seconds
     observations: list[dict[str, Any]] = []
@@ -298,6 +306,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "boundaries": [
             "Only one non-secret Space variable may be added or updated.",
             "Verification uses supported HfApi variable readback and bounded same-host GET convergence.",
+            "Probe retries preserve the canonical application URL and carry attempt identity only in headers.",
             "No Space hardware, visibility, sleep policy, secret, model, dataset, or branch state is changed.",
         ],
     }

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -86,6 +86,15 @@ class SourceBindingTests(unittest.TestCase):
             "SZLHOLDINGS/a11oy", "SZL_GIT_SHA", self.sha, "/api/build-info"
         )
 
+    @staticmethod
+    def observed_payload(revision: str) -> dict[str, object]:
+        return {
+            "status": "OBSERVED",
+            "build": {"state": "OBSERVED", "revision": revision},
+            "runtime": {"python": "3.12"},
+            "receipt_minted": False,
+        }
+
     def test_normalize_requires_exact_repo_key_sha_and_same_host_path(self):
         self.assertEqual(self.normalized["revision"], self.sha)
         for args in (
@@ -115,21 +124,25 @@ class SourceBindingTests(unittest.TestCase):
             binding.verify_variable(api, self.normalized)
 
     def test_runtime_probe_requires_observed_exact_revision_and_no_receipt(self):
-        payload = {
-            "status": "OBSERVED",
-            "build": {"state": "OBSERVED", "revision": self.sha},
-            "runtime": {"python": "3.12"},
-            "receipt_minted": False,
-        }
+        payload = self.observed_payload(self.sha)
         session = FakeSession(FakeResponse(payload))
         report = binding.verify_runtime_probe(self.normalized, session=session)
+        canonical = "https://szlholdings-a11oy.hf.space/api/build-info"
         self.assertTrue(report["matched"])
+        self.assertEqual(report["url"], canonical)
+        self.assertEqual(session.calls[0][0], canonical)
+        self.assertNotIn("__szl_", session.calls[0][0])
+        request = session.calls[0][1]
+        self.assertFalse(request["allow_redirects"])
         self.assertEqual(
-            report["url"],
-            "https://szlholdings-a11oy.hf.space/api/build-info",
+            request["headers"][binding.PROBE_SOURCE_HEADER],
+            self.sha,
         )
-        self.assertIn("__szl_source_revision=" + self.sha, session.calls[0][0])
-        self.assertFalse(session.calls[0][1]["allow_redirects"])
+        self.assertEqual(request["headers"][binding.PROBE_ATTEMPT_HEADER], "1")
+        self.assertEqual(
+            request["headers"]["Cache-Control"],
+            "no-cache, no-store, max-age=0",
+        )
 
         payload["build"]["revision"] = "b" * 40
         with self.assertRaisesRegex(binding.SourceBindingError, "did not converge"):
@@ -139,15 +152,27 @@ class SourceBindingTests(unittest.TestCase):
                 timeout_seconds=0,
             )
 
+    def test_runtime_probe_preserves_caller_query_verbatim(self):
+        normalized = binding.normalize_binding(
+            "SZLHOLDINGS/a11oy",
+            "SZL_GIT_SHA",
+            self.sha,
+            "/api/build-info?refresh=1&mode=full",
+        )
+        session = FakeSession(FakeResponse(self.observed_payload(self.sha)))
+        report = binding.verify_runtime_probe(normalized, session=session)
+        canonical = (
+            "https://szlholdings-a11oy.hf.space/"
+            "api/build-info?refresh=1&mode=full"
+        )
+        self.assertEqual(report["url"], canonical)
+        self.assertEqual(session.calls[0][0], canonical)
+        self.assertNotIn("__szl_source_revision", session.calls[0][0])
+        self.assertNotIn("__szl_probe_attempt", session.calls[0][0])
+
     def test_runtime_probe_converges_from_stale_revision_and_records_every_attempt(self):
-        stale = {
-            "build": {"state": "OBSERVED", "revision": "b" * 40},
-            "receipt_minted": False,
-        }
-        current = {
-            "build": {"state": "OBSERVED", "revision": self.sha},
-            "receipt_minted": False,
-        }
+        stale = self.observed_payload("b" * 40)
+        current = self.observed_payload(self.sha)
         clock = FakeClock()
         session = FakeSession([FakeResponse(stale), FakeResponse(current)])
         report = binding.verify_runtime_probe(
@@ -163,13 +188,44 @@ class SourceBindingTests(unittest.TestCase):
         self.assertEqual(len(report["observations"]), 2)
         self.assertFalse(report["observations"][0]["matched"])
         self.assertTrue(report["observations"][1]["matched"])
-        self.assertNotEqual(session.calls[0][0], session.calls[1][0])
+        self.assertEqual(session.calls[0][0], session.calls[1][0])
+        first_headers = session.calls[0][1]["headers"]
+        second_headers = session.calls[1][1]["headers"]
+        self.assertEqual(first_headers[binding.PROBE_ATTEMPT_HEADER], "1")
+        self.assertEqual(second_headers[binding.PROBE_ATTEMPT_HEADER], "2")
+        self.assertEqual(first_headers[binding.PROBE_SOURCE_HEADER], self.sha)
+        self.assertEqual(second_headers[binding.PROBE_SOURCE_HEADER], self.sha)
+
+    def test_runtime_probe_retries_transient_404_without_changing_url(self):
+        current = self.observed_payload(self.sha)
+        clock = FakeClock()
+        session = FakeSession(
+            [
+                FakeResponse(
+                    {"detail": "Application not found"},
+                    status=404,
+                    content_type="text/html",
+                ),
+                FakeResponse(current),
+            ]
+        )
+        report = binding.verify_runtime_probe(
+            self.normalized,
+            session=session,
+            timeout_seconds=10,
+            interval_seconds=2,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+        self.assertTrue(report["matched"])
+        self.assertEqual(report["attempt_count"], 2)
+        self.assertEqual(report["observations"][0]["http_status"], 404)
+        self.assertEqual(report["observations"][1]["http_status"], 200)
+        self.assertEqual(session.calls[0][0], session.calls[1][0])
+        self.assertNotIn("__szl_", session.calls[0][0])
 
     def test_runtime_probe_exhaustion_is_bounded_and_retains_observations(self):
-        stale = {
-            "build": {"state": "OBSERVED", "revision": "b" * 40},
-            "receipt_minted": False,
-        }
+        stale = self.observed_payload("b" * 40)
         clock = FakeClock()
         with self.assertRaises(binding.SourceBindingError) as raised:
             binding.verify_runtime_probe(
@@ -202,10 +258,12 @@ class SourceBindingTests(unittest.TestCase):
                 timeout_seconds=0,
             )
 
-    def test_source_contains_no_secret_or_hardware_mutation(self):
+    def test_source_contains_no_synthetic_query_or_privileged_mutation(self):
         with open(MODULE_PATH, encoding="utf-8") as fh:
             source = fh.read()
         for forbidden in (
+            "__szl_source_revision",
+            "__szl_probe_attempt",
             "add_space_secret",
             "delete_space_secret",
             "request_space_hardware",


### PR DESCRIPTION
## Measured failure

Relates to `szl-holdings/platform#716` and `szl-holdings/platform#717`.

The restart-enabled Hatun deployment proved the exact Hugging Face commit, every managed file, and all declared bare smoke routes—including `/api/build-info`—with HTTP 200. The subsequent source-binding verifier then retried 37 URLs of the form:

`/api/build-info?__szl_source_revision=<sha>&__szl_probe_attempt=<n>`

Every query-mutated request returned Hugging Face's generic application-not-found HTTP 404, even though the canonical `/api/build-info` route was healthy. The query mutation changed routing at the provider edge; the application and exact source binding were not the failing components.

## Repair

- Request the canonical caller-supplied probe path verbatim on every attempt.
- Preserve any legitimate caller query string, such as `?refresh=1`, without adding synthetic parameters.
- Move exact source revision and attempt identity into `X-SZL-Source-Revision` and `X-SZL-Probe-Attempt` headers.
- Keep `Cache-Control: no-cache, no-store, max-age=0`, `Pragma: no-cache`, JSON acceptance, redirect refusal, per-request timeout bounds, and the 180-second convergence loop.
- Continue accepting only `build.state=OBSERVED`, the exact expected 40-character SHA, and `receipt_minted=false`.
- Continue failing closed on transport errors, non-200 responses, non-JSON responses, stale or malformed source identity, and bounded exhaustion.

## Adversarial coverage

The network-free contract suite now proves:

- canonical URL equality for every retry;
- legitimate caller query preservation;
- no synthetic `__szl_*` parameters in source or requests;
- exact revision and changing attempt identity in headers;
- transient HTTP 404 followed by exact-source convergence;
- stale source rejection and bounded evidence retention;
- no secret, hardware, visibility, sleep-policy, restart, or repository-setting mutation.

## Boundaries

- No caller workflow, Space, model, dataset, secret value, hardware, visibility, sleep policy, DNS, or branch-protection mutation.
- No direct Hugging Face write from this pull request.
- Hatun and YARQA incidents remain open until their callers pin the merged controller revision and protected-main deployments prove current public health and exact served source identity.

The branch is exactly current protected main plus two focused commits, changes only the shared verifier and its tests, and is zero commits behind.