### PR TITLE
fix(hf): accept exact-source pre-existing release receipts

### DIFF
--- a/.github/scripts/hf_space_source_binding.py
+++ b/.github/scripts/hf_space_source_binding.py
@@ -33,6 +33,8 @@ import requests
 from huggingface_hub import HfApi
 
 SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+ATTESTATION_ID = re.compile(r"^[0-9]+$")
 VARIABLE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
 REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 REPORT_SCHEMA = "szl.hf-space-source-binding/v1"
@@ -135,6 +137,72 @@ def _probe_headers(binding: Mapping[str, str], attempt: int) -> dict[str, str]:
     }
 
 
+def _reported_receipt_status(
+    payload: Mapping[str, Any], expected_revision: str
+) -> dict[str, Any]:
+    """Validate a read-only receipt observation without requiring absence.
+
+    A GET probe must never mint a receipt, but it may observe a release
+    attestation that the runtime loaded at startup. An asserted receipt is
+    admitted only when it is exact-source bound and has a canonical GitHub
+    OIDC attestation reference.
+    """
+
+    minted = payload.get("receipt_minted")
+    if minted is False:
+        return {
+            "minted": False,
+            "valid": True,
+            "state": "NOT_REPORTED_AS_MINTED",
+        }
+    if minted is not True:
+        return {
+            "minted": minted,
+            "valid": False,
+            "state": "INVALID_RECEIPT_FLAG",
+        }
+
+    receipt = payload.get("release_receipt")
+    if not isinstance(receipt, Mapping):
+        return {
+            "minted": True,
+            "valid": False,
+            "state": "MISSING_RELEASE_RECEIPT",
+        }
+
+    source_revision = str(receipt.get("source_revision") or "").lower()
+    subject = str(receipt.get("subject") or "")
+    digest = str(receipt.get("subject_sha256") or "").lower()
+    attestation_id = str(receipt.get("attestation_id") or "")
+    attestation_url = str(receipt.get("attestation_url") or "")
+    parsed = urlsplit(attestation_url)
+    parts = [part for part in parsed.path.split("/") if part]
+    canonical_url = (
+        parsed.scheme == "https"
+        and parsed.netloc == "github.com"
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.query
+        and not parsed.fragment
+        and len(parts) == 4
+        and parts[2] == "attestations"
+        and parts[3] == attestation_id
+    )
+    valid = (
+        str(receipt.get("state") or "").upper() == "GITHUB_OIDC_ATTESTED"
+        and source_revision == expected_revision
+        and subject == "hf-deploy-manifest.json"
+        and SHA256.fullmatch(digest) is not None
+        and ATTESTATION_ID.fullmatch(attestation_id) is not None
+        and canonical_url
+    )
+    return {
+        "minted": True,
+        "valid": valid,
+        "state": "GITHUB_OIDC_ATTESTED" if valid else "INVALID_RELEASE_RECEIPT",
+    }
+
+
 def _runtime_probe_observation(
     binding: Mapping[str, str],
     *,
@@ -191,17 +259,19 @@ def _runtime_probe_observation(
         return observation
     observed = str(build.get("revision") or "").lower()
     state = str(build.get("state") or "").upper()
-    receipt_minted = payload.get("receipt_minted")
+    receipt = _reported_receipt_status(payload, binding["revision"])
     matched = (
         observed == binding["revision"]
         and state == "OBSERVED"
-        and receipt_minted is False
+        and receipt["valid"] is True
     )
     observation.update(
         {
             "build_state": state,
             "observed_revision": observed,
-            "receipt_minted": receipt_minted,
+            "receipt_minted": receipt["minted"],
+            "receipt_state": receipt["state"],
+            "receipt_valid": receipt["valid"],
             "matched": matched,
         }
     )

--- a/.github/scripts/test_hf_space_source_binding.py
+++ b/.github/scripts/test_hf_space_source_binding.py
@@ -87,12 +87,35 @@ class SourceBindingTests(unittest.TestCase):
         )
 
     @staticmethod
-    def observed_payload(revision: str) -> dict[str, object]:
-        return {
+    def observed_payload(
+        revision: str,
+        *,
+        receipt_minted: bool = False,
+        release_receipt: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
             "status": "OBSERVED",
             "build": {"state": "OBSERVED", "revision": revision},
             "runtime": {"python": "3.12"},
-            "receipt_minted": False,
+            "receipt_minted": receipt_minted,
+        }
+        if release_receipt is not None:
+            payload["release_receipt"] = release_receipt
+        return payload
+
+    def valid_receipt(self, revision: str | None = None) -> dict[str, object]:
+        source_revision = revision or self.sha
+        attestation_id = "123456789"
+        return {
+            "state": "GITHUB_OIDC_ATTESTED",
+            "source_revision": source_revision,
+            "subject": "hf-deploy-manifest.json",
+            "subject_sha256": "c" * 64,
+            "attestation_id": attestation_id,
+            "attestation_url": (
+                "https://github.com/szl-holdings/killinchu/attestations/"
+                + attestation_id
+            ),
         }
 
     def test_normalize_requires_exact_repo_key_sha_and_same_host_path(self):
@@ -151,6 +174,61 @@ class SourceBindingTests(unittest.TestCase):
                 session=FakeSession(FakeResponse(payload)),
                 timeout_seconds=0,
             )
+
+    def test_runtime_probe_accepts_valid_existing_oidc_receipt(self):
+        payload = self.observed_payload(
+            self.sha,
+            receipt_minted=True,
+            release_receipt=self.valid_receipt(),
+        )
+        report = binding.verify_runtime_probe(
+            self.normalized,
+            session=FakeSession(FakeResponse(payload)),
+        )
+        observation = report["observations"][0]
+        self.assertTrue(report["matched"])
+        self.assertTrue(observation["receipt_minted"])
+        self.assertTrue(observation["receipt_valid"])
+        self.assertEqual(observation["receipt_state"], "GITHUB_OIDC_ATTESTED")
+
+    def test_runtime_probe_rejects_unbound_or_malformed_existing_receipt(self):
+        invalid_receipts = [
+            None,
+            self.valid_receipt("b" * 40),
+            {**self.valid_receipt(), "subject_sha256": "short"},
+            {**self.valid_receipt(), "attestation_id": "not-numeric"},
+            {
+                **self.valid_receipt(),
+                "attestation_url": "https://evil.example/attestations/123456789",
+            },
+        ]
+        for receipt in invalid_receipts:
+            with self.subTest(receipt=receipt):
+                payload = self.observed_payload(
+                    self.sha,
+                    receipt_minted=True,
+                    release_receipt=receipt,
+                )
+                with self.assertRaisesRegex(
+                    binding.SourceBindingError, "did not converge"
+                ):
+                    binding.verify_runtime_probe(
+                        self.normalized,
+                        session=FakeSession(FakeResponse(payload)),
+                        timeout_seconds=0,
+                    )
+
+    def test_runtime_probe_rejects_missing_or_non_boolean_receipt_flag(self):
+        for value in (None, "false", 0, 1):
+            with self.subTest(value=value):
+                payload = self.observed_payload(self.sha)
+                payload["receipt_minted"] = value
+                with self.assertRaises(binding.SourceBindingError):
+                    binding.verify_runtime_probe(
+                        self.normalized,
+                        session=FakeSession(FakeResponse(payload)),
+                        timeout_seconds=0,
+                    )
 
     def test_runtime_probe_preserves_caller_query_verbatim(self):
         normalized = binding.normalize_binding(


### PR DESCRIPTION
## Current-main successor

This carries only the source-binding repair from #651 onto protected main after #652 independently fixed the organization profile budget.

## Repair

- preserve the explicit no-receipt state;
- accept a reported existing receipt only when it is `GITHUB_OIDC_ATTESTED`, bound to the expected exact source SHA, names `hf-deploy-manifest.json`, has a lowercase SHA-256 subject digest, has a numeric attestation ID, and uses a canonical query-free GitHub attestation URL;
- reject missing/non-boolean receipt flags and malformed, foreign, or source-drifted receipts;
- record receipt validity/state in the secret-free observation;
- preserve the read-only GET probe: it mints nothing and performs no provider mutation.

## Lineage

- current protected main: `682ea4aa223ed5992be13bde4fdbc2cb0a8445a5`
- candidate commit: `ebffdba7c6916fc7c74ca73317fdf6c06f85a3cc`
- exact source/test blobs from reviewed #651: `79a1f147...` and `4166bd14...`
- current profile from merged #652 is retained byte-for-byte

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>