### PR TITLE
fix(convergence): bind public rollout to the live A11oy origin

### DIFF
--- a/.github/scripts/public_estate_convergence.py
+++ b/.github/scripts/public_estate_convergence.py
@@ -2,14 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Verify and selectively repair the two canonical SZL public origins.
 
-The controller proves each origin's root document and its exact local visual
-contract. The product front door is the GitHub Pages site published from
-``szl-holdings.github.io`` and uses Responsive Apex v3. The independent proof
-origin is published from ``a11oy-net`` and uses Spectral Proof v2.
+The controller proves each origin from the bytes served by that origin. The
+product front door is ``a-11-oy.com`` with canonical source
+``szl-holdings/a11oy@main``; its deployment authority is external to this
+controller, so product drift is observe-only until a bounded deploy action is
+explicitly bound here. The independent proof origin ``a11oy.net`` is published
+from ``a11oy-net`` and keeps its existing GitHub Pages rebuild path.
 
-When explicitly authorized, this controller may request only the corresponding
-existing GitHub Pages rebuild endpoint. It never edits source, DNS, Cloudflare,
-secrets, pages, models, datasets, Hugging Face resources, or application state.
+When explicitly authorized, this controller may request only a repair action
+that is declared on the corresponding origin contract. It never edits source,
+DNS, Cloudflare, secrets, pages, models, datasets, Hugging Face resources, or
+application state.
 """
 from __future__ import annotations
 
@@ -25,7 +28,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 GITHUB_API = "https://api.github.com"
-USER_AGENT = "SZL-Public-Estate-Convergence/3.0"
+USER_AGENT = "SZL-Public-Estate-Convergence/3.1"
 TOKEN_NAMES = ("SZL_GITHUB_TOKEN", "GH_CONTROL_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 
 
@@ -43,23 +46,25 @@ class OriginContract:
     spectral_literals: tuple[str, ...]
     controller_literals: tuple[str, ...]
     advisory_health: str
-    repair: str
+    health_literals: tuple[str, ...]
+    repair: str | None
 
 
 CONTRACTS = (
     OriginContract(
         name="a-11-oy.com",
         root="https://a-11-oy.com/",
-        spectral_asset="https://a-11-oy.com/assets/szl-responsive-apex-v3.css",
-        controller_asset="https://a-11-oy.com/assets/szl-responsive-apex-v3.js",
+        spectral_asset="https://a-11-oy.com/static/3d/holographic.html",
+        controller_asset="https://a-11-oy.com/api/a11oy/v1/honest",
         root_literals=(
-            "/assets/szl-responsive-apex-v3.css",
-            "/assets/szl-responsive-apex-v3.js",
+            "TASK-FIRST ENTRY POINTS",
+            "Choose the view that matches your job.",
         ),
-        spectral_literals=("SZL Apex Responsive Experience v3", "--apex-touch: 44px"),
-        controller_literals=("SZL Apex Responsive Experience v3", "__SZL_APEX_RESPONSIVE_V3__"),
-        advisory_health="https://a-11-oy.com/origin-status.json",
-        repair="PRODUCT_PAGES_BUILD",
+        spectral_literals=("A11oy Holographic Operations", "Evidence status"),
+        controller_literals=('"organ":"a11oy"', '"locked_formula_count":8'),
+        advisory_health="https://a-11-oy.com/healthz",
+        health_literals=('"status":"ok"', '"organ":"a11oy"'),
+        repair=None,
     ),
     OriginContract(
         name="a11oy.net",
@@ -70,6 +75,7 @@ CONTRACTS = (
         spectral_literals=("SZL Spectral Proof v2", ".szl-proof-spectral-field"),
         controller_literals=("SZL Proof Flow Shell v2", "/assets/szl-spectral-proof-v2.css"),
         advisory_health="https://a11oy.net/health.json",
+        health_literals=(),
         repair="A11OY_NET_PAGES_BUILD",
     ),
 )
@@ -136,19 +142,19 @@ def probe_origin(contract: OriginContract) -> dict[str, Any]:
     root = probe(contract.root, contract.root_literals)
     spectral = probe(contract.spectral_asset, contract.spectral_literals)
     controller = probe(contract.controller_asset, contract.controller_literals)
-    health_status, health_raw, _, health_final = request("GET", contract.advisory_health)
+    health = probe(contract.advisory_health, contract.health_literals)
     return {
         "name": contract.name,
         "root": root,
         "spectral_asset": spectral,
         "controller_asset": controller,
-        "advisory_health": {
-            "url": contract.advisory_health,
-            "final_url": health_final,
-            "http_status": health_status,
-            "bytes": len(health_raw),
-        },
-        "operational": root["verified"] and spectral["verified"] and controller["verified"],
+        "advisory_health": health,
+        "operational": (
+            root["verified"]
+            and spectral["verified"]
+            and controller["verified"]
+            and health["verified"]
+        ),
     }
 
 
@@ -166,13 +172,6 @@ def github_action(
 
 
 def request_repair(contract: OriginContract, token: str) -> dict[str, Any]:
-    if contract.repair == "PRODUCT_PAGES_BUILD":
-        status = github_action(
-            "POST",
-            "/repos/szl-holdings/szl-holdings.github.io/pages/builds",
-            token,
-        )
-        return {"action": contract.repair, "http_status": status, "source_mutation": False}
     if contract.repair == "A11OY_NET_PAGES_BUILD":
         status = github_action(
             "POST",
@@ -209,6 +208,16 @@ def main() -> int:
         for contract, observed in zip(CONTRACTS, before, strict=True):
             if observed["operational"]:
                 continue
+            if contract.repair is None:
+                repairs.append(
+                    {
+                        "origin": contract.name,
+                        "action": "OBSERVE_ONLY",
+                        "state": "NO_BOUNDED_REPAIR",
+                        "source_mutation": False,
+                    }
+                )
+                continue
             if not token:
                 repairs.append(
                     {
@@ -242,7 +251,7 @@ def main() -> int:
 
     complete = all(row["operational"] for row in after)
     report = {
-        "schema": "szl.public-estate-convergence/v3",
+        "schema": "szl.public-estate-convergence/v3.1",
         "generated_at": utc_now(),
         "repair_requested": args.repair,
         "token_available": bool(token),

--- a/.github/workflows/public-estate-convergence.yml
+++ b/.github/workflows/public-estate-convergence.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       repair:
-        description: Request only the existing deploy paths when live readback fails
+        description: Request only bounded deploy paths when live readback fails
         required: false
         type: boolean
         default: true
@@ -140,8 +140,8 @@ jobs:
           for row in report["after"]:
               print(
                   f"- `{row['name']}` — `{'OPERATIONAL' if row['operational'] else 'NOT PROVEN'}`; "
-                  f"root `{row['root']['http_status']}`; spectral asset `{row['spectral_asset']['http_status']}`; "
-                  f"controller `{row['controller_asset']['http_status']}`"
+                  f"root `{row['root']['http_status']}`; surface probe `{row['spectral_asset']['http_status']}`; "
+                  f"controller `{row['controller_asset']['http_status']}`; health `{row['advisory_health']['http_status']}`"
               )
           if report["repairs"]:
               print()
@@ -178,12 +178,12 @@ jobs:
           for row in report["after"]:
               print(
                   f"- `{row['name']}` — `{'OPERATIONAL' if row['operational'] else 'NOT PROVEN'}`; "
-                  f"root `{row['root']['http_status']}`; spectral `{row['spectral_asset']['http_status']}`; "
-                  f"controller `{row['controller_asset']['http_status']}`"
+                  f"root `{row['root']['http_status']}`; surface `{row['spectral_asset']['http_status']}`; "
+                  f"controller `{row['controller_asset']['http_status']}`; health `{row['advisory_health']['http_status']}`"
               )
           PY
           title='[runtime] Canonical public-origin drift'
-          issue="$(gh issue list --state open --search \"$title in:title\" --json number,title --jq '.[] | select(.title == "'"$title"'") | .number' | head -n1)"
+          issue="$(gh issue list --state open --limit 100 --json number,title --jq '.[] | select(.title == "[runtime] Canonical public-origin drift") | .number' | head -n1)"
           complete="$(python -I -P -c 'import json,os; print(str(bool(json.load(open(os.environ["REPORT_PATH"]))["summary"]["complete"])).lower())')"
           if [ "$complete" = true ]; then
             if [ -n "$issue" ]; then

--- a/tests/test_public_estate_convergence.py
+++ b/tests/test_public_estate_convergence.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / ".github" / "scripts" / "public_estate_convergence.py"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "public-estate-convergence.yml"
 SPEC = importlib.util.spec_from_file_location("public_estate_convergence", MODULE_PATH)
 assert SPEC and SPEC.loader
 convergence = importlib.util.module_from_spec(SPEC)
@@ -18,26 +19,27 @@ sys.modules[SPEC.name] = convergence
 SPEC.loader.exec_module(convergence)
 
 
-def test_two_canonical_origins_have_source_native_visual_contracts() -> None:
+def test_two_canonical_origins_have_source_native_contracts() -> None:
     assert [row.name for row in convergence.CONTRACTS] == ["a-11-oy.com", "a11oy.net"]
     product, proof = convergence.CONTRACTS
-    assert product.spectral_asset.endswith("/assets/szl-responsive-apex-v3.css")
-    assert product.controller_asset.endswith("/assets/szl-responsive-apex-v3.js")
-    assert product.advisory_health.endswith("/origin-status.json")
-    assert product.repair == "PRODUCT_PAGES_BUILD"
+    assert product.spectral_asset.endswith("/static/3d/holographic.html")
+    assert product.controller_asset.endswith("/api/a11oy/v1/honest")
+    assert product.advisory_health.endswith("/healthz")
+    assert product.repair is None
     assert proof.spectral_asset.endswith("/assets/szl-spectral-proof-v2.css")
     assert proof.controller_asset.endswith("/scripts/szl-flow-proof.js")
     assert proof.repair == "A11OY_NET_PAGES_BUILD"
 
 
-def test_product_root_requires_both_published_responsive_assets() -> None:
+def test_product_root_tracks_the_live_a11oy_front_door() -> None:
     product = convergence.CONTRACTS[0]
     assert product.root_literals == (
-        "/assets/szl-responsive-apex-v3.css",
-        "/assets/szl-responsive-apex-v3.js",
+        "TASK-FIRST ENTRY POINTS",
+        "Choose the view that matches your job.",
     )
-    assert "SZL Apex Responsive Experience v3" in product.spectral_literals
-    assert "__SZL_APEX_RESPONSIVE_V3__" in product.controller_literals
+    assert "A11oy Holographic Operations" in product.spectral_literals
+    assert '"organ":"a11oy"' in product.controller_literals
+    assert '"status":"ok"' in product.health_literals
 
 
 def test_probe_requires_http_200_bytes_and_every_literal() -> None:
@@ -56,17 +58,11 @@ def test_probe_requires_http_200_bytes_and_every_literal() -> None:
         assert convergence.probe("https://example.test/", ("alpha",))["verified"] is False
 
 
-def test_product_repair_requests_the_actual_front_door_pages_build() -> None:
-    contract = convergence.CONTRACTS[0]
-    with mock.patch.object(convergence, "github_action", return_value=201) as action:
-        receipt = convergence.request_repair(contract, "secret")
-    action.assert_called_once_with(
-        "POST",
-        "/repos/szl-holdings/szl-holdings.github.io/pages/builds",
-        "secret",
-    )
-    assert receipt["source_mutation"] is False
-    assert receipt["action"] == "PRODUCT_PAGES_BUILD"
+def test_product_has_no_misbound_pages_repair() -> None:
+    product = convergence.CONTRACTS[0]
+    assert product.repair is None
+    text = MODULE_PATH.read_text(encoding="utf-8")
+    assert "/repos/szl-holdings/szl-holdings.github.io/pages/builds" not in text
 
 
 def test_proof_repair_requests_existing_pages_build_only() -> None:
@@ -107,6 +103,12 @@ def test_source_contains_no_content_dns_cloudflare_or_hf_mutator() -> None:
     )
     for fragment in forbidden:
         assert fragment not in text
+
+
+def test_drift_issue_lookup_does_not_shell_split_the_title() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert '--search \\"$title in:title\\"' not in text
+    assert 'select(.title == "[runtime] Canonical public-origin drift")' in text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Public Estate Convergence was failing against a stale deployment model: it treated `szl-holdings.github.io` Pages as the deployment authority for `a-11-oy.com`, even though the live product identifies `szl-holdings/a11oy@main` as canonical source and currently serves that source.

## Change
- verify the live product front door using the current task-first contract
- prove the live holographic surface, `/api/a11oy/v1/honest`, and `/healthz`
- make product-origin repair observe-only until a bounded real deploy authority is explicitly bound
- retain the valid `a11oy.net` GitHub Pages repair
- require health proof in the operational result
- fix drift-issue lookup so a title containing spaces is not shell-split
- update network-free regression tests

No DNS, Cloudflare, secrets, Hugging Face, model, dataset, or application-state mutation is introduced.