### PR TITLE
fix(security): align Trivy SARIF with declared severity

### DIFF
--- a/.github/workflows/reusable-trivy.yml
+++ b/.github/workflows/reusable-trivy.yml
@@ -2,6 +2,9 @@ name: Reusable — Trivy filesystem scan
 
 # Runs Trivy in filesystem mode against the checked-out tree. Catches
 # vulnerable dependencies, exposed secrets, and misconfigured IaC files.
+# SARIF normally includes all severities regardless of `severity`; the explicit
+# limiter below keeps both the report and failing exit code aligned to the
+# caller's declared policy while preserving the selected findings for upload.
 
 on:
   workflow_call:
@@ -44,6 +47,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: ${{ inputs.severity }}
+          limit-severities-for-sarif: true
           ignore-unfixed: ${{ inputs.ignore-unfixed }}
           exit-code: '1'
 


### PR DESCRIPTION
## Failure

The reusable Trivy workflow declares `HIGH,CRITICAL` as its default blocking policy, but Trivy SARIF includes every severity unless its SARIF limiter is explicitly enabled. On `immune#100`, two MEDIUM findings in `pnpm-lock.yaml` therefore caused a false failure of the HIGH/CRITICAL gate even though table-mode scans reported zero HIGH/CRITICAL findings.

## Fix

Add:

```yaml
limit-severities-for-sarif: true
```

to the pinned `aquasecurity/trivy-action` invocation. This makes SARIF output and `exit-code: '1'` honor the caller's existing `severity` input. Selected findings remain uploaded to GitHub code scanning and remain blocking; no CVE is ignored, suppressed, or dismissed.

## Evidence

The exact Immune PR merge tree reproduced two SARIF results, both MEDIUM (`CVE-2026-82417`, score 5.3; `CVE-2026-82562`, score 3.7), while the reusable gate's declared policy was HIGH/CRITICAL. The upstream action documents that SARIF emits all severities by default and requires this input to override that behavior.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>