### PR TITLE
fix(security): use the managed organization token for CodeQL convergence

### DIFF
--- a/.github/workflows/org-code-scanning-baseline-contract.yml
+++ b/.github/workflows/org-code-scanning-baseline-contract.yml
@@ -63,12 +63,17 @@ jobs:
               + "{{ github.run_id }}-$"
               + "{{ github.run_attempt }}"
           )
+          token_chain = (
+              "secrets.SZL_ORG_ADMIN_TOKEN || secrets.ORG_ADMIN_TOKEN || "
+              "secrets.SZL_GITHUB_TOKEN || secrets.GH_PAT || github.token"
+          )
           required = (
               "permissions:\n  contents: read\n  issues: write\n  security-events: write",
               "python .github/scripts/org_code_scanning_baseline_v2.py",
               "--apply",
               "if-no-files-found: error",
               artifact_template,
+              token_chain,
           )
           for token in required:
               if workflow.count(token) != 1:

--- a/.github/workflows/org-code-scanning-baseline.yml
+++ b/.github/workflows/org-code-scanning-baseline.yml
@@ -36,7 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     env:
-      SZL_ORG_TOKEN: ${{ secrets.SZL_ORG_ADMIN_TOKEN || secrets.ORG_ADMIN_TOKEN || secrets.GH_PAT || github.token }}
+      # Prefer the established organization-capable secret alias used by the
+      # frontier operator. The repository token is a fail-closed fallback and
+      # cannot acquire cross-repository code-security scope.
+      SZL_ORG_TOKEN: ${{ secrets.SZL_ORG_ADMIN_TOKEN || secrets.ORG_ADMIN_TOKEN || secrets.SZL_GITHUB_TOKEN || secrets.GH_PAT || github.token }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0


### PR DESCRIPTION
## Incident

Protected-main CodeQL baseline run `33709097798` completed its local contracts and emitted its receipt, but every one of the 63 eligible public repositories returned the same GitHub `403 Resource not accessible by integration` while reading native default setup. The workflow had fallen through to an integration-scoped credential because it did not include the established `SZL_GITHUB_TOKEN` alias already used by the organization frontier operator.

## Repair

- Add `SZL_GITHUB_TOKEN` ahead of the generic PAT and repository-token fallbacks.
- Preserve `SZL_ORG_ADMIN_TOKEN` and `ORG_ADMIN_TOKEN` as higher-precedence explicit aliases.
- Preserve fail-closed behavior: if the managed credential still lacks code-security scope, the provider sweep remains red and issue #586 remains open.
- Extend the read-only workflow contract to lock the exact credential precedence and prevent regression.

## Evidence

Run `33709097798` proved the source contracts, receipt validation, and artifact upload work. Its retained receipt classified `63 BLOCKED` and `2 SKIPPED_NO_SUPPORTED_LANGUAGE`; no repository was falsely reported configured.

## Scope

Two workflow files only. No source repository, branch, ruleset, visibility, secret value, provider resource, or alert is changed by this pull request.

Exact base: `390bc250f58f36eb87c85d1a7071bfde531b9b5c`

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>