### PR TITLE
ci(ux): run the live browser audit when its contract lands

### DIFF
--- a/.github/workflows/public-experience-v3.yml
+++ b/.github/workflows/public-experience-v3.yml
@@ -90,6 +90,7 @@ jobs:
     name: Phone-to-theatre live browser audit
     needs: contract
     if: >-
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')


### PR DESCRIPTION
## Purpose

Close the gap between changing the Public Experience audit contract and obtaining fresh rendered evidence. Protected pushes that change the auditor, responsive assets, tests, workflow, or rollout controller now run the phone-to-theatre live job immediately rather than waiting for the next six-hour schedule.

## Behavior

- Pull requests remain network-free contract checks only.
- Protected `main` pushes within the existing narrow path filter execute the live browser matrix.
- Existing schedule, manual dispatch, and successful central rollout triggers are preserved.
- The audit still uploads immutable JSON, Markdown, and screenshot evidence, reconciles the exception issue, and fails when measured cases fail.

## Exact scope

- Base: `0db3069955d402e7f19ff5623f2784691a7e4f53`.
- Head: `6af61cdc5ca038ed955faf716ce2cecffb3c94ee`.
- One workflow condition only.
- No provider, DNS, Hugging Face, model, dataset, Space, secret, billing, or branch-protection mutation.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>