### PR TITLE
feat(hf): restore and feature SZL Atlas across the public estate

### DIFF
--- a/.github/workflows/publish-operator-spaces.yml
+++ b/.github/workflows/publish-operator-spaces.yml
@@ -122,16 +122,19 @@ jobs:
                   'repo': 'szl-real-estate',
                   'hf_repo': 'SZLHOLDINGS/szl-real-estate',
                   'smoke_paths': '["/","/healthz","/api/second-brain","/api/formulas"]',
+                  'create_if_missing': 'false',
               },
               {
                   'repo': 'szl-command-lab',
                   'hf_repo': 'SZLHOLDINGS/szl-command-lab',
                   'smoke_paths': '["/","/healthz"]',
+                  'create_if_missing': 'true',
               },
               {
                   'repo': 'lyte-lattice',
                   'hf_repo': 'SZLHOLDINGS/lyte-lattice',
                   'smoke_paths': '["/","/healthz","/api/second-brain","/api/formulas"]',
+                  'create_if_missing': 'false',
               },
           ]
           matrix = publish.get('strategy', {}).get('matrix', {}).get('include')
@@ -141,8 +144,9 @@ jobs:
           required_fragments = (
               'ref: main',
               'Validate Hugging Face card metadata before mutation',
-              'yaml.safe_load',
-              'short_description is',
+              'Create missing Space under exact matrix authority',
+              'CREATE_IF_MISSING',
+              "api.create_repo(",
               '--require-default-branch-tip',
               '--restart-space',
               '--attest',
@@ -204,12 +208,15 @@ jobs:
           - repo: szl-real-estate
             hf_repo: SZLHOLDINGS/szl-real-estate
             smoke_paths: '["/","/healthz","/api/second-brain","/api/formulas"]'
+            create_if_missing: 'false'
           - repo: szl-command-lab
             hf_repo: SZLHOLDINGS/szl-command-lab
             smoke_paths: '["/","/healthz"]'
+            create_if_missing: 'true'
           - repo: lyte-lattice
             hf_repo: SZLHOLDINGS/lyte-lattice
             smoke_paths: '["/","/healthz","/api/second-brain","/api/formulas"]'
+            create_if_missing: 'false'
     concurrency:
       group: hf-central-publish-${{ matrix.repo }}
       cancel-in-progress: false
@@ -350,6 +357,131 @@ jobs:
             echo "::error::No Hugging Face write credential is available in the central repository secret scope."
             exit 2
           }
