### PR TITLE
feat: launch the SZL Frontier design kernel across A11oy, Killinchu, and Hatun

### DIFF
--- a/.github/design/frontier-v1/brands.json
+++ b/.github/design/frontier-v1/brands.json
@@ -1,0 +1,105 @@
+{
+  "schema": "szl.frontier-design.registry/v1",
+  "version": "1.0.0",
+  "source_repository": "szl-holdings/.github",
+  "asset_contract": {
+    "css": "szl-frontier.css",
+    "javascript": "szl-frontier.js",
+    "runtime_dependencies": [],
+    "network_fetches": 0,
+    "authority": "PRESENTATION_ONLY"
+  },
+  "brands": {
+    "a11oy": {
+      "title": "A11oy",
+      "descriptor": "Governed command fabric",
+      "motif": "alloy lattice",
+      "home": "https://a-11-oy.com/",
+      "hostnames": ["a-11-oy.com", "www.a-11-oy.com", "szlholdings-a11oy.hf.space"],
+      "repository_candidates": ["szl-holdings/a11oy"],
+      "entrypoint_candidates": [
+        "pages/console.html",
+        "web/index.html",
+        "index.html",
+        "templates/index.html",
+        "web/living-anatomy.html"
+      ],
+      "python_entrypoint_candidates": ["serve.py", "app.py"]
+    },
+    "killinchu": {
+      "title": "Killinchu",
+      "descriptor": "Aerial intelligence & defense",
+      "motif": "condor flight lines",
+      "home": "https://killinchu.net/",
+      "hostnames": ["killinchu.net", "www.killinchu.net", "szlholdings-killinchu.hf.space"],
+      "repository_candidates": ["szl-holdings/killinchu"],
+      "entrypoint_candidates": [
+        "elite/index.html",
+        "web/elite.html",
+        "web/index.html",
+        "index.html",
+        "templates/index.html"
+      ],
+      "python_entrypoint_candidates": [
+        "killinchu_elite_console.py",
+        "serve.py",
+        "app.py"
+      ]
+    },
+    "hatun": {
+      "title": "Hatun",
+      "descriptor": "Sovereign orchestration layer",
+      "motif": "radial khipu rings",
+      "home": "https://a-11-oy.com/wires",
+      "hostnames": ["hatun.a-11-oy.com", "szlholdings-hatun.hf.space", "szlholdings-hatun-mcp.hf.space"],
+      "repository_candidates": [
+        "szl-holdings/hatun",
+        "szl-holdings/hatun-mcp",
+        "szl-holdings/szl-hatun"
+      ],
+      "entrypoint_candidates": [
+        "web/hatun.html",
+        "web/wires.html",
+        "pages/hatun.html",
+        "pages/wires.html",
+        "templates/index.html",
+        "index.html"
+      ],
+      "python_entrypoint_candidates": ["serve.py", "server.py", "app.py"],
+      "fallback": {
+        "repository": "szl-holdings/a11oy",
+        "entrypoint_candidates": [
+          "web/wires.html",
+          "pages/wires.html",
+          "web/hatun.html",
+          "pages/hatun.html"
+        ]
+      }
+    }
+  },
+  "patch_policy": {
+    "html_markers": {
+      "head_start": "<!-- szl-frontier-design:head:v1 -->",
+      "head_end": "<!-- /szl-frontier-design:head:v1 -->",
+      "body_start": "<!-- szl-frontier-design:body:v1 -->",
+      "body_end": "<!-- /szl-frontier-design:body:v1 -->"
+    },
+    "excluded_directories": [
+      ".git",
+      ".venv",
+      "node_modules",
+      "vendor",
+      "dist",
+      "build",
+      "coverage",
+      "docs",
+      "tests",
+      "test",
+      "third_party"
+    ],
+    "maximum_entrypoints_per_brand": 3,
+    "direct_main_push": false,
+    "delete_existing_content": false,
+    "runtime_cdn": false
+  }
+}

