### PR TITLE
docs(fleet): canonical public seven vs hologram-label conflict

### DIFF
--- a/docs/CANONICAL_FLEET.md
+++ b/docs/CANONICAL_FLEET.md
@@ -1,0 +1,24 @@
+# Canonical public fleet — 2026-09-03
+
+Source of the seven: `szl-holdings/platform` pull request #718 (merged 2026-09-02).
+
+## Public seven (KEEP)
+
+| Repo | Role | Honesty rule |
+|---|---|---|
+| `szl-holdings/a11oy` | Command center | Flagship. Live. |
+| `szl-holdings/killinchu` | Counter-UAS reference | Public synthetic. No public effector. |
+| `szl-holdings/david-leads` | Official-source broker research | Live public Space. Not a hologram of a11oy. |
+| `szl-holdings/anatomy` | Living anatomy | Live public Space. |
+| `szl-holdings/immune` | Receipt-chain defense matrix | Live public Space. |
+| `szl-holdings/szl-real-estate` | Public-records underwriting surface | Occupancy UNAVAILABLE unless measured. |
+| `szl-holdings/szl-atelier` | Model-card walker Space | Listed in the public seven. GitHub archive flag and “ARCHIVED hologram of szl-forge” description conflict with that listing. |
+
+## Intended GitHub descriptions (owner PATCH — this connector cannot set `description`)
+
+- `david-leads`: `David Leads — official-source broker research with evidence receipts. Public Space: SZLHOLDINGS/david-leads.`
+- `szl-atelier`: `SZL Atelier — walk SZLHOLDINGS model cards. Public Space: SZLHOLDINGS/szl-atelier. Sibling of szl-forge, not a discarded hologram.`
+
+Do not GitHub-archive a repo that remains in the public seven.
+
+Folded Spaces stay private. Do not recreate `yarqa` or `hatun-mcp` as warm-flagship incidents.


### PR DESCRIPTION
## Why

`david-leads` and `szl-atelier` are in the public seven from platform#718 while GitHub descriptions still say ARCHIVED hologram.

## What

Adds `docs/CANONICAL_FLEET.md` with KEEP list and intended description strings.

This connector cannot PATCH GitHub `description` or un-archive. Owner console still has to apply those two strings.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>