+
+      - name: Create missing Space under exact matrix authority
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REF: ${{ github.ref }}
+          REPO: ${{ matrix.repo }}
+          HF_REPO: ${{ matrix.hf_repo }}
+          CREATE_IF_MISSING: ${{ matrix.create_if_missing }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          set -euo pipefail
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P <<'PY'
+          from __future__ import annotations
+
+          import importlib.util
+          import json
+          import os
+          import re
+          import time
+          from pathlib import Path
+          from types import SimpleNamespace
+
+          from huggingface_hub import HfApi
+
+          repo = os.environ['REPO']
+          github_repo = f'szl-holdings/{repo}'
+          hf_repo = os.environ['HF_REPO']
+          source_sha = os.environ['SOURCE_SHA'].lower()
+          create_raw = os.environ['CREATE_IF_MISSING'].strip().lower()
+          if create_raw not in {'true', 'false'}:
+              raise SystemExit('create_if_missing must be exactly true or false')
+          create_if_missing = create_raw == 'true'
+          if not re.fullmatch(r'[0-9a-f]{40}', source_sha):
+              raise SystemExit('source SHA is not exact')
+
+          spec = importlib.util.spec_from_file_location(
+              'hf_deployer',
+              'tools/.github/scripts/hf_deploy_from_dockerfile.py',
+          )
+          if spec is None or spec.loader is None:
+              raise SystemExit('could not load exact central deployer')
+          deployer = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(deployer)
+
+          api = HfApi(token=os.environ['HF_TOKEN'])
+          report = {
+              'schema': 'szl.hf-space-create/v1',
+              'github_repository': github_repo,
+              'source_revision': source_sha,
+              'target': hf_repo,
+              'authorized_create': create_if_missing,
+              'state': 'UNKNOWN',
+              'created': False,
+          }
+
+          try:
+              info = api.repo_info(repo_id=hf_repo, repo_type='space')
+          except Exception as exc:  # SDK exception classes are version-bound
+              status = deployer._http_status_from_exception(exc)
+              if status != 404:
+                  raise
+              if not create_if_missing:
+                  raise SystemExit(
+                      f'{hf_repo} is missing and this matrix row cannot create it'
+                  ) from exc
+              exact_create_authority = {
+                  (
+                      'szl-holdings/szl-command-lab',
+                      'SZLHOLDINGS/szl-command-lab',
+                  )
+              }
+              if (github_repo, hf_repo) not in exact_create_authority:
+                  raise SystemExit(
+                      'missing-Space creation is not authorized for this source/target pair'
+                  ) from exc
+
+              # Creation is a provider mutation, so revalidate the source default
+              # branch immediately before the write. The normal deployer repeats
+              # this guard immediately before the subsequent content commit.
+              deployer.require_current_default_branch_tip(
+                  SimpleNamespace(
+                      github_repo=github_repo,
+                      source_sha=source_sha,
+                      require_default_branch_tip=True,
+                  )
+              )
+              api.create_repo(
+                  repo_id=hf_repo,
+                  repo_type='space',
+                  space_sdk='docker',
+                  private=False,
+                  exist_ok=False,
+              )
+              report['created'] = True
+              info = None
+              for _ in range(6):
+                  try:
+                      info = api.repo_info(repo_id=hf_repo, repo_type='space')
+                      break
+                  except Exception as read_exc:
+                      if deployer._http_status_from_exception(read_exc) != 404:
+                          raise
+                      time.sleep(2)
+              if info is None:
+                  raise SystemExit('created Space did not become readable after bounded retries')
+
+          observed_id = str(getattr(info, 'id', '') or getattr(info, 'repo_id', ''))
+          observed_private = bool(getattr(info, 'private', False))
+          if observed_id and observed_id != hf_repo:
+              raise SystemExit(
+                  f'provider identity mismatch: expected {hf_repo}, observed {observed_id}'
+              )
+          if observed_private:
+              raise SystemExit('public Atlas target unexpectedly resolved as private')
+          report['state'] = 'CREATED' if report['created'] else 'EXISTING'
+          output = Path(f'evidence/{repo}/hf-space-create-report.json')
+          output.write_text(
+              json.dumps(report, indent=2, sort_keys=True) + '\n',
+              encoding='utf-8',
+          )
+          print(json.dumps(report, indent=2, sort_keys=True))
+          PY
 
       - name: Deploy exact Dockerfile-derived closure
         shell: bash

--- a/huggingface/org-card/README.md
+++ b/huggingface/org-card/README.md
@@ -26,9 +26,9 @@ Frontier infrastructure for decisions that must remain bounded, inspectable,
 and reproducible.
 
 [**Enter the product**](https://a-11-oy.com) ·
-[**Build from source**](https://github.com/szl-holdings) ·
+[**Explore SZL Atlas**](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) ·
 [**Inspect evidence**](https://a11oy.net) ·
-[**Browse the Hub**](https://huggingface.co/SZLHOLDINGS)
+[**Build from source**](https://github.com/szl-holdings)
 
 </div>
 
@@ -40,11 +40,23 @@ Start with [A11oy](https://a-11-oy.com) for the product, operating boundary,
 and outcome. Review [diligence and evidence](https://a11oy.net) before relying
 on a capability claim.
 
+### Explore
+
+[**SZL Atlas**](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab)
+is the searchable public estate: models, first-class kernels, datasets, Spaces,
+usage signals, source links, and evidence boundaries in one responsive surface.
+
+[Models](https://huggingface.co/SZLHOLDINGS/models) ·
+[Kernels](https://huggingface.co/SZLHOLDINGS/kernels) ·
+[Datasets](https://huggingface.co/SZLHOLDINGS/datasets) ·
+[Spaces](https://huggingface.co/SZLHOLDINGS/spaces) ·
+[Collections](https://huggingface.co/SZLHOLDINGS/collections)
+
 ### Build
 
 Use [GitHub](https://github.com/szl-holdings) for source, tests, contracts, and
-quick starts. Use the [Hub](https://huggingface.co/SZLHOLDINGS) for published
-models, kernels, datasets, and demonstrations.
+quick starts. Each published artifact owns its lineage, intended use,
+evaluation, compatibility, and limitations.
 
 ### Verify
 
@@ -54,19 +66,14 @@ exact revisions, limitations, and the
 
 ## Command fabric
 
-**A11oy** governs decisions and bounded execution.
-
-**Khipu models** and **SZL kernels** expose their own lineage, intended use,
-evaluation, compatibility, and limitation claims.
+**A11oy** governs decisions and bounded execution. **Khipu models** and
+**SZL kernels** provide portable reasoning and compute primitives.
 
 **Killinchu** is a public synthetic counter-UAS reference. Public actuation is
 **SIMULATED**; no live weapon command is claimed.
 
 **Receipt Verifier** checks scoped integrity and origin. It does not prove
 truth, safety, performance, compliance, or authorization.
-
-**SZL Lake** carries admitted evidence and data artifacts. Freshness,
-completeness, jurisdiction, and source limits remain explicit.
 
 <details>
 <summary><strong>Evidence architecture</strong></summary>
@@ -79,19 +86,20 @@ completeness, jurisdiction, and source limits remain explicit.
 
 ## Artifact contract
 
-Evidence labels and operational state are separate. A running Space or HTTP
-200 proves reachability only. Lambda uniqueness remains **Conjecture 1**.
+A running Space, public listing, download count, or HTTP 200 proves neither
+readiness nor superiority. Lambda uniqueness remains **Conjecture 1**.
 [`SZLHOLDINGS/SZLHOLDINGS`](https://huggingface.co/datasets/SZLHOLDINGS/SZLHOLDINGS)
 is a **HISTORICAL** mirror.
 
 ## Current state
 
-[A11oy readiness](https://a-11-oy.com/api/a11oy/v1/readiness) ·
-[Killinchu build](https://szlholdings-killinchu.hf.space/api/build-info) ·
-[Served source](https://szlholdings-readme.static.hf.space/deployment.json)
+[Atlas health](https://szlholdings-szl-command-lab.hf.space/healthz) ·
+[Live catalog](https://szlholdings-szl-command-lab.hf.space/api/catalog) ·
+[Atlas source binding](https://szlholdings-szl-command-lab.hf.space/api/build-info) ·
+[A11oy readiness](https://a-11-oy.com/api/a11oy/v1/readiness)
 
-No production authorization, regulatory approval, adoption, or investment
-outcome is claimed.
+No production authorization, regulatory approval, adoption, funding, revenue,
+or investment outcome is claimed.
 
 ## Reproduce and verify
 
@@ -109,6 +117,6 @@ python -m http.server 8000 --directory "$preview_dir"
 
 <div align="center">
 
-**Understand · build · verify**
+**Understand · explore · build · verify**
 
 </div>


### PR DESCRIPTION
## Objective

Restore `SZLHOLDINGS/szl-command-lab` as the live **SZL Atlas**, then make it the primary public exploration route for the Hugging Face estate while preserving the authority model:

- `a-11-oy.com` remains the product and experience origin;
- `a11oy.net` remains the evidence and verification surface;
- GitHub remains the technical source;
- the Hugging Face organization card remains the organization front door.

## Provider blocker found and removed

The source showcase was merged at `szl-holdings/szl-command-lab@2f947dbeab8711b7f850ef4b1e1570c37c47b83c`, but the central publisher proved that `SZLHOLDINGS/szl-command-lab` no longer existed: the authenticated Hub tree returned exact HTTP 404 before mutation.

This change adds a bounded recovery path to the existing central operator-Space publisher:

- creation is enabled only for the exact pair `szl-holdings/szl-command-lab` → `SZLHOLDINGS/szl-command-lab`;
- all other matrix targets remain creation-disabled;
- source SHA, default-branch tip, target identity, public visibility, and Docker SDK are checked before or immediately after the write;
- transient/provider errors other than 404 remain fail-closed;
- creation evidence is uploaded with the normal immutable publication evidence;
- ordinary exact-source deployment, restart, byte attestation, and smoke verification still run afterward.

## Organization showcase

- adds a prominent `Explore SZL Atlas` route alongside product, evidence, and source;
- adds a concise **Explore** path for models, first-class kernels, datasets, Spaces, usage signals, source links, and evidence boundaries;
- adds direct Models, Kernels, Datasets, Spaces, and Collections routes;
- adds Atlas health, catalog, and source-binding routes to Current state;
- retains the approved hero, canonical WebP, reproduction command, mobile-safe no-table layout, `SIMULATED`, `HISTORICAL`, and Conjecture 1 boundaries.

## Truth boundary

The Atlas is a discovery and evidence-navigation surface. Public listing, downloads, HTTP 200, or polished presentation do not establish readiness, superiority, authorization, adoption, revenue, funding, fame, or an investment outcome.

After merge, protected-main workflows will recreate the exact missing Space, publish the Atlas from source main, verify the running commit and bytes, then update `SZLHOLDINGS/README` with public readback evidence.