### PR TITLE
fix(hf): restore the public SZL organization card

### DIFF
--- a/.github/scripts/hf_space_visibility.py
+++ b/.github/scripts/hf_space_visibility.py
@@ -1,0 +1,246 @@
+"""Keep the Hugging Face organization-card Space publicly readable.
+
+Hugging Face renders an organization card only when a public Space named
+``README`` exists in the organization. This helper makes the visibility
+contract explicit, then verifies the Space metadata without authentication so
+a protected/private regression cannot silently remove the front door.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlsplit
+from urllib.request import Request, urlopen
+
+MAX_RESPONSE_BYTES = 1_000_000
+
+
+class VisibilityContractError(RuntimeError):
+    """Raised when the organization-card Space is not verifiably public."""
+
+
+@dataclass(frozen=True)
+class VisibilityReport:
+    schema: str
+    repo_id: str
+    requested_visibility: str
+    authenticated_visibility: str
+    unauthenticated_status: int
+    unauthenticated_visibility: str
+    unauthenticated_readable: bool
+    changed: bool
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, indent=2) + "\n"
+
+
+def _visibility_from_info(info: Any) -> str:
+    visibility = getattr(info, "visibility", None)
+    if isinstance(visibility, str) and visibility:
+        return visibility.casefold()
+    private = getattr(info, "private", None)
+    if private is True:
+        return "private"
+    if private is False:
+        return "public-or-protected"
+    return "unknown"
+
+
+def _metadata_visibility(payload: dict[str, Any]) -> str:
+    visibility = payload.get("visibility")
+    if isinstance(visibility, str) and visibility:
+        return visibility.casefold()
+    private = payload.get("private")
+    if private is True:
+        return "private"
+    if private is False:
+        return "public"
+    return "unknown"
+
+
+def _trusted_huggingface_url(url: str) -> bool:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return False
+    return bool(
+        parsed.scheme == "https"
+        and parsed.hostname == "huggingface.co"
+        and parsed.username is None
+        and parsed.password is None
+    )
+
+
+def fetch_public_metadata(
+    repo_id: str,
+    opener: Callable[..., Any] = urlopen,
+) -> tuple[int, dict[str, Any], str]:
+    """Fetch Space metadata without a token and enforce origin/size bounds."""
+
+    url = f"https://huggingface.co/api/spaces/{quote(repo_id, safe='/')}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "szl-hf-org-card-visibility/1",
+        },
+    )
+    with opener(request, timeout=20) as response:
+        status = int(getattr(response, "status", response.getcode()))
+        final_url = response.geturl()
+        if not _trusted_huggingface_url(final_url):
+            raise VisibilityContractError(
+                "unauthenticated metadata request left the Hugging Face origin"
+            )
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise VisibilityContractError("unauthenticated metadata response is oversized")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VisibilityContractError(
+            "unauthenticated metadata response is not valid JSON"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise VisibilityContractError("unauthenticated metadata response is not an object")
+    return status, payload, final_url
+
+
+def _metadata_matches_public_repo(payload: dict[str, Any], repo_id: str) -> tuple[bool, str]:
+    observed_id = payload.get("id") or payload.get("repo_id")
+    if not isinstance(observed_id, str) or observed_id.casefold() != repo_id.casefold():
+        return False, "unknown"
+    visibility = _metadata_visibility(payload)
+    # An explicit public value is ideal. Older Hub responses expose only
+    # private=false; unauthenticated success plus that flag is still a valid
+    # public-readability proof. Unknown metadata fails closed.
+    return visibility == "public", visibility
+
+
+def _set_public(api: Any, repo_id: str) -> None:
+    try:
+        api.update_repo_settings(
+            repo_id=repo_id,
+            repo_type="space",
+            visibility="public",
+        )
+    except TypeError as exc:
+        raise VisibilityContractError(
+            "installed huggingface_hub lacks protected/public visibility support"
+        ) from exc
+
+
+def ensure_public_space(
+    repo_id: str,
+    token: str,
+    *,
+    wait_seconds: int = 90,
+    check_only: bool = False,
+    api_factory: Callable[..., Any] | None = None,
+    opener: Callable[..., Any] = urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> VisibilityReport:
+    """Set public visibility and prove unauthenticated readability."""
+
+    if not repo_id or "/" not in repo_id:
+        raise VisibilityContractError("repo_id must be namespace/name")
+    if not token:
+        raise VisibilityContractError("HF_TOKEN is required")
+    if wait_seconds < 1 or wait_seconds > 600:
+        raise VisibilityContractError("wait_seconds must be between 1 and 600")
+
+    if api_factory is None:
+        try:
+            from huggingface_hub import HfApi
+        except ImportError as exc:
+            raise VisibilityContractError("huggingface_hub is required") from exc
+        api_factory = HfApi
+
+    api = api_factory(token=token)
+    before = api.repo_info(repo_id=repo_id, repo_type="space")
+    before_visibility = _visibility_from_info(before)
+    changed = False
+    if not check_only:
+        _set_public(api, repo_id)
+        changed = before_visibility != "public"
+
+    after = api.repo_info(repo_id=repo_id, repo_type="space")
+    authenticated_visibility = _visibility_from_info(after)
+    if authenticated_visibility in {"private", "protected", "unknown"}:
+        raise VisibilityContractError(
+            "authenticated repository metadata does not report a public Space"
+        )
+
+    deadline = time.monotonic() + wait_seconds
+    last_status = 0
+    last_visibility = "unknown"
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            status, payload, _ = fetch_public_metadata(repo_id, opener=opener)
+            last_status = status
+            matches, last_visibility = _metadata_matches_public_repo(payload, repo_id)
+            if status == 200 and matches:
+                return VisibilityReport(
+                    schema="szl.hf-space-visibility/v1",
+                    repo_id=repo_id,
+                    requested_visibility="public",
+                    authenticated_visibility=authenticated_visibility,
+                    unauthenticated_status=status,
+                    unauthenticated_visibility=last_visibility,
+                    unauthenticated_readable=True,
+                    changed=changed,
+                )
+            last_error = "public metadata did not identify a public target Space"
+        except (HTTPError, URLError, TimeoutError, VisibilityContractError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            if isinstance(exc, HTTPError):
+                last_status = exc.code
+        sleeper(3)
+
+    raise VisibilityContractError(
+        "Space did not become publicly readable without authentication "
+        f"(status={last_status}, visibility={last_visibility}, last={last_error})"
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Enforce and verify public visibility for a Hugging Face Space."
+    )
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--wait-seconds", type=int, default=90)
+    parser.add_argument("--check-only", action="store_true")
+    parser.add_argument("--report")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    token = os.environ.get("HF_TOKEN", "")
+    try:
+        report = ensure_public_space(
+            args.repo_id,
+            token,
+            wait_seconds=args.wait_seconds,
+            check_only=args.check_only,
+        )
+    except VisibilityContractError as exc:
+        print(f"error: {exc}")
+        return 2
+    encoded = report.to_json()
+    print(encoded, end="")
+    if args.report:
+        with open(args.report, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_space_visibility.py
+++ b/.github/scripts/test_hf_space_visibility.py
@@ -1,0 +1,198 @@
+import json
+import types
+import unittest
+from unittest import mock
+
+import hf_space_visibility as visibility
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        payload,
+        status=200,
+        url="https://huggingface.co/api/spaces/SZLHOLDINGS/README",
+    ):
+        self.payload = json.dumps(payload).encode("utf-8")
+        self.status = status
+        self.url = url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, size=-1):
+        return self.payload[:size]
+
+    def geturl(self):
+        return self.url
+
+    def getcode(self):
+        return self.status
+
+
+class FakeApi:
+    def __init__(self, *, token, before="private", after="public"):
+        self.token = token
+        self.before = before
+        self.after = after
+        self.updated = False
+        self.calls = []
+
+    def repo_info(self, *, repo_id, repo_type):
+        current = self.after if self.updated else self.before
+        return types.SimpleNamespace(
+            visibility=current,
+            private=current == "private",
+        )
+
+    def update_repo_settings(self, **kwargs):
+        self.calls.append(kwargs)
+        self.updated = True
+
+
+class SpaceVisibilityTests(unittest.TestCase):
+    def test_sets_public_and_proves_unauthenticated_readability(self):
+        api = FakeApi(token="redacted")
+
+        report = visibility.ensure_public_space(
+            "SZLHOLDINGS/README",
+            "redacted",
+            wait_seconds=3,
+            api_factory=lambda **_: api,
+            opener=lambda *_args, **_kwargs: FakeResponse(
+                {
+                    "id": "SZLHOLDINGS/README",
+                    "visibility": "public",
+                    "private": False,
+                }
+            ),
+            sleeper=lambda _seconds: None,
+        )
+
+        self.assertTrue(report.unauthenticated_readable)
+        self.assertTrue(report.changed)
+        self.assertEqual(report.unauthenticated_visibility, "public")
+        self.assertEqual(
+            api.calls,
+            [
+                {
+                    "repo_id": "SZLHOLDINGS/README",
+                    "repo_type": "space",
+                    "visibility": "public",
+                }
+            ],
+        )
+
+    def test_private_false_is_accepted_for_older_public_metadata(self):
+        api = FakeApi(token="redacted", before="public", after="public")
+        report = visibility.ensure_public_space(
+            "SZLHOLDINGS/README",
+            "redacted",
+            wait_seconds=2,
+            check_only=True,
+            api_factory=lambda **_: api,
+            opener=lambda *_args, **_kwargs: FakeResponse(
+                {"id": "SZLHOLDINGS/README", "private": False}
+            ),
+            sleeper=lambda _seconds: None,
+        )
+        self.assertEqual(report.unauthenticated_visibility, "public")
+        self.assertFalse(report.changed)
+        self.assertEqual(api.calls, [])
+
+    def test_protected_metadata_fails_closed(self):
+        api = FakeApi(token="redacted", before="protected", after="protected")
+        with self.assertRaisesRegex(
+            visibility.VisibilityContractError,
+            "does not report a public Space",
+        ):
+            visibility.ensure_public_space(
+                "SZLHOLDINGS/README",
+                "redacted",
+                wait_seconds=2,
+                check_only=True,
+                api_factory=lambda **_: api,
+                opener=lambda *_args, **_kwargs: FakeResponse(
+                    {"id": "SZLHOLDINGS/README", "visibility": "protected"}
+                ),
+                sleeper=lambda _seconds: None,
+            )
+
+    def test_wrong_public_repo_id_never_passes(self):
+        api = FakeApi(token="redacted", before="public", after="public")
+        clock = iter([0.0, 0.0, 1.1])
+        with mock.patch.object(
+            visibility.time,
+            "monotonic",
+            side_effect=lambda: next(clock),
+        ):
+            with self.assertRaisesRegex(
+                visibility.VisibilityContractError,
+                "did not become publicly readable",
+            ):
+                visibility.ensure_public_space(
+                    "SZLHOLDINGS/README",
+                    "redacted",
+                    wait_seconds=1,
+                    check_only=True,
+                    api_factory=lambda **_: api,
+                    opener=lambda *_args, **_kwargs: FakeResponse(
+                        {"id": "OTHER/README", "visibility": "public"}
+                    ),
+                    sleeper=lambda _seconds: None,
+                )
+
+    def test_untrusted_redirect_is_rejected(self):
+        with self.assertRaisesRegex(
+            visibility.VisibilityContractError,
+            "left the Hugging Face origin",
+        ):
+            visibility.fetch_public_metadata(
+                "SZLHOLDINGS/README",
+                opener=lambda *_args, **_kwargs: FakeResponse(
+                    {"id": "SZLHOLDINGS/README", "visibility": "public"},
+                    url="https://evil.example/api/spaces/SZLHOLDINGS/README",
+                ),
+            )
+
+    def test_missing_token_fails_before_network(self):
+        with self.assertRaisesRegex(visibility.VisibilityContractError, "HF_TOKEN"):
+            visibility.ensure_public_space("SZLHOLDINGS/README", "")
+
+    def test_main_never_prints_token(self):
+        report = visibility.VisibilityReport(
+            schema="szl.hf-space-visibility/v1",
+            repo_id="SZLHOLDINGS/README",
+            requested_visibility="public",
+            authenticated_visibility="public",
+            unauthenticated_status=200,
+            unauthenticated_visibility="public",
+            unauthenticated_readable=True,
+            changed=True,
+        )
+        with mock.patch.dict(
+            "os.environ",
+            {"HF_TOKEN": "super-secret-token"},
+            clear=False,
+        ):
+            with mock.patch.object(
+                visibility,
+                "ensure_public_space",
+                return_value=report,
+            ):
+                with mock.patch("builtins.print") as printer:
+                    rc = visibility.main(["--repo-id", "SZLHOLDINGS/README"])
+        self.assertEqual(rc, 0)
+        output = " ".join(
+            str(arg)
+            for call in printer.call_args_list
+            for arg in call.args
+        )
+        self.assertNotIn("super-secret-token", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -10,8 +10,10 @@ on:
       - "profile/assets/**"
       - "profile/assets/evidence-lattice-v2.webp"
       - ".github/scripts/hf_static_space_deploy.py"
+      - ".github/scripts/hf_space_visibility.py"
       - ".github/scripts/hf_org_card_embed_check.py"
       - ".github/scripts/public_front_door_check.py"
+      - ".github/scripts/test_hf_space_visibility.py"
       - ".github/scripts/test_hf_org_card_embed_check.py"
       - ".github/scripts/test_hf_static_space_deploy.py"
       - ".github/scripts/test_public_front_door_check.py"
@@ -53,6 +55,12 @@ jobs:
           -s .github/scripts
           -p test_hf_static_space_deploy.py
 
+      - name: Test public visibility contract
+        run: >-
+          python -m unittest discover
+          -s .github/scripts
+          -p test_hf_space_visibility.py
+
       - name: Test public front-door contract
         run: >-
           python -m unittest discover
@@ -74,6 +82,15 @@ jobs:
       - name: Install exact Hub client
         run: python -m pip install --disable-pip-version-check "huggingface_hub==1.19.0"
 
+      - name: Restore public organization-card visibility
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: >-
+          python .github/scripts/hf_space_visibility.py
+          --repo-id SZLHOLDINGS/README
+          --wait-seconds 120
+          --report hf-org-card-visibility-pre.json
+
       - name: Publish and verify exact source
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -88,11 +105,24 @@ jobs:
           --wait-seconds 600
           --report hf-org-card-deploy-report.json
 
+      - name: Confirm public visibility after publication
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: >-
+          python .github/scripts/hf_space_visibility.py
+          --repo-id SZLHOLDINGS/README
+          --check-only
+          --wait-seconds 120
+          --report hf-org-card-visibility-post.json
+
       - name: Upload deployment evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hf-org-card-deploy-evidence
-          path: hf-org-card-deploy-report.json
+          path: |
+            hf-org-card-deploy-report.json
+            hf-org-card-visibility-pre.json
+            hf-org-card-visibility-post.json
           if-no-files-found: warn
           retention-days: 90


### PR DESCRIPTION
## Problem

The canonical `SZLHOLDINGS/README` Space contains the organization front door, but the public Hugging Face organization page currently renders **No organization card** because the Space is not anonymously readable.

Hugging Face only surfaces an organization card from a public Space named exactly `README`. The existing exact-source publisher verifies files and runtime output, but it did not enforce or attest the Space visibility boundary.

## Change

- add `hf_space_visibility.py` to request `visibility=public` for the exact org-card Space;
- verify authenticated metadata without exposing credentials;
- independently read `/api/spaces/SZLHOLDINGS/README` without authentication and fail closed unless the response identifies the exact public target;
- bound redirects and response size;
- run the visibility contract before publication and again after publication;
- persist pre-publication, deployment, and post-publication evidence as workflow artifacts;
- add seven unit tests covering public, protected, wrong-repository, redirect, token, and disclosure cases.

## Boundary

This PR changes no model, dataset, application logic, DNS, secrets, or unrelated Space. It does not weaken branch protection or publication authority. The provider write remains limited to the production workflow and the existing scoped `HF_TOKEN`.

## Verification

Locally:

```text
python -m unittest .github/scripts/test_hf_space_visibility.py
7 tests passed
```

After merge, the protected main push will restore public visibility, publish the exact source revision, verify the live bytes, and prove the Space remains anonymously readable.