### PR TITLE
docs(org): evening recapture 16 Spaces / 44 models / 33 datasets

### DIFF
--- a/docs/GITHUB_HF_ALIGNMENT_2026-09-04-E.md
+++ b/docs/GITHUB_HF_ALIGNMENT_2026-09-04-E.md
@@ -1,0 +1,27 @@
+# GitHub ↔ Hugging Face alignment — evening recapture 2026-09-04
+
+**Status:** `SOURCE_MIRROR_RECAPTURE_PUBLISHED`
+**Captured:** 2026-09-04T23:37:00Z
+**Evidence class:** MEASURED (Hub public API + live HTTP) + REPORTED (classification)
+**Does not rewrite:** `docs/GITHUB_HF_ALIGNMENT.md` or `docs/GITHUB_HF_ALIGNMENT_2026-09-04.md` (18:55Z).
+
+Product: https://a-11-oy.com
+Proof: https://a11oy.net
+Analog: https://szlholdings-immune.hf.space/nexus.html
+
+Do not mint `SZLHOLDINGS/nexus`. Public product line: a11oy / killinchu / immune.
+
+## Measured this pass
+
+| Surface | Count | Source |
+| --- | ---: | --- |
+| Hub Spaces public API | 16 | GET /api/spaces?author=SZLHOLDINGS&limit=100 |
+| Hub models | 44 | GET /api/models?author=SZLHOLDINGS&limit=100 |
+| Hub datasets | 33 | GET /api/datasets?author=SZLHOLDINGS&limit=100 |
+| Delta vs 18:55Z | +1 Space (ayllu), +1 dataset | same APIs |
+
+Live HTTP 200: a-11-oy.com, a-11-oy.com/immune, a11oy.net, a11oy.net/estate/operational-payload-1/, szlholdings-immune.hf.space/nexus.html, szlholdings-a11oy.hf.space.
+
+Honesty JSON from a-11-oy.com/api/a11oy/v1/honest this pass: organ=a11oy, git_sha=6acc6c7522620b51915373c278d52c7a95ffb3bd, doctrine v11 LOCKED 749/14/163, locked_formula_count=8, lambda=Conjecture 1.
+
+ready=false. winner=null. energy=UNAVAILABLE. Lambda = Conjecture 1 OPEN.


### PR DESCRIPTION
## Why
Live unauth Hub API this pass is 16 public Spaces, 44 models, 33 datasets. The 18:55Z recapture and org profile still say 15 / 32. Ayllu is the +1 Space. Do not rewrite the morning snapshot.

## What
- `docs/GITHUB_HF_ALIGNMENT_2026-09-04-E.md` — evening MEASURED recapture
- Does not mint `SZLHOLDINGS/nexus`
- Does not green Λ
- Energy UNAVAILABLE

## Honesty
ready=false. winner=null. Lambda = Conjecture 1 OPEN. HTTP 200 is reachability, not ATO.

Squash only if green.

Signed-off-by: Lutar, Stephen P <stephenlutar2@gmail.com>