### PR TITLE
fix(estate): record Terra presentation publisher honestly

### DIFF
--- a/.github/scripts/run_holographic_spaces_v2.py
+++ b/.github/scripts/run_holographic_spaces_v2.py
@@ -75,13 +75,20 @@ def _fixed_streamlit_adapter(content: str, slug: str) -> str:
 
 core.adapt_streamlit = _fixed_streamlit_adapter
 
-# Install the additive responsive refresh before the target-repository gate so
-# already-bound repositories are promoted back into a reviewable v3 plan.
+# Install the additive responsive refresh before the source-authority and target
+# contracts so publisher-managed surfaces cannot be converted back into guessed
+# product-repository edits by an inner adapter.
 responsive = load_module(
     "szl_responsive_space_contract",
     HERE / "responsive_space_contract.py",
 )
 responsive.install(core)
+
+authority = load_module(
+    "szl_source_authority_contract",
+    HERE / "source_authority_contract.py",
+)
+authority.install(core)
 
 targets = load_module(
     "szl_holographic_target_contract",

--- a/.github/scripts/source_authority_contract.py
+++ b/.github/scripts/source_authority_contract.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Bind rollout automation to the reviewed Space presentation authority.
+
+The base rollout controller intentionally excludes central repositories from
+heuristic matching. This extension preserves that safety boundary while making
+the protected local source map truly authoritative: an explicit mapping is
+resolved exactly, never replaced by a heuristic fallback, and generated
+publisher surfaces are recorded as publisher-managed instead of receiving a
+guessed frontend edit in a product repository.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+PUBLISHER_MANAGED_STATUS = "publisher-managed"
+PUBLISHER_OWNERSHIP = "publisher-generated-flagship"
+CORE_MANAGED_SPACES = frozenset({"a11oy"})
+
+
+def _active_repository(repo: Mapping[str, Any]) -> bool:
+    return not any(
+        (
+            repo.get("archived"),
+            repo.get("disabled"),
+            repo.get("fork"),
+        )
+    )
+
+
+def _source_entries(core: Any) -> dict[str, dict[str, Any]]:
+    path = Path(core.LOCAL_SOURCE_MAP)
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema") != "szl.public-space-source-map/v1":
+        raise core.RolloutError(
+            "LOCAL_SOURCE_MAP_SCHEMA_INVALID",
+            str(payload.get("schema")),
+        )
+    values = payload.get("sources")
+    if not isinstance(values, list):
+        raise core.RolloutError(
+            "LOCAL_SOURCE_MAP_INVALID",
+            "sources must be a list",
+        )
+
+    entries: dict[str, dict[str, Any]] = {}
+    for item in values:
+        if not isinstance(item, dict):
+            raise core.RolloutError(
+                "LOCAL_SOURCE_MAP_INVALID",
+                "source entries must be objects",
+            )
+        slug = core._space_slug(item.get("space"))
+        repo = core._canonical_repo(item.get("repo"))
+        if not slug or not repo:
+            raise core.RolloutError(
+                "LOCAL_SOURCE_MAP_INVALID",
+                json.dumps(item, sort_keys=True),
+            )
+        normalized = dict(item)
+        normalized["space"] = slug
+        normalized["repo"] = repo
+        previous = entries.get(slug)
+        if previous and previous != normalized:
+            raise core.RolloutError("LOCAL_SOURCE_MAP_CONFLICT", slug)
+        entries[slug] = normalized
+    return entries
+
+
+def _append_group(
+    grouped: dict[str, tuple[list[Any], int, str]],
+    repository: str,
+    space: Any,
+    score: int,
+    reason: str,
+) -> None:
+    current = grouped.get(repository)
+    if current:
+        spaces, previous_score, previous_reason = current
+        spaces.append(space)
+        grouped[repository] = (
+            spaces,
+            max(previous_score, score),
+            previous_reason + "; " + reason,
+        )
+    else:
+        grouped[repository] = ([space], score, reason)
+
+
+def install(core: Any) -> None:
+    """Install exact source-authority resolution and publisher boundaries once."""
+    if getattr(core, "_szl_source_authority_contract_installed", False):
+        return
+
+    original_group_mappings = core.group_mappings
+    original_plan_repository = core.plan_repository
+
+    def group_mappings(
+        spaces: Sequence[Any],
+        repos: list[dict[str, Any]],
+        explicit: Mapping[str, str],
+    ) -> tuple[
+        dict[str, tuple[list[Any], int, str]],
+        list[dict[str, Any]],
+    ]:
+        exact_spaces: list[Any] = []
+        heuristic_spaces: list[Any] = []
+        unmapped: list[dict[str, Any]] = []
+
+        for space in spaces:
+            slug = core.normalize(space.slug)
+            if slug in CORE_MANAGED_SPACES:
+                unmapped.append(
+                    {
+                        "slug": space.slug,
+                        "sdk": space.sdk,
+                        "stage": space.stage,
+                        "reason": (
+                            "core product Space is managed outside the vertical "
+                            "rollout controller"
+                        ),
+                    }
+                )
+            elif explicit.get(slug):
+                exact_spaces.append(space)
+            else:
+                heuristic_spaces.append(space)
+
+        grouped, heuristic_unmapped = original_group_mappings(
+            heuristic_spaces,
+            repos,
+            explicit,
+        )
+        unmapped.extend(heuristic_unmapped)
+
+        available = {
+            str(repo.get("full_name") or ""): repo
+            for repo in repos
+            if _active_repository(repo) and repo.get("full_name")
+        }
+        for space in exact_spaces:
+            slug = core.normalize(space.slug)
+            repository = str(explicit[slug])
+            repo = available.get(repository)
+            if repo is None:
+                unmapped.append(
+                    {
+                        "slug": space.slug,
+                        "sdk": space.sdk,
+                        "stage": space.stage,
+                        "reason": (
+                            "declared source repository is unavailable; "
+                            "heuristic fallback is forbidden"
+                        ),
+                        "declared_repository": repository,
+                    }
+                )
+                continue
+            score, reason = core.mapping_score(space, repo, explicit)
+            if score != 1000:
+                raise core.RolloutError(
+                    "LOCAL_SOURCE_MAP_NOT_AUTHORITATIVE",
+                    f"{space.slug} did not receive the canonical mapping score",
+                )
+            _append_group(grouped, repository, space, score, reason)
+        return grouped, unmapped
+
+    core.group_mappings = group_mappings
+
+    def plan_repository(
+        github: Any,
+        repo: Mapping[str, Any],
+        spaces: list[Any],
+        score: int,
+        reason: str,
+        css: str,
+        javascript: str,
+    ) -> Any:
+        entries = _source_entries(core)
+        full_name = str(repo.get("full_name") or "")
+        managed: list[tuple[Any, dict[str, Any]]] = []
+        ordinary: list[Any] = []
+        for space in spaces:
+            entry = entries.get(core.normalize(space.slug))
+            if (
+                entry
+                and entry.get("repo") == full_name
+                and entry.get("ownership") == PUBLISHER_OWNERSHIP
+            ):
+                managed.append((space, entry))
+            else:
+                ordinary.append(space)
+
+        if not managed:
+            return original_plan_repository(
+                github,
+                repo,
+                spaces,
+                score,
+                reason,
+                css,
+                javascript,
+            )
+        if ordinary:
+            raise core.RolloutError(
+                "MIXED_PUBLISHER_AUTHORITY",
+                (
+                    f"{full_name} mixes publisher-generated and directly "
+                    "adaptable Spaces in one rollout plan"
+                ),
+            )
+
+        default_branch = str(repo.get("default_branch") or "main")
+        plan = core.Plan(full_name, default_branch, spaces, score, reason)
+        paths = {
+            str(item.get("path") or "")
+            for item in github.tree(full_name, default_branch)
+        }
+        entrypoints: list[str] = []
+        for space, entry in managed:
+            source_root = entry.get("source_root")
+            if not isinstance(source_root, str) or not source_root:
+                raise core.RolloutError(
+                    "PUBLISHER_ENTRYPOINT_UNDECLARED",
+                    f"{space.slug} has no publisher source_root",
+                )
+            if source_root not in paths:
+                raise core.RolloutError(
+                    "PUBLISHER_ENTRYPOINT_MISSING",
+                    f"{full_name}:{source_root} does not exist",
+                )
+            entrypoints.append(source_root)
+
+        plan.status = PUBLISHER_MANAGED_STATUS
+        plan.adapter = "publisher-generator"
+        plan.entrypoint = ", ".join(sorted(set(entrypoints)))
+        plan.changes = []
+        plan.error = None
+        return plan
+
+    core.plan_repository = plan_repository
+    core._szl_source_authority_contract_installed = True

--- a/.github/scripts/source_authority_contract.py
+++ b/.github/scripts/source_authority_contract.py
@@ -2,9 +2,10 @@
 """Bind rollout automation to the reviewed Space presentation authority.
 
 The base rollout controller intentionally excludes central repositories from
-heuristic matching. This extension preserves that safety boundary while making
-the protected local source map truly authoritative: an explicit mapping is
-resolved exactly, never replaced by a heuristic fallback, and generated
+heuristic and provider-derived matching. This extension preserves that safety
+boundary while making the protected local source map truly authoritative: only
+a locally reviewed mapping can bypass the central-repository exclusion, no
+declared local target falls back to a heuristic candidate, and generated
 publisher surfaces are recorded as publisher-managed instead of receiving a
 guessed frontend edit in a product repository.
 """
@@ -27,6 +28,10 @@ def _active_repository(repo: Mapping[str, Any]) -> bool:
             repo.get("fork"),
         )
     )
