### PR TITLE
docs(org): recapture GitHub ↔ Hugging Face alignment

### DIFF
--- a/docs/GITHUB_HF_ALIGNMENT_2026-09-04.md
+++ b/docs/GITHUB_HF_ALIGNMENT_2026-09-04.md
@@ -1,0 +1,64 @@
+# GitHub ↔ Hugging Face alignment — recapture 2026-09-04
+
+**Status:** `SOURCE_MIRROR_RECAPTURE_PUBLISHED`  
+**Captured:** 2026-09-04T18:55:00Z  
+**Evidence class:** MEASURED (counts and HTTP) + REPORTED (classification)  
+**Does not rewrite:** `docs/GITHUB_HF_ALIGNMENT.md` (2026-08-29 snapshot) or a11oy-net frozen Hub inventory.
+
+GitHub org [`szl-holdings`](https://github.com/szl-holdings) is protected source.  
+Hugging Face org [`SZLHOLDINGS`](https://huggingface.co/SZLHOLDINGS) is the public artifact / runtime mirror.
+
+One product, two IMMUNE URLs. Do not delete Channel A or Channel B.
+
+## Measured this pass
+
+| Surface | Count | Source |
+| --- | ---: | --- |
+| GitHub public repos listed | 115 | `gh api orgs/szl-holdings` |
+| GitHub rows returned | 121 | `gh repo list` (incl. private + archived) |
+| GitHub archived | 34 | same |
+| GitHub private observed | 6 | same |
+| Hub models | 44 | `/api/models?author=SZLHOLDINGS` |
+| Hub datasets | 32 | `/api/datasets?author=SZLHOLDINGS` |
+| Hub Spaces public API | 15 | `/api/spaces?author=SZLHOLDINGS` |
+
+## Public Spaces (keep)
+
+| Hub Space | GitHub twin | Product / homepage |
+| --- | --- | --- |
+| [SZLHOLDINGS/immune](https://huggingface.co/spaces/SZLHOLDINGS/immune) | [szl-holdings/immune](https://github.com/szl-holdings/immune) | [a-11-oy.com/immune](https://a-11-oy.com/immune) |
+| [SZLHOLDINGS/immune-lattice](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice) | [szl-holdings/immune](https://github.com/szl-holdings/immune) (canonical). `immune-lattice` repo is ARCHIVED hologram | Channel B COP |
+| [SZLHOLDINGS/a11oy](https://huggingface.co/spaces/SZLHOLDINGS/a11oy) | [szl-holdings/a11oy](https://github.com/szl-holdings/a11oy) | [a-11-oy.com](https://a-11-oy.com) |
+| [SZLHOLDINGS/killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) | [szl-holdings/killinchu](https://github.com/szl-holdings/killinchu) | [a-11-oy.com/killinchu](https://a-11-oy.com/killinchu) |
+| [SZLHOLDINGS/counsel](https://huggingface.co/spaces/SZLHOLDINGS/counsel) | `counsel` GitHub repo ARCHIVED | Space remains public runtime |
+| [SZLHOLDINGS/terra](https://huggingface.co/spaces/SZLHOLDINGS/terra) | vertical-services + szl-real-estate | Space runtime |
+| [SZLHOLDINGS/sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | vertical-services | Space runtime |
+| [SZLHOLDINGS/finance](https://huggingface.co/spaces/SZLHOLDINGS/finance) | vertical-services + szl-quant | Space runtime |
+| [SZLHOLDINGS/lyte](https://huggingface.co/spaces/SZLHOLDINGS/lyte) | [lyte-lattice](https://github.com/szl-holdings/lyte-lattice) | [a-11-oy.com/lyte](https://a-11-oy.com/lyte) |
+| [SZLHOLDINGS/vertical-services](https://huggingface.co/spaces/SZLHOLDINGS/vertical-services) | [vertical-services](https://github.com/szl-holdings/vertical-services) | Hub homepage set this pass |
+| [SZLHOLDINGS/szl-command-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) | [szl-command-lab](https://github.com/szl-holdings/szl-command-lab) | Hub homepage set this pass |
+| [SZLHOLDINGS/david-leads](https://huggingface.co/spaces/SZLHOLDINGS/david-leads) | [david-leads](https://github.com/szl-holdings/david-leads) | already Hub |
+| [SZLHOLDINGS/szl-constellation](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | [szl-constellation](https://github.com/szl-holdings/szl-constellation) | Hub homepage set this pass |
+| [SZLHOLDINGS/szl-frontier](https://huggingface.co/spaces/SZLHOLDINGS/szl-frontier) | [szl-frontier](https://github.com/szl-holdings/szl-frontier) | already Hub |
+| [SZLHOLDINGS/szl-model-inference-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-model-inference-lab) | fold into szl-serve / szl-command-lab | Space runtime |
+
+## Not public product Spaces
+
+HTTP 401 on Hub API this pass. Do not advertise as LIVE.
+
+- `SZLHOLDINGS/nexus` — runtime is IMMUNE Channel A `/nexus.html`
+- `SZLHOLDINGS/anatomy`
+- `SZLHOLDINGS/szl-khipu` — public twin is model [SZL-Khipu-1.5B](https://huggingface.co/SZLHOLDINGS/SZL-Khipu-1.5B)
+- `SZLHOLDINGS/holographic`, `cosmos`, `sda`, `yarqa`, `immune-demo`, `vessels`
+
+## Rule
+
+1. Do not delete `SZLHOLDINGS/immune` or `SZLHOLDINGS/immune-lattice`.
+2. Do not mint a public `SZLHOLDINGS/nexus` Space.
+3. Flagship GitHub homepages stay on a-11-oy.com / a11oy.net when that is the product URL.
+4. Kernel / software twins that lacked a homepage now point at the public Hub model or Space.
+5. Frozen 2026-08-29 and 2026-08-31 inventories stay historical.
+
+Lorenz OP (Channel A = Channel B): input `c5fcc5029392a5e4f7cd65a655d5379cd65d8f915b2ee96a1db5d44e35ea2358` · output `4071a2f2faca744907747cb2cc82a9d841e125fa287240505f9f9a8454a399ac`. Energy UNAVAILABLE. Λ = Conjecture 1 OPEN.
+
+This recapture cannot write the Hub from this operator session (no Hub token). Spaces listed above were already uploaded and RUNNING when measured.

--- a/profile/README.md
+++ b/profile/README.md
@@ -30,13 +30,15 @@ Authority and evidence are validated before action. Runtime stays inside the bou
 - **Product** · [a-11-oy.com](https://a-11-oy.com): Command Center, console, interactive verify
 - **Proof** · [a11oy.net](https://a11oy.net): RECORD, diligence, atlas; not a product host
 - **Source** · [github.com/szl-holdings/a11oy](https://github.com/szl-holdings/a11oy)
-- **Artifacts** · [huggingface.co/SZLHOLDINGS](https://huggingface.co/SZLHOLDINGS): pin a11oy, szl-khipu, szl-atelier, killinchu, and immune
+- **Artifacts** · [huggingface.co/SZLHOLDINGS](https://huggingface.co/SZLHOLDINGS): 15 public Spaces, 44 models, 32 datasets
+- **IMMUNE** · product [a-11-oy.com/immune](https://a-11-oy.com/immune) · Channel A [SZLHOLDINGS/immune](https://huggingface.co/spaces/SZLHOLDINGS/immune) · Channel B [SZLHOLDINGS/immune-lattice](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice) · NEXUS plane lives on Channel A `/nexus.html` — Hub Space `SZLHOLDINGS/nexus` is **not** a public product
+- **Source twins** · [github.com/szl-holdings](https://github.com/szl-holdings) homepages point at the matching Hub card when the twin is public
 
 [a11oy-factory](https://github.com/szl-holdings/a11oy-factory) is a bind, not a second flagship. Killinchu is a public synthetic reference with **SIMULATED** public actuation. The verifier Space points to the product and proof surfaces; it is not a flagship.
 
 ## Portfolio
 
-- **Defense** · [immune](https://github.com/szl-holdings/immune)
+- **Defense** · [immune](https://github.com/szl-holdings/immune) · tab [a-11-oy.com/immune](https://a-11-oy.com/immune) · Lorenz OP MEASURED on Channel A/B hashes `c5fcc502…` / `4071a2f2…`
 - **Finance** · [szl-quant](https://github.com/szl-holdings/szl-quant): paper-only, not financial advice
 - **Real estate** · [szl-real-estate](https://github.com/szl-holdings/szl-real-estate): occupancy **UNAVAILABLE**
 - **Insurance** · **ROADMAP**
@@ -54,7 +56,8 @@ Authority and evidence are validated before action. Runtime stays inside the bou
 
 - [a11oy honest](https://a-11-oy.com/api/a11oy/v1/honest): locked-8, Λ = Conjecture 1, kernel `c7c0ba17`
 - [a11oy.net health.json](https://a11oy.net/health.json): static document, signer unavailable, not DSSE-LIVE
-- Hub: pin five Spaces. Unpin holograms. Do not pin factory. The verifier is a pointer.
+- Hub public Spaces (measured 2026-09-04): `immune`, `immune-lattice`, `a11oy`, `killinchu`, `counsel`, `terra`, `sentra`, `finance`, `lyte`, `vertical-services`, `szl-command-lab`, `david-leads`, `szl-constellation`, `szl-frontier`, `szl-model-inference-lab`. Keep both IMMUNE channels. Do not mint `SZLHOLDINGS/nexus`. `SZLHOLDINGS/anatomy` and `SZLHOLDINGS/szl-khipu` Spaces are **not** public — GitHub `szl-khipu` homepage is the [SZL-Khipu-1.5B](https://huggingface.co/SZLHOLDINGS/SZL-Khipu-1.5B) model.
+- Recapture: [GITHUB_HF_ALIGNMENT_2026-09-04.md](https://github.com/szl-holdings/.github/blob/main/docs/GITHUB_HF_ALIGNMENT_2026-09-04.md)
 
 The dataset [`SZLHOLDINGS/SZLHOLDINGS`](https://huggingface.co/datasets/SZLHOLDINGS/SZLHOLDINGS) is a **HISTORICAL** mirror.
 


### PR DESCRIPTION
## Why
Operator asked GitHub org `szl-holdings` aligned with Hugging Face org `SZLHOLDINGS`, uploaded and published.

## What
- Org profile lists the measured 15 public Spaces and the IMMUNE two-URL doctrine.
- New recapture `docs/GITHUB_HF_ALIGNMENT_2026-09-04.md`. Does **not** rewrite the 2026-08-29 snapshot.
- Does not delete Channel A `SZLHOLDINGS/immune` or Channel B `SZLHOLDINGS/immune-lattice`.
- Does not mint `SZLHOLDINGS/nexus`.

## Metadata already patched (no PR)
GitHub homepages now point at public Hub twins for command-lab, vertical-services, constellation, Khipu-1.5B, YARQA-ATTN, and the kernel model cards that had empty homepages. `szl-khipu` homepage no longer cites the 401 Space.

## Honesty
Energy UNAVAILABLE. Λ = Conjecture 1 OPEN. Lorenz OP hashes `c5fcc502…` / `4071a2f2…`.