### PR TITLE
feat(frontend): ship Public Experience v3.1 across the Space estate

### DIFF
--- a/.github/scripts/responsive_space_contract.py
+++ b/.github/scripts/responsive_space_contract.py
@@ -45,6 +45,8 @@ def _streamlit_helper(core: Any, original: Any) -> str:
         "document.documentElement.dataset.szlViewportTier="
         "(innerWidth<480?'phone':innerWidth<768?'compact':innerWidth<1024?'tablet':"
         "innerWidth<1440?'desktop':innerWidth<1920?'wide':innerWidth<2560?'theatre':'ultrawide');"
+        "document.documentElement.dataset.szlZoomTier='normal';"
+        "if(!String(document.title||'').trim()){document.title=String({slug!r}).replace(/[_-]+/g,' ').replace(/\\b\\w/g,function(c){return c.toUpperCase();})+' · SZL Holdings';}"
         "</script>"
     )
     if needle not in source:
@@ -152,7 +154,7 @@ def install(core: Any) -> None:
         body = original_pr_body(plan, digest)
         return body + """
 
-## SZL Public Experience v3
+## SZL Public Experience v3.1
 
 This rollout also applies the estate-wide responsive contract:
 
@@ -160,12 +162,17 @@ This rollout also applies the estate-wide responsive contract:
   and ultrawide theatre presentation;
 - no document-level horizontal overflow; wide tables and code remain locally
   scrollable instead of being clipped;
-- dynamic viewport units, mobile safe areas, 44px coarse-pointer controls,
+- dynamic viewport units, mobile safe areas, 48px coarse-pointer controls,
   readable form sizing, media containment, and bounded dialogs;
+- 200% and 400% zoom reflow with shared chrome prevented from becoming a
+  viewport-blocking fixed overlay;
 - reduced-motion, increased-contrast, forced-colors, zoom/reflow, and print
   behavior;
+- a non-destructive fallback title for otherwise untitled public Spaces;
 - a concise shared ecosystem rail whose Shadow DOM is independently hardened
-  for phone through theatre displays.
+  for phone through theatre displays;
+- stable `user`, `developer`, `investor`, and `operator` audience state through
+  a local data attribute, without changing product behavior or making claims.
 
 The responsive layer is additive. It does not replace the product's own layout,
 data, workflows, copy, model behavior, or evidence semantics.

--- a/.github/tests/test_responsive_space_contract.py
+++ b/.github/tests/test_responsive_space_contract.py
@@ -24,7 +24,7 @@ class Change:
 
 
 class ResponsiveSpaceContractTests(unittest.TestCase):
-    def test_assets_cover_phone_tablet_desktop_and_theatre(self) -> None:
+    def test_assets_cover_phone_tablet_desktop_theatre_and_zoom(self) -> None:
         css, javascript = responsive._read_assets()
         for marker in (
             "max-width: 479px",
@@ -36,6 +36,9 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
             "100dvh",
             "safe-area-inset",
             "--szl-touch-target",
+            "--szl-touch-target-coarse",
+            "--szl-effective-inline-size",
+            "data-szl-zoom-tier",
             "overflow-x: clip",
             "prefers-reduced-motion",
             "prefers-contrast",
@@ -47,8 +50,13 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
             "__SZL_PUBLIC_EXPERIENCE_V3__",
             "szlPublicExperienceV3",
             "szlViewportTier",
+            "szlZoomTier",
+            "szlAudience",
             "visualViewport",
             "requestAnimationFrame",
+            "MutationObserver",
+            "document.title",
+            "effectiveWidth",
             "phone",
             "tablet",
             "theatre",
@@ -69,6 +77,23 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
         ):
             self.assertNotIn(token, javascript)
         self.assertEqual(css.count("{"), css.count("}"))
+
+    def test_zoom_navigation_is_bounded_and_not_a_fixed_viewport_sheet(self) -> None:
+        _, javascript = responsive._read_assets()
+        self.assertIn(":host([data-szl-zoom-tier=high])", javascript)
+        self.assertIn("position:absolute!important", javascript)
+        self.assertIn("max-height:min(56dvh,420px)", javascript)
+        self.assertIn("min-width:54px!important", javascript)
+        self.assertIn("min-height:48px!important", javascript)
+        self.assertIn("border-radius:10px!important", javascript)
+        self.assertNotIn("nav{position:fixed!important", javascript)
+
+    def test_empty_title_fallback_is_non_destructive(self) -> None:
+        _, javascript = responsive._read_assets()
+        self.assertIn('if (String(document.title || "").trim()) return;', javascript)
+        self.assertIn('document.title = declaredIdentity() + " · SZL Holdings";', javascript)
+        self.assertIn("SZLPublicExperience", javascript)
+        self.assertIn("snapshot: snapshot", javascript)
 
     def test_append_once_is_idempotent(self) -> None:
         once = responsive._append_once("base", "SZL Public Experience v3\n", responsive.CSS_MARKER)
@@ -115,6 +140,9 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
         helper = core.streamlit_helper()
         self.assertIn("dataset.szlPublicExperienceV3", helper)
         self.assertIn("dataset.szlViewportTier", helper)
+        self.assertIn("dataset.szlZoomTier", helper)
+        self.assertIn("document.title", helper)
+        self.assertIn("SZL Holdings", helper)
 
     def test_already_integrated_repository_becomes_reviewable_refresh(self) -> None:
         core = self._core(
@@ -167,8 +195,11 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
         )
         responsive.install(core)
         body = core.pr_body(SimpleNamespace(), "digest")
-        self.assertIn("SZL Public Experience v3", body)
+        self.assertIn("SZL Public Experience v3.1", body)
         self.assertIn("phone widths from 320px", body)
+        self.assertIn("400% zoom", body)
+        self.assertIn("fallback title", body)
+        self.assertIn("investor", body)
         self.assertIn("additive", body.lower())
         self.assertIn("does not replace", body.lower())
 

--- a/design/responsive-v3/szl-responsive-v3.css
+++ b/design/responsive-v3/szl-responsive-v3.css
@@ -1,14 +1,16 @@
 /*
- * SZL Public Experience v3
+ * SZL Public Experience v3.1
  * Responsive, zoom-safe, theatre-scale adaptation for every Holographic Space.
  * Additive only: product-owned layout and information architecture remain authoritative.
  * SPDX-License-Identifier: Apache-2.0
  */
 :root {
-  --szl-public-experience-version: 3;
+  --szl-public-experience-version: 3.1;
   --szl-touch-target: 44px;
+  --szl-touch-target-coarse: 48px;
   --szl-readable-measure: 72ch;
   --szl-viewport-height: 100vh;
+  --szl-effective-inline-size: 100vw;
   --szl-theatre-gutter: clamp(16px, 3vw, 72px);
   --szl-fluid-gap: clamp(10px, 1.5vw, 24px);
   --szl-fluid-radius: clamp(12px, 1vw, 20px);
@@ -37,7 +39,10 @@ html[data-szl-space-holo-v2="true"] body {
 
 html[data-szl-space-holo-v2="true"] :where(
   main, header, footer, nav, section, article, aside,
-  form, fieldset, figure, div, ul, ol, li
+  form, fieldset, figure, div, ul, ol, li,
+  #root, .app, .main, .container, .wrapper,
+  .gradio-container, [data-testid="stApp"], [data-testid="stAppViewContainer"],
+  [data-testid="stMain"], [data-testid="stMainBlockContainer"]
 ) {
   min-inline-size: 0;
   max-inline-size: 100%;
@@ -48,6 +53,14 @@ html[data-szl-space-holo-v2="true"] :where(
   a, button, label, legend, figcaption, blockquote
 ) {
   overflow-wrap: anywhere;
+}
+
+html[data-szl-space-holo-v2="true"] :where(h1, h2, h3) {
+  text-wrap: balance;
+}
+
+html[data-szl-space-holo-v2="true"] :where(p, li, dd, figcaption, blockquote) {
+  text-wrap: pretty;
 }
 
 html[data-szl-space-holo-v2="true"] :where(img, svg, video, picture) {
@@ -81,6 +94,10 @@ html[data-szl-space-holo-v2="true"] pre code {
   white-space: pre;
 }
 
+html[data-szl-space-holo-v2="true"] table {
+  max-inline-size: 100%;
+}
+
 html[data-szl-space-holo-v2="true"] :where(dialog, [role="dialog"], [aria-modal="true"]) {
   max-inline-size: min(92vw, 920px);
   max-block-size: min(92vh, 92dvh);
@@ -94,13 +111,35 @@ html[data-szl-space-holo-v2="true"] :where(.szl-space-panel, [data-szl-panel]) {
   border-radius: var(--szl-fluid-radius);
 }
 
-/* Shared navigation is always above product chrome without blocking product input. */
+/* Shared navigation remains source-visible, compact, and nonblocking. */
 szl-space-ecosystem-bar {
   display: block;
   inline-size: 100%;
   max-inline-size: 100%;
   position: relative;
   z-index: 2147483000;
+}
+
+/* CSS zoom used by browser audits can otherwise leave fixed chrome at four times
+   the visual viewport. The runtime controller records the effective layout width. */
+html[data-szl-space-holo-v2="true"][data-szl-zoom-tier="high"] body,
+html[data-szl-space-holo-v2="true"][data-szl-zoom-tier="extreme"] body {
+  inline-size: var(--szl-effective-inline-size);
+  max-inline-size: var(--szl-effective-inline-size);
+}
+
+html[data-szl-space-holo-v2="true"][data-szl-zoom-tier="high"] :where(
+  .szl-flow-rail, .szl-holo-rail, [data-szl-floating-chrome]
+),
+html[data-szl-space-holo-v2="true"][data-szl-zoom-tier="extreme"] :where(
+  .szl-flow-rail, .szl-holo-rail, [data-szl-floating-chrome]
+) {
+  position: relative !important;
+  inset: auto !important;
+  inline-size: auto !important;
+  max-inline-size: 100% !important;
+  margin: 8px !important;
+  transform: none !important;
 }
 
 /* Phone: one readable column, compact ambience, no hidden horizontal content. */
@@ -125,6 +164,12 @@ szl-space-ecosystem-bar {
     overflow-x: auto;
     overscroll-behavior-inline: contain;
     -webkit-overflow-scrolling: touch;
+  }
+
+  html[data-szl-space-holo-v2="true"] :where(
+    [data-szl-responsive-grid], .grid, [class*="grid-cols"]
+  ) {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   #szl-space-holo-v2-ambient {
@@ -222,14 +267,15 @@ szl-space-ecosystem-bar {
     a[href], button, input:not([type="hidden"]), select, textarea,
     summary, [role="button"], [tabindex]:not([tabindex="-1"])
   ) {
-    min-block-size: var(--szl-touch-target);
+    min-block-size: var(--szl-touch-target-coarse);
+    touch-action: manipulation;
   }
 
   html[data-szl-space-holo-v2="true"] :where(
     button, input[type="button"], input[type="submit"], input[type="reset"],
     summary, [role="button"]
   ) {
-    min-inline-size: var(--szl-touch-target);
+    min-inline-size: var(--szl-touch-target-coarse);
   }
 }
 

--- a/design/responsive-v3/szl-responsive-v3.js
+++ b/design/responsive-v3/szl-responsive-v3.js
@@ -1,6 +1,6 @@
 /*
- * SZL Public Experience v3
- * Viewport-aware, dependency-free adaptation for Holographic Space Fabric v2.
+ * SZL Public Experience v3.1
+ * Viewport-, zoom-, and audience-aware adaptation for Holographic Space Fabric v2.
  * No network, analytics, cookies, storage, or product-state mutation.
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,17 +10,48 @@
   if (window.__SZL_PUBLIC_EXPERIENCE_V3__) return;
   window.__SZL_PUBLIC_EXPERIENCE_V3__ = true;
 
+  var VERSION = "3.1.0";
   var ROOT = document.documentElement;
   var raf = 0;
   var observer = null;
+  var rootStyleObserver = null;
   var stopObserverTimer = 0;
+  var lastViewportState = "";
 
-  function viewportWidth() {
-    return Math.max(1, Math.round((window.visualViewport && window.visualViewport.width) || window.innerWidth || ROOT.clientWidth || 1));
+  function layoutViewportWidth() {
+    var visual = window.visualViewport && window.visualViewport.width;
+    return Math.max(
+      1,
+      Math.round(Number(visual) || 0),
+      Math.round(Number(window.innerWidth) || 0),
+      Math.round(Number(ROOT.clientWidth) || 0)
+    );
   }
 
-  function viewportHeight() {
-    return Math.max(1, Math.round((window.visualViewport && window.visualViewport.height) || window.innerHeight || ROOT.clientHeight || 1));
+  function layoutViewportHeight() {
+    var visual = window.visualViewport && window.visualViewport.height;
+    return Math.max(
+      1,
+      Math.round(Number(visual) || 0),
+      Math.round(Number(window.innerHeight) || 0),
+      Math.round(Number(ROOT.clientHeight) || 0)
+    );
+  }
+
+  function cssZoom() {
+    var value = 1;
+    try {
+      value = Number.parseFloat(window.getComputedStyle(ROOT).zoom || ROOT.style.zoom || "1");
+    } catch (_error) {
+      value = Number.parseFloat(ROOT.style.zoom || "1");
+    }
+    return Number.isFinite(value) && value > 0 ? value : 1;
+  }
+
+  function zoomTier(value) {
+    if (value >= 3) return "extreme";
+    if (value >= 1.5) return "high";
+    return "normal";
   }
 
   function tier(width) {
@@ -37,15 +68,84 @@
     return width >= height ? "landscape" : "portrait";
   }
 
+  function audience() {
+    var value = "";
+    try {
+      value = new URLSearchParams(window.location.search || "").get("view") || "";
+    } catch (_error) {}
+    value = String(value).toLowerCase();
+    if (value === "developer" || value === "dev" || value === "build") return "developer";
+    if (value === "investor" || value === "diligence") return "investor";
+    if (value === "operator" || value === "command") return "operator";
+    return "user";
+  }
+
+  function humanize(value) {
+    return String(value || "")
+      .replace(/^szlholdings[-/]/i, "")
+      .replace(/^szl-holdings[-/]/i, "")
+      .replace(/[_-]+/g, " ")
+      .replace(/\b\w/g, function (character) { return character.toUpperCase(); })
+      .trim();
+  }
+
+  function declaredIdentity() {
+    var meta = document.querySelector('meta[name="szl-space-slug"]');
+    var value = ROOT.dataset.szlSpaceLabel || ROOT.dataset.szlSpaceSlug ||
+      (meta && meta.getAttribute("content")) || "";
+    if (!value) {
+      var match = String(window.location.hostname || "").match(/^(?:szlholdings|szl-holdings)-(.+?)(?:\.static)?\.hf\.space$/i);
+      value = match ? match[1] : "";
+    }
+    return humanize(value) || "SZL Holdings";
+  }
+
+  function ensureDocumentTitle() {
+    if (String(document.title || "").trim()) return;
+    document.title = declaredIdentity() + " · SZL Holdings";
+  }
+
+  function syncBars(currentZoomTier) {
+    document.querySelectorAll("szl-space-ecosystem-bar").forEach(function (bar) {
+      bar.dataset.szlZoomTier = currentZoomTier;
+    });
+  }
+
+  function snapshot() {
+    var width = layoutViewportWidth();
+    var height = layoutViewportHeight();
+    var zoom = cssZoom();
+    return Object.freeze({
+      version: VERSION,
+      width: width,
+      height: height,
+      effectiveWidth: Math.max(280, Math.round(width / zoom)),
+      zoom: zoom,
+      zoomTier: zoomTier(zoom),
+      viewportTier: tier(Math.max(280, Math.round(width / zoom))),
+      orientation: orientation(width, height),
+      audience: audience()
+    });
+  }
+
   function applyViewportState() {
     raf = 0;
-    var width = viewportWidth();
-    var height = viewportHeight();
+    var state = snapshot();
+    var key = [state.width, state.height, state.zoom.toFixed(3), state.audience].join("|");
+    syncBars(state.zoomTier);
+    ensureDocumentTitle();
+    if (key === lastViewportState) return;
+    lastViewportState = key;
+
     ROOT.dataset.szlPublicExperienceV3 = "true";
-    ROOT.dataset.szlViewportTier = tier(width);
-    ROOT.dataset.szlViewportOrientation = orientation(width, height);
-    ROOT.style.setProperty("--szl-viewport-width", width + "px");
-    ROOT.style.setProperty("--szl-viewport-height", height + "px");
+    ROOT.dataset.szlViewportTier = state.viewportTier;
+    ROOT.dataset.szlViewportOrientation = state.orientation;
+    ROOT.dataset.szlZoomTier = state.zoomTier;
+    ROOT.dataset.szlAudience = state.audience;
+    ROOT.style.setProperty("--szl-viewport-width", state.width + "px");
+    ROOT.style.setProperty("--szl-viewport-height", state.height + "px");
+    ROOT.style.setProperty("--szl-effective-inline-size", state.effectiveWidth + "px");
+    ROOT.style.setProperty("--szl-page-zoom", state.zoom.toFixed(3));
   }
 
   function scheduleViewportState() {
@@ -56,11 +156,12 @@
   function responsiveBarStyle() {
     return [
       ":host{position:sticky!important;top:0!important;inline-size:100%!important;max-inline-size:100%!important;z-index:2147483000!important}",
+      ":host([data-szl-zoom-tier=high]),:host([data-szl-zoom-tier=extreme]){position:relative!important;top:auto!important}",
       ".bar{min-height:56px!important;padding-block:8px!important;padding-inline:max(clamp(12px,2.3vw,30px),env(safe-area-inset-left,0px)) max(clamp(12px,2.3vw,30px),env(safe-area-inset-right,0px))!important}",
-      "nav a,button{min-width:44px!important;min-height:44px!important;touch-action:manipulation!important}",
+      "nav a,button{min-width:54px!important;min-height:48px!important;border-radius:10px!important;touch-action:manipulation!important}",
       "nav{max-width:100%!important}",
-      "@media(max-width:700px){.bar{grid-template-columns:minmax(0,1fr) auto!important;gap:8px!important}.identity{min-width:0!important}.label{max-width:min(58vw,360px)!important}.eyebrow{font-size:8px!important}button{display:inline-flex!important}nav{position:fixed!important;top:calc(64px + env(safe-area-inset-top,0px))!important;right:max(8px,env(safe-area-inset-right,0px))!important;left:max(8px,env(safe-area-inset-left,0px))!important;max-height:min(72dvh,540px)!important;overflow:auto!important;overscroll-behavior:contain!important;padding:8px!important;border-radius:14px!important}nav a{justify-content:flex-start!important;padding-inline:14px!important}}",
-      "@media(max-width:420px){.bar{min-height:54px!important;padding-block:5px!important}.copy{gap:0!important}.label{font-size:12px!important}.mark{width:22px!important;height:22px!important}nav{top:calc(60px + env(safe-area-inset-top,0px))!important}}",
+      "@media(max-width:700px){.bar{position:relative!important;grid-template-columns:minmax(0,1fr) auto!important;gap:8px!important}.identity{min-width:0!important}.label{max-width:min(58vw,360px)!important}.eyebrow{font-size:8px!important}button{display:inline-flex!important}nav{position:absolute!important;top:calc(100% + 7px)!important;right:max(8px,env(safe-area-inset-right,0px))!important;left:max(8px,env(safe-area-inset-left,0px))!important;max-height:min(56dvh,420px)!important;max-width:calc(100vw - 16px)!important;overflow:auto!important;overscroll-behavior:contain!important;padding:8px!important;border-radius:14px!important}nav a{justify-content:flex-start!important;padding-inline:14px!important}}",
+      "@media(max-width:420px){.bar{min-height:54px!important;padding-block:5px!important}.copy{gap:0!important}.label{font-size:12px!important}.mark{width:22px!important;height:22px!important}nav{top:calc(100% + 5px)!important}}",
       "@media(min-width:1440px){.bar{min-height:60px!important;padding-inline:max(40px,env(safe-area-inset-left,0px)) max(40px,env(safe-area-inset-right,0px))!important}nav a{padding-inline:14px!important}}",
       "@media(min-width:1920px){.bar{min-height:64px!important;padding-inline:max(64px,env(safe-area-inset-left,0px)) max(64px,env(safe-area-inset-right,0px))!important}.label{font-size:14px!important}nav{gap:8px!important}nav a{min-height:48px!important;padding-inline:18px!important;font-size:12px!important}}",
       "@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition:none!important;animation:none!important}}",
@@ -75,9 +176,11 @@
     style.textContent = responsiveBarStyle();
     bar.shadowRoot.appendChild(style);
     bar.dataset.szlResponsiveV3 = "true";
+    bar.dataset.szlZoomTier = ROOT.dataset.szlZoomTier || zoomTier(cssZoom());
 
     var nav = bar.shadowRoot.querySelector("nav");
     var button = bar.shadowRoot.querySelector("button");
+    if (button) button.setAttribute("title", "Open SZL product, proof, source, and Space navigation");
     if (nav) {
       nav.querySelectorAll("a").forEach(function (link) {
         link.addEventListener("click", function () {
@@ -115,13 +218,27 @@
     }, 30000);
   }
 
+  function startRootStyleObserver() {
+    if (!window.MutationObserver || rootStyleObserver) return;
+    rootStyleObserver = new MutationObserver(scheduleViewportState);
+    rootStyleObserver.observe(ROOT, { attributes: true, attributeFilter: ["style"] });
+  }
+
   function initialize() {
     applyViewportState();
+    startRootStyleObserver();
     startBarObserver();
     if (window.customElements && customElements.whenDefined) {
       customElements.whenDefined("szl-space-ecosystem-bar").then(enhanceBars).catch(function () {});
     }
   }
+
+  Object.defineProperty(window, "SZLPublicExperience", {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze({ version: VERSION, snapshot: snapshot })
+  });
 
   window.addEventListener("resize", scheduleViewportState, { passive: true });
   window.addEventListener("orientationchange", scheduleViewportState, { passive: true });
@@ -134,6 +251,7 @@
   });
   window.addEventListener("pagehide", function () {
     if (observer) observer.disconnect();
+    if (rootStyleObserver) rootStyleObserver.disconnect();
     if (stopObserverTimer) window.clearTimeout(stopObserverTimer);
     if (raf) window.cancelAnimationFrame(raf);
   }, { once: true });

--- a/docs/PUBLIC_EXPERIENCE_V3.md
+++ b/docs/PUBLIC_EXPERIENCE_V3.md
@@ -1,4 +1,4 @@
-# SZL Public Experience v3
+# SZL Public Experience v3.1
 
 ## Purpose
 
@@ -6,6 +6,58 @@ Every public SZL product must remain functional and legible from a 320px phone
 through a 3440px ultrawide theatre display while retaining its own product
 identity. Shared mechanics may be centralized; product information architecture,
 data, workflows, evidence semantics, and visual motif remain source-owned.
+
+The target is not one generic skin. The target is one predictable operating
+language across distinct products: clear purpose, one obvious first action,
+progressive disclosure, inspectable proof, and full reflow for touch, keyboard,
+zoom, assistive technology, and command-room displays.
+
+## Design synthesis
+
+The standard adapts established public principles without copying proprietary
+layouts, branding, assets, or source code:
+
+- **Apple:** fit primary content to the screen, avoid horizontal scrolling,
+  preserve familiar interactions, provide comfortable hit targets, support
+  larger text, and keep controls near the content they affect.
+- **NVIDIA:** treat WCAG 2.2 AA as a development standard rather than a final
+  audit checkbox, and continuously audit the whole public surface.
+- **Material:** change the scaffold at meaningful breakpoints instead of merely
+  shrinking a desktop canvas.
+- **Fluent:** retain functionality at 400% zoom, manage keyboard focus, and
+  collapse complex controls into simpler responsive forms when space is tight.
+- **SZL:** preserve a unique motif and business workflow for every product while
+  sharing accessibility, navigation, evidence labels, and source/proof handoffs.
+
+Authoritative references:
+
+- Apple Human Interface Guidelines — Accessibility:
+  `https://developer.apple.com/design/human-interface-guidelines/accessibility/`
+- Apple UI Design Dos and Don'ts:
+  `https://developer.apple.com/design/tips/`
+- NVIDIA.com Accessibility Help:
+  `https://www.nvidia.com/en-us/about-nvidia/accessibility/`
+- Material Design canonical adaptive layouts:
+  `https://m3.material.io/foundations/layout/canonical-examples/overview`
+- Fluent 2 Accessibility:
+  `https://fluent2.microsoft.design/accessibility`
+
+## Audience-first information contract
+
+Every flagship surface must support four concise journeys without duplicating
+or falsifying information:
+
+| Audience | First question | Required first-order path |
+|---|---|---|
+| User | What can I accomplish here? | Outcome, primary action, current state, next step |
+| Operator | What requires attention now? | Signals, blocked actions, approvals, evidence, rollback |
+| Developer | How does this work and how do I reproduce it? | Source, API or contract, local run path, tests, limitations |
+| Investor | What is the wedge and what is proved? | Market problem, product differentiation, live proof, architecture, explicit gaps |
+
+The shared runtime exposes only a local `data-szl-audience` state and a
+read-only `window.SZLPublicExperience.snapshot()` helper. Products may use that
+state to prioritize navigation or documentation, but it never changes business
+logic, claims, model behavior, policy, or evidence status.
 
 ## Public origin roles
 
@@ -60,11 +112,16 @@ document is interactive.
 The shared layer provides:
 
 - dynamic viewport units with a JavaScript `visualViewport` fallback;
-- safe-area-aware shared navigation;
+- explicit CSS-zoom detection and an effective layout width for 200% and 400%
+  reflow tests;
+- safe-area-aware shared navigation whose mobile menu is bounded in document
+  flow rather than becoming a full-screen fixed sheet;
 - phone, compact, tablet, desktop, wide, theatre, and ultrawide tiers;
-- bounded media, dialogs, code blocks, and wide tables;
+- bounded media, dialogs, code blocks, wide tables, Gradio, and Streamlit
+  containers;
 - long-token and URL wrapping;
-- 44px coarse-pointer controls;
+- 44px minimum controls and 48px coarse-pointer controls;
+- a non-destructive fallback title only when a public Space has no title;
 - local-only assets with no analytics, cookies, storage, external fonts, or
   runtime CDN;
 - reduced-motion, increased-contrast, forced-colors, print, and zoom behavior;
@@ -79,11 +136,26 @@ build circuit, recursive weave, agent swarm, cell membrane, and checksum ledger.
 Unknown public Space slugs receive a stable deterministic identity rather than a
 random theme.
 
+## Developer contract
+
+Every generated source PR must identify:
+
+- canonical GitHub source and mapped Hugging Face Space;
+- exact adapter and entrypoint;
+- changed paths and asset digest;
+- viewport, touch, zoom, keyboard, motion, contrast, forced-color, and print
+  requirements;
+- the repository's own required checks;
+- deployment and live-verification boundaries.
+
+The shared assets expose no network calls, analytics, cookies, storage, model
+state, or hidden telemetry. A source merge is not a deployment claim.
+
 ## Delivery sequence
 
 1. Audit the current public inventory and canonical source map.
-2. Refresh every already-integrated source repository on
-   `design/szl-public-experience-v3`.
+2. Bootstrap or refresh every high-confidence static, Next.js, Gradio, or
+   Streamlit source repository on `design/szl-public-experience-v3`.
 3. Run the repository-owned `SZL Public Experience v3 Contract`.
 4. Squash-merge only after reported checks complete green.
 5. Let the source-owned publisher deploy the application.


### PR DESCRIPTION
## Outcome

Upgrade the organization-wide responsive layer from a nominal viewport contract to a measured, user-facing mobile/zoom/audience contract, then let the existing protected rollout controller propagate it to every high-confidence SZLHOLDINGS Space source repository.

## Evidence-driven defects addressed

The live Public Experience audit currently records missing v3 markers, empty document titles, sub-44px controls, high-zoom horizontal overflow, and fixed chrome covering more than 88% of the viewport across the canonical domains and several flagship Spaces.

This change addresses the source-owned classes of failure without weakening the auditor:

- compute an effective layout width when CSS zoom reaches 200% or 400%;
- observe root zoom changes without polling or network access;
- prevent shared chrome from becoming a full-screen fixed sheet;
- reserve 48px coarse-pointer controls and 54×48 shared navigation targets;
- constrain common Gradio, Streamlit, app-root, table, code, media, and dialog containers;
- supply a non-destructive title only when a Space document is untitled;
- publish stable `user`, `developer`, `investor`, and `operator` audience state through local data attributes and a read-only snapshot API;
- preserve each product's own palette, motif, information architecture, workflows, data, and evidence semantics.

## Industry synthesis

The documented contract translates—not copies—public guidance from Apple, NVIDIA, Material, and Fluent:

- fit primary content to the screen and maintain comfortable hit targets;
- integrate WCAG 2.2 AA into development and continuous audit;
- change scaffolds at meaningful breakpoints;
- retain full functionality and focus behavior at 400% zoom.

## Changed paths

- `design/responsive-v3/szl-responsive-v3.css`
- `design/responsive-v3/szl-responsive-v3.js`
- `.github/scripts/responsive_space_contract.py`
- `.github/tests/test_responsive_space_contract.py`
- `docs/PUBLIC_EXPERIENCE_V3.md`

## Local verification

- network-free responsive contract: 8/8 tests passed;
- Python compilation passed;
- JavaScript syntax passed under `node --check`;
- stylesheet braces are balanced;
- no fetch, analytics, cookies, local/session storage, external font, or runtime CDN dependency was added.

## Rollout behavior after merge

The existing `Roll out Holographic Space Fabric v2` protected-main workflow is path-triggered by these assets and controller files. On merge it will:

1. run the network-free controller and target contracts;
2. inventory public SZLHOLDINGS Spaces;
3. map canonical source repositories;
4. bootstrap or refresh static, Next.js, Gradio, and Streamlit adapters;
5. open source-repository PRs on `design/szl-public-experience-v3`;
6. squash-merge only exact heads whose repository checks finish green;
7. emit a secret-free rollout receipt.

## Honesty boundary

A central merge is not a live deployment claim. Provider 401/404 responses, unresolved source mappings, failed source-repository checks, deployment lag, and browser readback remain explicit blockers in the existing issues and audits. No model, dataset, Space visibility, hardware, billing, credential, branch protection, product logic, or evidence classification changes in this PR.