### PR TITLE
fix(frontier): preserve current truth and idempotent convergence

### DIFF
--- a/.github/scripts/frontier_payload/config.py
+++ b/.github/scripts/frontier_payload/config.py
@@ -31,23 +31,23 @@ VESSELS_CARD_URL = (
     "main/docs/hf-cards/SZLHOLDINGS-vessels.README.md"
 )
 VESSELS_SPACE = "SZLHOLDINGS/vessels"
+# Anatomy left this hold set only after the source-controlled lifecycle guardian
+# proved public RUNNING/HANDLES_ONLY operation on 2026-09-03.
 PRIVATE_SPACES = (
-    "hatun-mcp", "immune", "szl-model-inference-lab", "yarqa", "anatomy",
+    "hatun-mcp", "immune", "szl-model-inference-lab", "yarqa",
 )
 
 REPOSITORY_METADATA = {
     "szl-holdings/david-leads": {
         "description": (
-            "Canonical public investor and lead-qualification surface; "
-            "evidence-labelled company, product, market, diligence, and "
-            "contact dossiers generated from live/public source inventories."
+            "David Leads — official-source broker research with evidence receipts. "
+            "Public Space: SZLHOLDINGS/david-leads."
         ),
     },
     "szl-holdings/szl-atelier": {
         "description": (
-            "Canonical SZL visual-asset and image-rendering studio; "
-            "generated-media workflows, model adapters, and provenance-aware "
-            "creative tooling."
+            "SZL Atelier — walk SZLHOLDINGS model cards. Public Space: "
+            "SZLHOLDINGS/szl-atelier. Sibling of szl-forge, not a discarded hologram."
         ),
         "archived": False,
     },

--- a/.github/scripts/frontier_payload/controls.py
+++ b/.github/scripts/frontier_payload/controls.py
@@ -105,6 +105,7 @@ def converge_vessels_card(hf_token: str | None, *, apply: bool) -> dict[str, Any
         "source_url": VESSELS_CARD_URL,
         "visibility_mutated": False,
         "hardware_mutated": False,
+        "provider_write_performed": False,
     }
     source = request("GET", VESSELS_CARD_URL, timeout=30)
     if source.get("status") != 200:
@@ -121,6 +122,21 @@ def converge_vessels_card(hf_token: str | None, *, apply: bool) -> dict[str, Any
         row.update(state="BLOCKED_SOURCE", verified=False, error=str(exc))
         return row
     row.update(source_sha256=digest(card), source_bytes=len(card))
+
+    # Read first and make the operator idempotent. A matching public README is
+    # already the desired terminal state and must not mint a duplicate commit.
+    try:
+        before = _anonymous_hf_readback()
+        row.update(readback_before_status=200, readback_before_sha256=digest(before))
+        if before == card:
+            row.update(state="VERIFIED_NOOP", verified=True)
+            return row
+    except Exception as exc:
+        row.update(
+            readback_before_status=None,
+            readback_before_sha256=None,
+            readback_before_error=str(redact(str(exc))),
+        )
 
     if apply:
         if not hf_token:
@@ -140,7 +156,7 @@ def converge_vessels_card(hf_token: str | None, *, apply: bool) -> dict[str, Any
                 repo_type="space",
                 commit_message="docs: mark vessels consolidated into killinchu",
             )
-            row["provider_commit"] = str(commit)
+            row.update(provider_commit=str(commit), provider_write_performed=True)
         except Exception as exc:
             row.update(state="BLOCKED_WRITE", verified=False, error=str(redact(str(exc))))
             return row

--- a/.github/scripts/frontier_payload/operator.py
+++ b/.github/scripts/frontier_payload/operator.py
@@ -70,8 +70,10 @@ def main(argv: list[str] | None = None) -> int:
             ],
             "state": "EXPIRED_AWAITING_ENGINE_SIGNATURE",
             "next_action": (
-                "regenerate a fresh reviewed jobspec through the repository controller, "
-                "then run the enrolled owner-key signing ceremony"
+                "create and review a new immutable successor jobspec with a fresh "
+                "expires_at window and updated admitted bindings/tests; current main "
+                "exposes no safe expiration-only regenerator; then complete the "
+                "enrolled owner-key signing ceremony"
             ),
             "automated_here": False,
         },

--- a/.github/scripts/frontier_payload/verify.py
+++ b/.github/scripts/frontier_payload/verify.py
@@ -61,6 +61,7 @@ def terminal_status(report: Mapping[str, Any]) -> str:
 
 def markdown_summary(report: Mapping[str, Any]) -> str:
     public, card = report["public_estate"], report["vessels_card"]
+    held_count = len(report.get("private_spaces") or [])
     lines = [
         "<!-- SZL-FRONTIER-PAYLOAD-CONVERGENCE-V1 -->",
         "## Frontier payload convergence receipt",
@@ -86,9 +87,10 @@ def markdown_summary(report: Mapping[str, Any]) -> str:
         "",
         "### Guarded external boundary",
         "",
-        "- The five named private Spaces were not made public. Each remains held for build and claims review.",
+        f"- The `{held_count}` Spaces still in the private hold set were not made public; each remains held for build and claims review.",
+        "- `SZLHOLDINGS/anatomy` is outside that hold set after its source-controlled guardian proved public `RUNNING` / `HANDLES_ONLY` operation.",
         "- Nemo-v3 reviewed jobspecs remain expired; no signature or queue authorization was attempted.",
-        "- The owner must regenerate a fresh reviewed spec through the repository controller and complete the enrolled-key ceremony.",
+        "- Current `szl-gpu-bridge` main exposes no safe expiration-only regenerator. A new immutable successor must be reviewed with updated admitted bindings/tests before the enrolled-key ceremony.",
         "- No token value is present in this receipt.",
         "",
     ]


### PR DESCRIPTION
## Why

The production operator from #622 landed correctly but its first snapshot predated three state changes verified during the same execution window.

## Corrections

- use the exact repository descriptions approved in #617;
- unarchive `szl-atelier` while preserving its canonical public-seven role;
- remove `SZLHOLDINGS/anatomy` from the private hold set after the source-controlled guardian proved public `RUNNING` / `HANDLES_ONLY` operation;
- make Vessels card convergence read-before-write and return `VERIFIED_NOOP` when anonymous bytes already match, preventing duplicate Hugging Face commits;
- stop claiming that `szl-gpu-bridge` exposes an expiration-only jobspec regenerator; require a new immutable reviewed successor with updated admitted bindings/tests before owner signing;
- make the receipt summary count the actual held Space set dynamically.

## Boundaries unchanged

No token value, branch protection, repository secret, private Space visibility, Cloudflare state, Nemo signature, or Nemo queue entry is mutated by this patch.

Base: `25f19f8fcb8b573be86e11d0e1c53bcc0b302bf1`
Head: `f4e0bc1ed9bf2d427342d83a992fdf285690d427`

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>