+
+
+def _repository_is_excluded(core: Any, full_name: str) -> bool:
+    return full_name.split("/", 1)[-1] in core.EXCLUDED_REPOS
 
 
 def _source_entries(core: Any) -> dict[str, dict[str, Any]]:
@@ -106,7 +111,8 @@ def install(core: Any) -> None:
         dict[str, tuple[list[Any], int, str]],
         list[dict[str, Any]],
     ]:
-        exact_spaces: list[Any] = []
+        local_entries = _source_entries(core)
+        reviewed_exact: list[tuple[Any, dict[str, Any]]] = []
         heuristic_spaces: list[Any] = []
         unmapped: list[dict[str, Any]] = []
 
@@ -124,10 +130,33 @@ def install(core: Any) -> None:
                         ),
                     }
                 )
-            elif explicit.get(slug):
-                exact_spaces.append(space)
-            else:
+                continue
+
+            entry = local_entries.get(slug)
+            if entry is None:
+                # Provider metadata can still improve ordinary matching, but it
+                # remains inside the base controller's excluded-repository
+                # boundary and therefore cannot acquire local review authority.
                 heuristic_spaces.append(space)
+                continue
+
+            repository = str(entry["repo"])
+            if _repository_is_excluded(core, repository):
+                if entry.get("ownership") != PUBLISHER_OWNERSHIP:
+                    raise core.RolloutError(
+                        "LOCAL_EXCLUDED_REPOSITORY_UNAUTHORIZED",
+                        (
+                            f"{space.slug} maps to excluded repository "
+                            f"{repository} without publisher ownership"
+                        ),
+                    )
+                source_root = entry.get("source_root")
+                if not isinstance(source_root, str) or not source_root:
+                    raise core.RolloutError(
+                        "PUBLISHER_ENTRYPOINT_UNDECLARED",
+                        f"{space.slug} has no publisher source_root",
+                    )
+            reviewed_exact.append((space, entry))
 
         grouped, heuristic_unmapped = original_group_mappings(
             heuristic_spaces,
@@ -141,9 +170,9 @@ def install(core: Any) -> None:
             for repo in repos
             if _active_repository(repo) and repo.get("full_name")
         }