--- a/.github/design/frontier-v1/szl-frontier.css
+++ b/.github/design/frontier-v1/szl-frontier.css
@@ -1,0 +1,525 @@
+/*
+ * SZL Frontier Design Kernel v1.0.0
+ * Copyright 2026 SZL Holdings — SPDX-License-Identifier: Apache-2.0
+ *
+ * One visual grammar; three distinct identities. This file is vendored into
+ * each product repository at an exact reviewed Git revision. It has no CDN,
+ * font, image, analytics, cookie, or JavaScript dependency.
+ */
+@layer szl.reset, szl.tokens, szl.shell, szl.components, szl.motion, szl.responsive;
+
+@layer szl.tokens {
+  :root {
+    --szl-font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --szl-font-mono: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    --szl-space-1: .25rem;
+    --szl-space-2: .5rem;
+    --szl-space-3: .75rem;
+    --szl-space-4: 1rem;
+    --szl-space-5: 1.25rem;
+    --szl-space-6: 1.5rem;
+    --szl-space-8: 2rem;
+    --szl-space-10: 2.5rem;
+    --szl-space-12: 3rem;
+    --szl-space-16: 4rem;
+    --szl-radius-sm: .55rem;
+    --szl-radius-md: .9rem;
+    --szl-radius-lg: 1.35rem;
+    --szl-radius-xl: 1.9rem;
+    --szl-content: 1180px;
+    --szl-readable: 72ch;
+    --szl-ease: cubic-bezier(.22, 1, .36, 1);
+    --szl-duration: 260ms;
+    --szl-black: #05070b;
+    --szl-white: #f4f8fb;
+  }
+
+  body[data-szl-frontier="a11oy"] {
+    --szl-bg: #070b10;
+    --szl-bg-deep: #030507;
+    --szl-panel: rgba(15, 24, 31, .74);
+    --szl-panel-strong: rgba(17, 29, 37, .94);
+    --szl-line: rgba(116, 239, 224, .18);
+    --szl-line-strong: rgba(116, 239, 224, .42);
+    --szl-text: #edf8f7;
+    --szl-muted: #93aaa9;
+    --szl-accent: #73f0df;
+    --szl-accent-rgb: 115, 240, 223;
+    --szl-accent-2: #d8b66a;
+    --szl-accent-2-rgb: 216, 182, 106;
+    --szl-danger: #ff7d88;
+    --szl-brand-gradient: linear-gradient(118deg, #73f0df 0%, #9ee7ff 45%, #d8b66a 100%);
+    --szl-motif-angle: 90deg;
+    --szl-motif-size: 42px;
+  }
+
+  body[data-szl-frontier="killinchu"] {
+    --szl-bg: #07101a;
+    --szl-bg-deep: #03070d;
+    --szl-panel: rgba(9, 25, 40, .76);
+    --szl-panel-strong: rgba(10, 31, 50, .94);
+    --szl-line: rgba(125, 200, 255, .2);
+    --szl-line-strong: rgba(125, 200, 255, .48);
+    --szl-text: #f1f8ff;
+    --szl-muted: #98aec2;
+    --szl-accent: #7dc8ff;
+    --szl-accent-rgb: 125, 200, 255;
+    --szl-accent-2: #f0aa5b;
+    --szl-accent-2-rgb: 240, 170, 91;
+    --szl-danger: #ff6f78;
+    --szl-brand-gradient: linear-gradient(118deg, #7dc8ff 0%, #9ae8f4 48%, #f0aa5b 100%);
+    --szl-motif-angle: 132deg;
+    --szl-motif-size: 58px;
+  }
+
+  body[data-szl-frontier="hatun"] {
+    --szl-bg: #0c0915;
+    --szl-bg-deep: #05030a;
+    --szl-panel: rgba(24, 17, 39, .76);
+    --szl-panel-strong: rgba(31, 22, 50, .94);
+    --szl-line: rgba(189, 165, 255, .2);
+    --szl-line-strong: rgba(189, 165, 255, .48);
+    --szl-text: #f7f3ff;
+    --szl-muted: #aea4c1;
+    --szl-accent: #bda5ff;
+    --szl-accent-rgb: 189, 165, 255;
+    --szl-accent-2: #67e8c0;
+    --szl-accent-2-rgb: 103, 232, 192;
+    --szl-danger: #ff7eaa;
+    --szl-brand-gradient: linear-gradient(118deg, #bda5ff 0%, #8fc8ff 48%, #67e8c0 100%);
+    --szl-motif-angle: 45deg;
+    --szl-motif-size: 52px;
+  }
+}
+
+@layer szl.reset {
+  body.szl-frontier {
+    color-scheme: dark;
+    min-width: 0;
+    background-color: var(--szl-bg, #070b10);
+    color: var(--szl-text, #edf8f7);
+    font-family: var(--szl-font-sans);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: clip;
+  }
+
+  body.szl-frontier *,
+  body.szl-frontier *::before,
+  body.szl-frontier *::after {
+    box-sizing: border-box;
+  }
+
+  body.szl-frontier :where(img, svg, video, canvas, iframe) {
+    max-width: 100%;
+  }
+
+  body.szl-frontier :where(button, input, textarea, select) {
+    font: inherit;
+  }
+
+  body.szl-frontier :where(a, button, input, textarea, select, summary, [tabindex]):focus-visible {
+    outline: 2px solid var(--szl-accent);
+    outline-offset: 3px;
+    border-radius: max(.2rem, var(--szl-radius-sm));
+  }
+
+  body.szl-frontier :where(a) {
+    text-underline-offset: .2em;
+    text-decoration-thickness: .08em;
+  }
+
+  body.szl-frontier ::selection {
+    color: var(--szl-bg-deep);
+    background: var(--szl-accent);
+  }
+}
+
+@layer szl.shell {
+  body.szl-frontier::before,
+  body.szl-frontier::after {
+    content: "";
+    position: fixed;
+    z-index: -2;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  body.szl-frontier::before {
+    background:
+      radial-gradient(circle at 12% -12%, rgba(var(--szl-accent-rgb), .16), transparent 32rem),
+      radial-gradient(circle at 88% 8%, rgba(var(--szl-accent-2-rgb), .11), transparent 30rem),
+      linear-gradient(180deg, var(--szl-bg-deep), var(--szl-bg) 48%, var(--szl-bg-deep));
+  }
+
+  body.szl-frontier::after {
+    z-index: -1;
+    opacity: .34;
+    background-image:
+      linear-gradient(var(--szl-motif-angle), rgba(var(--szl-accent-rgb), .055) 1px, transparent 1px),
+      linear-gradient(calc(var(--szl-motif-angle) + 90deg), rgba(var(--szl-accent-rgb), .035) 1px, transparent 1px);
+    background-size: var(--szl-motif-size) var(--szl-motif-size);
+    mask-image: linear-gradient(to bottom, black, transparent 78%);
+  }
+
+  body[data-szl-frontier="killinchu"]::after {
+    transform: skewY(-2deg) scale(1.05);
+    transform-origin: top right;
+    background-size: 82px 24px;
+  }
+
+  body[data-szl-frontier="hatun"]::after {
+    opacity: .3;
+    background-image:
+      radial-gradient(circle at center, transparent 0 20px, rgba(var(--szl-accent-rgb), .075) 21px 22px, transparent 23px),
+      linear-gradient(45deg, rgba(var(--szl-accent-2-rgb), .04) 1px, transparent 1px);
+    background-size: 104px 104px, 52px 52px;
+  }
+
+  .szl-frontier-rail {
+    position: relative;
+    z-index: 1000;
+    width: 100%;
+    min-height: 44px;
+    border-bottom: 1px solid var(--szl-line);
+    background: color-mix(in srgb, var(--szl-bg-deep) 88%, transparent);
+    -webkit-backdrop-filter: blur(18px) saturate(140%);
+    backdrop-filter: blur(18px) saturate(140%);
+  }
+
+  .szl-frontier-rail[data-scrolled="true"] {
+    box-shadow: 0 10px 35px rgba(0, 0, 0, .22);
+  }
+
+  .szl-frontier-rail__inner {
+    width: min(var(--szl-content), calc(100% - 2rem));
+    min-height: 44px;
+    margin-inline: auto;
+    display: flex;
+    align-items: center;
+    gap: var(--szl-space-4);
+  }
+
+  .szl-frontier-rail__brand {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    gap: .55rem;
+    color: var(--szl-text);
+    text-decoration: none;
+    font-family: var(--szl-font-mono);
+    font-size: .72rem;
+    font-weight: 700;
+    letter-spacing: .095em;
+    text-transform: uppercase;
+  }
+
+  .szl-frontier-rail__mark {
+    width: 1.4rem;
+    height: 1.4rem;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid var(--szl-line-strong);
+    border-radius: .44rem;
+    color: var(--szl-accent);
+    background: rgba(var(--szl-accent-rgb), .08);
+    box-shadow: inset 0 0 16px rgba(var(--szl-accent-rgb), .08);
+  }
+
+  .szl-frontier-rail__descriptor {
+    color: var(--szl-muted);
+    font-size: .68rem;
+    white-space: nowrap;
+  }
+
+  .szl-frontier-rail__nav {
+    min-width: 0;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: .2rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+  }
+
+  .szl-frontier-rail__nav::-webkit-scrollbar { display: none; }
+
+  .szl-frontier-rail__nav a {
+    min-height: 36px;
+    padding: .48rem .7rem;
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    color: var(--szl-muted);
+    text-decoration: none;
+    font-size: .72rem;
+    letter-spacing: .035em;
+    transition: color var(--szl-duration) var(--szl-ease), border-color var(--szl-duration) var(--szl-ease), background var(--szl-duration) var(--szl-ease);
+  }
+
+  .szl-frontier-rail__nav a:hover,
+  .szl-frontier-rail__nav a[aria-current="page"] {
+    color: var(--szl-text);
+    border-color: var(--szl-line);
+    background: rgba(var(--szl-accent-rgb), .075);
+  }
+
+  body.szl-frontier :where(main, .container, .wrap, .shell, .page-shell) {
+    min-width: 0;
+  }
+
+  body.szl-frontier :where(.szl-frontier-container) {
+    width: min(var(--szl-content), calc(100% - 2rem));
+    margin-inline: auto;
+  }
+}
+
+@layer szl.components {
+  body.szl-frontier :where(h1, h2, h3, h4) {
+    color: var(--szl-text);
+    text-wrap: balance;
+  }
+
+  body.szl-frontier :where(h1) {
+    letter-spacing: -.045em;
+  }
+
+  body.szl-frontier :where(p, li) {
+    text-wrap: pretty;
+  }
+
+  body.szl-frontier :where(.eyebrow, .kicker, .overline, [data-eyebrow]) {
+    color: var(--szl-accent);
+    font-family: var(--szl-font-mono);
+    font-size: .72rem;
+    font-weight: 700;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+  }
+
+  body.szl-frontier :where(.gradient-text, [data-szl-gradient-text]) {
+    color: transparent;
+    background: var(--szl-brand-gradient);
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
+  body.szl-frontier :where(.card, .panel, .tile, article, [data-card]) {
+    border-color: var(--szl-line);
+  }
+
+  body.szl-frontier :where(.szl-frontier-card) {
+    position: relative;
+    overflow: hidden;
+    padding: clamp(1rem, 2.5vw, 1.5rem);
+    border: 1px solid var(--szl-line);
+    border-radius: var(--szl-radius-lg);
+    background: linear-gradient(145deg, rgba(255, 255, 255, .035), transparent 45%), var(--szl-panel);
+    box-shadow: 0 20px 55px rgba(0, 0, 0, .2), inset 0 1px rgba(255, 255, 255, .04);
+  }
+
+  body.szl-frontier :where(.szl-frontier-card)::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 46%;
+    height: 1px;
+    background: linear-gradient(90deg, var(--szl-accent), transparent);
+  }
+
+  body.szl-frontier :where(button, .button, .btn, [role="button"], input[type="submit"]) {
+    min-height: 44px;
+  }
+
+  body.szl-frontier :where(.szl-frontier-button) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: .55rem;
+    min-height: 44px;
+    padding: .72rem 1rem;
+    border: 1px solid var(--szl-line-strong);
+    border-radius: .78rem;
+    color: var(--szl-bg-deep);
+    background: var(--szl-brand-gradient);
+    text-decoration: none;
+    font-weight: 750;
+    box-shadow: 0 10px 30px rgba(var(--szl-accent-rgb), .13);
+    transition: transform var(--szl-duration) var(--szl-ease), box-shadow var(--szl-duration) var(--szl-ease), filter var(--szl-duration) var(--szl-ease);
+  }
+
+  body.szl-frontier :where(.szl-frontier-button):hover {
+    transform: translateY(-2px);
+    filter: saturate(1.08) brightness(1.04);
+    box-shadow: 0 16px 38px rgba(var(--szl-accent-rgb), .2);
+  }
+
+  body.szl-frontier :where(.szl-frontier-button--quiet) {
+    color: var(--szl-text);
+    background: rgba(var(--szl-accent-rgb), .075);
+    box-shadow: none;
+  }
+
+  body.szl-frontier :where(.badge, .pill, .chip, [data-status], .szl-frontier-chip) {
+    border-color: var(--szl-line);
+  }
+
+  body.szl-frontier :where(.szl-frontier-chip) {
+    min-height: 28px;
+    padding: .32rem .62rem;
+    display: inline-flex;
+    align-items: center;
+    gap: .42rem;
+    border: 1px solid var(--szl-line);
+    border-radius: 999px;
+    color: var(--szl-muted);
+    background: rgba(var(--szl-accent-rgb), .055);
+    font-family: var(--szl-font-mono);
+    font-size: .66rem;
+    letter-spacing: .055em;
+    text-transform: uppercase;
+  }
+
+  body.szl-frontier :where(.szl-frontier-chip)::before {
+    content: "";
+    width: .42rem;
+    height: .42rem;
+    border-radius: 50%;
+    background: var(--szl-accent);
+    box-shadow: 0 0 12px rgba(var(--szl-accent-rgb), .75);
+  }
+
+  body.szl-frontier :where(table) {
+    border-collapse: separate;
+    border-spacing: 0;
+    max-width: 100%;
+  }
+
+  body.szl-frontier :where(th) {
+    color: var(--szl-muted);
+    font-family: var(--szl-font-mono);
+    font-size: .72rem;
+    letter-spacing: .07em;
+    text-transform: uppercase;
+  }
+
+  body.szl-frontier :where(code, pre, kbd, samp) {
+    font-family: var(--szl-font-mono);
+  }
+
+  body.szl-frontier :where(pre) {
+    max-width: 100%;
+    overflow: auto;
+    border: 1px solid var(--szl-line);
+    border-radius: var(--szl-radius-md);
+    background: rgba(0, 0, 0, .26);
+  }
+
+  body.szl-frontier :where(input, textarea, select) {
+    color: var(--szl-text);
+    border-color: var(--szl-line);
+    background-color: rgba(0, 0, 0, .18);
+  }
+
+  body.szl-frontier [data-szl-frontier-reveal] {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  body.szl-frontier [data-szl-frontier-reveal][data-visible="true"] {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@layer szl.motion {
+  body.szl-frontier [data-szl-frontier-reveal] {
+    transition: opacity 520ms var(--szl-ease), transform 520ms var(--szl-ease);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    body.szl-frontier .szl-frontier-rail__mark {
+      animation: szl-frontier-breathe 4.8s ease-in-out infinite;
+    }
+  }
+
+  @keyframes szl-frontier-breathe {
+    0%, 100% { box-shadow: inset 0 0 16px rgba(var(--szl-accent-rgb), .08), 0 0 0 rgba(var(--szl-accent-rgb), 0); }
+    50% { box-shadow: inset 0 0 20px rgba(var(--szl-accent-rgb), .14), 0 0 20px rgba(var(--szl-accent-rgb), .12); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body.szl-frontier *,
+    body.szl-frontier *::before,
+    body.szl-frontier *::after {
+      scroll-behavior: auto !important;
+      animation-duration: .001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: .001ms !important;
+    }
+
+    body.szl-frontier [data-szl-frontier-reveal] {
+      opacity: 1;
+      transform: none;
+    }
+  }
+}
+
+@layer szl.responsive {
+  @media (max-width: 760px) {
+    .szl-frontier-rail__inner {
+      width: min(100% - 1rem, var(--szl-content));
+      gap: .65rem;
+    }
+
+    .szl-frontier-rail__descriptor {
+      display: none;
+    }
+
+    .szl-frontier-rail__brand {
+      font-size: .67rem;
+    }
+
+    .szl-frontier-rail__nav a {
+      min-height: 40px;
+      padding-inline: .62rem;
+    }
+  }
+
+  @media (max-width: 390px) {
+    .szl-frontier-rail__inner {
+      width: calc(100% - .75rem);
+    }
+
+    .szl-frontier-rail__brand span:not(.szl-frontier-rail__mark) {
+      max-width: 7.5rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  @media (forced-colors: active) {
+    .szl-frontier-rail,
+    body.szl-frontier :where(.szl-frontier-card, .szl-frontier-button, .szl-frontier-chip) {
+      border: 1px solid CanvasText;
+    }
+
+    .szl-frontier-rail__mark,
+    body.szl-frontier :where(.szl-frontier-button) {
+      color: ButtonText;
+      background: ButtonFace;
+    }
+  }
+
+  @media print {
+    .szl-frontier-rail { display: none !important; }
+    body.szl-frontier::before,
+    body.szl-frontier::after { display: none; }
+    body.szl-frontier { color: #111; background: #fff; }
+  }
+}

--- a/.github/design/frontier-v1/szl-frontier.js
+++ b/.github/design/frontier-v1/szl-frontier.js
@@ -1,0 +1,192 @@
+/*
+ * SZL Frontier Design Kernel v1.0.0
+ * Copyright 2026 SZL Holdings — SPDX-License-Identifier: Apache-2.0
+ *
+ * Progressive enhancement only: no CDN, eval, analytics, cookies, storage,
+ * network fetch, innerHTML, framework dependency, or mutation authority.
+ */
+(function () {
+  "use strict";
+
+  var VERSION = "1.0.0";
+  var BRANDS = {
+    a11oy: {
+      name: "A11oy",
+      mark: "◈",
+      descriptor: "Governed command fabric",
+      home: "https://a-11-oy.com/"
+    },
+    killinchu: {
+      name: "Killinchu",
+      mark: "▲",
+      descriptor: "Aerial intelligence & defense",
+      home: "https://killinchu.net/"
+    },
+    hatun: {
+      name: "Hatun",
+      mark: "◎",
+      descriptor: "Sovereign orchestration layer",
+      home: "https://a-11-oy.com/wires"
+    }
+  };
+
+  function safeBrand(value) {
+    value = String(value || "").toLowerCase().trim();
+    return Object.prototype.hasOwnProperty.call(BRANDS, value) ? value : "a11oy";
+  }
+
+  function element(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (typeof text === "string") node.textContent = text;
+    return node;
+  }
+
+  function externalLink(label, href, current) {
+    var link = element("a", "szl-frontier-rail__link", label);
+    link.href = href;
+    link.rel = "noopener noreferrer";
+    if (current) {
+      link.setAttribute("aria-current", "page");
+      link.removeAttribute("target");
+    } else {
+      link.target = "_blank";
+    }
+    return link;
+  }
+
+  function buildRail(brandKey) {
+    var brand = BRANDS[brandKey];
+    var rail = element("header", "szl-frontier-rail");
+    rail.id = "szl-frontier-rail";
+    rail.setAttribute("data-szl-frontier-version", VERSION);
+    rail.setAttribute("data-scrolled", "false");
+    rail.setAttribute("aria-label", "SZL ecosystem navigation");
+
+    var inner = element("div", "szl-frontier-rail__inner");
+    var identity = externalLink(brand.name, brand.home, true);
+    identity.className = "szl-frontier-rail__brand";
+
+    var mark = element("span", "szl-frontier-rail__mark", brand.mark);
+    mark.setAttribute("aria-hidden", "true");
+    var brandLabel = element("span", "", brand.name);
+    identity.replaceChildren(mark, brandLabel);
+
+    var descriptor = element(
+      "span",
+      "szl-frontier-rail__descriptor",
+      brand.descriptor
+    );
+
+    var navigation = element("nav", "szl-frontier-rail__nav");
+    navigation.setAttribute("aria-label", "SZL products");
+    Object.keys(BRANDS).forEach(function (key) {
+      navigation.appendChild(
+        externalLink(BRANDS[key].name, BRANDS[key].home, key === brandKey)
+      );
+    });
+
+    var state = element("span", "szl-frontier-chip", "Public surface");
+    state.setAttribute("title", "The page shell loaded. This is not a backend health claim.");
+
+    inner.appendChild(identity);
+    inner.appendChild(descriptor);
+    inner.appendChild(navigation);
+    inner.appendChild(state);
+    rail.appendChild(inner);
+    return rail;
+  }
+
+  function installRevealObserver() {
+    var targets = Array.prototype.slice.call(
+      document.querySelectorAll("[data-szl-frontier-reveal]")
+    );
+    if (!targets.length) return;
+
+    var reduceMotion = false;
+    try {
+      reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    } catch (_error) {
+      reduceMotion = false;
+    }
+
+    if (reduceMotion || !("IntersectionObserver" in window)) {
+      targets.forEach(function (target) {
+        target.setAttribute("data-visible", "true");
+      });
+      return;
+    }
+
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.setAttribute("data-visible", "true");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { rootMargin: "0px 0px -8% 0px", threshold: 0.08 }
+    );
+    targets.forEach(function (target) { observer.observe(target); });
+  }
+
+  function installScrollState(rail) {
+    var queued = false;
+    function update() {
+      rail.setAttribute("data-scrolled", window.scrollY > 8 ? "true" : "false");
+      queued = false;
+    }
+    function onScroll() {
+      if (queued) return;
+      queued = true;
+      window.requestAnimationFrame(update);
+    }
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+  }
+
+  function promoteExplicitComponents() {
+    document.querySelectorAll("[data-szl-card]").forEach(function (node) {
+      node.classList.add("szl-frontier-card");
+    });
+    document.querySelectorAll("[data-szl-button]").forEach(function (node) {
+      node.classList.add("szl-frontier-button");
+    });
+    document.querySelectorAll("[data-szl-button='quiet']").forEach(function (node) {
+      node.classList.add("szl-frontier-button--quiet");
+    });
+  }
+
+  function boot() {
+    if (!document.body) return;
+    var brandKey = safeBrand(document.body.getAttribute("data-szl-frontier"));
+    document.body.setAttribute("data-szl-frontier", brandKey);
+    document.body.classList.add("szl-frontier");
+
+    var rail = document.getElementById("szl-frontier-rail");
+    if (!rail) {
+      rail = buildRail(brandKey);
+      document.body.insertBefore(rail, document.body.firstChild);
+    }
+
+    promoteExplicitComponents();
+    installRevealObserver();
+    installScrollState(rail);
+
+    var detail = Object.freeze({
+      schema: "szl.frontier-design.ready/v1",
+      version: VERSION,
+      brand: brandKey,
+      authority: "PRESENTATION_ONLY"
+    });
+    window.SZL_FRONTIER_DESIGN = detail;
+    document.dispatchEvent(new CustomEvent("szl:frontier-ready", { detail: detail }));
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot, { once: true });
+  } else {
+    boot();
+  }
+})();

--- a/.github/scripts/rollout_frontier_design.py
+++ b/.github/scripts/rollout_frontier_design.py
@@ -1,0 +1,918 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Roll out the reviewed SZL Frontier Design Kernel through protected pull requests.
+
+The operator is intentionally bounded:
+
+* GitHub remains authoritative; no target default branch is pushed directly.
+* Target repositories and entry points are discovered from a reviewed registry.
+* Assets are vendored at the exact organization-design source revision.
+* Existing page content is preserved; only marker-delimited shell hooks are added.
+* Every candidate is validated locally before a branch is pushed.
+* A secret-free receipt records source, targets, files, tests, PRs, and blockers.
+
+The script never changes domains, hosting allocation, billing, secrets, branch
+protection, or runtime data. It does not print authentication material.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+API = "https://api.github.com"
+DEFAULT_ORG = "szl-holdings"
+USER_AGENT = "szl-frontier-design-rollout/1.0"
+TOKEN_KEYS = ("GH_ADMIN_TOKEN", "ORG_ADMIN_TOKEN", "GH_ORG_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+MAX_TREE_BYTES = 8 * 1024 * 1024
+MAX_API_BYTES = 4 * 1024 * 1024
+
+HEAD_START = "<!-- szl-frontier-design:head:v1 -->"
+HEAD_END = "<!-- /szl-frontier-design:head:v1 -->"
+BODY_START = "<!-- szl-frontier-design:body:v1 -->"
+BODY_END = "<!-- /szl-frontier-design:body:v1 -->"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def canonical_sha256(value: Any) -> str:
+    return sha256_bytes(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    )
+
+
+def token_from_environment() -> tuple[str | None, str | None]:
+    for key in TOKEN_KEYS:
+        value = os.environ.get(key, "").strip()
+        if value:
+            return value, key
+    return None, None
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    timeout: int = 180,
+) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        args,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if check and completed.returncode != 0:
+        command = " ".join(args[:3])
+        detail = (completed.stderr or completed.stdout or "command failed").strip()[-1600:]
+        raise RuntimeError(f"{command}: {detail}")
+    return completed
+
+
+class GitHubAPI:
+    def __init__(self, token: str | None) -> None:
+        self.token = token
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        allow_404: bool = False,
+        limit: int = MAX_API_BYTES,
+    ) -> tuple[int, Any]:
+        url = path if path.startswith("https://") else API + path
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": USER_AGENT,
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        body = None
+        if payload is not None:
+            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                raw = response.read(limit + 1)
+                status = int(response.status)
+        except urllib.error.HTTPError as exc:
+            raw = exc.read(min(limit, 256 * 1024))
+            status = int(exc.code)
+            if status == 404 and allow_404:
+                return status, None
+            message = raw.decode("utf-8", "replace")[:1200]
+            raise RuntimeError(f"GitHub {method} {path} returned HTTP {status}: {message}") from exc
+        if len(raw) > limit:
+            raise RuntimeError(f"GitHub response exceeded {limit} bytes: {path}")
+        if not raw:
+            return status, None
+        try:
+            return status, json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            return status, raw.decode("utf-8", "replace")
+
+    def repo(self, full_name: str) -> dict[str, Any] | None:
+        status, payload = self.request("GET", f"/repos/{full_name}", allow_404=True)
+        return payload if status == 200 and isinstance(payload, dict) else None
+
+    def tree(self, full_name: str, ref: str) -> list[str]:
+        encoded = urllib.parse.quote(ref, safe="")
+        status, payload = self.request(
+            "GET",
+            f"/repos/{full_name}/git/trees/{encoded}?recursive=1",
+            limit=MAX_TREE_BYTES,
+        )
+        if status != 200 or not isinstance(payload, dict):
+            raise RuntimeError(f"tree inventory unavailable for {full_name}@{ref}")
+        if payload.get("truncated") is True:
+            raise RuntimeError(f"tree inventory truncated for {full_name}@{ref}; refusing partial discovery")
+        return sorted(
+            str(item.get("path"))
+            for item in payload.get("tree", [])
+            if isinstance(item, dict) and item.get("type") == "blob" and item.get("path")
+        )
+
+    def open_pr(self, full_name: str, branch: str, base: str) -> dict[str, Any] | None:
+        owner = full_name.split("/", 1)[0]
+        query = urllib.parse.urlencode(
+            {"state": "open", "head": f"{owner}:{branch}", "base": base, "per_page": 20}
+        )
+        _, payload = self.request("GET", f"/repos/{full_name}/pulls?{query}")
+        if isinstance(payload, list) and payload:
+            return payload[0] if isinstance(payload[0], dict) else None
+        return None
+
+    def create_pr(
+        self,
+        full_name: str,
+        *,
+        branch: str,
+        base: str,
+        title: str,
+        body: str,
+    ) -> dict[str, Any]:
+        _, payload = self.request(
+            "POST",
+            f"/repos/{full_name}/pulls",
+            {
+                "title": title,
+                "head": branch,
+                "base": base,
+                "body": body,
+                "maintainer_can_modify": True,
+                "draft": False,
+            },
+        )
+        if not isinstance(payload, dict) or not payload.get("number"):
+            raise RuntimeError(f"GitHub did not return a pull request for {full_name}")
+        return payload
+
+    def required_checks(self, full_name: str, branch: str) -> bool:
+        try:
+            status, payload = self.request(
+                "GET", f"/repos/{full_name}/branches/{urllib.parse.quote(branch, safe='')}/protection",
+                allow_404=True,
+            )
+        except RuntimeError:
+            return False
+        if status != 200 or not isinstance(payload, dict):
+            return False
+        checks = payload.get("required_status_checks")
+        if not isinstance(checks, dict):
+            return False
+        return bool(checks.get("contexts") or checks.get("checks"))
+
+    def enable_auto_merge(self, pull_request: dict[str, Any]) -> tuple[bool, str]:
+        node_id = str(pull_request.get("node_id") or "")
+        if not node_id:
+            return False, "pull request node id unavailable"
+        try:
+            _, payload = self.request(
+                "POST",
+                "/graphql",
+                {
+                    "query": (
+                        "mutation($id:ID!){enablePullRequestAutoMerge(input:{"
+                        "pullRequestId:$id,mergeMethod:SQUASH}){pullRequest{number}}}"
+                    ),
+                    "variables": {"id": node_id},
+                },
+            )
+        except RuntimeError as exc:
+            return False, str(exc)[:500]
+        if isinstance(payload, dict) and payload.get("errors"):
+            return False, str(payload["errors"])[:500]
+        return True, "enabled"
+
+
+@dataclass(frozen=True)
+class BrandTarget:
+    brand: str
+    repo: str
+    default_branch: str
+    entrypoints: tuple[str, ...]
+    discovery: str
+
+
+def excluded(path: str, excluded_directories: set[str]) -> bool:
+    parts = Path(path).parts
+    return any(part in excluded_directories for part in parts[:-1])
+
+
+def dynamic_entrypoints(
+    paths: Iterable[str],
+    *,
+    brand: str,
+    excluded_directories: set[str],
+    maximum: int,
+) -> list[str]:
+    scored: list[tuple[int, str]] = []
+    for path in paths:
+        lower = path.lower()
+        if excluded(path, excluded_directories):
+            continue
+        suffix = Path(path).suffix.lower()
+        if suffix not in {".html", ".htm", ".py"}:
+            continue
+        score = 0
+        name = Path(path).name.lower()
+        depth = len(Path(path).parts)
+        if name in {"index.html", "index.htm"}:
+            score += 80
+        if name in {"app.py", "serve.py", "server.py"}:
+            score += 35
+        if brand in lower:
+            score += 100
+        if brand == "killinchu" and "elite" in lower:
+            score += 75
+        if brand == "hatun" and any(token in lower for token in ("wire", "mcp", "orchestrat")):
+            score += 75
+        if brand == "a11oy" and any(token in lower for token in ("console", "home", "landing")):
+            score += 60
+        if lower.startswith(("web/", "pages/", "templates/", "static/", "public/")):
+            score += 20
+        score -= depth * 3
+        if score > 20:
+            scored.append((score, path))
+    scored.sort(key=lambda item: (-item[0], len(item[1]), item[1]))
+    return [path for _, path in scored[:maximum]]
+
+
+def candidate_entrypoints(
+    paths: list[str],
+    config: dict[str, Any],
+    *,
+    brand: str,
+    patch_policy: dict[str, Any],
+    fallback: bool = False,
+) -> list[str]:
+    path_set = set(paths)
+    exact = list(config.get("entrypoint_candidates") or [])
+    if fallback:
+        exact = list((config.get("fallback") or {}).get("entrypoint_candidates") or exact)
+    exact += list(config.get("python_entrypoint_candidates") or [])
+    selected = [path for path in exact if path in path_set]
+    maximum = int(patch_policy.get("maximum_entrypoints_per_brand") or 3)
+    if selected:
+        return selected[:maximum]
+    return dynamic_entrypoints(
+        paths,
+        brand=brand,
+        excluded_directories=set(patch_policy.get("excluded_directories") or []),
+        maximum=maximum,
+    )
+
+
+def resolve_targets(
+    api: GitHubAPI,
+    registry: dict[str, Any],
+    *,
+    organization: str,
+) -> tuple[list[BrandTarget], list[dict[str, Any]]]:
+    resolved: list[BrandTarget] = []
+    blockers: list[dict[str, Any]] = []
+    patch_policy = registry.get("patch_policy") or {}
+    for brand, config_any in (registry.get("brands") or {}).items():
+        config = config_any if isinstance(config_any, dict) else {}
+        chosen: BrandTarget | None = None
+        inspected: list[str] = []
+        for full_name in config.get("repository_candidates") or []:
+            if not str(full_name).startswith(organization + "/"):
+                continue
+            repo = api.repo(str(full_name))
+            if repo is None or bool(repo.get("archived")):
+                continue
+            default = str(repo.get("default_branch") or "main")
+            paths = api.tree(str(full_name), default)
+            entries = candidate_entrypoints(
+                paths, config, brand=brand, patch_policy=patch_policy
+            )
+            inspected.append(f"{full_name}:{len(entries)}")
+            if entries:
+                chosen = BrandTarget(
+                    brand=brand,
+                    repo=str(full_name),
+                    default_branch=default,
+                    entrypoints=tuple(entries),
+                    discovery="dedicated-repository",
+                )
+                break
+        if chosen is None:
+            fallback = config.get("fallback") or {}
+            fallback_repo = str(fallback.get("repository") or "")
+            if fallback_repo.startswith(organization + "/"):
+                repo = api.repo(fallback_repo)
+                if repo is not None and not bool(repo.get("archived")):
+                    default = str(repo.get("default_branch") or "main")
+                    paths = api.tree(fallback_repo, default)
+                    entries = candidate_entrypoints(
+                        paths,
+                        config,
+                        brand=brand,
+                        patch_policy=patch_policy,
+                        fallback=True,
+                    )
+                    inspected.append(f"{fallback_repo}:fallback:{len(entries)}")
+                    if entries:
+                        chosen = BrandTarget(
+                            brand=brand,
+                            repo=fallback_repo,
+                            default_branch=default,
+                            entrypoints=tuple(entries),
+                            discovery="registered-fallback",
+                        )
+        if chosen is None:
+            blockers.append(
+                {
+                    "brand": brand,
+                    "state": "BLOCKED",
+                    "reason": "No non-archived registered repository contained a safe entry point.",
+                    "inspected": inspected,
+                }
+            )
+        else:
+            resolved.append(chosen)
+    return resolved, blockers
+
+
+def strip_marker_block(text: str, start: str, end: str) -> str:
+    pattern = re.compile(re.escape(start) + r".*?" + re.escape(end) + r"\s*", re.DOTALL)
+    return pattern.sub("", text)
+
+
+def patch_body_tag(text: str, brand: str) -> str:
+    pattern = re.compile(r"<body\b(?P<attrs>[^>]*)>", re.IGNORECASE)
+    match = pattern.search(text)
+    if not match:
+        raise ValueError("HTML body tag not found")
+    attrs = match.group("attrs")
+    attrs = re.sub(r"\sdata-szl-frontier\s*=\s*(['\"]).*?\1", "", attrs, flags=re.IGNORECASE)
+    class_match = re.search(r"\sclass\s*=\s*(['\"])(.*?)\1", attrs, flags=re.IGNORECASE | re.DOTALL)
+    if class_match:
+        classes = class_match.group(2).split()
+        if "szl-frontier" not in classes:
+            classes.append("szl-frontier")
+        replacement = f' class="{" ".join(classes)}"'
+        attrs = attrs[: class_match.start()] + replacement + attrs[class_match.end() :]
+    else:
+        attrs += ' class="szl-frontier"'
+    attrs += f' data-szl-frontier="{brand}"'
+    replacement = "<body" + attrs + ">"
+    return text[: match.start()] + replacement + text[match.end() :]
+
+
+def patch_entry(text: str, *, brand: str, css_url: str, js_url: str) -> str:
+    if "</head>" not in text.lower() or "</body>" not in text.lower():
+        raise ValueError("entry point lacks closing head/body tags")
+    text = strip_marker_block(text, HEAD_START, HEAD_END)
+    text = strip_marker_block(text, BODY_START, BODY_END)
+    text = patch_body_tag(text, brand)
+    head_block = (
+        f"\n{HEAD_START}\n"
+        f'<link rel="stylesheet" href="{css_url}" data-szl-frontier-asset="css-v1">\n'
+        f"{HEAD_END}\n"
+    )
+    body_block = (
+        f"\n{BODY_START}\n"
+        f'<script src="{js_url}" defer data-szl-frontier-asset="js-v1"></script>\n'
+        f"{BODY_END}\n"
+    )
+    text = re.sub(r"</head>", head_block + "</head>", text, count=1, flags=re.IGNORECASE)
+    text = re.sub(r"</body>", body_block + "</body>", text, count=1, flags=re.IGNORECASE)
+    return text
+
+
+def choose_asset_location(repo_root: Path, entrypoints: list[str]) -> tuple[Path, str]:
+    if (repo_root / "static").is_dir():
+        return Path("static/szl/frontier-v1"), "/static/szl/frontier-v1"
+    if (repo_root / "public").is_dir():
+        return Path("public/szl/frontier-v1"), "/szl/frontier-v1"
+    if (repo_root / "assets").is_dir():
+        return Path("assets/szl/frontier-v1"), "/assets/szl/frontier-v1"
+    if (repo_root / "web" / "assets").is_dir() or all(path.startswith("web/") for path in entrypoints):
+        return Path("web/assets/szl/frontier-v1"), "/assets/szl/frontier-v1"
+    if any(path.endswith(".py") for path in entrypoints):
+        raise RuntimeError(
+            "Python-rendered entry selected but no static/public/assets root exists; refusing broken asset URLs"
+        )
+    return Path("assets/szl/frontier-v1"), "/assets/szl/frontier-v1"
+
+
+def write_target_test(repo_root: Path, contract_path: Path) -> Path:
+    tests_dir = repo_root / "tests"
+    if tests_dir.is_dir():
+        test_path = tests_dir / "test_szl_frontier_design.py"
+        root_expression = "Path(__file__).resolve().parents[1]"
+    else:
+        test_path = repo_root / "test_szl_frontier_design.py"
+        root_expression = "Path(__file__).resolve().parent"
+    relative_contract = contract_path.relative_to(repo_root).as_posix()
+    test_path.write_text(
+        f'''#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generated network-free contract test for SZL Frontier Design Kernel v1."""
+from __future__ import annotations
+
+import hashlib
+import json
+import unittest
+from pathlib import Path
+
+ROOT = {root_expression}
+CONTRACT = ROOT / {relative_contract!r}
+HEAD = "{HEAD_START}"
+BODY = "{BODY_START}"
+
+
+def contract_value(payload, key):
+    return payload.get(key)
+
+
+class FrontierDesignContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    def test_source_is_exact_and_presentation_only(self) -> None:
+        self.assertEqual(contract_value(self.contract, "schema"), "szl.frontier-design.installation/v1")
+        self.assertRegex(contract_value(self.contract, "source_revision"), r"^[0-9a-f]{{40}}$")
+        self.assertEqual(contract_value(self.contract, "authority"), "PRESENTATION_ONLY")
+        self.assertFalse(bool(self.contract.get("direct_main_push")))
+
+    def test_assets_match_reviewed_digests(self) -> None:
+        for name, record in self.contract["assets"].items():
+            path = ROOT / record["path"]
+            self.assertTrue(path.is_file(), f"missing {{name}} asset: {{path}}")
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            self.assertEqual(digest, record["sha256"])
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("@import url", text)
+            self.assertNotIn("<script src=\"http", text)
+
+    def test_each_entry_is_marker_bound_once(self) -> None:
+        for record in self.contract["entrypoints"]:
+            path = ROOT / record["path"]
+            text = path.read_text(encoding="utf-8")
+            self.assertEqual(text.count(HEAD), 1, path)
+            self.assertEqual(text.count(BODY), 1, path)
+            self.assertIn(f'data-szl-frontier="{{record["brand"]}}"', text)
+            self.assertIn("szl-frontier", text)
+            self.assertIn(record["css_url"], text)
+            self.assertIn(record["js_url"], text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+''',
+        encoding="utf-8",
+    )
+    return test_path
+
+
+def git_environment(token: str, temp_root: Path) -> dict[str, str]:
+    askpass = temp_root / "git-askpass.sh"
+    askpass.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n"
+        "  *Username*) printf '%s\\n' 'x-access-token' ;;\n"
+        "  *) printf '%s\\n' \"$SZL_GH_TOKEN\" ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    askpass.chmod(askpass.stat().st_mode | stat.S_IXUSR)
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_ASKPASS": str(askpass),
+            "GIT_TERMINAL_PROMPT": "0",
+            "SZL_GH_TOKEN": token,
+            "GIT_AUTHOR_NAME": "Stephen P. Lutar",
+            "GIT_AUTHOR_EMAIL": "stephenlutar2@gmail.com",
+            "GIT_COMMITTER_NAME": "Stephen P. Lutar",
+            "GIT_COMMITTER_EMAIL": "stephenlutar2@gmail.com",
+        }
+    )
+    return env
+
+
+def grouped_targets(targets: list[BrandTarget]) -> dict[str, list[BrandTarget]]:
+    grouped: dict[str, list[BrandTarget]] = {}
+    for target in targets:
+        grouped.setdefault(target.repo, []).append(target)
+    return grouped
+
+
+def install_repo(
+    *,
+    api: GitHubAPI,
+    token: str,
+    source_root: Path,
+    source_revision: str,
+    registry: dict[str, Any],
+    repo: str,
+    targets: list[BrandTarget],
+    branch_prefix: str,
+    apply: bool,
+    work_root: Path,
+) -> dict[str, Any]:
+    default_branch = targets[0].default_branch
+    if any(target.default_branch != default_branch for target in targets):
+        raise RuntimeError(f"inconsistent default branches for grouped target {repo}")
+    branch = f"{branch_prefix}-{source_revision[:12]}"
+    existing = api.open_pr(repo, branch, default_branch)
+    if existing is not None:
+        return {
+            "repository": repo,
+            "brands": [target.brand for target in targets],
+            "branch": branch,
+            "state": "EXISTING_PR",
+            "pull_request": {
+                "number": existing.get("number"),
+                "url": existing.get("html_url"),
+            },
+        }
+
+    repo_root = work_root / repo.split("/", 1)[1]
+    env = git_environment(token, work_root)
+    run(
+        [
+            "git",
+            "clone",
+            "--filter=blob:none",
+            "--no-tags",
+            "--branch",
+            default_branch,
+            f"https://github.com/{repo}.git",
+            str(repo_root),
+        ],
+        env=env,
+        timeout=300,
+    )
+    run(["git", "checkout", "-b", branch], cwd=repo_root, env=env)
+
+    all_entries = sorted({path for target in targets for path in target.entrypoints})
+    asset_relative, asset_url = choose_asset_location(repo_root, all_entries)
+    asset_dir = repo_root / asset_relative
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    source_css = source_root / ".github" / "design" / "frontier-v1" / "szl-frontier.css"
+    source_js = source_root / ".github" / "design" / "frontier-v1" / "szl-frontier.js"
+    css_dest = asset_dir / "szl-frontier.css"
+    js_dest = asset_dir / "szl-frontier.js"
+    shutil.copyfile(source_css, css_dest)
+    shutil.copyfile(source_js, js_dest)
+
+    changed_entries: list[dict[str, Any]] = []
+    modified_python: list[str] = []
+    for target in sorted(targets, key=lambda item: item.brand):
+        for entry in target.entrypoints:
+            path = repo_root / entry
+            if not path.is_file():
+                raise RuntimeError(f"discovered entry disappeared after clone: {repo}:{entry}")
+            original = path.read_text(encoding="utf-8")
+            patched = patch_entry(
+                original,
+                brand=target.brand,
+                css_url=asset_url + "/szl-frontier.css",
+                js_url=asset_url + "/szl-frontier.js",
+            )
+            path.write_text(patched, encoding="utf-8")
+            if path.suffix.lower() == ".py":
+                modified_python.append(entry)
+            changed_entries.append(
+                {
+                    "brand": target.brand,
+                    "path": entry,
+                    "discovery": target.discovery,
+                    "css_url": asset_url + "/szl-frontier.css",
+                    "js_url": asset_url + "/szl-frontier.js",
+                }
+            )
+
+    contract_path = repo_root / "design" / "szl-frontier-contract.json"
+    contract_path.parent.mkdir(parents=True, exist_ok=True)
+    contract = {
+        "schema": "szl.frontier-design.installation/v1",
+        "version": registry.get("version"),
+        "source_repository": registry.get("source_repository"),
+        "source_revision": source_revision,
+        "repository": repo,
+        "default_branch": default_branch,
+        "brands": sorted(target.brand for target in targets),
+        "entrypoints": changed_entries,
+        "assets": {
+            "css": {
+                "path": css_dest.relative_to(repo_root).as_posix(),
+                "sha256": sha256_bytes(css_dest.read_bytes()),
+            },
+            "javascript": {
+                "path": js_dest.relative_to(repo_root).as_posix(),
+                "sha256": sha256_bytes(js_dest.read_bytes()),
+            },
+        },
+        "authority": "PRESENTATION_ONLY",
+        "runtime_dependencies": [],
+        "network_fetches": 0,
+        "direct_main_push": False,
+        "delete_existing_content": False,
+        "generated_at": utc_now(),
+    }
+    contract["contract_sha256"] = canonical_sha256(contract)
+    contract_path.write_text(json.dumps(contract, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    test_path = write_target_test(repo_root, contract_path)
+
+    validations: list[dict[str, Any]] = []
+    for command in (
+        [sys.executable, str(test_path.relative_to(repo_root))],
+        ["git", "diff", "--check"],
+    ):
+        result = run(command, cwd=repo_root, env=env)
+        validations.append(
+            {
+                "command": " ".join(command),
+                "status": "PASS",
+                "output": (result.stdout or result.stderr).strip()[-900:],
+            }
+        )
+    if modified_python:
+        command = [sys.executable, "-m", "py_compile", *modified_python]
+        result = run(command, cwd=repo_root, env=env)
+        validations.append(
+            {
+                "command": "python -m py_compile " + " ".join(modified_python),
+                "status": "PASS",
+                "output": (result.stdout or result.stderr).strip()[-900:],
+            }
+        )
+
+    run(["git", "add", "--all"], cwd=repo_root, env=env)
+    status = run(["git", "status", "--porcelain"], cwd=repo_root, env=env)
+    if not status.stdout.strip():
+        return {
+            "repository": repo,
+            "brands": [target.brand for target in targets],
+            "branch": branch,
+            "state": "ALREADY_ALIGNED",
+            "validations": validations,
+        }
+
+    summary = ", ".join(sorted(target.brand for target in targets))
+    run(
+        [
+            "git",
+            "commit",
+            "-m",
+            f"feat(design): install SZL Frontier shell for {summary}",
+            "-m",
+            f"Source-bound to szl-holdings/.github@{source_revision}.",
+            "-m",
+            "Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>",
+        ],
+        cwd=repo_root,
+        env=env,
+    )
+    commit_sha = run(["git", "rev-parse", "HEAD"], cwd=repo_root, env=env).stdout.strip()
+
+    if not apply:
+        return {
+            "repository": repo,
+            "brands": [target.brand for target in targets],
+            "branch": branch,
+            "candidate_commit": commit_sha,
+            "state": "DRY_RUN_VALIDATED",
+            "entrypoints": changed_entries,
+            "assets": contract["assets"],
+            "validations": validations,
+        }
+
+    run(["git", "push", "--set-upstream", "origin", branch], cwd=repo_root, env=env, timeout=300)
+    title = "feat(design): install the SZL Frontier visual system v1"
+    body = (
+        "## Frontier design rollout\n\n"
+        f"Installs the reviewed organization design kernel from `szl-holdings/.github@{source_revision}`.\n\n"
+        f"**Brand adapters:** {summary}.\n\n"
+        "### Contract\n\n"
+        "- one shared spacing, typography, navigation, component, focus, and motion grammar;\n"
+        "- distinct palette and spatial motif for each product;\n"
+        "- progressive enhancement with zero runtime CDN or analytics dependency;\n"
+        "- existing page content preserved; only marker-delimited hooks added;\n"
+        "- mobile, reduced-motion, forced-colors, keyboard-focus, and print behavior included;\n"
+        "- presentation authority only—no API, data, secret, domain, hardware, or billing mutation.\n\n"
+        "### Changed entry points\n\n"
+        + "\n".join(f"- `{row['path']}` → `{row['brand']}`" for row in changed_entries)
+        + "\n\n### Verification\n\n"
+        + "\n".join(f"- `{row['command']}`: **PASS**" for row in validations)
+        + "\n\nSigned-off-by: Stephen Lutar <stephenlutar2@gmail.com>"
+    )
+    pull_request = api.create_pr(
+        repo,
+        branch=branch,
+        base=default_branch,
+        title=title,
+        body=body,
+    )
+    auto_merge = {"enabled": False, "reason": "required checks not detected"}
+    if api.required_checks(repo, default_branch):
+        enabled, reason = api.enable_auto_merge(pull_request)
+        auto_merge = {"enabled": enabled, "reason": reason}
+
+    return {
+        "repository": repo,
+        "brands": [target.brand for target in targets],
+        "default_branch": default_branch,
+        "branch": branch,
+        "candidate_commit": commit_sha,
+        "state": "PR_OPEN",
+        "entrypoints": changed_entries,
+        "assets": contract["assets"],
+        "validations": validations,
+        "pull_request": {
+            "number": pull_request.get("number"),
+            "url": pull_request.get("html_url"),
+            "node_id": pull_request.get("node_id"),
+        },
+        "auto_merge": auto_merge,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true", help="Push candidate branches and open PRs")
+    parser.add_argument("--organization", default=DEFAULT_ORG)
+    parser.add_argument("--branch-prefix", default="design/szl-frontier-v1")
+    parser.add_argument("--receipt", type=Path, default=Path("frontier-design-rollout-receipt.json"))
+    parser.add_argument("--source-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    source_root = args.source_root.resolve()
+    design_root = source_root / ".github" / "design" / "frontier-v1"
+    registry_path = design_root / "brands.json"
+    css_path = design_root / "szl-frontier.css"
+    js_path = design_root / "szl-frontier.js"
+    for required in (registry_path, css_path, js_path):
+        if not required.is_file():
+            raise SystemExit(f"required design artifact missing: {required}")
+
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    source_revision = run(["git", "rev-parse", "HEAD"], cwd=source_root).stdout.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+        raise SystemExit("design source is not an exact Git revision")
+
+    token, token_source = token_from_environment()
+    receipt: dict[str, Any] = {
+        "schema": "szl.frontier-design.rollout-receipt/v1",
+        "generated_at": utc_now(),
+        "apply": bool(args.apply),
+        "organization": args.organization,
+        "source": {
+            "repository": registry.get("source_repository"),
+            "revision": source_revision,
+            "version": registry.get("version"),
+            "css_sha256": sha256_bytes(css_path.read_bytes()),
+            "javascript_sha256": sha256_bytes(js_path.read_bytes()),
+            "registry_sha256": sha256_bytes(registry_path.read_bytes()),
+        },
+        "credential": {"present": bool(token), "source": token_source},
+        "targets": [],
+        "blockers": [],
+        "status": "FAIL",
+    }
+
+    def persist() -> None:
+        receipt["receipt_sha256"] = canonical_sha256(
+            {key: value for key, value in receipt.items() if key != "receipt_sha256"}
+        )
+        args.receipt.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+    if args.apply and not token:
+        receipt["blockers"].append(
+            {
+                "state": "BLOCKED",
+                "reason": "No organization-scoped GitHub credential is available for cross-repository PR creation.",
+            }
+        )
+        persist()
+        return 2
+
+    api = GitHubAPI(token)
+    try:
+        targets, blockers = resolve_targets(api, registry, organization=args.organization)
+        receipt["blockers"].extend(blockers)
+        if not targets:
+            receipt["blockers"].append(
+                {"state": "BLOCKED", "reason": "No registered design target resolved."}
+            )
+            persist()
+            return 2
+
+        if token is None:
+            receipt["blockers"].append(
+                {
+                    "state": "BLOCKED",
+                    "reason": "Repository discovery succeeded, but candidate validation requires authenticated cloning.",
+                }
+            )
+            persist()
+            return 2
+
+        with tempfile.TemporaryDirectory(prefix="szl-frontier-rollout-") as temporary:
+            work_root = Path(temporary)
+            for repo, repo_targets in sorted(grouped_targets(targets).items()):
+                try:
+                    result = install_repo(
+                        api=api,
+                        token=token,
+                        source_root=source_root,
+                        source_revision=source_revision,
+                        registry=registry,
+                        repo=repo,
+                        targets=repo_targets,
+                        branch_prefix=args.branch_prefix,
+                        apply=args.apply,
+                        work_root=work_root,
+                    )
+                    receipt["targets"].append(result)
+                except Exception as exc:
+                    receipt["blockers"].append(
+                        {
+                            "repository": repo,
+                            "brands": [target.brand for target in repo_targets],
+                            "state": "BLOCKED",
+                            "reason": f"{type(exc).__name__}: {exc}"[:1800],
+                        }
+                    )
+    except Exception as exc:
+        receipt["blockers"].append(
+            {"state": "BLOCKED", "reason": f"{type(exc).__name__}: {exc}"[:1800]}
+        )
+
+    successful_states = {"PR_OPEN", "EXISTING_PR", "ALREADY_ALIGNED", "DRY_RUN_VALIDATED"}
+    target_ok = bool(receipt["targets"]) and all(
+        target.get("state") in successful_states for target in receipt["targets"]
+    )
+    receipt["status"] = "PASS" if target_ok and not receipt["blockers"] else "PARTIAL"
+    receipt["completed_at"] = utc_now()
+    persist()
+    print(
+        json.dumps(
+            {
+                "status": receipt["status"],
+                "source_revision": source_revision,
+                "target_count": len(receipt["targets"]),
+                "blocker_count": len(receipt["blockers"]),
+                "receipt": str(args.receipt),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if receipt["status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_frontier_design.py
+++ b/.github/scripts/test_frontier_design.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Network-free regression tests for SZL Frontier Design Kernel v1."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DESIGN = ROOT / ".github" / "design" / "frontier-v1"
+SCRIPT = ROOT / ".github" / "scripts" / "rollout_frontier_design.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "frontier-design-rollout.yml"
+
+_spec = importlib.util.spec_from_file_location("rollout_frontier_design", SCRIPT)
+assert _spec and _spec.loader
+rollout = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rollout)
+
+
+class FrontierKernelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.registry = json.loads((DESIGN / "brands.json").read_text(encoding="utf-8"))
+        cls.css = (DESIGN / "szl-frontier.css").read_text(encoding="utf-8")
+        cls.javascript = (DESIGN / "szl-frontier.js").read_text(encoding="utf-8")
+
+    def test_registry_has_one_shared_kernel_and_three_distinct_adapters(self) -> None:
+        self.assertEqual(self.registry["schema"], "szl.frontier-design.registry/v1")
+        self.assertEqual(self.registry["version"], "1.0.0")
+        self.assertEqual(set(self.registry["brands"]), {"a11oy", "killinchu", "hatun"})
+        motifs = {record["motif"] for record in self.registry["brands"].values()}
+        descriptors = {record["descriptor"] for record in self.registry["brands"].values()}
+        self.assertEqual(len(motifs), 3)
+        self.assertEqual(len(descriptors), 3)
+        self.assertEqual(self.registry["asset_contract"]["network_fetches"], 0)
+        self.assertEqual(self.registry["asset_contract"]["authority"], "PRESENTATION_ONLY")
+
+    def test_css_exposes_shared_components_and_distinct_brand_tokens(self) -> None:
+        for brand in ("a11oy", "killinchu", "hatun"):
+            self.assertEqual(
+                self.css.count(f'body[data-szl-frontier="{brand}"]'),
+                1,
+                brand,
+            )
+        for component in (
+            ".szl-frontier-rail",
+            ".szl-frontier-card",
+            ".szl-frontier-button",
+            ".szl-frontier-chip",
+            ":focus-visible",
+            "prefers-reduced-motion",
+            "forced-colors",
+        ):
+            self.assertIn(component, self.css)
+        self.assertNotIn("@import url", self.css.lower())
+        self.assertNotRegex(self.css, r"https?://")
+
+    def test_javascript_is_progressive_and_presentation_only(self) -> None:
+        for brand in ("a11oy", "killinchu", "hatun"):
+            self.assertIn(f"{brand}:", self.javascript)
+        for required in (
+            "DOMContentLoaded",
+            "IntersectionObserver",
+            "prefers-reduced-motion",
+            "szl:frontier-ready",
+            "PRESENTATION_ONLY",
+        ):
+            self.assertIn(required, self.javascript)
+        for forbidden in (
+            "eval(",
+            "new Function(",
+            ".innerHTML",
+            "document.cookie",
+            "localStorage",
+            "sessionStorage",
+            "fetch(",
+            "XMLHttpRequest",
+        ):
+            self.assertNotIn(forbidden, self.javascript)
+
+    def test_html_patcher_is_marker_bound_and_idempotent(self) -> None:
+        source = "<!doctype html><html><head><title>x</title></head><body class=\"existing\"><main>x</main></body></html>"
+        once = rollout.patch_entry(
+            source,
+            brand="killinchu",
+            css_url="/static/szl/frontier-v1/szl-frontier.css",
+            js_url="/static/szl/frontier-v1/szl-frontier.js",
+        )
+        twice = rollout.patch_entry(
+            once,
+            brand="killinchu",
+            css_url="/static/szl/frontier-v1/szl-frontier.css",
+            js_url="/static/szl/frontier-v1/szl-frontier.js",
+        )
+        self.assertEqual(once, twice)
+        self.assertEqual(once.count(rollout.HEAD_START), 1)
+        self.assertEqual(once.count(rollout.BODY_START), 1)
+        self.assertIn('class="existing szl-frontier"', once)
+        self.assertIn('data-szl-frontier="killinchu"', once)
+        self.assertIn("<main>x</main>", once)
+
+    def test_unknown_or_malformed_pages_fail_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            rollout.patch_entry(
+                "<html><head></head><main>no body</main></html>",
+                brand="hatun",
+                css_url="x.css",
+                js_url="x.js",
+            )
+        with self.assertRaises(ValueError):
+            rollout.patch_entry(
+                "<body></body>",
+                brand="a11oy",
+                css_url="x.css",
+                js_url="x.js",
+            )
+
+    def test_dynamic_discovery_excludes_docs_tests_and_dependencies(self) -> None:
+        selected = rollout.dynamic_entrypoints(
+            [
+                "docs/index.html",
+                "tests/index.html",
+                "node_modules/pkg/index.html",
+                "web/hatun.html",
+                "web/index.html",
+                "server.py",
+            ],
+            brand="hatun",
+            excluded_directories={"docs", "tests", "node_modules"},
+            maximum=3,
+        )
+        self.assertIn("web/hatun.html", selected)
+        self.assertNotIn("docs/index.html", selected)
+        self.assertNotIn("tests/index.html", selected)
+        self.assertNotIn("node_modules/pkg/index.html", selected)
+
+    def test_rollout_never_pushes_a_default_branch(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('branch = f"{branch_prefix}-{source_revision[:12]}"', source)
+        self.assertIn('"direct_main_push": False', source)
+        self.assertNotRegex(source, r"git[^\n]+push[^\n]+origin[^\n]+(?:main|master)[\"']")
+        self.assertIn("git", source)
+        self.assertIn("diff", source)
+        self.assertIn("--check", source)
+        self.assertIn("py_compile", source)
+
+    def test_workflow_is_pinned_and_emits_a_receipt(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch", text)
+        self.assertIn("rollout_frontier_design.py", text)
+        self.assertIn("test_frontier_design.py", text)
+        self.assertIn("frontier-design-rollout-receipt.json", text)
+        self.assertIn("GH_ADMIN_TOKEN", text)
+        for uses_line in re.findall(r"^\s*uses:\s*(.+)$", text, flags=re.MULTILINE):
+            self.assertRegex(uses_line, r"@[0-9a-f]{40}(?:\s|$)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_frontier_design.py
+++ b/.github/scripts/test_frontier_design.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import sys
 import unittest
 from pathlib import Path
 
@@ -17,6 +18,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "frontier-design-rollout.yml"
 _spec = importlib.util.spec_from_file_location("rollout_frontier_design", SCRIPT)
 assert _spec and _spec.loader
 rollout = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = rollout
 _spec.loader.exec_module(rollout)
 
 

--- a/.github/workflows/fix-frontier-kernel-contract-once.yml
+++ b/.github/workflows/fix-frontier-kernel-contract-once.yml
@@ -1,0 +1,76 @@
+name: Fix Frontier kernel contract once
+
+on:
+  push:
+    branches:
+      - feat/frontier-design-kernel-v1-20260903
+    paths:
+      - .github/workflows/fix-frontier-kernel-contract-once.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: fix-frontier-kernel-contract-once
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    steps:
+      - name: Checkout exact candidate branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: feat/frontier-design-kernel-v1-20260903
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Apply measured kernel corrections
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git hash-object .github/design/frontier-v1/szl-frontier.css)" = b8960d2bfc4e5e58fbe97e2c783642a96866ff3b
+          test "$(git hash-object .github/scripts/rollout_frontier_design.py)" = db294f2a5dcb595ae017967b22672587e878d2e0
+          python - <<'PY'
+          from pathlib import Path
+
+          css_path = Path('.github/design/frontier-v1/szl-frontier.css')
+          css = css_path.read_text(encoding='utf-8')
+          for brand in ('killinchu', 'hatun'):
+              old = f'  body[data-szl-frontier="{brand}"]::after {{'
+              new = f'  body.szl-frontier[data-szl-frontier="{brand}"]::after {{'
+              if css.count(old) != 1:
+                  raise SystemExit(f'CSS selector repair target drifted: {brand}')
+              css = css.replace(old, new, 1)
+          css_path.write_text(css, encoding='utf-8')
+
+          script_path = Path('.github/scripts/rollout_frontier_design.py')
+          script = script_path.read_text(encoding='utf-8')
+          old = '    pattern = re.compile(re.escape(start) + r".*?" + re.escape(end) + r"\\s*", re.DOTALL)'
+          new = '    pattern = re.compile(r"(?:[ \\t]*\\r?\\n)?" + re.escape(start) + r".*?" + re.escape(end) + r"[ \\t]*(?:\\r?\\n)?", re.DOTALL)'
+          if script.count(old) != 1:
+              raise SystemExit('marker-strip repair target drifted')
+          script = script.replace(old, new, 1)
+          script_path.write_text(script, encoding='utf-8')
+          PY
+          python -m py_compile .github/scripts/rollout_frontier_design.py
+          python .github/scripts/test_frontier_design.py
+          git rm .github/workflows/fix-frontier-kernel-contract-once.yml
+          git diff --check
+          mapfile -t changed < <(git diff --name-only | sort)
+          test "${#changed[@]}" -eq 3
+          test "${changed[0]}" = .github/design/frontier-v1/szl-frontier.css
+          test "${changed[1]}" = .github/scripts/rollout_frontier_design.py
+          test "${changed[2]}" = .github/workflows/fix-frontier-kernel-contract-once.yml
+
+      - name: Commit clean candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .github/design/frontier-v1/szl-frontier.css .github/scripts/rollout_frontier_design.py .github/workflows/fix-frontier-kernel-contract-once.yml
+          git commit -m 'fix(frontier): make selectors unique and patching idempotent' -m 'Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>'
+          git push origin HEAD:feat/frontier-design-kernel-v1-20260903

--- a/.github/workflows/fix-frontier-kernel-contract-once.yml
+++ b/.github/workflows/fix-frontier-kernel-contract-once.yml
@@ -58,8 +58,8 @@ jobs:
           python -m py_compile .github/scripts/rollout_frontier_design.py
           python .github/scripts/test_frontier_design.py
           git rm .github/workflows/fix-frontier-kernel-contract-once.yml
-          git diff --check
-          mapfile -t changed < <(git diff --name-only | sort)
+          git diff --check HEAD
+          mapfile -t changed < <(git diff --name-only HEAD | sort)
           test "${#changed[@]}" -eq 3
           test "${changed[0]}" = .github/design/frontier-v1/szl-frontier.css
           test "${changed[1]}" = .github/scripts/rollout_frontier_design.py

--- a/.github/workflows/frontier-design-rollout.yml
+++ b/.github/workflows/frontier-design-rollout.yml
@@ -1,0 +1,167 @@
+name: SZL Frontier design rollout
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/design/frontier-v1/**"
+      - ".github/scripts/rollout_frontier_design.py"
+      - ".github/scripts/test_frontier_design.py"
+      - ".github/workflows/frontier-design-rollout.yml"
+      - "docs/FRONTIER_DESIGN_KERNEL.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/design/frontier-v1/**"
+      - ".github/scripts/rollout_frontier_design.py"
+      - ".github/scripts/test_frontier_design.py"
+      - ".github/workflows/frontier-design-rollout.yml"
+      - "docs/FRONTIER_DESIGN_KERNEL.md"
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Open or refresh protected rollout pull requests"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: szl-frontier-design-v1-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  contract:
+    name: Validate shared kernel and protected rollout contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Compile rollout operator
+        run: python -m py_compile .github/scripts/rollout_frontier_design.py
+
+      - name: Run network-free design contracts
+        run: python .github/scripts/test_frontier_design.py
+
+  rollout:
+    name: Vendor exact kernel and open target pull requests
+    needs: contract
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.apply == true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN || secrets.ORG_ADMIN_TOKEN || secrets.GH_ORG_TOKEN || secrets.GH_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
+      RECEIPT: frontier-design-rollout-receipt.json
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact protected-main design source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Assert exact protected-main source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          git fetch --no-tags --depth=1 origin main
+          test "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)"
+
+      - name: Roll out source-bound design candidates
+        id: rollout
+        shell: bash
+        run: |
+          set +e
+          python .github/scripts/rollout_frontier_design.py \
+            --apply \
+            --source-root . \
+            --receipt "$RECEIPT"
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Publish compact job summary
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f "$RECEIPT" ]; then
+            echo '## SZL Frontier design rollout' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '**BLOCKED:** rollout receipt was not produced.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path("frontier-design-rollout-receipt.json").read_text())
+          print("## SZL Frontier design rollout")
+          print()
+          print(f"- Status: **{data.get('status', 'UNKNOWN')}**")
+          print(f"- Source: `{data.get('source', {}).get('revision', 'UNAVAILABLE')}`")
+          print(f"- Target repositories: **{len(data.get('targets', []))}**")
+          print(f"- Blockers: **{len(data.get('blockers', []))}**")
+          for row in data.get("targets", []):
+              pr = row.get("pull_request") or {}
+              url = pr.get("url")
+              suffix = f" — {url}" if url else ""
+              print(f"- `{row.get('repository')}` · {', '.join(row.get('brands', []))} · **{row.get('state')}**{suffix}")
+          for blocker in data.get("blockers", []):
+              print(f"- BLOCKED `{blocker.get('repository') or blocker.get('brand') or 'rollout'}`: {blocker.get('reason')}")
+          PY
+
+      - name: Upload immutable rollout receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: frontier-design-rollout-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.RECEIPT }}
+          if-no-files-found: warn
+          retention-days: 180
+
+      - name: Enforce rollout result
+        shell: bash
+        env:
+          EXIT_CODE: ${{ steps.rollout.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          test -f "$RECEIPT"
+          test "${EXIT_CODE:-2}" = "0"
+          python - <<'PY'
+          import json
+          data = json.load(open("frontier-design-rollout-receipt.json", encoding="utf-8"))
+          assert data.get("status") == "PASS", data
+          assert not data.get("blockers"), data.get("blockers")
+          assert data.get("targets"), data
+          PY

--- a/docs/FRONTIER_DESIGN_KERNEL.md
+++ b/docs/FRONTIER_DESIGN_KERNEL.md
@@ -1,0 +1,112 @@
+# SZL Frontier Design Kernel v1
+
+## Decision
+
+A11oy, Killinchu, and Hatun are one ecosystem, not three unrelated templates and not three recolored copies. They share a single versioned visual grammar while retaining distinct product identities.
+
+| Surface | Role | Distinct identity |
+|---|---|---|
+| A11oy | governed command fabric | graphite, cyan, and restrained gold; alloy-lattice geometry |
+| Killinchu | aerial intelligence and defense | deep navy, electric sky, and condor amber; directional flight lines |
+| Hatun | sovereign orchestration layer | obsidian violet, orchid, and mineral green; radial khipu rings |
+
+## Shared grammar
+
+The kernel standardizes:
+
+- spacing and readable content widths;
+- typography and hierarchy;
+- one compact ecosystem rail;
+- cards, buttons, chips, tables, code surfaces, and form controls;
+- visible keyboard focus and 44-pixel minimum controls;
+- responsive horizontal navigation instead of clipped navigation;
+- reduced-motion, forced-colors, and print behavior;
+- progressive reveal motion that disappears when reduced motion is requested.
+
+It does **not** standardize product-specific information architecture, hero copy, application workflows, data semantics, or operational status language.
+
+## Runtime boundary
+
+The CSS and JavaScript are vendored into each target repository at an exact reviewed Git SHA. They make no network request and contain no CDN, analytics, cookie, local-storage, authentication, API, model, or mutation dependency. The top rail's “Public surface” chip means only that the presentation shell loaded; it is not a backend-health claim.
+
+The JavaScript performs additive progressive enhancement:
+
+1. identifies the declared brand from `data-szl-frontier`;
+2. installs one accessible ecosystem rail if absent;
+3. upgrades only explicitly marked components;
+4. observes explicitly marked reveal elements;
+5. emits `szl:frontier-ready` with `authority: PRESENTATION_ONLY`.
+
+## Source and rollout
+
+Authoritative files:
+
+```text
+.github/design/frontier-v1/brands.json
+.github/design/frontier-v1/szl-frontier.css
+.github/design/frontier-v1/szl-frontier.js
+.github/scripts/rollout_frontier_design.py
+.github/workflows/frontier-design-rollout.yml
+```
+
+Every rollout follows:
+
+```text
+Resolve registered repository
+→ Discover bounded entry points
+→ Clone default branch
+→ Create candidate branch
+→ Vendor exact CSS/JS
+→ Add marker-delimited hooks
+→ Write source-binding contract
+→ Run offline tests and Python compilation
+→ Push candidate branch
+→ Open protected pull request
+→ Merge only through repository governance
+→ Deploy through that repository's existing canonical publisher
+→ Verify the live public surface
+```
+
+The rollout controller never pushes a target default branch, alters branch protection, changes DNS, changes Hugging Face hardware, changes billing, writes runtime data, or exposes a token. Hatun repository discovery is explicit: it checks registered dedicated repositories first and uses the registered A11oy `/wires` source only when no dedicated runnable entry point exists.
+
+## Installation contract
+
+Each target receives:
+
+```text
+design/szl-frontier-contract.json
+<served-asset-root>/szl/frontier-v1/szl-frontier.css
+<served-asset-root>/szl/frontier-v1/szl-frontier.js
+tests/test_szl_frontier_design.py  # or root fallback when no tests directory exists
+```
+
+Page hooks are bounded by these markers:
+
+```html
+<!-- szl-frontier-design:head:v1 -->
+<link rel="stylesheet" href=".../szl-frontier.css" data-szl-frontier-asset="css-v1">
+<!-- /szl-frontier-design:head:v1 -->
+
+<body class="szl-frontier" data-szl-frontier="a11oy|killinchu|hatun">
+
+<!-- szl-frontier-design:body:v1 -->
+<script src=".../szl-frontier.js" defer data-szl-frontier-asset="js-v1"></script>
+<!-- /szl-frontier-design:body:v1 -->
+```
+
+Re-running the patcher replaces its own marker blocks and preserves all other page content.
+
+## Acceptance gates
+
+A candidate is not rollout-ready unless:
+
+- the registry contains exactly the three reviewed brand adapters;
+- the CSS contains all three unique token scopes and the shared accessibility behavior;
+- the JavaScript has no network, storage, cookie, `eval`, or `innerHTML` path;
+- every modified entry point contains exactly one head and body marker;
+- asset bytes match the SHA-256 values in the target contract;
+- `git diff --check` passes;
+- modified Python-rendered pages compile;
+- a protected pull request exists or the target is already aligned.
+
+Live deployment remains the responsibility of each product repository's existing canonical publisher. A merged design PR is not represented as live until its public origin is observed with the expected assets and brand marker.


### PR DESCRIPTION
Closed unmerged after architecture review. The rollout injects a new `szl-frontier-rail` into every selected entry point, which would recreate the stacked-navigation defect already removed from A11oy by `a11oy#1780/#1781` and could override product-native shells in Killinchu and Hatun. The branch also still contains a temporary self-mutating repair workflow and its own rollout contract remains red.

The reusable design principles—shared spacing, accessibility, motion limits, brand-specific tokens, clean-room originality, and 44px controls—remain valid, but they must be consumed as tokens/contracts by each product’s existing shell rather than installed as another global navigation layer. No live source was deleted or rolled back.