### PR TITLE
fix(frontend): align Public Experience v3 target gate with responsive hosts

### DIFF
--- a/.github/scripts/holographic_target_contract.py
+++ b/.github/scripts/holographic_target_contract.py
@@ -53,7 +53,6 @@ jobs:
               raise SystemExit('missing holographic CSS')
           css_required = (
               'SZL Public Experience v3',
-              'data-szl-space-motif',
               '--szl-touch-target',
               '100dvh',
               'safe-area-inset',


### PR DESCRIPTION
The generated target workflow incorrectly required `data-szl-space-motif` inside product-owned CSS hosts such as david-leads `holo.css`. That selector belongs to the centralized holographic asset layer and is already covered by central asset tests.

This change removes only that mismatched literal from the per-repository CSS gate. It preserves the blocking requirements for Public Experience v3, 44/48px touch mechanics, dynamic viewport units, safe areas, overflow containment, phone/tablet/desktop/theatre breakpoints, reduced motion, contrast, forced colors, print behavior, JS runtime markers, no tracking/storage behavior, active source binding, syntax checks, and `git diff --check`.

This is the smallest source-level correction needed for the six recovered Space PRs to be evaluated against the contract they actually implement.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>