-        for space in exact_spaces:
+        for space, entry in reviewed_exact:
             slug = core.normalize(space.slug)
-            repository = str(explicit[slug])
+            repository = str(entry["repo"])
             repo = available.get(repository)
             if repo is None:
                 unmapped.append(
@@ -152,14 +181,18 @@ def install(core: Any) -> None:
                         "sdk": space.sdk,
                         "stage": space.stage,
                         "reason": (
-                            "declared source repository is unavailable; "
+                            "declared local source repository is unavailable; "
                             "heuristic fallback is forbidden"
                         ),
                         "declared_repository": repository,
                     }
                 )
                 continue
-            score, reason = core.mapping_score(space, repo, explicit)
+            score, reason = core.mapping_score(
+                space,
+                repo,
+                {slug: repository},
+            )
             if score != 1000:
                 raise core.RolloutError(
                     "LOCAL_SOURCE_MAP_NOT_AUTHORITATIVE",

--- a/.github/tests/test_rollout_source_authority.py
+++ b/.github/tests/test_rollout_source_authority.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -100,6 +101,63 @@ class SourceAuthorityContract(unittest.TestCase):
                 and "managed outside" in item["reason"]
                 for item in unmapped
             )
+        )
+
+    def test_provider_mapping_cannot_bypass_excluded_repositories(self) -> None:
+        remote = core.Space(
+            "provider-only",
+            "docker",
+            "RUNNING",
+            "https://example.invalid/provider-only",
+        )
+        grouped, unmapped = core.group_mappings(
+            [remote],
+            [repo("szl-holdings/a11oy")],
+            {"provider-only": "szl-holdings/a11oy"},
+        )
+        self.assertEqual(grouped, {})
+        self.assertEqual(unmapped[0]["slug"], "provider-only")
+        self.assertIn("no source repository", unmapped[0]["reason"])
+
+    def test_local_excluded_mapping_requires_publisher_ownership(self) -> None:
+        original = core.LOCAL_SOURCE_MAP
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "source-map.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema": "szl.public-space-source-map/v1",
+                        "sources": [
+                            {
+                                "space": "unauthorized-central",
+                                "repo": "szl-holdings/a11oy",
+                                "ownership": "source-owned-flagship",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            core.LOCAL_SOURCE_MAP = path
+            try:
+                with self.assertRaises(core.RolloutError) as context:
+                    core.group_mappings(
+                        [
+                            core.Space(
+                                "unauthorized-central",
+                                "docker",
+                                "RUNNING",
+                                "https://example.invalid/unauthorized-central",
+                            )
+                        ],
+                        [repo("szl-holdings/a11oy")],
+                        {"unauthorized-central": "szl-holdings/a11oy"},
+                    )
+            finally:
+                core.LOCAL_SOURCE_MAP = original
+        self.assertEqual(
+            context.exception.code,
+            "LOCAL_EXCLUDED_REPOSITORY_UNAUTHORIZED",
         )
 
     def test_missing_explicit_repository_never_falls_back_to_product_repo(self) -> None:

--- a/.github/tests/test_rollout_source_authority.py
+++ b/.github/tests/test_rollout_source_authority.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Network-free contracts for rollout source and publisher authority."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CORE_PATH = ROOT / ".github" / "scripts" / "rollout_holographic_spaces_v2.py"
+AUTHORITY_PATH = ROOT / ".github" / "scripts" / "source_authority_contract.py"
+SOURCE_MAP = ROOT / "design" / "responsive-v3" / "flagship-space-sources.json"
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+core = load("rollout_source_authority_core_test", CORE_PATH)
+authority = load("rollout_source_authority_contract_test", AUTHORITY_PATH)
+authority.install(core)
+
+
+def repo(full_name: str, **values):
+    name = full_name.split("/", 1)[-1]
+    return {
+        "full_name": full_name,
+        "name": name,
+        "default_branch": "main",
+        "homepage": "",
+        "description": "",
+        "topics": [],
+        "archived": False,
+        "disabled": False,
+        "fork": False,
+        **values,
+    }
+
+
+class SourceAuthorityContract(unittest.TestCase):
+    def test_terra_map_names_the_actual_publisher(self) -> None:
+        payload = json.loads(SOURCE_MAP.read_text(encoding="utf-8"))
+        terra = next(item for item in payload["sources"] if item["space"] == "terra")
+        self.assertEqual(terra["repo"], "szl-holdings/a11oy")
+        self.assertEqual(
+            terra["source_root"],
+            "scripts/hf_publish_vertical_flagships_v4_impl.py",
+        )
+        self.assertEqual(
+            terra["ownership"],
+            authority.PUBLISHER_OWNERSHIP,
+        )
+        self.assertEqual(
+            terra["product_source"],
+            "szl-holdings/szl-real-estate",
+        )
+        self.assertEqual(
+            terra["product_source_deployment_state"],
+            "LINKED_NOT_PUBLISHED",
+        )
+
+    def test_explicit_publisher_mapping_beats_product_repo_heuristics(self) -> None:
+        spaces = [
+            core.Space("terra", "docker", "RUNNING", "https://example.invalid/terra"),
+            core.Space("a11oy", "docker", "RUNNING", "https://example.invalid/a11oy"),
+        ]
+        repositories = [
+            repo("szl-holdings/a11oy"),
+            repo(
+                "szl-holdings/szl-real-estate",
+                homepage="https://huggingface.co/spaces/SZLHOLDINGS/terra",
+                description="Terra public Space frontend",
+                topics=["huggingface"],
+            ),
+        ]
+        grouped, unmapped = core.group_mappings(
+            spaces,
+            repositories,
+            {
+                "terra": "szl-holdings/a11oy",
+                "a11oy": "szl-holdings/a11oy",
+            },
+        )
+        self.assertIn("szl-holdings/a11oy", grouped)
+        self.assertEqual(
+            [space.slug for space in grouped["szl-holdings/a11oy"][0]],
+            ["terra"],
+        )
+        self.assertNotIn("szl-holdings/szl-real-estate", grouped)
+        self.assertTrue(
+            any(
+                item["slug"] == "a11oy"
+                and "managed outside" in item["reason"]
+                for item in unmapped
+            )
+        )
+
+    def test_missing_explicit_repository_never_falls_back_to_product_repo(self) -> None:
+        terra = core.Space(
+            "terra",
+            "docker",
+            "RUNNING",
+            "https://example.invalid/terra",
+        )
+        grouped, unmapped = core.group_mappings(
+            [terra],
+            [
+                repo(
+                    "szl-holdings/szl-real-estate",
+                    homepage="https://huggingface.co/spaces/SZLHOLDINGS/terra",
+                    description="Terra public Space frontend",
+                    topics=["huggingface"],
+                )
+            ],
+            {"terra": "szl-holdings/a11oy"},
+        )
+        self.assertEqual(grouped, {})
+        self.assertEqual(unmapped[0]["declared_repository"], "szl-holdings/a11oy")
+        self.assertIn("fallback is forbidden", unmapped[0]["reason"])
+
+    def test_generated_publisher_is_recorded_without_a_guessed_frontend_edit(self) -> None:
+        class GitHub:
+            @staticmethod
+            def tree(full_name, default_branch):
+                self.assertEqual(full_name, "szl-holdings/a11oy")
+                self.assertEqual(default_branch, "main")
+                return [
+                    {
+                        "path": (
+                            "scripts/"
+                            "hf_publish_vertical_flagships_v4_impl.py"
+                        )
+                    }
+                ]
+
+        terra = core.Space(
+            "terra",
+            "docker",
+            "RUNNING",
+            "https://example.invalid/terra",
+        )
+        plan = core.plan_repository(
+            GitHub(),
+            repo("szl-holdings/a11oy"),
+            [terra],
+            1000,
+            "canonical source map",
+            "css",
+            "javascript",
+        )
+        self.assertEqual(plan.status, authority.PUBLISHER_MANAGED_STATUS)
+        self.assertEqual(plan.adapter, "publisher-generator")
+        self.assertEqual(
+            plan.entrypoint,
+            "scripts/hf_publish_vertical_flagships_v4_impl.py",
+        )
+        self.assertEqual(plan.changes, [])
+        self.assertIsNone(plan.error)
+
+    def test_missing_publisher_entrypoint_fails_closed(self) -> None:
+        class GitHub:
+            @staticmethod
+            def tree(_full_name, _default_branch):
+                return []
+
+        terra = core.Space(
+            "terra",
+            "docker",
+            "RUNNING",
+            "https://example.invalid/terra",
+        )
+        with self.assertRaises(core.RolloutError) as context:
+            core.plan_repository(
+                GitHub(),
+                repo("szl-holdings/a11oy"),
+                [terra],
+                1000,
+                "canonical source map",
+                "css",
+                "javascript",
+            )
+        self.assertEqual(context.exception.code, "PUBLISHER_ENTRYPOINT_MISSING")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/rollout-holographic-space-fabric-v2.yml
+++ b/.github/workflows/rollout-holographic-space-fabric-v2.yml
@@ -8,9 +8,11 @@ on:
       - ".github/scripts/rollout_holographic_spaces_v2.py"
       - ".github/scripts/run_holographic_spaces_v2.py"
       - ".github/scripts/responsive_space_contract.py"
+      - ".github/scripts/source_authority_contract.py"
       - ".github/scripts/holographic_target_contract.py"
       - ".github/tests/test_holographic_spaces_v2.py"
       - ".github/tests/test_responsive_space_contract.py"
+      - ".github/tests/test_rollout_source_authority.py"
       - ".github/tests/test_holographic_target_contract.py"
       - "design/holographic-v2/**"
       - "design/responsive-v3/**"
@@ -73,11 +75,13 @@ jobs:
             .github/scripts/rollout_holographic_spaces_v2.py \
             .github/scripts/run_holographic_spaces_v2.py \
             .github/scripts/responsive_space_contract.py \
+            .github/scripts/source_authority_contract.py \
             .github/scripts/holographic_target_contract.py
           node --check design/holographic-v2/szl-space-hologram.js
           node --check design/responsive-v3/szl-responsive-v3.js
           python .github/tests/test_holographic_spaces_v2.py
           python .github/tests/test_responsive_space_contract.py
+          python .github/tests/test_rollout_source_authority.py
           python .github/tests/test_holographic_target_contract.py
       - name: Discover, refresh, review, and merge through repository gates
         shell: bash

--- a/design/responsive-v3/flagship-space-sources.json
+++ b/design/responsive-v3/flagship-space-sources.json
@@ -15,8 +15,11 @@
     },
     {
       "space": "terra",
-      "repo": "szl-holdings/szl-real-estate",
-      "ownership": "source-owned-flagship"
+      "repo": "szl-holdings/a11oy",
+      "source_root": "scripts/hf_publish_vertical_flagships_v4_impl.py",
+      "ownership": "publisher-generated-flagship",
+      "product_source": "szl-holdings/szl-real-estate",
+      "product_source_deployment_state": "LINKED_NOT_PUBLISHED"
     },
     {
       "space": "sentra",
@@ -57,6 +60,7 @@
     "A source mapping identifies the repository responsible for the public product surface; it does not prove that a deployment is current or healthy.",
     "The map is a protected local fallback. Public provider metadata may enrich it but cannot silently override it.",
     "Sentra's API/control-plane service and Vessels' archived deployment packaging remain separate from their active platform-monorepo frontend sources.",
+    "A publisher-generated mapping records the exact generator entrypoint and never authorizes a guessed frontend edit in the linked product repository.",
     "A mapped repository without a reviewed public entrypoint remains BLOCKED rather than receiving a guessed edit."
   ]
 }

