### PR TITLE
fix: align the org control plane to live source-bound Anatomy

### DIFF
--- a/.github/data/anatomy_map_registry.json
+++ b/.github/data/anatomy_map_registry.json
@@ -1,11 +1,12 @@
 {
-  "schema": 2,
-  "_comment": "Active Anatomy-map evidence registry after the KEEP-6 public-cut decision. The SZLHOLDINGS/anatomy Hugging Face Space is intentionally folded, paused, and private; it is not an active public source and must never require a bearer token in CI. The active contract compares the two byte-shared source blocks (a11oy and killinchu), the canonical GitHub source deck, and the product-origin rendering at a-11-oy.com. Every surface must preserve exactly the canonical locked-8 {F1,F4,F7,F11,F12,F18,F19,F22} and the Lambda=Conjecture-1 honesty label. Marker-block sources are additionally compared capability-for-capability. Add an active surface only when it is independently reachable without credentials and belongs to the current product architecture (kinds: github | url).",
+  "schema": 3,
+  "_comment": "Active Living Anatomy evidence registry after the 2026-09-03 source-bound restoration. GitHub szl-holdings/anatomy is authoritative; the public SZLHOLDINGS/anatomy Hugging Face Space is an active Docker deployment mirror; a-11-oy.com is the product entry point. All public checks are credential-free and fail closed. Every invariant surface must preserve exactly the canonical locked-8 {F1,F4,F7,F11,F12,F18,F19,F22} and the Lambda=Conjecture-1 honesty label. Marker-block sources are additionally compared capability-for-capability. The HF runtime also exposes exact Anatomy and Second Brain source revisions, 575 public handles, handles-only retrieval, zero private graph nodes, and read-only authority through its version, evidence, and Brain contracts.",
   "canonical_locked": ["F1", "F4", "F7", "F11", "F12", "F18", "F19", "F22"],
   "surfaces": [
     { "id": "a11oy-console",         "kind": "github", "repo": "szl-holdings/a11oy",     "path": "pages/console.html",         "extract": "marker_block" },
     { "id": "killinchu-elite",       "kind": "github", "repo": "szl-holdings/killinchu", "path": "killinchu_elite_console.py", "extract": "marker_block" },
     { "id": "anatomy-src",           "kind": "github", "repo": "szl-holdings/anatomy",   "paths": ["data.js", "index.html"],   "extract": "invariant_scan" },
+    { "id": "hf-anatomy",            "kind": "url",    "urls": ["https://szlholdings-anatomy.hf.space/data.js", "https://szlholdings-anatomy.hf.space/index.html"], "extract": "invariant_scan" },
     { "id": "a11oy-anatomy-product", "kind": "url",    "urls": ["https://a-11-oy.com/anatomy-map/data.js"], "extract": "invariant_scan" }
   ]
 }

