### PR TITLE
docs(hf): evolve duplicate Space names; keep immune A/B

### DIFF
--- a/docs/HF_SPACES_EVOLVE_2026-09-04.md
+++ b/docs/HF_SPACES_EVOLVE_2026-09-04.md
@@ -25,18 +25,18 @@ Do not mint `SZLHOLDINGS/nexus`. Do not delete Channel A or Channel B.
 | [killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) | Drone-intel organ | Keep. Product tab [a-11-oy.com/killinchu](https://a-11-oy.com/killinchu). |
 | [immune](https://huggingface.co/spaces/SZLHOLDINGS/immune) | Channel A HUD | Keep. One product, this URL. |
 | [immune-lattice](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice) | Channel B COP | Keep. Not a duplicate product. GitHub `immune-lattice` repo stays archived hologram. |
-| [ayllu](https://huggingface.co/spaces/SZLHOLDINGS/ayllu) | Counsel product runtime | Keep. Title should stay **Ayllu**, not a second Counsel flagship. |
-| [counsel](https://huggingface.co/spaces/SZLHOLDINGS/counsel) | Vertical PRISM runtime | Evolve title/README into a pointer at `ayllu`. Do not delete the URL. |
+| [counsel](https://huggingface.co/spaces/SZLHOLDINGS/counsel) | PRISM Counsel legal flagship | Keep title **PRISM Counsel**. Product, not a pointer. |
+| [ayllu](https://huggingface.co/spaces/SZLHOLDINGS/ayllu) | 11-seat council hologram | Evolve title off “Ayllu Counsel”. Point at `counsel` + a-11-oy.com. Do not delete. |
 | [terra](https://huggingface.co/spaces/SZLHOLDINGS/terra) | Land vertical | Keep as child of vertical-services. |
-| [sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | Policy-gate vertical | Keep as child. |
+| [sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | Cyber-intel vertical | Keep. Docs must split SENTRA organ vs this Space. |
 | [finance](https://huggingface.co/spaces/SZLHOLDINGS/finance) | Finance vertical | Keep slug. Display name PURIQ is brand, not a second Space. |
 | [lyte](https://huggingface.co/spaces/SZLHOLDINGS/lyte) | Signal lattice | Keep. Twin [lyte-lattice](https://github.com/szl-holdings/lyte-lattice). |
-| [vertical-services](https://huggingface.co/spaces/SZLHOLDINGS/vertical-services) | Multiplex parent | Keep. Not a duplicate of the four children. |
-| [szl-command-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) | Lab hologram | Evolve: lab, not flagship. Flagship remains `a11oy`. |
+| [vertical-services](https://huggingface.co/spaces/SZLHOLDINGS/vertical-services) | Multiplex fabric | Keep. Not a duplicate of the four children. |
+| [szl-command-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) | Lab hologram | Evolve: pointer/atlas under a11oy. Not flagship. |
 | [david-leads](https://huggingface.co/spaces/SZLHOLDINGS/david-leads) | Lead command | Keep. |
-| [szl-constellation](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Public hologram atlas | Keep as the public map. Runtime error on rebuild is UNAVAILABLE, not LIVE. |
-| [szl-frontier](https://huggingface.co/spaces/SZLHOLDINGS/szl-frontier) | Memory covenant | Keep. |
-| [szl-model-inference-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-model-inference-lab) | Inference lab | Fold narrative into command-lab / atelier. Keep URL. |
+| [szl-constellation](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Atlas hologram | Keep URL. Rebuild/503 is UNAVAILABLE, not LIVE. |
+| [szl-frontier](https://huggingface.co/spaces/SZLHOLDINGS/szl-frontier) | Memory-covenant lab | Evolve: lab, not flagship. |
+| [szl-model-inference-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-model-inference-lab) | Inference lab | Fold narrative into command-lab. Keep URL. |
 
 ## Duplicate-name clusters — evolve, do not wipe
 
@@ -49,8 +49,9 @@ Old consolidation that archives the Hub Space `immune-lattice` is **void**.
 ### 2. Counsel collision
 
 Observed titles: **PRISM Counsel** (`counsel`) and **Ayllu Counsel** (`ayllu`).
-Evolve `counsel` README + card into “PRISM vertical runtime — counsel product lives at `SZLHOLDINGS/ayllu`”.
-Keep both URLs. GitHub `counsel` stays archived.
+`counsel` stays the legal flagship.
+`ayllu` evolves to an 11-seat council hologram pointing at `counsel` and a-11-oy.com.
+Keep both URLs. GitHub `counsel` repo stays archived; Hub Space stays public.
 
 ### 3. Hologram cluster
 
@@ -63,22 +64,24 @@ Nervous lineage for IMMUNE is Channel A + Channel B, not the anatomy Space.
 
 `SZLHOLDINGS/szl-khipu` Space is 401.
 Public artifact is the **model** [SZL-Khipu-1.5B](https://huggingface.co/SZLHOLDINGS/SZL-Khipu-1.5B).
-Do not mint a replacement Space. Homepage of GitHub `szl-khipu` points at the model.
+Do not mint a replacement Space.
 
 ### 5. Command cluster
 
 `a11oy` = product command.
-`szl-command-lab` = lab / energy-honest hologram.
+`szl-command-lab` = lab / energy-honest hologram under a11oy.
 Do not pin both as flagship.
 
-### 6. Energy cluster
+### 6. SENTRA organ vs sentra Space
 
-Collection cards named Energy Attestation Holo / Energy-Attested Inference are not in the public Spaces API.
-Energy class on IMMUNE remains **UNAVAILABLE**. Do not fabricate joules.
+IMMUNE organ SENTRA is admission inside the kernel.
+Hub Space `sentra` is the cyber-intel vertical.
+Same name, different artifacts. Docs must keep them apart.
 
-### 7. Verifier cluster
+### 7. Energy + verifier
 
-`governed-receipt-verifier` is 401. Proof lives on [a11oy.net](https://a11oy.net). Leave the Space as a pointer when it is public again. Do not mint a twin.
+Energy cards are not in the public Spaces API. IMMUNE energy stays **UNAVAILABLE**.
+`governed-receipt-verifier` is 401. Proof lives on [a11oy.net](https://a11oy.net).
 
 ## Placement chosen
 
@@ -99,4 +102,4 @@ No fourth product. No new Hub Space for this thread.
 - energy UNAVAILABLE
 - Λ = Conjecture 1 OPEN
 
-Owner action still required to retitle Hub cards and to open protected Spaces. This file is the public map, not a Hub write token.
+Owner action still required to retitle Hub cards (`ayllu` off “Ayllu Counsel”) and to open protected Spaces. This file is the public map, not a Hub write token.

--- a/docs/HF_SPACES_EVOLVE_2026-09-04.md
+++ b/docs/HF_SPACES_EVOLVE_2026-09-04.md
@@ -1,0 +1,102 @@
+# HF Spaces evolve — 2026-09-04
+
+**Status:** SOURCE_MIRROR_REGISTRY_PUBLISHED  
+**Evidence class:** MEASURED public API + REPORTED org-page titles  
+**Does not rewrite:** frozen 2026-08-31 `public-inventory.json` / `estate.json`  
+**Supersedes:** `docs/HF_SPACES_CONSOLIDATION.md` clause that archives `SZLHOLDINGS/immune-lattice`
+
+Product stays [a-11-oy.com/immune](https://a-11-oy.com/immune).  
+Proof stays [a11oy.net](https://a11oy.net).  
+Do not mint `SZLHOLDINGS/nexus`. Do not delete Channel A or Channel B.
+
+## Measured this pass
+
+| Surface | Count | Source |
+| --- | ---: | --- |
+| Public Spaces via `/api/spaces?author=SZLHOLDINGS` | 16 | Hub public API |
+| New since 2026-09-04 alignment recapture | +1 `ayllu` | same |
+| Hub pages that return 401 | anatomy, szl-khipu, holographic, cosmos, governed-receipt-verifier | anonymous GET |
+
+## Public Spaces (keep running)
+
+| Hub Space | Role | Evolve |
+| --- | --- | --- |
+| [a11oy](https://huggingface.co/spaces/SZLHOLDINGS/a11oy) | Flagship command | Keep. Product is [a-11-oy.com](https://a-11-oy.com). |
+| [killinchu](https://huggingface.co/spaces/SZLHOLDINGS/killinchu) | Drone-intel organ | Keep. Product tab [a-11-oy.com/killinchu](https://a-11-oy.com/killinchu). |
+| [immune](https://huggingface.co/spaces/SZLHOLDINGS/immune) | Channel A HUD | Keep. One product, this URL. |
+| [immune-lattice](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice) | Channel B COP | Keep. Not a duplicate product. GitHub `immune-lattice` repo stays archived hologram. |
+| [ayllu](https://huggingface.co/spaces/SZLHOLDINGS/ayllu) | Counsel product runtime | Keep. Title should stay **Ayllu**, not a second Counsel flagship. |
+| [counsel](https://huggingface.co/spaces/SZLHOLDINGS/counsel) | Vertical PRISM runtime | Evolve title/README into a pointer at `ayllu`. Do not delete the URL. |
+| [terra](https://huggingface.co/spaces/SZLHOLDINGS/terra) | Land vertical | Keep as child of vertical-services. |
+| [sentra](https://huggingface.co/spaces/SZLHOLDINGS/sentra) | Policy-gate vertical | Keep as child. |
+| [finance](https://huggingface.co/spaces/SZLHOLDINGS/finance) | Finance vertical | Keep slug. Display name PURIQ is brand, not a second Space. |
+| [lyte](https://huggingface.co/spaces/SZLHOLDINGS/lyte) | Signal lattice | Keep. Twin [lyte-lattice](https://github.com/szl-holdings/lyte-lattice). |
+| [vertical-services](https://huggingface.co/spaces/SZLHOLDINGS/vertical-services) | Multiplex parent | Keep. Not a duplicate of the four children. |
+| [szl-command-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) | Lab hologram | Evolve: lab, not flagship. Flagship remains `a11oy`. |
+| [david-leads](https://huggingface.co/spaces/SZLHOLDINGS/david-leads) | Lead command | Keep. |
+| [szl-constellation](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Public hologram atlas | Keep as the public map. Runtime error on rebuild is UNAVAILABLE, not LIVE. |
+| [szl-frontier](https://huggingface.co/spaces/SZLHOLDINGS/szl-frontier) | Memory covenant | Keep. |
+| [szl-model-inference-lab](https://huggingface.co/spaces/SZLHOLDINGS/szl-model-inference-lab) | Inference lab | Fold narrative into command-lab / atelier. Keep URL. |
+
+## Duplicate-name clusters — evolve, do not wipe
+
+### 1. IMMUNE pair (not a duplicate)
+
+`immune` and `immune-lattice` are Channel A and Channel B of one product.
+GitHub canonical is [szl-holdings/immune](https://github.com/szl-holdings/immune).
+Old consolidation that archives the Hub Space `immune-lattice` is **void**.
+
+### 2. Counsel collision
+
+Observed titles: **PRISM Counsel** (`counsel`) and **Ayllu Counsel** (`ayllu`).
+Evolve `counsel` README + card into “PRISM vertical runtime — counsel product lives at `SZLHOLDINGS/ayllu`”.
+Keep both URLs. GitHub `counsel` stays archived.
+
+### 3. Hologram cluster
+
+Public: `szl-constellation`.
+401 / not a public product: `anatomy`, `holographic`, `cosmos`.
+Paint those 401s **UNAVAILABLE**. Do not advertise LIVE anatomy.
+Nervous lineage for IMMUNE is Channel A + Channel B, not the anatomy Space.
+
+### 4. Khipu cluster
+
+`SZLHOLDINGS/szl-khipu` Space is 401.
+Public artifact is the **model** [SZL-Khipu-1.5B](https://huggingface.co/SZLHOLDINGS/SZL-Khipu-1.5B).
+Do not mint a replacement Space. Homepage of GitHub `szl-khipu` points at the model.
+
+### 5. Command cluster
+
+`a11oy` = product command.
+`szl-command-lab` = lab / energy-honest hologram.
+Do not pin both as flagship.
+
+### 6. Energy cluster
+
+Collection cards named Energy Attestation Holo / Energy-Attested Inference are not in the public Spaces API.
+Energy class on IMMUNE remains **UNAVAILABLE**. Do not fabricate joules.
+
+### 7. Verifier cluster
+
+`governed-receipt-verifier` is 401. Proof lives on [a11oy.net](https://a11oy.net). Leave the Space as a pointer when it is public again. Do not mint a twin.
+
+## Placement chosen
+
+| Role | Surface |
+| --- | --- |
+| Source | GitHub `szl-holdings/immune` + org `.github` |
+| Product tab | https://a-11-oy.com/immune |
+| Runtime A | https://szlholdings-immune.hf.space |
+| Runtime B | https://szlholdings-immune-lattice.hf.space |
+| Proof | https://a11oy.net |
+
+No fourth product. No new Hub Space for this thread.
+
+## Lorenz OP (unchanged)
+
+- inputHash `c5fcc5029392a5e4f7cd65a655d5379cd65d8f915b2ee96a1db5d44e35ea2358`
+- outputHash `4071a2f2faca744907747cb2cc82a9d841e125fa287240505f9f9a8454a399ac`
+- energy UNAVAILABLE
+- Λ = Conjecture 1 OPEN
+
+Owner action still required to retitle Hub cards and to open protected Spaces. This file is the public map, not a Hub write token.


### PR DESCRIPTION
## Why

Public Hub API now lists **16** Spaces (ayllu landed after the 15-Space alignment recapture). Org/collection cards still show colliding titles and 401 twins.

Stale `docs/HF_SPACES_CONSOLIDATION.md` said to archive `SZLHOLDINGS/immune-lattice`. That clause is void. Channel A and Channel B stay.

## Change

Adds `docs/HF_SPACES_EVOLVE_2026-09-04.md`.

- KEEP pair: `immune` + `immune-lattice`
- KEEP flagships: `a11oy`, `killinchu`, `counsel` (PRISM), `david-leads`
- EVOLVE collision: `ayllu` title off “Ayllu Counsel”; hologram pointing at `counsel`
- EVOLVE labs: `szl-command-lab`, `szl-frontier`, `szl-model-inference-lab` under a11oy
- 401 stays UNAVAILABLE: anatomy, holographic, cosmos, szl-khipu Space, governed-receipt-verifier
- Placement: product [a-11-oy.com/immune](https://a-11-oy.com/immune), proof [a11oy.net](https://a11oy.net)
- No new Hub Space. No Hub write token in this PR.

## Proof

Anonymous `/api/spaces?author=SZLHOLDINGS` = 16. Channel B anatomy stage UNAVAILABLE. Lorenz hashes unchanged.

Signed-off-by: Lutar, Stephen P. <stephenlutar2@gmail.com>