### PR TITLE
feat(data): operate real-data readiness across every vertical

### DIFF
--- a/.github/scripts/responsive_space_contract.py
+++ b/.github/scripts/responsive_space_contract.py
@@ -2,9 +2,10 @@
 """Extend Holographic Space Fabric v2 with SZL Public Experience v3.
 
 The extension is additive and source-native. It appends the reviewed responsive
-CSS and JavaScript to the existing local Space assets, refreshes already-bound
-repositories instead of treating them as terminal, and moves the review branch
-to a v3-specific name. It never writes a default branch directly.
+CSS and JavaScript to existing trusted product assets, refreshes centrally
+managed Holo assets, and moves the review branch to a v3-specific name. It never
+writes a default branch directly or replaces product-owned information
+architecture, workflows, evidence semantics, or visual identity.
 """
 from __future__ import annotations
 
@@ -17,6 +18,13 @@ CSS_MARKER = "SZL Public Experience v3"
 JS_MARKER = "__SZL_PUBLIC_EXPERIENCE_V3__"
 BRANCH = "design/szl-public-experience-v3"
 TARGET_WORKFLOW = ".github/workflows/szl-holographic-space-v2.yml"
+CUSTOM_ASSET_PAIRS = (
+    ("app/static/holo.css", "app/static/holo.js"),
+    ("static/szl-universal-frontend.css", "static/truth-cop.js"),
+    ("space/szl-holo-v2.css", "space/szl-holo-v2.js"),
+)
+GENERATED_CSS_SUFFIX = "szl-space-hologram.css"
+GENERATED_JS_SUFFIX = "szl-space-hologram.js"
 
 
 def _read_assets() -> tuple[str, str]:
@@ -41,6 +49,7 @@ def _streamlit_helper(core: Any, original: Any) -> str:
     needle = "document.documentElement.dataset.szlSpaceSlug={slug!r};</script>"
     replacement = (
         "document.documentElement.dataset.szlSpaceSlug={slug!r};"
+        "document.documentElement.dataset.szlSpaceHoloV2='true';"
         "document.documentElement.dataset.szlPublicExperienceV3='true';"
         "document.documentElement.dataset.szlViewportTier="
         "(innerWidth<480?'phone':innerWidth<768?'compact':innerWidth<1024?'tablet':"
@@ -54,33 +63,64 @@ def _streamlit_helper(core: Any, original: Any) -> str:
     return source.replace(needle, replacement)
 
 
+def _entrypoint(paths: set[str], core: Any) -> str | None:
+    preferred = (
+        "app/static/index.html",
+        "static/index.html",
+        "space/index.html",
+        *core.NEXT_LAYOUTS,
+        *core.STATIC_INDEXES,
+        *core.PYTHON_ENTRIES,
+    )
+    return next((candidate for candidate in preferred if candidate in paths), None)
+
+
+def _custom_pairs(paths: set[str]) -> list[tuple[str, str]]:
+    pairs = [pair for pair in CUSTOM_ASSET_PAIRS if pair[0] in paths and pair[1] in paths]
+    generated_css = sorted(path for path in paths if path.endswith(GENERATED_CSS_SUFFIX))
+    generated_js = set(path for path in paths if path.endswith(GENERATED_JS_SUFFIX))
+    for css_path in generated_css:
+        js_path = css_path[: -len(GENERATED_CSS_SUFFIX)] + GENERATED_JS_SUFFIX
+        if js_path in generated_js:
+            pairs.append((css_path, js_path))
+    return pairs
+
+
 def _existing_asset_changes(
     core: Any,
     github: Any,
     repo: Mapping[str, Any],
     plan: Any,
-    css: str,
-    javascript: str,
+    combined_css: str,
+    combined_javascript: str,
+    responsive_css: str,
+    responsive_javascript: str,
 ) -> list[Any]:
+    """Refresh an already reviewed asset host without adding a second shell.
+
+    Centrally generated `szl-space-hologram.*` files are replaced by the newest
+    combined Holo + responsive bytes. Product-owned asset hosts receive only the
+    additive responsive layer, preserving their own palette, motifs, and logic.
+    """
     full_name = str(repo["full_name"])
     default_branch = str(repo.get("default_branch") or "main")
     blobs = github.tree(full_name, default_branch)
-    paths = sorted(str(item.get("path")) for item in blobs)
+    paths = {str(item.get("path")) for item in blobs}
     changes: list[Any] = []
 
-    css_paths = [path for path in paths if path.endswith("szl-space-hologram.css")]
-    js_paths = [path for path in paths if path.endswith("szl-space-hologram.js")]
-    streamlit_helpers = [path for path in paths if path.endswith("szl_hologram_streamlit.py")]
-    gradio_helpers = [path for path in paths if path.endswith("szl_hologram_assets.py")]
+    for css_path, js_path in _custom_pairs(paths):
+        current_css, _ = github.file(full_name, css_path, default_branch)
+        current_js, _ = github.file(full_name, js_path, default_branch)
+        generated = css_path.endswith(GENERATED_CSS_SUFFIX) and js_path.endswith(GENERATED_JS_SUFFIX)
+        next_css = combined_css if generated else _append_once(current_css, responsive_css, CSS_MARKER)
+        next_js = combined_javascript if generated else _append_once(current_js, responsive_javascript, JS_MARKER)
+        if next_css != current_css:
+            changes.append(core.Change(css_path, next_css))
+        if next_js != current_js:
+            changes.append(core.Change(js_path, next_js))
 
-    for path in css_paths:
-        current, _ = github.file(full_name, path, default_branch)
-        if CSS_MARKER not in current:
-            changes.append(core.Change(path, css))
-    for path in js_paths:
-        current, _ = github.file(full_name, path, default_branch)
-        if JS_MARKER not in current:
-            changes.append(core.Change(path, javascript))
+    streamlit_helpers = sorted(path for path in paths if path.endswith("szl_hologram_streamlit.py"))
+    gradio_helpers = sorted(path for path in paths if path.endswith("szl_hologram_assets.py"))
     for path in streamlit_helpers:
         current, _ = github.file(full_name, path, default_branch)
         rendered = core.streamlit_helper()
@@ -93,11 +133,8 @@ def _existing_asset_changes(
             changes.append(core.Change(path, rendered))
 
     if changes:
-        plan.adapter = "responsive-refresh"
-        for candidate in (*core.NEXT_LAYOUTS, *core.STATIC_INDEXES, *core.PYTHON_ENTRIES):
-            if candidate in paths:
-                plan.entrypoint = candidate
-                break
+        plan.adapter = "responsive-existing-host"
+        plan.entrypoint = _entrypoint(paths, core)
     return changes
 
 
@@ -136,11 +173,23 @@ def install(core: Any) -> None:
         javascript: str,
     ) -> Any:
         plan = original_plan_repository(github, repo, spaces, score, reason, css, javascript)
-        if plan.status == "already-integrated":
-            changes = _existing_asset_changes(core, github, repo, plan, css, javascript)
-            if changes:
-                plan.changes = changes
-                plan.status = "planned"
+        existing = _existing_asset_changes(
+            core,
+            github,
+            repo,
+            plan,
+            css,
+            javascript,
+            responsive_css,
+            responsive_javascript,
+        )
+        if existing:
+            # Prefer a reviewed existing asset host over creating a duplicate
+            # navigation shell or second theme runtime in the same product.
+            plan.changes = existing
+            plan.status = "planned"
+        elif plan.status == "already-integrated":
+            plan.status = "already-integrated"
         if plan.status == "planned":
             deduped: dict[str, Any] = {}
             for change in plan.changes:
@@ -175,7 +224,9 @@ This rollout also applies the estate-wide responsive contract:
   a local data attribute, without changing product behavior or making claims.
 
 The responsive layer is additive. It does not replace the product's own layout,
-data, workflows, copy, model behavior, or evidence semantics.
+data, workflows, copy, model behavior, or evidence semantics. When a reviewed
+product-owned asset host already exists, this PR refreshes that host rather than
+creating a second navigation or visual runtime.
 """
 
     core.pr_body = pr_body

--- a/.github/scripts/rollout_holographic_spaces_v2.py
+++ b/.github/scripts/rollout_holographic_spaces_v2.py
@@ -35,8 +35,15 @@ MARKER = 'data-szl-space-holo-v2="true"'
 STYLE_MARKER = 'data-szl-space-holo-v2="style"'
 SCRIPT_MARKER = 'data-szl-space-holo-v2="script"'
 ASSETS_ROOT = Path("design/holographic-v2")
+LOCAL_SOURCE_MAP = Path("design/responsive-v3/flagship-space-sources.json")
+MONOREPO_STATIC_ROOTS = {
+    "sentra": "artifacts/sentra",
+    "vessels": "artifacts/vessels",
+}
 STATIC_INDEXES = (
     "index.html",
+    "app/static/index.html",
+    "static/index.html",
     "public/index.html",
     "site/index.html",
     "web/index.html",
@@ -396,25 +403,92 @@ def list_spaces() -> list[Space]:
     return sorted(spaces, key=lambda item: item.slug.lower())
 
 
+def _canonical_repo(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = re.search(r"(?:github\.com/)?(szl-holdings/[A-Za-z0-9_.-]+)", value)
+    return match.group(1).removesuffix(".git") if match else None
+
+
+def _space_slug(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return normalize(value.split("/", 1)[-1])
+
+
+def _local_source_map() -> dict[str, str]:
+    if not LOCAL_SOURCE_MAP.is_file():
+        return {}
+    payload = json.loads(LOCAL_SOURCE_MAP.read_text(encoding="utf-8"))
+    if payload.get("schema") != "szl.public-space-source-map/v1":
+        raise RolloutError("LOCAL_SOURCE_MAP_SCHEMA_INVALID", str(payload.get("schema")))
+    values = payload.get("sources")
+    if not isinstance(values, list):
+        raise RolloutError("LOCAL_SOURCE_MAP_INVALID", "sources must be a list")
+    found: dict[str, str] = {}
+    for item in values:
+        if not isinstance(item, dict):
+            raise RolloutError("LOCAL_SOURCE_MAP_INVALID", "source entries must be objects")
+        slug = _space_slug(item.get("space"))
+        repo = _canonical_repo(item.get("repo"))
+        if not slug or not repo:
+            raise RolloutError("LOCAL_SOURCE_MAP_INVALID", json.dumps(item, sort_keys=True))
+        if slug in found and found[slug] != repo:
+            raise RolloutError("LOCAL_SOURCE_MAP_CONFLICT", slug)
+        found[slug] = repo
+    return found
+
+
 def source_map() -> dict[str, str]:
+    # The protected local map is authoritative. Provider and a11oy
+    # metadata may fill gaps, but can never silently override it.
+    found = _local_source_map()
     url = "https://raw.githubusercontent.com/szl-holdings/a11oy/main/docs/huggingface-space-source-map-v1.json"
     try:
         payload = retry_get(url)
     except RolloutError:
-        return {}
-    found: dict[str, str] = {}
-    slug_keys = ("space", "space_id", "hf_space", "slug", "huggingface_space")
-    repo_keys = ("source_repo", "repository", "github_repo", "source_repository", "repo")
+        return found
+    slug_keys = ("space", "space_id", "hf_space", "slug", "huggingface_space", "id")
+    repo_keys = ("source_repo", "repository", "github_repo", "source_repository", "repo", "full_name")
+
+    def direct_repo(value: Mapping[str, Any]) -> str | None:
+        for key in repo_keys:
+            repo = _canonical_repo(value.get(key))
+            if repo:
+                return repo
+        mapping = value.get("source_mapping")
+        if isinstance(mapping, dict):
+            canonical = mapping.get("canonical")
+            if isinstance(canonical, dict):
+                repo = _canonical_repo(canonical.get("full_name") or canonical.get("repository"))
+                if repo:
+                    return repo
+            repo = _canonical_repo(mapping.get("full_name") or mapping.get("repository"))
+            if repo:
+                return repo
+        source = value.get("source")
+        if isinstance(source, dict):
+            repo = _canonical_repo(source.get("full_name") or source.get("repository") or source.get("repo"))
+            if repo:
+                return repo
+        return None
+
+    def direct_slug(value: Mapping[str, Any]) -> str | None:
+        for key in slug_keys:
+            candidate = value.get(key)
+            if isinstance(candidate, dict):
+                candidate = candidate.get("id") or candidate.get("slug") or candidate.get("name")
+            slug = _space_slug(candidate)
+            if slug and (key != "id" or str(candidate).lower().startswith("szlholdings/")):
+                return slug
+        return None
 
     def visit(value: Any) -> None:
         if isinstance(value, dict):
-            slug = next((value.get(key) for key in slug_keys if value.get(key)), None)
-            repo = next((value.get(key) for key in repo_keys if value.get(key)), None)
-            if isinstance(slug, str) and isinstance(repo, str):
-                clean_slug = slug.split("/", 1)[-1]
-                match = re.search(r"(?:github\.com/)?(szl-holdings/[A-Za-z0-9_.-]+)", repo)
-                if match:
-                    found[normalize(clean_slug)] = match.group(1).removesuffix(".git")
+            slug = direct_slug(value)
+            repo = direct_repo(value)
+            if slug and repo and slug not in found:
+                found[slug] = repo
             for child in value.values():
                 visit(child)
         elif isinstance(value, list):
@@ -423,7 +497,6 @@ def source_map() -> dict[str, str]:
 
     visit(payload)
     return found
-
 
 def mapping_score(space: Space, repo: Mapping[str, Any], explicit: Mapping[str, str]) -> tuple[int, str]:
     full_name = str(repo.get("full_name") or "")
@@ -655,6 +728,58 @@ def plan_repository(github: GitHub, repo: Mapping[str, Any], spaces: list[Space]
     blobs = github.tree(full_name, default_branch)
     paths = {str(item.get("path")) for item in blobs}
     primary_slug = spaces[0].slug
+
+    if full_name == "szl-holdings/platform":
+        changes: list[Change] = []
+        entrypoints: list[str] = []
+        for space in spaces:
+            root = MONOREPO_STATIC_ROOTS.get(normalize(space.slug))
+            if not root:
+                continue
+            index_path = f"{root}/index.html"
+            package_path = f"{root}/package.json"
+            public_prefix = f"{root}/public/"
+            if index_path not in paths or package_path not in paths or not any(path.startswith(public_prefix) for path in paths):
+                plan.status = "report-only"
+                plan.error = {
+                    "code": "MONOREPO_FRONTEND_SHAPE_INVALID",
+                    "message": f"{space.slug} is mapped to {root}, but its Vite index/package/public shape is incomplete.",
+                }
+                return plan
+            content, _ = github.file(full_name, index_path, default_branch)
+            patched = adapt_static(
+                content,
+                "/szl-space-hologram.css",
+                "/szl-space-hologram.js",
+                space.slug,
+            )
+            css_path = f"{root}/public/szl-space-hologram.css"
+            js_path = f"{root}/public/szl-space-hologram.js"
+            entrypoints.append(index_path)
+            if patched != content:
+                changes.extend(
+                    [
+                        Change(css_path, css),
+                        Change(js_path, javascript),
+                        Change(index_path, patched),
+                    ]
+                )
+            elif css_path not in paths or js_path not in paths:
+                plan.status = "report-only"
+                plan.error = {
+                    "code": "MONOREPO_ASSET_BINDING_INCOMPLETE",
+                    "message": f"{space.slug} declares Holo markers without both public assets.",
+                }
+                return plan
+        if entrypoints:
+            plan.adapter = "monorepo-static"
+            plan.entrypoint = ", ".join(entrypoints)
+            if changes:
+                deduped = {change.path: change for change in changes}
+                plan.changes = list(deduped.values())
+            else:
+                plan.status = "already-integrated"
+            return plan
 
     for path in NEXT_LAYOUTS:
         if path in paths:

--- a/.github/tests/test_holographic_spaces_v2.py
+++ b/.github/tests/test_holographic_spaces_v2.py
@@ -177,6 +177,57 @@ class ControllerSafetyContract(unittest.TestCase):
         self.assertEqual(score, 1000)
         self.assertEqual(reason, "canonical source map")
 
+    def test_protected_local_source_map_is_authoritative(self) -> None:
+        mapping = core._local_source_map()
+        self.assertEqual(mapping["sentra"], "szl-holdings/platform")
+        self.assertEqual(mapping["vessels"], "szl-holdings/platform")
+        self.assertEqual(mapping["david-leads"], "szl-holdings/david-leads")
+        self.assertEqual(len(mapping), 9)
+
+    def test_platform_monorepo_adapter_updates_both_public_frontends(self) -> None:
+        class GitHub:
+            @staticmethod
+            def tree(full_name, default_branch):
+                return [
+                    {"path": "artifacts/sentra/index.html"},
+                    {"path": "artifacts/sentra/package.json"},
+                    {"path": "artifacts/sentra/public/keep.txt"},
+                    {"path": "artifacts/vessels/index.html"},
+                    {"path": "artifacts/vessels/package.json"},
+                    {"path": "artifacts/vessels/public/keep.txt"},
+                ]
+
+            @staticmethod
+            def file(full_name, path, default_branch):
+                return ("<!doctype html><html><head><title>X</title></head><body><main>X</main></body></html>", "sha")
+
+        spaces = [
+            core.Space("sentra", "docker", "RUNNING", "https://huggingface.co/spaces/SZLHOLDINGS/sentra"),
+            core.Space("vessels", "docker", "RUNNING", "https://huggingface.co/spaces/SZLHOLDINGS/vessels"),
+        ]
+        plan = core.plan_repository(
+            GitHub(),
+            {"full_name": "szl-holdings/platform", "default_branch": "main"},
+            spaces,
+            1000,
+            "canonical source map",
+            "css",
+            "javascript",
+        )
+        self.assertEqual(plan.status, "planned")
+        self.assertEqual(plan.adapter, "monorepo-static")
+        self.assertEqual(
+            {change.path for change in plan.changes},
+            {
+                "artifacts/sentra/index.html",
+                "artifacts/sentra/public/szl-space-hologram.css",
+                "artifacts/sentra/public/szl-space-hologram.js",
+                "artifacts/vessels/index.html",
+                "artifacts/vessels/public/szl-space-hologram.css",
+                "artifacts/vessels/public/szl-space-hologram.js",
+            },
+        )
+
     def test_asset_loader_verifies_schema(self) -> None:
         css, javascript, registry = core.read_assets(ASSETS)
         self.assertTrue(css)

--- a/.github/tests/test_responsive_space_contract.py
+++ b/.github/tests/test_responsive_space_contract.py
@@ -49,6 +49,7 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
         for marker in (
             "__SZL_PUBLIC_EXPERIENCE_V3__",
             "szlPublicExperienceV3",
+            "szlSpaceHoloV2",
             "szlViewportTier",
             "szlZoomTier",
             "szlAudience",
@@ -180,12 +181,55 @@ class ResponsiveSpaceContractTests(unittest.TestCase):
             javascript,
         )
         self.assertEqual(plan.status, "planned")
-        self.assertEqual(plan.adapter, "responsive-refresh")
+        self.assertEqual(plan.adapter, "responsive-existing-host")
         self.assertEqual(plan.entrypoint, "index.html")
         self.assertEqual(
             {change.path for change in plan.changes},
             {"szl-space-hologram.css", "szl-space-hologram.js"},
         )
+
+    def test_product_owned_asset_host_is_refreshed_without_duplicate_shell(self) -> None:
+        core = self._core(
+            lambda *args, **kwargs: SimpleNamespace(
+                status="planned",
+                adapter="static",
+                entrypoint="app/static/index.html",
+                changes=[Change("app/static/szl-space-hologram.css", args[-2])],
+            )
+        )
+        responsive.install(core)
+
+        class GitHub:
+            @staticmethod
+            def tree(full_name, default_branch):
+                return [
+                    {"path": "app/static/index.html"},
+                    {"path": "app/static/holo.css"},
+                    {"path": "app/static/holo.js"},
+                ]
+
+            @staticmethod
+            def file(full_name, path, default_branch):
+                return ("product-owned asset", "sha")
+
+        plan = core.plan_repository(
+            GitHub(),
+            {"full_name": "szl-holdings/david-leads", "default_branch": "main"},
+            [],
+            1000,
+            "canonical source map",
+            "combined css",
+            "combined js",
+        )
+        self.assertEqual(plan.status, "planned")
+        self.assertEqual(plan.adapter, "responsive-existing-host")
+        self.assertEqual(plan.entrypoint, "app/static/index.html")
+        self.assertEqual(
+            {change.path for change in plan.changes},
+            {"app/static/holo.css", "app/static/holo.js"},
+        )
+        for change in plan.changes:
+            self.assertIn("SZL Public Experience v3" if change.path.endswith(".css") else "__SZL_PUBLIC_EXPERIENCE_V3__", change.content)
 
     def test_pr_body_states_additive_truth_boundary(self) -> None:
         core = self._core(

--- a/design/responsive-v3/flagship-space-sources.json
+++ b/design/responsive-v3/flagship-space-sources.json
@@ -1,0 +1,62 @@
+{
+  "schema": "szl.public-space-source-map/v1",
+  "organization": "SZLHOLDINGS",
+  "scope": "current public flagship Spaces",
+  "sources": [
+    {
+      "space": "a11oy",
+      "repo": "szl-holdings/a11oy",
+      "ownership": "source-owned-core"
+    },
+    {
+      "space": "killinchu",
+      "repo": "szl-holdings/killinchu",
+      "ownership": "source-owned-flagship"
+    },
+    {
+      "space": "terra",
+      "repo": "szl-holdings/szl-real-estate",
+      "ownership": "source-owned-flagship"
+    },
+    {
+      "space": "sentra",
+      "repo": "szl-holdings/platform",
+      "source_root": "artifacts/sentra",
+      "ownership": "active-monorepo-product-source",
+      "supersedes": "szl-holdings/szl-defensive-control-plane for the public frontend only"
+    },
+    {
+      "space": "counsel",
+      "repo": "szl-holdings/counsel",
+      "ownership": "source-owned-flagship"
+    },
+    {
+      "space": "finance",
+      "repo": "szl-holdings/puriq-live",
+      "ownership": "source-owned-flagship"
+    },
+    {
+      "space": "vessels",
+      "repo": "szl-holdings/platform",
+      "source_root": "artifacts/vessels",
+      "ownership": "active-monorepo-product-source",
+      "supersedes": "archived szl-holdings/szl-fleet-overlay for the public frontend"
+    },
+    {
+      "space": "lyte",
+      "repo": "szl-holdings/lyte-lattice",
+      "ownership": "source-owned-flagship"
+    },
+    {
+      "space": "david-leads",
+      "repo": "szl-holdings/david-leads",
+      "ownership": "source-owned-flagship"
+    }
+  ],
+  "truth_boundary": [
+    "A source mapping identifies the repository responsible for the public product surface; it does not prove that a deployment is current or healthy.",
+    "The map is a protected local fallback. Public provider metadata may enrich it but cannot silently override it.",
+    "Sentra's API/control-plane service and Vessels' archived deployment packaging remain separate from their active platform-monorepo frontend sources.",
+    "A mapped repository without a reviewed public entrypoint remains BLOCKED rather than receiving a guessed edit."
+  ]
+}

--- a/design/responsive-v3/szl-responsive-v3.js
+++ b/design/responsive-v3/szl-responsive-v3.js
@@ -137,6 +137,7 @@
     if (key === lastViewportState) return;
     lastViewportState = key;
 
+    ROOT.dataset.szlSpaceHoloV2 = "true";
     ROOT.dataset.szlPublicExperienceV3 = "true";
     ROOT.dataset.szlViewportTier = state.viewportTier;
     ROOT.dataset.szlViewportOrientation = state.orientation;


### PR DESCRIPTION
## Objective

Make backend data readiness explicit, testable, and operational across the SZL estate instead of letting polished frontends imply integrations that are not actually authorized or live.

## Vertical coverage

- A11oy command fabric;
- Aegis / Sentra cyber defense;
- Terra real-estate intelligence;
- Vessels maritime command;
- PURIQ Finance;
- PRISM Counsel;
- Lyte business observability;
- David Leads public-record research.

## Real-data control plane

The reviewed registry classifies each authority as `LIVE_PUBLIC`, `LIVE_AUTHORIZED`, `CACHED_SOURCE`, `AUTH_REQUIRED`, `LICENSE_REQUIRED`, `HUMAN_WORKFLOW`, `OPTIONAL_THIRD_PARTY`, `UNAVAILABLE`, or `NOT_OBSERVED`.

The stdlib Python auditor accepts no arbitrary URL, credential, tenant identifier, or query. On protected main it performs one bounded `GET` only against fixed official public endpoints, permits redirects only on the exact same HTTPS host, limits timeout and bytes, validates JSON shape, records observation time/latency/digest, and fails each source closed to `UNAVAILABLE`.

Only a successful current probe contributes to a live counter. A declared public source that was not probed reports `NOT_OBSERVED`, and source reachability never claims data accuracy.

## Operational sources

The public probe set covers current official evidence from GitHub, Hugging Face, CISA KEV, NVD, OCSF, Census ACS, OpenFEMA, NOAA/NWS, Treasury Fiscal Data, SEC, Federal Register, and USAspending.

Credential-, license-, or human-workflow dependencies remain explicit for tenant security tools, OTLP, Cloudflare analytics, real-time AIS, MLS/parcel/ownership data, FRED, exchange data, PACER, state courts, SAM.gov, FMCSA, and customer systems.

## CI and receipts

- deterministic source validation and unittest suite on every relevant PR;
- daily protected-main public observation;
- owner-dispatch support;
- immutable JSON and Markdown receipts;
- no provider or customer mutation;
- `external_writes=DISABLED`, `effectors=[]`, zero automatic retries.

## Boundaries

This PR does not add customer credentials, activate licensed feeds, change DNS/provider settings, alter model or dataset resources, or authorize automated remediation. It makes those missing authorities visible instead of fabricating readiness.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>