### PR TITLE
fix(hf): retire legacy org-card collateral before publication

### DIFF
--- a/.github/scripts/hf_org_card_publish_cleanup.py
+++ b/.github/scripts/hf_org_card_publish_cleanup.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Remove the exact legacy files blocking the SZL Hugging Face org-card publish.
+
+This is intentionally a separate, one-purpose migration rather than relaxing
+the canonical publisher's deletion-closed manifest. The files remain in the
+Hugging Face Git history; only their current-branch entries are removed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+TARGET_REPOSITORY = "SZLHOLDINGS/README"
+SOURCE_REPOSITORY = "szl-holdings/.github"
+WORKFLOW_PATH = ".github/workflows/hf-org-card-autopublish.yml"
+SCHEMA = "szl.hf-org-card-legacy-cleanup/v1"
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+TOKEN_RE = re.compile(
+    r"(?:hf_[A-Za-z0-9]{8,}|Bearer\s+[A-Za-z0-9._~+/-]+=*|"
+    r"gh[oprsu]_[A-Za-z0-9_]{8,}|github_pat_[A-Za-z0-9_]{8,})",
+    re.I,
+)
+LEGACY_PATHS = (
+    "GOVERNANCE.md",
+    "MODELS.txt",
+    "SEVEN_SPACES.md",
+    "SPACE_PROVENANCE_FRONTIER.json",
+    "seven-spaces.yaml",
+)
+
+
+class CleanupError(RuntimeError):
+    """Raised when cleanup authority or provider readback is incomplete."""
+
+
+@dataclass(frozen=True)
+class CleanupReport:
+    schema: str
+    state: str
+    target: str
+    source_revision: str
+    deleted_paths: tuple[str, ...]
+    missing_paths: tuple[str, ...]
+    before_head: str
+    after_head: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, indent=2) + "\n"
+
+
+def redact(value: str) -> str:
+    return TOKEN_RE.sub("[REDACTED]", value)
+
+
+def assert_authority(source_sha: str, environ: dict[str, str]) -> None:
+    """Accept only the first protected-main push attempt of the central workflow."""
+
+    if not SHA40.fullmatch(source_sha):
+        raise CleanupError("source revision must be an exact lowercase Git SHA")
+    expected = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "push",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_REPOSITORY": SOURCE_REPOSITORY,
+        "GITHUB_SHA": source_sha,
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_WORKFLOW_REF": (
+            f"{SOURCE_REPOSITORY}/{WORKFLOW_PATH}@refs/heads/main"
+        ),
+    }
+    mismatches = sorted(
+        name for name, wanted in expected.items() if environ.get(name) != wanted
+    )
+    if not environ.get("HF_TOKEN"):
+        mismatches.append("HF_TOKEN")
+    if mismatches:
+        raise CleanupError(
+            "cleanup authority mismatch: " + ", ".join(sorted(set(mismatches)))
+        )
+
+
+def cleanup_legacy_paths(
+    *,
+    source_sha: str,
+    token: str,
+    environ: dict[str, str] | None = None,
+    wait_seconds: int = 120,
+    api_factory: Callable[..., Any] | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> CleanupReport:
+    """Delete only the reviewed legacy paths and prove the exact result."""
+
+    env = dict(os.environ if environ is None else environ)
+    assert_authority(source_sha, env)
+    if token != env.get("HF_TOKEN"):
+        raise CleanupError("explicit token does not match the authorized environment")
+    if not 1 <= wait_seconds <= 600:
+        raise CleanupError("wait_seconds must be between 1 and 600")
+
+    if api_factory is None:
+        try:
+            from huggingface_hub import CommitOperationDelete, HfApi
+        except ImportError as exc:
+            raise CleanupError("huggingface_hub is required") from exc
+    else:
+        CommitOperationDelete = None  # type: ignore[assignment,misc]
+        HfApi = api_factory  # type: ignore[assignment,misc]
+
+    api = HfApi(token=token)
+    before = api.repo_info(repo_id=TARGET_REPOSITORY, repo_type="space")
+    before_head = str(getattr(before, "sha", ""))
+    if not SHA40.fullmatch(before_head):
+        raise CleanupError("Hugging Face returned an invalid pre-cleanup head")
+
+    remote_files = set(api.list_repo_files(repo_id=TARGET_REPOSITORY, repo_type="space"))
+    present = tuple(path for path in LEGACY_PATHS if path in remote_files)
+    missing = tuple(path for path in LEGACY_PATHS if path not in remote_files)
+    if not present:
+        return CleanupReport(
+            schema=SCHEMA,
+            state="ALREADY_CLEAN",
+            target=TARGET_REPOSITORY,
+            source_revision=source_sha,
+            deleted_paths=(),
+            missing_paths=missing,
+            before_head=before_head,
+            after_head=before_head,
+        )
+
+    if api_factory is None:
+        operations = [CommitOperationDelete(path_in_repo=path) for path in present]
+    else:
+        operations = [path for path in present]
+    commit = api.create_commit(
+        repo_id=TARGET_REPOSITORY,
+        repo_type="space",
+        operations=operations,
+        commit_message="chore: retire legacy organization-card collateral",
+        parent_commit=before_head,
+    )
+    commit_oid = str(getattr(commit, "oid", ""))
+    if not SHA40.fullmatch(commit_oid):
+        raise CleanupError("Hugging Face returned an invalid cleanup commit OID")
+
+    deadline = time.monotonic() + wait_seconds
+    last_head = ""
+    last_files: set[str] = set()
+    while time.monotonic() < deadline:
+        info = api.repo_info(repo_id=TARGET_REPOSITORY, repo_type="space")
+        last_head = str(getattr(info, "sha", ""))
+        last_files = set(
+            api.list_repo_files(
+                repo_id=TARGET_REPOSITORY,
+                repo_type="space",
+                revision=commit_oid,
+            )
+        )
+        if last_head == commit_oid and not (set(LEGACY_PATHS) & last_files):
+            return CleanupReport(
+                schema=SCHEMA,
+                state="VERIFIED",
+                target=TARGET_REPOSITORY,
+                source_revision=source_sha,
+                deleted_paths=present,
+                missing_paths=missing,
+                before_head=before_head,
+                after_head=commit_oid,
+            )
+        sleeper(3)
+
+    remaining = sorted(set(LEGACY_PATHS) & last_files)
+    raise CleanupError(
+        "cleanup readback did not converge "
+        f"(head_matches={last_head == commit_oid}, remaining={remaining})"
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--source-sha", required=True)
+    result.add_argument("--wait-seconds", type=int, default=120)
+    result.add_argument("--report", type=Path)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        report = cleanup_legacy_paths(
+            source_sha=args.source_sha,
+            token=os.environ.get("HF_TOKEN", ""),
+            wait_seconds=args.wait_seconds,
+        )
+        payload = report.to_json()
+        if args.report is not None:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(payload, encoding="utf-8", newline="\n")
+        print(payload, end="")
+        return 0
+    except Exception as exc:
+        payload = json.dumps(
+            {
+                "schema": SCHEMA,
+                "state": "FAILED",
+                "source_revision": args.source_sha,
+                "error": redact(f"{type(exc).__name__}: {exc}"),
+            },
+            sort_keys=True,
+            indent=2,
+        ) + "\n"
+        if args.report is not None:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(payload, encoding="utf-8", newline="\n")
+        print(payload, end="")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_hf_org_card_publish_cleanup.py
+++ b/.github/scripts/test_hf_org_card_publish_cleanup.py
@@ -1,0 +1,197 @@
+import io
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import hf_org_card_publish_cleanup as cleanup
+
+
+class FakeApi:
+    def __init__(self, *, token, files=None, before="a" * 40):
+        self.token = token
+        self.files = set(files or ())
+        self.head = before
+        self.before = before
+        self.calls = []
+
+    def repo_info(self, *, repo_id, repo_type):
+        self.calls.append(("repo_info", repo_id, repo_type))
+        return types.SimpleNamespace(sha=self.head)
+
+    def list_repo_files(self, *, repo_id, repo_type, revision=None):
+        self.calls.append(("list_repo_files", repo_id, repo_type, revision))
+        return sorted(self.files)
+
+    def create_commit(
+        self,
+        *,
+        repo_id,
+        repo_type,
+        operations,
+        commit_message,
+        parent_commit,
+    ):
+        self.calls.append(
+            (
+                "create_commit",
+                repo_id,
+                repo_type,
+                tuple(operations),
+                commit_message,
+                parent_commit,
+            )
+        )
+        if parent_commit != self.head:
+            raise AssertionError("parent drift")
+        self.files.difference_update(operations)
+        self.head = "b" * 40
+        return types.SimpleNamespace(oid=self.head)
+
+
+class OrgCardPublishCleanupTests(unittest.TestCase):
+    def authority_env(self, source_sha="c" * 40):
+        return {
+            "GITHUB_ACTIONS": "true",
+            "GITHUB_EVENT_NAME": "push",
+            "GITHUB_REF": "refs/heads/main",
+            "GITHUB_REF_PROTECTED": "true",
+            "GITHUB_REPOSITORY": "szl-holdings/.github",
+            "GITHUB_SHA": source_sha,
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_WORKFLOW_REF": (
+                "szl-holdings/.github/"
+                ".github/workflows/hf-org-card-autopublish.yml@refs/heads/main"
+            ),
+            "HF_TOKEN": "hf-test-token-redacted",
+        }
+
+    def test_exact_protected_main_authority_is_accepted(self):
+        cleanup.assert_authority("c" * 40, self.authority_env())
+
+    def test_branch_dispatch_rerun_and_missing_token_are_rejected(self):
+        mutations = {
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "GITHUB_REF": "refs/heads/feature",
+            "GITHUB_REF_PROTECTED": "false",
+            "GITHUB_RUN_ATTEMPT": "2",
+            "GITHUB_WORKFLOW_REF": "wrong/workflow@refs/heads/main",
+            "HF_TOKEN": "",
+        }
+        for name, value in mutations.items():
+            with self.subTest(name=name):
+                environment = self.authority_env()
+                environment[name] = value
+                with self.assertRaisesRegex(cleanup.CleanupError, "authority mismatch"):
+                    cleanup.assert_authority("c" * 40, environment)
+
+    def test_cleanup_deletes_only_reviewed_paths_and_verifies_head(self):
+        files = {
+            "README.md",
+            "index.html",
+            "GOVERNANCE.md",
+            "MODELS.txt",
+            "SEVEN_SPACES.md",
+            "SPACE_PROVENANCE_FRONTIER.json",
+            "seven-spaces.yaml",
+            "assets/estate-command-system.svg",
+        }
+        api = FakeApi(token="hf-test-token-redacted", files=files)
+        report = cleanup.cleanup_legacy_paths(
+            source_sha="c" * 40,
+            token="hf-test-token-redacted",
+            environ=self.authority_env(),
+            wait_seconds=3,
+            api_factory=lambda **_: api,
+            sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(report.state, "VERIFIED")
+        self.assertEqual(report.deleted_paths, cleanup.LEGACY_PATHS)
+        self.assertEqual(report.after_head, "b" * 40)
+        self.assertIn("README.md", api.files)
+        self.assertIn("index.html", api.files)
+        self.assertIn("assets/estate-command-system.svg", api.files)
+        self.assertFalse(set(cleanup.LEGACY_PATHS) & api.files)
+        commit_call = next(call for call in api.calls if call[0] == "create_commit")
+        self.assertEqual(commit_call[1], "SZLHOLDINGS/README")
+        self.assertEqual(commit_call[3], cleanup.LEGACY_PATHS)
+
+    def test_already_clean_is_idempotent_and_does_not_commit(self):
+        api = FakeApi(
+            token="hf-test-token-redacted",
+            files={"README.md", "index.html"},
+        )
+        report = cleanup.cleanup_legacy_paths(
+            source_sha="c" * 40,
+            token="hf-test-token-redacted",
+            environ=self.authority_env(),
+            wait_seconds=3,
+            api_factory=lambda **_: api,
+            sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(report.state, "ALREADY_CLEAN")
+        self.assertEqual(report.deleted_paths, ())
+        self.assertFalse(any(call[0] == "create_commit" for call in api.calls))
+
+    def test_explicit_token_must_match_authorized_environment(self):
+        api = FakeApi(token="different", files={"README.md"})
+        with self.assertRaisesRegex(cleanup.CleanupError, "explicit token"):
+            cleanup.cleanup_legacy_paths(
+                source_sha="c" * 40,
+                token="different",
+                environ=self.authority_env(),
+                wait_seconds=3,
+                api_factory=lambda **_: api,
+            )
+
+    def test_invalid_provider_head_fails_before_mutation(self):
+        api = FakeApi(token="hf-test-token-redacted", files={"GOVERNANCE.md"}, before="bad")
+        with self.assertRaisesRegex(cleanup.CleanupError, "invalid pre-cleanup head"):
+            cleanup.cleanup_legacy_paths(
+                source_sha="c" * 40,
+                token="hf-test-token-redacted",
+                environ=self.authority_env(),
+                wait_seconds=3,
+                api_factory=lambda **_: api,
+            )
+        self.assertFalse(any(call[0] == "create_commit" for call in api.calls))
+
+    def test_failure_report_redacts_provider_token(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            stream = io.StringIO()
+            with (
+                mock.patch.dict(
+                    "os.environ",
+                    {"HF_TOKEN": "hf_1234567890secretvalue"},
+                    clear=False,
+                ),
+                mock.patch.object(
+                    cleanup,
+                    "cleanup_legacy_paths",
+                    side_effect=cleanup.CleanupError(
+                        "Bearer hf_1234567890secretvalue was rejected"
+                    ),
+                ),
+                mock.patch("sys.stdout", stream),
+            ):
+                result = cleanup.main(
+                    [
+                        "--source-sha",
+                        "c" * 40,
+                        "--report",
+                        str(path),
+                    ]
+                )
+            payload = path.read_text(encoding="utf-8")
+
+        self.assertEqual(result, 1)
+        self.assertNotIn("hf_1234567890secretvalue", payload)
+        self.assertIn("[REDACTED]", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/hf-org-card-autopublish.yml
+++ b/.github/workflows/hf-org-card-autopublish.yml
@@ -8,9 +8,11 @@ on:
       - "huggingface/org-card.manifest.json"
       - "profile/assets/estate-command-system.svg"
       - ".github/scripts/hf_org_card_autopublish.py"
+      - ".github/scripts/hf_org_card_publish_cleanup.py"
       - ".github/scripts/hf_space_visibility.py"
       - ".github/scripts/hf_static_space_deploy.py"
       - ".github/scripts/test_hf_org_card_autopublish.py"
+      - ".github/scripts/test_hf_org_card_publish_cleanup.py"
       - ".github/scripts/test_hf_space_visibility.py"
       - ".github/scripts/test_hf_static_space_deploy.py"
       - ".github/workflows/hf-org-card-autopublish.yml"
@@ -21,9 +23,11 @@ on:
       - "huggingface/org-card.manifest.json"
       - "profile/assets/estate-command-system.svg"
       - ".github/scripts/hf_org_card_autopublish.py"
+      - ".github/scripts/hf_org_card_publish_cleanup.py"
       - ".github/scripts/hf_space_visibility.py"
       - ".github/scripts/hf_static_space_deploy.py"
       - ".github/scripts/test_hf_org_card_autopublish.py"
+      - ".github/scripts/test_hf_org_card_publish_cleanup.py"
       - ".github/scripts/test_hf_space_visibility.py"
       - ".github/scripts/test_hf_static_space_deploy.py"
       - ".github/workflows/hf-org-card-autopublish.yml"
@@ -117,11 +121,11 @@ jobs:
         with:
           python-version: "3.12.10"
 
-      - name: Test central publisher before provider access
+      - name: Test cleanup and central publisher before provider access
         run: >-
           python -m unittest discover
           -s .github/scripts
-          -p test_hf_org_card_autopublish.py
+          -p 'test_hf_org_card_*publish*.py'
 
       - name: Install exact Hub client
         run: >-
@@ -137,6 +141,15 @@ jobs:
             echo "::error::No Hugging Face write credential is available in the central repository secret scope."
             exit 2
           }
+
+      - name: Retire exact legacy organization-card collateral
+        env:
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
+        run: >-
+          python .github/scripts/hf_org_card_publish_cleanup.py
+          --source-sha "${GITHUB_SHA}"
+          --wait-seconds 120
+          --report hf-org-card-cleanup-report.json
 
       - name: Restore visibility, publish exact bytes, and verify readback
         env:
@@ -155,6 +168,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: hf-org-card-autopublish-${{ github.run_id }}
-          path: hf-org-card-autopublish-report.json
+          path: |
+            hf-org-card-cleanup-report.json
+            hf-org-card-autopublish-report.json
           if-no-files-found: warn
           retention-days: 90

--- a/huggingface/org-card.manifest.json
+++ b/huggingface/org-card.manifest.json
@@ -75,7 +75,13 @@
     }
   },
   "prune": true,
-  "allowed_deletions": [],
+  "allowed_deletions": [
+    "GOVERNANCE.md",
+    "MODELS.txt",
+    "SEVEN_SPACES.md",
+    "SPACE_PROVENANCE_FRONTIER.json",
+    "seven-spaces.yaml"
+  ],
   "smoke": {
     "path": "/",
     "required_marker": "data-szl-surface=\"company-front-door\""

--- a/huggingface/org-card.manifest.json
+++ b/huggingface/org-card.manifest.json
@@ -75,13 +75,7 @@
     }
   },
   "prune": true,
-  "allowed_deletions": [
-    "GOVERNANCE.md",
-    "MODELS.txt",
-    "SEVEN_SPACES.md",
-    "SPACE_PROVENANCE_FRONTIER.json",
-    "seven-spaces.yaml"
-  ],
+  "allowed_deletions": [],
   "smoke": {
     "path": "/",
     "required_marker": "data-szl-surface=\"company-front-door\""


### PR DESCRIPTION
## Blocker removed

The protected-main organization-card publisher stopped before creating the final Hugging Face commit because five remote-only legacy files prevented its deletion-closed exact-set check:

- `GOVERNANCE.md`
- `MODELS.txt`
- `SEVEN_SPACES.md`
- `SPACE_PROVENANCE_FRONTIER.json`
- `seven-spaces.yaml`

## Change

- keep the canonical publication manifest deletion-closed with `allowed_deletions: []`;
- add a separate, fixed-target migration that can remove only those five reviewed paths from `SZLHOLDINGS/README`;
- reject branch dispatch, unprotected refs, reruns, target substitution, token mismatch, invalid provider heads, or incomplete readback;
- preserve the removed files in Hugging Face Git history;
- run cleanup immediately before the exact-source org-card publication;
- upload cleanup and publication evidence without credential content;
- add tests covering authority, exact deletion scope, idempotency, provider drift, and token redaction.

No model, dataset, DNS record, or unrelated Space is changed. Any additional remote path still stops the canonical publisher.

## Expected result

After merge, the central protected-main workflow retires the stale collateral, publishes the pixel-built SZL command-fabric card, verifies every expected file, and proves anonymous public readback.