--- a/estate/alignment.v1.json
+++ b/estate/alignment.v1.json
@@ -22,7 +22,9 @@
       "id": "terra",
       "brand": "Terra",
       "backend_source": "szl-holdings/szl-real-estate",
-      "presentation_source": "szl-holdings/szl-real-estate",
+      "presentation_source": "szl-holdings/a11oy:scripts/hf_publish_vertical_flagships_v4_impl.py",
+      "publisher_workflow": "szl-holdings/a11oy:.github/workflows/hf-sync.yml",
+      "product_source_deployment_state": "LINKED_NOT_PUBLISHED",
       "hub_surface": "SZLHOLDINGS/terra",
       "domain": "real-estate"
     },


### PR DESCRIPTION
The Terra estate contract currently identifies `szl-real-estate` as the presentation source, but the canonical A11oy publisher builds the served presentation and links to that product repository. Record the actual implementation and publishing workflow, and make the product deployment relation explicit as `LINKED_NOT_PUBLISHED`.

The canonical Space remains `SZLHOLDINGS/terra`. This change introduces no provider writer and does not claim product-source bytes are running. The source-side delegation verifier is being updated in a companion PR to enforce this mapping and emit a commit-addressed receipt.

Validation: JSON parsing and `git diff --check` passed. The companion verifier's 12 regression tests cover the corrected owner, target drift, duplicate bodies, and false deployment claims; all 15 source repository tests passed. This is a signed commit; promotion still requires current checks and review under the repository's active rules.
