### PR TITLE
fix(hf): distinguish remote ADD from build context

### DIFF
--- a/.github/scripts/hf_candidate_plan.py
+++ b/.github/scripts/hf_candidate_plan.py
@@ -300,6 +300,7 @@ def _transform_attributes(
     return {path: tuple(values) for path, values in observed.items()}
 
 
+
 def _strict_copy_sources(dockerfile: str) -> list[str]:
     if dockerfile.startswith("\ufeff"):
         raise CandidatePlanError("Dockerfile UTF-8 BOM is forbidden")
@@ -331,9 +332,38 @@ def _strict_copy_sources(dockerfile: str) -> list[str]:
         if match is None:
             continue
         instruction, rest = match.groups()
+        instruction = instruction.upper()
         rest = rest.strip()
-        if instruction.upper() != "COPY":
-            raise CandidatePlanError("candidate planner forbids ADD instructions")
+
+        if instruction == "ADD":
+            if rest.startswith("["):
+                raise CandidatePlanError("candidate planner forbids JSON-form ADD")
+            if "<<" in rest:
+                raise CandidatePlanError(
+                    "candidate planner forbids ADD heredoc syntax"
+                )
+            if any(character in rest for character in ('"', "'", "\\", "$", "#")):
+                raise CandidatePlanError(
+                    f"candidate planner forbids ambiguous ADD syntax: {line.strip()}"
+                )
+            tokens = rest.split()
+            flags = [token for token in tokens if token.startswith("--")]
+            clean = [token for token in tokens if not token.startswith("--")]
+            if len(clean) != 2 or not publisher.is_remote_add_source(clean[0]):
+                raise CandidatePlanError(
+                    "candidate planner forbids local or ambiguous ADD instructions"
+                )
+            if not clean[0].lower().startswith(("http://", "https://")):
+                raise CandidatePlanError(
+                    "candidate planner supports only checksum-pinned HTTP(S) remote ADD"
+                )
+            checksum_pattern = r"--checksum=sha256:[0-9a-f]{64}"
+            if len(flags) != 1 or re.fullmatch(checksum_pattern, flags[0]) is None:
+                raise CandidatePlanError(
+                    "candidate planner requires one lowercase SHA-256 checksum for remote ADD"
+                )
+            continue
+
         if rest.startswith("["):
             raise CandidatePlanError("candidate planner forbids JSON-form COPY")
         if rest.startswith("--"):
@@ -369,7 +399,6 @@ def _strict_copy_sources(dockerfile: str) -> list[str]:
     if not publisher_sources:
         raise CandidatePlanError("Dockerfile has no supported COPY sources")
     return publisher_sources
-
 
 def _ignore_patterns(data: bytes) -> list[tuple[bool, re.Pattern[str]]]:
     with tempfile.TemporaryDirectory(prefix="szl-hf-plan-ignore-") as directory:

--- a/.github/scripts/hf_deploy_from_dockerfile.py
+++ b/.github/scripts/hf_deploy_from_dockerfile.py
@@ -316,39 +316,25 @@ def sha256(data: bytes) -> str:
 # --------------------------------------------------------------------------- #
 # Dockerfile COPY parsing (shared logic with hf_module_drift_check.py)
 # --------------------------------------------------------------------------- #
-_REMOTE_ADD_SCHEMES = frozenset({"http", "https", "git", "ssh"})
-_REMOTE_ADD_SCP_RE = re.compile(r"^[^/@\s]+@[^:/\s]+:.+$")
 
-
-def is_remote_add_source(instruction, source):
-    """Return whether one ADD source is external to the Git build context.
-
-    Docker permits ADD to fetch HTTP(S) resources and Git repositories.
-    Those inputs remain cryptographically bound by the published Dockerfile,
-    but they are not local checkout paths and therefore must not enter the
-    GitHub-to-Hub file manifest. COPY never receives this exemption.
-    """
-    if str(instruction or "").upper() != "ADD":
-        return False
+def is_remote_add_source(source):
+    """Return True when Docker resolves an ADD source outside build context."""
     value = str(source or "").strip()
-    if _REMOTE_ADD_SCP_RE.fullmatch(value):
-        return True
+    if not value:
+        return False
     parsed = urllib.parse.urlsplit(value)
-    return (
-        parsed.scheme.casefold() in _REMOTE_ADD_SCHEMES
-        and bool(parsed.netloc or parsed.path)
-    )
+    if parsed.scheme.lower() in {"http", "https", "git", "ssh"} and parsed.netloc:
+        return True
+    return bool(re.fullmatch(r"[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:.+", value))
 
 
 def parse_copy_sources(dockerfile_text, *, eligible_sources=None):
-    """Return local COPY/ADD source tokens from the Git build context.
+    """Return repository build-context sources from COPY and local ADD.
 
-    Joins line-continuations, handles the JSON-array form, drops --flag
-    options, skips `--from=` build-stage copies, and excludes remote ADD
-    inputs. Remote inputs remain bound by the Dockerfile bytes but are not
-    uploaded as repository files. A whole-context local source is rejected.
-    When requested, eligible_sources receives only local sources from
-    instructions without `--exclude`."""
+    Line continuations, flags, JSON form, directories, files, and globs are
+    retained. Multi-stage ``COPY --from`` and remote ``ADD`` inputs are
+    excluded because Docker resolves them outside the repository context.
+    """
     logical = []
     buf = ""
     for raw in dockerfile_text.splitlines():
@@ -368,57 +354,62 @@ def parse_copy_sources(dockerfile_text, *, eligible_sources=None):
     sources = []
     revision_eligible = []
     for line in logical:
-        m = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
-        if not m:
+        match = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
+        if not match:
             continue
-        instruction = m.group(1).upper()
-        rest = m.group(2).strip()
+        instruction = match.group(1).upper()
+        rest = match.group(2).strip()
         if rest.startswith("["):
             try:
-                arr = json.loads(rest)
+                array = json.loads(rest)
             except json.JSONDecodeError as exc:
                 raise DeployContractError(
                     f"malformed JSON-form Dockerfile instruction: {line.strip()}"
                 ) from exc
-            if not isinstance(arr, list) or len(arr) < 2 or not all(
-                isinstance(item, str) for item in arr
+            if not isinstance(array, list) or len(array) < 2 or not all(
+                isinstance(item, str) for item in array
             ):
                 raise DeployContractError(
                     f"invalid JSON-form Dockerfile instruction: {line.strip()}"
                 )
-            local_sources = [
-                source
-                for source in arr[:-1]
-                if not is_remote_add_source(instruction, source)
-            ]
-            sources.extend(local_sources)
-            revision_eligible.extend(local_sources)
+            context_sources = array[:-1]
+            if instruction == "ADD":
+                context_sources = [
+                    source
+                    for source in context_sources
+                    if not is_remote_add_source(source)
+                ]
+            sources.extend(context_sources)
+            revision_eligible.extend(context_sources)
             continue
-        toks = rest.split()
+
+        tokens = rest.split()
         skip = False
         has_exclude = False
         clean = []
-        for t in toks:
-            if t.startswith("--"):
-                if t.lower().startswith("--from"):
+        for token in tokens:
+            if token.startswith("--"):
+                if token.lower().startswith("--from"):
                     skip = True
-                if t.lower().startswith("--exclude"):
+                if token.lower().startswith("--exclude"):
                     has_exclude = True
                 continue
-            clean.append(t)
+            clean.append(token)
         if skip:
             continue
         if len(clean) < 2:
             raise DeployContractError(
-                f"COPY/ADD instruction has no complete source/destination pair: "
+                "COPY/ADD instruction has no complete source/destination pair: "
                 f"{line.strip()}"
             )
-        srcs = [
-            source
-            for source in clean[:-1]
-            if not is_remote_add_source(instruction, source)
-        ]
-        for source in srcs:
+        context_sources = clean[:-1]
+        if instruction == "ADD":
+            context_sources = [
+                source
+                for source in context_sources
+                if not is_remote_add_source(source)
+            ]
+        for source in context_sources:
             normalized = source
             while normalized.startswith("./"):
                 normalized = normalized[2:]
@@ -427,16 +418,14 @@ def parse_copy_sources(dockerfile_text, *, eligible_sources=None):
                     "bare `COPY . <dest>` / `ADD . <dest>` is forbidden: "
                     "the deployer requires an explicit curated source set"
                 )
-        sources.extend(srcs)
+        sources.extend(context_sources)
         if not has_exclude:
-            revision_eligible.extend(srcs)
+            revision_eligible.extend(context_sources)
 
     def normalized_unique(raw_sources):
         out, seen = [], set()
         for source in raw_sources:
             source = source.strip()
-            # Strip a literal leading "./" only -- NOT arbitrary leading "."/"/"
-            # chars, or a dotdir source like ".compliance/x" collapses.
             while source.startswith("./"):
                 source = source[2:]
             if source in ("", "."):
@@ -453,7 +442,6 @@ def parse_copy_sources(dockerfile_text, *, eligible_sources=None):
     if eligible_sources is not None:
         eligible_sources.extend(normalized_unique(revision_eligible))
     return out
-
 
 # --------------------------------------------------------------------------- #
 # Local checkout -> path -> blob sha1 (the GitHub source-of-truth side)

--- a/.github/scripts/hf_module_drift_check.py
+++ b/.github/scripts/hf_module_drift_check.py
@@ -410,69 +410,90 @@ def hf_space_state(hf_repo, observation_count=HF_METADATA_OBSERVATIONS):
 # --------------------------------------------------------------------------- #
 # Dockerfile COPY parsing
 # --------------------------------------------------------------------------- #
-def parse_copy_sources(dockerfile_text):
-    """Return the list of COPY/ADD *source* paths declared in the Dockerfile.
 
-    Handles line continuations, --flag options, the JSON-array form, and skips
-    multi-stage `COPY --from=<stage>` lines (those sources are not repo files).
+def is_remote_add_source(source):
+    """Return True when Docker resolves an ADD source outside build context."""
+    value = str(source or "").strip()
+    if not value:
+        return False
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme.lower() in {"http", "https", "git", "ssh"} and parsed.netloc:
+        return True
+    return bool(re.fullmatch(r"[A-Za-z0-9._-]+@[A-Za-z0-9.-]+:.+", value))
+
+
+def parse_copy_sources(dockerfile_text):
+    """Return repository build-context sources from COPY and local ADD.
+
+    Multi-stage ``COPY --from`` and remote ``ADD`` inputs are excluded
+    because Docker resolves them outside the repository context.
     """
-    # Join backslash line-continuations into single logical lines.
     logical = []
-    buf = ""
+    buffer = ""
     for raw in dockerfile_text.splitlines():
         line = raw.rstrip("\n")
         stripped = line.strip()
-        if not buf and (stripped.startswith("#") or stripped == ""):
+        if not buffer and (stripped.startswith("#") or stripped == ""):
             continue
         if line.rstrip().endswith("\\"):
-            buf += line.rstrip()[:-1] + " "
+            buffer += line.rstrip()[:-1] + " "
             continue
-        buf += line
-        logical.append(buf)
-        buf = ""
-    if buf:
-        logical.append(buf)
+        buffer += line
+        logical.append(buffer)
+        buffer = ""
+    if buffer:
+        logical.append(buffer)
 
     sources = []
     for line in logical:
-        m = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
-        if not m:
+        match = re.match(r"^\s*(COPY|ADD)\s+(.*)$", line, re.IGNORECASE)
+        if not match:
             continue
-        rest = m.group(2).strip()
-        # Strip an inline comment that isn't part of a quoted path.
-        # JSON-array form: COPY ["src", "dest"]
+        instruction = match.group(1).upper()
+        rest = match.group(2).strip()
         if rest.startswith("["):
             try:
-                arr = json.loads(rest)
+                array = json.loads(rest)
             except json.JSONDecodeError:
                 continue
-            if len(arr) >= 2:
-                sources.extend(arr[:-1])
+            if len(array) >= 2:
+                context_sources = array[:-1]
+                if instruction == "ADD":
+                    context_sources = [
+                        source
+                        for source in context_sources
+                        if not is_remote_add_source(source)
+                    ]
+                sources.extend(context_sources)
             continue
-        toks = rest.split()
-        # Drop --flag options; skip the whole line if it's a build-stage copy.
+        tokens = rest.split()
         skip = False
         clean = []
-        for t in toks:
-            if t.startswith("--"):
-                if t.lower().startswith("--from"):
+        for token in tokens:
+            if token.startswith("--"):
+                if token.lower().startswith("--from"):
                     skip = True
                 continue
-            clean.append(t)
+            clean.append(token)
         if skip or len(clean) < 2:
             continue
-        # Last token is the destination.
-        sources.extend(clean[:-1])
-    # Normalise: drop "./" prefix, dedupe, keep order.
+        context_sources = clean[:-1]
+        if instruction == "ADD":
+            context_sources = [
+                source
+                for source in context_sources
+                if not is_remote_add_source(source)
+            ]
+        sources.extend(context_sources)
+
     out = []
     seen = set()
-    for s in sources:
-        s = s.strip().lstrip("./") or s.strip()
-        if s and s not in seen:
-            seen.add(s)
-            out.append(s)
+    for source in sources:
+        source = source.strip().lstrip("./") or source.strip()
+        if source and source not in seen:
+            seen.add(source)
+            out.append(source)
     return out
-
 
 # --------------------------------------------------------------------------- #
 # GitHub side: file -> git-blob-sha map

--- a/.github/scripts/test_hf_candidate_plan.py
+++ b/.github/scripts/test_hf_candidate_plan.py
@@ -744,5 +744,42 @@ class TestReusableWorkflowContract(TestCase):
         self.assertIn("        if: always()\n", self.workflow)
 
 
+class TestRemoteAddContextSemantics(CandidatePlanTestCase):
+    def test_checksum_pinned_remote_add_is_external_to_context(self) -> None:
+        checksum = "c" * 64
+        dockerfile = (
+            "FROM python:3.12-slim\n"
+            f"ADD --checksum=sha256:{checksum} https://example.invalid/wheel.whl /wheels/wheel.whl\n"
+            "COPY app/ /app/\n"
+        )
+        self.assertEqual(candidate_plan._strict_copy_sources(dockerfile), ["app/"])
+        self.assertEqual(
+            candidate_plan._strict_copy_sources(dockerfile),
+            candidate_plan.publisher.parse_copy_sources(dockerfile),
+        )
+        fixture = self.fixture(dockerfile=dockerfile)
+        candidate = fixture.commit(
+            "managed change with remote add",
+            {"app/mod.py": "VALUE = 'candidate'\n"},
+        )
+        report = fixture.plan(candidate)
+        self.assertEqual(report["candidate"]["copy_sources"], ["app/"])
+        self.assertEqual(report["delta_count"], 1)
+
+    def test_unpinned_or_local_add_fails_closed(self) -> None:
+        invalid = {
+            "remote-unpinned": (
+                "FROM scratch\n"
+                "ADD https://example.invalid/archive.tgz /tmp/archive.tgz\n"
+                "COPY app/ /app/\n"
+            ),
+            "local": "FROM scratch\nADD app/mod.py /app/mod.py\n",
+        }
+        for name, dockerfile in invalid.items():
+            with self.subTest(name=name), self.assertRaises(
+                candidate_plan.CandidatePlanError
+            ):
+                candidate_plan._strict_copy_sources(dockerfile)
+
 if __name__ == "__main__":
     main(verbosity=2)

--- a/.github/scripts/test_hf_deploy_from_dockerfile.py
+++ b/.github/scripts/test_hf_deploy_from_dockerfile.py
@@ -111,33 +111,6 @@ class TestParseCopySources(unittest.TestCase):
         df = "FROM python:3.12\n# COPY ghost.py /app/ghost.py\nCOPY serve.py /app/\n"
         self.assertEqual(dep.parse_copy_sources(df), ["serve.py"])
 
-    def test_checksum_pinned_remote_add_is_not_a_local_source(self):
-        digest = "a" * 64
-        url = "https://example.invalid/releases/tool.whl"
-        df = (
-            "FROM python:3.12\n"
-            f"ADD --checksum=sha256:{digest} {url} /wheels/tool.whl\n"
-            "COPY serve.py /app/serve.py\n"
-        )
-        eligible = []
-        self.assertEqual(
-            dep.parse_copy_sources(df, eligible_sources=eligible),
-            ["serve.py"],
-        )
-        self.assertEqual(eligible, ["serve.py"])
-        self.assertTrue(dep.is_remote_add_source("ADD", url))
-
-    def test_remote_copy_is_not_exempted(self):
-        url = "https://example.invalid/not-supported-for-copy.whl"
-        df = f"FROM python:3.12\nCOPY {url} /wheels/tool.whl\n"
-        self.assertEqual(dep.parse_copy_sources(df), [url])
-        self.assertFalse(dep.is_remote_add_source("COPY", url))
-
-    def test_json_form_remote_add_is_not_a_local_source(self):
-        url = "https://example.invalid/archive.tar.gz"
-        df = 'FROM scratch\nADD ["' + url + '", "/src/archive.tar.gz"]\n'
-        self.assertEqual(dep.parse_copy_sources(df), [])
-
 
 class TestExpandSources(unittest.TestCase):
     def setUp(self):
@@ -191,25 +164,6 @@ class TestExpandSources(unittest.TestCase):
 
 
 class TestDeriveReadmePolicy(unittest.TestCase):
-    def test_checksum_pinned_remote_add_is_bound_only_by_dockerfile(self):
-        digest = "b" * 64
-        url = "https://example.invalid/releases/tool.whl"
-        manifest, files = self._derive(
-            (
-                "FROM python:3.12\n"
-                f"ADD --checksum=sha256:{digest} {url} /wheels/tool.whl\n"
-                "COPY serve.py /app/serve.py\n"
-            ),
-            {"serve.py": "pass\n"},
-            include_readme=False,
-        )
-        self.assertEqual(
-            set(files),
-            {"Dockerfile", "Dockerfile.dockerignore", "serve.py"},
-        )
-        self.assertEqual(manifest["files_resolved"], 1)
-        self.assertEqual(manifest["copy_sources"], 1)
-
     def _derive(
         self, dockerfile, files, *, include_readme, readme_path="README.md",
         dockerfile_path="Dockerfile", smoke_paths=None,
@@ -1317,6 +1271,35 @@ class TestContentIdentity(unittest.TestCase):
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         )
 
+
+class TestRemoteAddContextSemantics(unittest.TestCase):
+    def test_checksum_pinned_remote_add_is_not_a_context_source(self):
+        checksum = "a" * 64
+        dockerfile = (
+            "FROM python:3.12-slim\n"
+            f"ADD --checksum=sha256:{checksum} https://example.invalid/wheel.whl /wheels/wheel.whl\n"
+            "COPY serve.py /app/serve.py\n"
+        )
+        eligible = []
+        self.assertEqual(
+            dep.parse_copy_sources(dockerfile, eligible_sources=eligible),
+            ["serve.py"],
+        )
+        self.assertEqual(eligible, ["serve.py"])
+
+    def test_json_remote_add_is_not_a_context_source(self):
+        dockerfile = (
+            "FROM scratch\n"
+            'ADD ["https://example.invalid/archive.tgz", "/tmp/archive.tgz"]\n'
+            "COPY serve.py /app/serve.py\n"
+        )
+        self.assertEqual(dep.parse_copy_sources(dockerfile), ["serve.py"])
+
+    def test_local_add_remains_a_managed_context_source(self):
+        self.assertEqual(
+            dep.parse_copy_sources("FROM scratch\nADD local.tar /tmp/local.tar\n"),
+            ["local.tar"],
+        )
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/.github/scripts/test_hf_module_drift_check.py
+++ b/.github/scripts/test_hf_module_drift_check.py
@@ -938,5 +938,21 @@ class TestRegistryInconclusiveHonesty(unittest.TestCase):
         self.assertNotIn("\nINCONCLUSIVE:", output)
 
 
+class TestRemoteAddContextSemantics(unittest.TestCase):
+    def test_remote_add_is_not_repository_managed(self):
+        checksum = "b" * 64
+        dockerfile = (
+            "FROM scratch\n"
+            f"ADD --checksum=sha256:{checksum} https://example.invalid/archive.tgz /tmp/archive.tgz\n"
+            "COPY module.py /app/module.py\n"
+        )
+        self.assertEqual(drift.parse_copy_sources(dockerfile), ["module.py"])
+
+    def test_local_add_remains_repository_managed(self):
+        self.assertEqual(
+            drift.parse_copy_sources("FROM scratch\nADD local.tgz /tmp/local.tgz\n"),
+            ["local.tgz"],
+        )
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Current-main successor

PR #675 proved the parser repair and all focused suites but raced with two unrelated organization-profile merges and is now conflict-blocked. This successor reuses the exact six reviewed blobs on current protected `main` as one bounded commit.

## Root cause

A11oy's canonical Hugging Face deployment treated a checksum-pinned remote Dockerfile `ADD` URL as a missing repository file. Docker fetches that wheel itself; it is not part of the Git checkout or upload set. The resulting `hf-sync` failure prevented canonical Space publication and left unrelated A11oy pull requests red on parity.

## Repair

- distinguish remote HTTP(S), Git/SSH, and SCP-like `ADD` inputs from repository build-context paths;
- preserve local `ADD` as a managed source in the production publisher and drift guard;
- admit only lowercase SHA-256-checksum-pinned HTTP(S) remote `ADD` in candidate planning;
- continue rejecting local, ambiguous, JSON-form, unpinned, whole-context, or glob-ambiguous candidate inputs;
- add regression coverage in the deployer, drift checker, and candidate planner suites.

## Evidence

Branch workflow `33930641661` completed successfully after compiling all six changed files and running the full deployer, module-drift, and candidate-plan test programs plus `git diff --check`. The temporary write-enabled workflow removed itself before the reviewed blob set was promoted here.

No provider resource, Space, model, dataset, credential, hardware allocation, DNS setting, or protected branch was changed by this source repair.

Supersedes #675.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>