--- a/.github/scripts/test_anatomy_product_contract.py
+++ b/.github/scripts/test_anatomy_product_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Network-free regression tests for the active Anatomy evidence architecture."""
+"""Network-free regression tests for the active Living Anatomy architecture."""
 from __future__ import annotations
 
 import json
@@ -24,18 +24,31 @@ class TestAnatomyProductContract(unittest.TestCase):
         cls.surfaces = cls.registry.get("surfaces", [])
 
     def test_registry_is_current_and_ids_are_unique(self) -> None:
-        self.assertGreaterEqual(int(self.registry.get("schema", 0)), 2)
+        self.assertGreaterEqual(int(self.registry.get("schema", 0)), 3)
         ids = [str(row.get("id", "")) for row in self.surfaces]
         self.assertTrue(all(ids))
         self.assertEqual(len(ids), len(set(ids)))
 
-    def test_folded_hf_space_is_not_an_active_surface(self) -> None:
-        ids = [str(row.get("id", "")) for row in self.surfaces]
-        kinds = [str(row.get("kind", "")) for row in self.surfaces]
-        self.assertNotIn("hf-anatomy", ids)
-        self.assertNotIn("hf_space", kinds)
-        for row in self.surfaces:
-            self.assertNotEqual(row.get("space"), "SZLHOLDINGS/anatomy")
+    def test_hf_space_is_an_active_public_credential_free_surface(self) -> None:
+        rows = [row for row in self.surfaces if row.get("id") == "hf-anatomy"]
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.get("kind"), "url")
+        self.assertEqual(row.get("extract"), "invariant_scan")
+        urls = row.get("urls")
+        self.assertEqual(
+            urls,
+            [
+                "https://szlholdings-anatomy.hf.space/data.js",
+                "https://szlholdings-anatomy.hf.space/index.html",
+            ],
+        )
+        for url in urls:
+            parsed = urlsplit(url)
+            self.assertEqual(parsed.scheme, "https")
+            self.assertEqual(parsed.hostname, "szlholdings-anatomy.hf.space")
+            self.assertIsNone(parsed.username)
+            self.assertIsNone(parsed.password)
 
     def test_product_origin_is_exact_and_credential_free(self) -> None:
         product_rows = [
@@ -55,28 +68,36 @@ class TestAnatomyProductContract(unittest.TestCase):
             self.assertIsNone(parsed.password)
 
     def test_active_workflows_have_no_hf_secret_contract(self) -> None:
-        forbidden = ("HF_TOKEN", "HF_READ_TOKEN", "secrets: inherit", "hf-anatomy")
+        forbidden = (
+            "HF_TOKEN",
+            "HF_READ_TOKEN",
+            "HF_ORG_TOKEN",
+            "HF_WRITE_TOKEN",
+            "secrets: inherit",
+        )
         for path in _ACTIVE_WORKFLOWS:
             text = path.read_text(encoding="utf-8")
             for token in forbidden:
                 self.assertNotIn(token, text, f"{token!r} found in {path.name}")
+
+    def test_cross_surface_watcher_includes_the_hf_runtime(self) -> None:
+        text = (_WORKFLOW_DIR / "anatomy-map-drift.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("HF Space, and product origin", text)
+        self.assertIn("Compare active Living Anatomy surfaces", text)
+        self.assertNotIn("--skip-kind url", text)
 
     def test_product_watcher_targets_only_the_product_surface(self) -> None:
         text = (_WORKFLOW_DIR / "anatomy-map-product-drift.yml").read_text(
             encoding="utf-8"
         )
         self.assertIn("--only a11oy-anatomy-product", text)
-        forbidden = (
-            "--only hf-anatomy",
-            "HF_TOKEN",
-            "HF_READ_TOKEN",
-            "huggingface.co",
-            "hf.space",
-        )
-        for token in forbidden:
+        self.assertNotIn("--only hf-anatomy", text)
+        for token in ("HF_TOKEN", "HF_READ_TOKEN", "HF_ORG_TOKEN", "HF_WRITE_TOKEN"):
             self.assertNotIn(token, text)
 
-    def test_obsolete_hf_watcher_is_removed(self) -> None:
+    def test_obsolete_mutating_hf_watcher_is_absent(self) -> None:
         self.assertFalse((_WORKFLOW_DIR / "anatomy-map-hf-drift.yml").exists())
 
 

--- a/.github/workflows/anatomy-map-drift.yml
+++ b/.github/workflows/anatomy-map-drift.yml
@@ -1,11 +1,11 @@
-name: Anatomy-map cross-surface drift
+name: Living Anatomy cross-surface drift
 
-# Active Anatomy evidence follows the KEEP-6 architecture: GitHub source blocks
-# plus the public product-origin rendering. SZLHOLDINGS/anatomy is intentionally
-# folded, paused, and private; it is not an active public source and this guard
-# never forwards a Hugging Face credential. Fetch/auth failure is ERROR, never a
-# silent pass. The checker enforces exactly the locked-8
-# {F1,F4,F7,F11,F12,F18,F19,F22}, Lambda=Conjecture-1, and marker-block parity.
+# GitHub szl-holdings/anatomy is authoritative. The public
+# SZLHOLDINGS/anatomy Docker Space is its source-bound deployment mirror, and
+# a-11-oy.com is the product entry point. All reads are public and
+# credential-free. Fetch/auth failure is ERROR, never a silent pass. The
+# checker enforces exactly the locked-8 {F1,F4,F7,F11,F12,F18,F19,F22},
+# Lambda=Conjecture-1, and marker-block parity across the active surfaces.
 
 on:
   schedule:
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   check:
-    name: Anatomy sources and product origin are honest and in sync
+    name: GitHub source, HF Space, and product origin are honest and in sync
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -64,7 +64,7 @@ jobs:
           python3 .github/scripts/test_anatomy_map_drift.py
           python3 .github/scripts/test_anatomy_product_contract.py
 
-      - name: Compare active Anatomy surfaces
+      - name: Compare active Living Anatomy surfaces
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -94,7 +94,7 @@ jobs:
           fi
           drift="$(python3 -c 'import json; r=json.load(open("anatomy_map_report.out.json")); print(" | ".join(r.get("findings", [])) or "see report")')"
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          payload="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' ":rotating_light: Anatomy product-origin drift: ${drift} Run: ${run_url}")"
+          payload="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' ":rotating_light: Living Anatomy cross-surface drift: ${drift} Run: ${run_url}")"
           code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d "$payload" "$SLACK_WEBHOOK_URL" || echo 000)"
           [ "$code" = "200" ] || echo "::warning::alert receiver returned HTTP ${code}; the red workflow remains authoritative."
 
@@ -102,14 +102,14 @@ jobs:
         run: |
           case "${CHECK_EXIT:-2}" in
             0)
-              echo "Active Anatomy sources and product origin are honest and in sync."
+              echo "GitHub source, HF Space, and product origin are honest and in sync."
               ;;
             1)
-              echo "::error::Anatomy drift detected. Inspect anatomy-map-drift-report."
+              echo "::error::Living Anatomy drift detected. Inspect anatomy-map-drift-report."
               exit 1
               ;;
             *)
-              echo "::error::An active Anatomy surface could not be fetched or validated."
+              echo "::error::An active Living Anatomy surface could not be fetched or validated."
               exit 1
               ;;
           esac

--- a/.github/workflows/anatomy-map-product-drift.yml
+++ b/.github/workflows/anatomy-map-product-drift.yml
@@ -1,9 +1,9 @@
-name: Anatomy-map product-origin drift watch
+name: Living Anatomy product-origin drift watch
 
-# The active public Anatomy rendering is the product-origin bundle at
-# a-11-oy.com/anatomy-map. The former SZLHOLDINGS/anatomy Space is intentionally
-# folded, paused, and private under KEEP-6 and is not probed here. This watcher
-# detects stale or dishonest product deployment without any provider credential.
+# This high-frequency watcher remains scoped to the product-origin bundle at
+# a-11-oy.com/anatomy-map. The credential-free cross-surface workflow separately
+# compares GitHub source, the active public Hugging Face deployment mirror, and
+# this product rendering. A product fetch or honesty failure is never hidden.
 
 on:
   schedule:
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   product-drift:
-    name: Product-origin Anatomy is reachable and honest
+    name: Product-origin Living Anatomy is reachable and honest
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -88,7 +88,7 @@ jobs:
           fi
           drift="$(python3 -c 'import json; r=json.load(open("anatomy_map_product_report.out.json")); print(" | ".join(r.get("findings", [])) or "see report")')"
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          payload="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' ":rotating_light: Anatomy product-origin drift: ${drift} Run: ${run_url}")"
+          payload="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' ":rotating_light: Living Anatomy product-origin drift: ${drift} Run: ${run_url}")"
           code="$(curl -sS -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d "$payload" "$SLACK_WEBHOOK_URL" || echo 000)"
           [ "$code" = "200" ] || echo "::warning::alert receiver returned HTTP ${code}; the red workflow remains authoritative."
 
@@ -96,14 +96,14 @@ jobs:
         run: |
           case "${CHECK_EXIT:-2}" in
             0)
-              echo "Product-origin Anatomy is reachable and preserves the honesty contract."
+              echo "Product-origin Living Anatomy is reachable and preserves the honesty contract."
               ;;
             1)
-              echo "::error::Product-origin Anatomy drift detected."
+              echo "::error::Product-origin Living Anatomy drift detected."
               exit 1
               ;;
             *)
-              echo "::error::Product-origin Anatomy could not be fetched or validated."
+              echo "::error::Product-origin Living Anatomy could not be fetched or validated."
               exit 1
               ;;
           esac

--- a/.github/workflows/reusable-anatomy-map-drift.yml
+++ b/.github/workflows/reusable-anatomy-map-drift.yml
@@ -1,10 +1,10 @@
-name: Reusable — Anatomy-map Drift Check
+name: Reusable — Living Anatomy Drift Check
 
 # Push-time guard for repositories that carry an active Anatomy source block.
-# The KEEP-6 architecture treats SZLHOLDINGS/anatomy as intentionally folded,
-# paused, and private. This reusable workflow therefore reads only public
-# GitHub source surfaces and the a-11-oy.com product-origin rendering. It has no
-# Hugging Face secret contract and callers pass no provider secrets.
+# GitHub is authoritative; the public SZLHOLDINGS/anatomy Space and the
+# a-11-oy.com product rendering are active credential-free witnesses. Callers
+# pass no provider secrets. Pull requests validate proposed GitHub source while
+# excluding independently deployed URL surfaces until protected main publishes.
 
 on:
   workflow_call:
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   anatomy-map-drift:
-    name: Anatomy map honest and in sync (locked-8 + Lambda=Conjecture-1)
+    name: Living Anatomy honest and in sync (locked-8 + Lambda=Conjecture-1)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -49,7 +49,7 @@ jobs:
           python3 .github/scripts/test_anatomy_map_drift.py
           python3 .github/scripts/test_anatomy_product_contract.py
 
-      - name: Compare active Anatomy surfaces
+      - name: Compare active Living Anatomy surfaces
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -57,7 +57,7 @@ jobs:
           EXTRA=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Validate the calling repository's proposed head while excluding
-            # the independently deployed product URL from the PR merge gate.
+            # independently deployed URL surfaces from the PR merge gate.
             EXTRA="--skip-kind url --ref-override ${{ github.repository }}=${{ github.event.pull_request.head.sha }}"
           fi
           python3 .github/scripts/anatomy_map_drift.py $EXTRA \
@@ -77,14 +77,14 @@ jobs:
         run: |
           case "${CHECK_EXIT:-2}" in
             0)
-              echo "Active Anatomy sources are honest and in sync."
+              echo "Active Living Anatomy sources are honest and in sync."
               ;;
             1)
-              echo "::error::Anatomy-map drift detected; inspect the uploaded report."
+              echo "::error::Living Anatomy drift detected; inspect the uploaded report."
               exit 1
               ;;
             *)
-              echo "::error::An active Anatomy source could not be fetched or validated."
+              echo "::error::An active Living Anatomy source could not be fetched or validated."
               exit 1
               ;;
           esac


### PR DESCRIPTION
## Root cause removed

The organization-level Anatomy registry and drift workflows still encoded the former KEEP-6 decision that `SZLHOLDINGS/anatomy` was folded, paused, and private. Those controls were read-only and did not cause the outage, but they contradicted the restored production architecture and would keep reporting the live Space incorrectly.

## What this changes

- promotes the public `SZLHOLDINGS/anatomy` Docker Space back into the active Anatomy evidence registry;
- retains `szl-holdings/anatomy` as authoritative GitHub source;
- compares the exact GitHub source deck, public HF deployment mirror, and product-origin rendering without a Hugging Face credential;
- keeps pull-request validation source-only where independently deployed URL surfaces cannot yet match the candidate;
- preserves locked-8 and Lambda=Conjecture-1 honesty checks;
- updates network-free tests so the HF Space is required and credential-free;
- leaves the high-frequency product-only watcher scoped to the product origin.

## Coordinated production state

- `szl-holdings/anatomy` PR #55 is merged and live at Git SHA `6e7f19a7b7597c618df52fffd5b1812d1e8a82c5`;
- `SZLHOLDINGS/anatomy` is public and RUNNING at HF revision `bc67032e37f74bb4ec8637838067253a2e87b2c4`;
- its source-bound Brain is revision `ff03b116a83f2b5302999ab4167d51e35aba3b5e`, exactly 575 public handles, handles-only, zero private graph nodes;
- `szl-holdings/a11oy` PR #1760 is merged and its 30-minute lifecycle guardian has passed against that live contract.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>