### PR TITLE
fix(ops): align public-origin convergence with the real Pages topology

### DIFF
--- a/.github/scripts/public_estate_convergence.py
+++ b/.github/scripts/public_estate_convergence.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Verify and selectively repair the two canonical SZL public origins.
 
-The controller proves the root document, the local Spectral v2 stylesheet, and
-the local Flow v2 controller for each origin. When explicitly authorized it may
-request the existing A11oy Hugging Face sync workflow or the existing GitHub
-Pages rebuild endpoint. It never edits source, DNS, Cloudflare, secrets, pages,
-models, datasets, or application state.
+The controller proves each origin's root document and its exact local visual
+contract. The product front door is the GitHub Pages site published from
+``szl-holdings.github.io`` and uses Responsive Apex v3. The independent proof
+origin is published from ``a11oy-net`` and uses Spectral Proof v2.
+
+When explicitly authorized, this controller may request only the corresponding
+existing GitHub Pages rebuild endpoint. It never edits source, DNS, Cloudflare,
+secrets, pages, models, datasets, Hugging Face resources, or application state.
 """
 from __future__ import annotations
 
@@ -17,13 +20,12 @@ import json
 import os
 import time
 import urllib.error
-import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any, Mapping
 
 GITHUB_API = "https://api.github.com"
-USER_AGENT = "SZL-Public-Estate-Convergence/2.0"
+USER_AGENT = "SZL-Public-Estate-Convergence/3.0"
 TOKEN_NAMES = ("SZL_GITHUB_TOKEN", "GH_CONTROL_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 
 
@@ -48,13 +50,16 @@ CONTRACTS = (
     OriginContract(
         name="a-11-oy.com",
         root="https://a-11-oy.com/",
-        spectral_asset="https://a-11-oy.com/assets/szl-spectral-v2.css",
-        controller_asset="https://a-11-oy.com/assets/szl-flow.js",
-        root_literals=("/assets/szl-flow.js",),
-        spectral_literals=("SZL Spectral Fabric v2", ".szl-spectral-field"),
-        controller_literals=("SZL Flow Shell v2", "/assets/szl-spectral-v2.css"),
-        advisory_health="https://a-11-oy.com/healthz",
-        repair="A11OY_HF_SYNC",
+        spectral_asset="https://a-11-oy.com/assets/szl-responsive-apex-v3.css",
+        controller_asset="https://a-11-oy.com/assets/szl-responsive-apex-v3.js",
+        root_literals=(
+            "/assets/szl-responsive-apex-v3.css",
+            "/assets/szl-responsive-apex-v3.js",
+        ),
+        spectral_literals=("SZL Apex Responsive Experience v3", "--apex-touch: 44px"),
+        controller_literals=("SZL Apex Responsive Experience v3", "__SZL_APEX_RESPONSIVE_V3__"),
+        advisory_health="https://a-11-oy.com/origin-status.json",
+        repair="PRODUCT_PAGES_BUILD",
     ),
     OriginContract(
         name="a11oy.net",
@@ -161,12 +166,11 @@ def github_action(
 
 
 def request_repair(contract: OriginContract, token: str) -> dict[str, Any]:
-    if contract.repair == "A11OY_HF_SYNC":
+    if contract.repair == "PRODUCT_PAGES_BUILD":
         status = github_action(
             "POST",
-            "/repos/szl-holdings/a11oy/actions/workflows/hf-sync.yml/dispatches",
+            "/repos/szl-holdings/szl-holdings.github.io/pages/builds",
             token,
-            {"ref": "main"},
         )
         return {"action": contract.repair, "http_status": status, "source_mutation": False}
     if contract.repair == "A11OY_NET_PAGES_BUILD":
@@ -238,7 +242,7 @@ def main() -> int:
 
     complete = all(row["operational"] for row in after)
     report = {
-        "schema": "szl.public-estate-convergence/v2",
+        "schema": "szl.public-estate-convergence/v3",
         "generated_at": utc_now(),
         "repair_requested": args.repair,
         "token_available": bool(token),

--- a/tests/test_public_estate_convergence.py
+++ b/tests/test_public_estate_convergence.py
@@ -18,12 +18,26 @@ sys.modules[SPEC.name] = convergence
 SPEC.loader.exec_module(convergence)
 
 
-def test_two_canonical_origins_have_local_spectral_contracts() -> None:
+def test_two_canonical_origins_have_source_native_visual_contracts() -> None:
     assert [row.name for row in convergence.CONTRACTS] == ["a-11-oy.com", "a11oy.net"]
-    assert convergence.CONTRACTS[0].spectral_asset.endswith("/assets/szl-spectral-v2.css")
-    assert convergence.CONTRACTS[1].spectral_asset.endswith("/assets/szl-spectral-proof-v2.css")
-    assert convergence.CONTRACTS[0].controller_asset.endswith("/assets/szl-flow.js")
-    assert convergence.CONTRACTS[1].controller_asset.endswith("/scripts/szl-flow-proof.js")
+    product, proof = convergence.CONTRACTS
+    assert product.spectral_asset.endswith("/assets/szl-responsive-apex-v3.css")
+    assert product.controller_asset.endswith("/assets/szl-responsive-apex-v3.js")
+    assert product.advisory_health.endswith("/origin-status.json")
+    assert product.repair == "PRODUCT_PAGES_BUILD"
+    assert proof.spectral_asset.endswith("/assets/szl-spectral-proof-v2.css")
+    assert proof.controller_asset.endswith("/scripts/szl-flow-proof.js")
+    assert proof.repair == "A11OY_NET_PAGES_BUILD"
+
+
+def test_product_root_requires_both_published_responsive_assets() -> None:
+    product = convergence.CONTRACTS[0]
+    assert product.root_literals == (
+        "/assets/szl-responsive-apex-v3.css",
+        "/assets/szl-responsive-apex-v3.js",
+    )
+    assert "SZL Apex Responsive Experience v3" in product.spectral_literals
+    assert "__SZL_APEX_RESPONSIVE_V3__" in product.controller_literals
 
 
 def test_probe_requires_http_200_bytes_and_every_literal() -> None:
@@ -42,17 +56,17 @@ def test_probe_requires_http_200_bytes_and_every_literal() -> None:
         assert convergence.probe("https://example.test/", ("alpha",))["verified"] is False
 
 
-def test_product_repair_dispatches_existing_main_sync_only() -> None:
+def test_product_repair_requests_the_actual_front_door_pages_build() -> None:
     contract = convergence.CONTRACTS[0]
-    with mock.patch.object(convergence, "github_action", return_value=204) as action:
+    with mock.patch.object(convergence, "github_action", return_value=201) as action:
         receipt = convergence.request_repair(contract, "secret")
     action.assert_called_once_with(
         "POST",
-        "/repos/szl-holdings/a11oy/actions/workflows/hf-sync.yml/dispatches",
+        "/repos/szl-holdings/szl-holdings.github.io/pages/builds",
         "secret",
-        {"ref": "main"},
     )
     assert receipt["source_mutation"] is False
+    assert receipt["action"] == "PRODUCT_PAGES_BUILD"
 
 
 def test_proof_repair_requests_existing_pages_build_only() -> None:
@@ -76,7 +90,7 @@ def test_token_precedence_prefers_governed_pat() -> None:
         assert convergence.token_from_environment() == ("governed", "SZL_GITHUB_TOKEN")
 
 
-def test_source_contains_no_content_dns_or_cloudflare_mutator() -> None:
+def test_source_contains_no_content_dns_cloudflare_or_hf_mutator() -> None:
     text = MODULE_PATH.read_text(encoding="utf-8")
     forbidden = (
         "/contents/",
@@ -86,6 +100,7 @@ def test_source_contains_no_content_dns_or_cloudflare_mutator() -> None:
         "/git/commits",
         "cloudflare.com/client",
         "/dns_records",
+        "hf-sync.yml/dispatches",
         "create_commit",
         "update_file",
         "delete_file",


### PR DESCRIPTION
## Problem

Closes #577 after post-merge live readback.

The convergence controller was treating `a-11-oy.com` as the A11oy Hugging Face runtime. It probed `/assets/szl-spectral-v2.css` and `/assets/szl-flow.js`, then dispatched `a11oy/hf-sync.yml` when those expectedly returned 404.

The product front door is actually published from `szl-holdings/szl-holdings.github.io`. Its committed and bound visual contract is Responsive Apex v3:

- `/assets/szl-responsive-apex-v3.css`
- `/assets/szl-responsive-apex-v3.js`
- `/origin-status.json`

The independent proof origin remains `a11oy-net` with Spectral Proof v2.

## Fix

- Probe the two exact Responsive Apex v3 product assets and require both references in the root document.
- Use the committed `origin-status.json` as the product front-door advisory document rather than pretending the static site exposes a runtime `/healthz`.
- Request only the existing `szl-holdings.github.io` Pages rebuild when the product origin drifts.
- Retain the existing `a11oy-net` Pages repair for the proof origin.
- Remove the unrelated Hugging Face publisher from this controller's mutation surface.
- Add network-free tests for the exact source repository, asset identities, root markers, repair endpoint, and negative mutation boundary.

## Boundaries

No source content, DNS, Cloudflare, Hugging Face resource, runtime, model, dataset, secret, or application state is mutated by the controller. A root 200 alone still does not pass; the exact local style and controller bytes must also contain their expected contract literals.

The branch is exactly two commits ahead of current protected main and zero behind. Merge only after the exact-head contract, security, doctrine, and workflow checks are green; #577 closes only after the protected-main convergence run verifies both public origins.