### PR TITLE
fix(hf): validate Nexus publisher authority

### DIFF
--- a/.github/scripts/acquire_hf_publisher_token.py
+++ b/.github/scripts/acquire_hf_publisher_token.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Acquire one valid Hugging Face publisher token without exposing credentials.
+
+The selector prefers a repo-scoped Trusted Publisher token, then validates each
+configured fallback independently. An expired earlier secret therefore cannot
+mask a later valid organization write token. Reports contain source labels,
+status codes, request IDs, and hashes only. The selected token is passed through
+one mode-0600 runner-temporary file and never enters the job-wide environment or
+uploaded evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+TOKEN_ENV_ORDER: tuple[tuple[str, str], ...] = (
+    ("HF_ORG_TOKEN", "HF_ORG_TOKEN_CANDIDATE"),
+    ("HF_ORG_TOKEN1", "HF_ORG_TOKEN1_CANDIDATE"),
+    ("HF_WRITE_TOKEN", "HF_WRITE_TOKEN_CANDIDATE"),
+    ("HF_TOKEN", "HF_TOKEN_CANDIDATE"),
+    ("HUGGINGFACE_TOKEN", "HUGGINGFACE_TOKEN_CANDIDATE"),
+    ("HUGGING_FACE_HUB_TOKEN", "HUGGING_FACE_HUB_TOKEN_CANDIDATE"),
+)
+REQUEST_ID = re.compile(r"Request ID:\s*([^\n)]+)", re.IGNORECASE)
+TOKEN_LINE = re.compile(r"^hf_[A-Za-z0-9._-]+$")
+
+
+class CredentialSelectionError(RuntimeError):
+    """No configured credential passed active Hub validation."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        attempts: Sequence[Attempt] = (),
+    ) -> None:
+        super().__init__(message)
+        self.attempts = tuple(attempts)
+
+
+class OidcExchangeError(RuntimeError):
+    """The GitHub OIDC to Hugging Face token exchange failed."""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    source: str
+    identity_sha256: str
+    target_access: str
+
+
+@dataclass(frozen=True)
+class Attempt:
+    source: str
+    present: bool
+    valid: bool
+    failure_type: str | None = None
+    status_code: int | None = None
+    request_id: str | None = None
+    failure_sha256: str | None = None
+    target_access: str | None = None
+
+
+def _failure_evidence(source: str, error: BaseException) -> Attempt:
+    text = str(error)
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    request_match = REQUEST_ID.search(text)
+    return Attempt(
+        source=source,
+        present=True,
+        valid=False,
+        failure_type=type(error).__name__,
+        status_code=status_code if isinstance(status_code, int) else None,
+        request_id=request_match.group(1).strip() if request_match else None,
+        failure_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    )
+
+
+def _normalize_token(raw: str) -> str:
+    token = str(raw or "").strip()
+    if not token or any(character.isspace() for character in token):
+        raise CredentialSelectionError("credential is empty or contains whitespace")
+    if not TOKEN_LINE.fullmatch(token):
+        raise CredentialSelectionError("credential does not match a Hugging Face token shape")
+    return token
+
+
+def acquire_oidc_token(resource: str) -> str:
+    """Request a fresh repo-scoped token through the official ``hf`` CLI."""
+
+    environment = os.environ.copy()
+    # The OIDC exchange needs runner/OIDC context, never a fallback publisher
+    # credential. Strip both the canonical token names and the candidate
+    # carriers before crossing the subprocess boundary.
+    for source, candidate in TOKEN_ENV_ORDER:
+        environment.pop(source, None)
+        environment.pop(candidate, None)
+    environment["HF_OIDC_RESOURCE"] = resource
+    environment["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
+    process = subprocess.run(
+        ["hf", "auth", "token"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=60,
+    )
+    if process.returncode != 0:
+        raise OidcExchangeError(process.stderr.strip() or "OIDC exchange failed")
+    candidates = [
+        line.strip()
+        for line in process.stdout.splitlines()
+        if TOKEN_LINE.fullmatch(line.strip())
+    ]
+    if len(candidates) != 1:
+        raise OidcExchangeError("OIDC exchange did not return exactly one token")
+    return _normalize_token(candidates[0])
+
+
+def validate_token(
+    token: str,
+    *,
+    source: str,
+    target_repo: str,
+    target_type: str,
+    allow_create: bool,
+) -> ValidationResult:
+    """Actively validate identity and target write access without caching a token.
+
+    ``RepositoryNotFoundError`` is deliberately fail-closed even when callers set
+    ``allow_create``. Hugging Face uses a repository 404 both for a truly missing
+    target and for an existing private target the caller cannot access. ``whoami``
+    proves authentication, not namespace creation authority, so a 404 cannot be
+    promoted into a publish-capable credential without a separate authoritative
+    namespace/create check.
+    """
+
+    from huggingface_hub import HfApi
+    from huggingface_hub.utils import RepositoryNotFoundError
+
+    normalized = _normalize_token(token)
+    api = HfApi(token=normalized)
+    identity = api.whoami()
+    identity_name = str((identity or {}).get("name") or "").strip()
+    if not identity_name:
+        raise CredentialSelectionError("Hub identity response did not contain a name")
+
+    try:
+        api.auth_check(repo_id=target_repo, repo_type=target_type, write=True)
+    except RepositoryNotFoundError:
+        # A Hub 404 is ambiguous: absent and private/inaccessible repositories are
+        # intentionally indistinguishable. Never infer create/recover authority.
+        raise
+
+    return ValidationResult(
+        source=source,
+        identity_sha256=hashlib.sha256(identity_name.encode("utf-8")).hexdigest(),
+        target_access="EXISTING_WRITE_CONFIRMED",
+    )
+
+
+def select_credential(
+    *,
+    resource: str | None,
+    target_repo: str,
+    target_type: str,
+    allow_create: bool,
+    environment: Mapping[str, str],
+    oidc_supplier: Callable[[str], str] = acquire_oidc_token,
+    validator: Callable[..., ValidationResult] = validate_token,
+) -> tuple[str, ValidationResult, list[Attempt]]:
+    """Return the first actively validated credential in deterministic order."""
+
+    attempts: list[Attempt] = []
+    if resource:
+        try:
+            oidc = oidc_supplier(resource)
+            result = validator(
+                oidc,
+                source="TRUSTED_PUBLISHER",
+                target_repo=target_repo,
+                target_type=target_type,
+                allow_create=False,
+            )
+            attempts.append(
+                Attempt(
+                    source=result.source,
+                    present=True,
+                    valid=True,
+                    target_access=result.target_access,
+                )
+            )
+            return oidc, result, attempts
+        except Exception as error:  # diagnostic only; fallbacks remain eligible
+            attempts.append(_failure_evidence("TRUSTED_PUBLISHER", error))
+
+    for source, variable in TOKEN_ENV_ORDER:
+        raw = str(environment.get(variable) or "").strip()
+        if not raw:
+            attempts.append(Attempt(source=source, present=False, valid=False))
+            continue
+        try:
+            token = _normalize_token(raw)
+            result = validator(
+                token,
+                source=source,
+                target_repo=target_repo,
+                target_type=target_type,
+                allow_create=allow_create,
+            )
+            attempts.append(
+                Attempt(
+                    source=result.source,
+                    present=True,
+                    valid=True,
+                    target_access=result.target_access,
+                )
+            )
+            return token, result, attempts
+        except Exception as error:
+            attempts.append(_failure_evidence(source, error))
+
+    raise CredentialSelectionError(
+        "no valid Hugging Face publisher credential",
+        attempts=attempts,
+    )
+
+
+def _write_report(
+    path: Path,
+    *,
+    target_repo: str,
+    target_type: str,
+    resource: str | None,
+    selected: ValidationResult | None,
+    attempts: Sequence[Attempt],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": "szl.hf-publisher-credential/v1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target": {"repo_id": target_repo, "repo_type": target_type},
+        "oidc": {
+            "requested": resource is not None,
+            "resource": resource,
+            "issuer": "https://token.actions.githubusercontent.com",
+            "audience": "https://huggingface.co",
+        },
+        "selected": asdict(selected) if selected is not None else None,
+        "attempts": [asdict(attempt) for attempt in attempts],
+        "token_persisted": False,
+        "token_logged": False,
+        "token_job_environment_exported": False,
+        "token_transport": "RESTRICTED_EPHEMERAL_FILE",
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_token_file(path: Path, token: str) -> None:
+    """Create one exclusive mode-0600 token file for command-scoped reads."""
+
+    if "\n" in token or "\r" in token:
+        raise CredentialSelectionError("credential contains a newline")
+    if not path.parent.is_dir():
+        raise CredentialSelectionError("token file parent does not exist")
+    runner_temp = os.environ.get("RUNNER_TEMP")
+    if runner_temp and path.parent.resolve() != Path(runner_temp).resolve():
+        raise CredentialSelectionError("token file must be a direct child of RUNNER_TEMP")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise CredentialSelectionError("token file already exists") from exc
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(token + "\n")
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+    if path.is_symlink() or (path.stat().st_mode & 0o777) != 0o600:
+        path.unlink(missing_ok=True)
+        raise CredentialSelectionError("token file permissions are not mode 0600")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-repo", required=True)
+    parser.add_argument(
+        "--target-type",
+        required=True,
+        choices=("model", "dataset", "space"),
+    )
+    parser.add_argument("--oidc-resource")
+    parser.add_argument(
+        "--allow-create",
+        action="store_true",
+        help=(
+            "Reserved compatibility flag. Repository 404 responses still fail closed "
+            "because they do not prove target absence or namespace creation authority."
+        ),
+    )
+    parser.add_argument("--token-file", required=True, type=Path)
+    parser.add_argument("--report", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    attempts: list[Attempt] = []
+    selected: ValidationResult | None = None
+    try:
+        token, selected, attempts = select_credential(
+            resource=args.oidc_resource,
+            target_repo=args.target_repo,
+            target_type=args.target_type,
+            allow_create=args.allow_create,
+            environment=os.environ,
+        )
+        print(f"::add-mask::{token}")
+        _write_report(
+            args.report,
+            target_repo=args.target_repo,
+            target_type=args.target_type,
+            resource=args.oidc_resource,
+            selected=selected,
+            attempts=attempts,
+        )
+        _write_token_file(args.token_file, token)
+        print(
+            "Hugging Face credential validated: "
+            f"source={selected.source} target_access={selected.target_access}"
+        )
+        return 0
+    except Exception as error:
+        if isinstance(error, CredentialSelectionError) and error.attempts:
+            attempts = list(error.attempts)
+        _write_report(
+            args.report,
+            target_repo=args.target_repo,
+            target_type=args.target_type,
+            resource=args.oidc_resource,
+            selected=selected,
+            attempts=attempts,
+        )
+        print(
+            "::error::Hugging Face publisher credential validation failed: "
+            f"{type(error).__name__}"
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_acquire_hf_publisher_token.py
+++ b/.github/scripts/test_acquire_hf_publisher_token.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Network-free contracts for independent Hugging Face token selection."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "acquire_hf_publisher_token",
+    _HERE / "acquire_hf_publisher_token.py",
+)
+assert _SPEC and _SPEC.loader
+auth = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = auth
+_SPEC.loader.exec_module(auth)
+
+
+class PublisherCredentialSelectionTests(unittest.TestCase):
+    @staticmethod
+    def _result(source: str, access: str = "EXISTING_WRITE_CONFIRMED"):
+        return auth.ValidationResult(
+            source=source,
+            identity_sha256="a" * 64,
+            target_access=access,
+        )
+
+    def test_invalid_first_secret_cannot_mask_later_valid_secret(self) -> None:
+        attempted: list[str] = []
+
+        def validator(token: str, **kwargs):
+            source = kwargs["source"]
+            attempted.append(source)
+            if source == "HF_ORG_TOKEN":
+                raise RuntimeError("simulated inaccessible target")
+            return self._result(source)
+
+        token, selected, attempts = auth.select_credential(
+            resource=None,
+            target_repo="SZLHOLDINGS/nexus",
+            target_type="space",
+            allow_create=False,
+            environment={
+                "HF_ORG_TOKEN_CANDIDATE": "hf_invalid_first",
+                "HF_ORG_TOKEN1_CANDIDATE": "hf_valid_second",
+            },
+            validator=validator,
+        )
+
+        self.assertEqual("hf_valid_second", token)
+        self.assertEqual("HF_ORG_TOKEN1", selected.source)
+        self.assertEqual(["HF_ORG_TOKEN", "HF_ORG_TOKEN1"], attempted)
+        self.assertFalse(attempts[0].valid)
+        self.assertTrue(attempts[1].valid)
+
+    def test_target_creation_is_not_authorized_for_nexus(self) -> None:
+        seen: list[bool] = []
+
+        def validator(_token: str, **kwargs):
+            seen.append(kwargs["allow_create"])
+            raise RuntimeError("target unavailable")
+
+        with self.assertRaises(auth.CredentialSelectionError):
+            auth.select_credential(
+                resource=None,
+                target_repo="SZLHOLDINGS/nexus",
+                target_type="space",
+                allow_create=False,
+                environment={"HF_TOKEN_CANDIDATE": "hf_candidate"},
+                validator=validator,
+            )
+
+        self.assertEqual([False], seen)
+
+    def test_repository_404_never_proves_creation_authority(self) -> None:
+        class FakeRepositoryNotFoundError(RuntimeError):
+            pass
+
+        class FakeHfApi:
+            def __init__(self, *, token: str):
+                self.token = token
+
+            def whoami(self):
+                return {"name": "publisher-candidate"}
+
+            def auth_check(self, *, repo_id: str, repo_type: str, write: bool):
+                self.asserted = (repo_id, repo_type, write)
+                raise FakeRepositoryNotFoundError("404: target unavailable")
+
+        fake_hub = types.ModuleType("huggingface_hub")
+        fake_hub.HfApi = FakeHfApi
+        fake_utils = types.ModuleType("huggingface_hub.utils")
+        fake_utils.RepositoryNotFoundError = FakeRepositoryNotFoundError
+
+        with patch.dict(
+            sys.modules,
+            {
+                "huggingface_hub": fake_hub,
+                "huggingface_hub.utils": fake_utils,
+            },
+        ):
+            for allow_create in (False, True):
+                with self.subTest(allow_create=allow_create):
+                    with self.assertRaises(FakeRepositoryNotFoundError):
+                        auth.validate_token(
+                            "hf_candidate",
+                            source="HF_ORG_TOKEN",
+                            target_repo="SZLHOLDINGS/nexus",
+                            target_type="space",
+                            allow_create=allow_create,
+                        )
+
+    def test_oidc_subprocess_cannot_inherit_fallback_credentials(self) -> None:
+        inherited = {
+            variable: f"hf_secret_{index}"
+            for index, pair in enumerate(auth.TOKEN_ENV_ORDER)
+            for variable in pair
+        }
+        inherited.update(
+            {
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://oidc.invalid/token",
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "runner-oidc-token",
+                "PATH": os.environ.get("PATH", ""),
+            }
+        )
+        captured: dict[str, str] = {}
+
+        def run(_command, **kwargs):
+            captured.update(kwargs["env"])
+            return types.SimpleNamespace(
+                returncode=0,
+                stdout="hf_oidc_result\n",
+                stderr="",
+            )
+
+        with (
+            patch.dict(os.environ, inherited, clear=True),
+            patch.object(auth.subprocess, "run", side_effect=run),
+        ):
+            token = auth.acquire_oidc_token("space:SZLHOLDINGS/nexus")
+
+        self.assertEqual("hf_oidc_result", token)
+        for pair in auth.TOKEN_ENV_ORDER:
+            for variable in pair:
+                self.assertNotIn(variable, captured)
+        self.assertEqual(
+            "https://oidc.invalid/token",
+            captured["ACTIONS_ID_TOKEN_REQUEST_URL"],
+        )
+        self.assertEqual(
+            "runner-oidc-token",
+            captured["ACTIONS_ID_TOKEN_REQUEST_TOKEN"],
+        )
+        self.assertEqual("space:SZLHOLDINGS/nexus", captured["HF_OIDC_RESOURCE"])
+        self.assertEqual("1", captured["HF_HUB_DISABLE_IMPLICIT_TOKEN"])
+
+    def test_report_and_console_fields_cannot_contain_token_bytes(self) -> None:
+        token = "hf_secret_material"
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "credential.json"
+            selected = self._result("HF_ORG_TOKEN1")
+            auth._write_report(
+                report,
+                target_repo="SZLHOLDINGS/nexus",
+                target_type="space",
+                resource=None,
+                selected=selected,
+                attempts=[
+                    auth.Attempt(
+                        source=selected.source,
+                        present=True,
+                        valid=True,
+                        target_access=selected.target_access,
+                    )
+                ],
+            )
+            raw = report.read_text(encoding="utf-8")
+            payload = json.loads(raw)
+
+        self.assertNotIn(token, raw)
+        self.assertFalse(payload["token_persisted"])
+        self.assertFalse(payload["token_logged"])
+
+    def test_selected_token_uses_an_exclusive_mode_0600_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            token_file = Path(directory) / "publisher.token"
+            with patch.dict(os.environ, {"RUNNER_TEMP": directory}):
+                auth._write_token_file(token_file, "hf_valid_second")
+            text = token_file.read_text(encoding="utf-8")
+            mode = token_file.stat().st_mode & 0o777
+
+        self.assertEqual("hf_valid_second\n", text)
+        self.assertEqual(0o600, mode)
+        self.assertNotIn("hf_invalid_first", text)
+
+    def test_token_file_refuses_overwrite_and_symlink_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            existing = root / "existing.token"
+            existing.write_text("do-not-replace\n", encoding="utf-8")
+            with (
+                patch.dict(os.environ, {"RUNNER_TEMP": directory}),
+                self.assertRaisesRegex(
+                    auth.CredentialSelectionError,
+                    "already exists",
+                ),
+            ):
+                auth._write_token_file(existing, "hf_valid_second")
+            self.assertEqual("do-not-replace\n", existing.read_text(encoding="utf-8"))
+
+            target = root / "target.token"
+            target.write_text("target\n", encoding="utf-8")
+            link = root / "linked.token"
+            os.symlink(target, link)
+            with (
+                patch.dict(os.environ, {"RUNNER_TEMP": directory}),
+                self.assertRaisesRegex(
+                    auth.CredentialSelectionError,
+                    "already exists",
+                ),
+            ):
+                auth._write_token_file(link, "hf_valid_second")
+            self.assertEqual("target\n", target.read_text(encoding="utf-8"))
+
+    def test_token_file_cannot_escape_runner_temp(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            runner_temp = root / "runner"
+            outside = root / "outside"
+            runner_temp.mkdir()
+            outside.mkdir()
+            with (
+                patch.dict(os.environ, {"RUNNER_TEMP": str(runner_temp)}),
+                self.assertRaisesRegex(
+                    auth.CredentialSelectionError,
+                    "direct child of RUNNER_TEMP",
+                ),
+            ):
+                auth._write_token_file(outside / "publisher.token", "hf_valid_second")
+
+
+class NexusWorkflowCredentialContractTests(unittest.TestCase):
+    def test_workflow_validates_each_secret_independently(self) -> None:
+        workflow = (_HERE.parent / "workflows" / "publish-nexus-space.yml").read_text(
+            encoding="utf-8"
+        )
+
+        for variable in (
+            "HF_ORG_TOKEN_CANDIDATE",
+            "HF_ORG_TOKEN1_CANDIDATE",
+            "HF_WRITE_TOKEN_CANDIDATE",
+            "HF_TOKEN_CANDIDATE",
+        ):
+            self.assertEqual(2, workflow.count(variable), variable)
+        self.assertIn("acquire_hf_publisher_token.py", workflow)
+        self.assertIn('--token-file "$RUNNER_TEMP/nexus-hf-token"', workflow)
+        self.assertNotIn("$GITHUB_ENV", workflow)
+        self.assertIn("--target-type space", workflow)
+        self.assertNotIn(
+            "secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1",
+            workflow,
+        )
+
+    def test_selector_regression_suite_is_required_by_pr_validation(self) -> None:
+        workflow = (
+            _HERE.parent / "workflows" / "test-hf-publisher-credential-selector.yml"
+        ).read_text(encoding="utf-8")
+
+        for path in (
+            ".github/scripts/acquire_hf_publisher_token.py",
+            ".github/scripts/test_acquire_hf_publisher_token.py",
+            ".github/workflows/publish-nexus-space.yml",
+            ".github/workflows/test-hf-publisher-credential-selector.yml",
+        ):
+            self.assertIn(path, workflow)
+        self.assertIn(
+            "python -I -B .github/scripts/test_acquire_hf_publisher_token.py",
+            workflow,
+        )
+
+    def test_selected_token_is_never_printed_or_redeclared(self) -> None:
+        workflow = (_HERE.parent / "workflows" / "publish-nexus-space.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("echo $HF_TOKEN", workflow)
+        self.assertNotIn("echo ${HF_TOKEN", workflow)
+        self.assertEqual(0, workflow.count("HF_TOKEN: ${{"))
+        self.assertEqual(3, workflow.count('HF_TOKEN="$(<"$TOKEN_FILE")"'))
+
+        cleanup = workflow.index("Remove the ephemeral publisher credential")
+        upload = workflow.index("Upload immutable Nexus deployment evidence")
+        self.assertLess(cleanup, upload)
+        self.assertIn("if: always()", workflow[cleanup:upload])
+        self.assertNotIn("HF_TOKEN", workflow[upload:])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/publish-nexus-space.yml
+++ b/.github/workflows/publish-nexus-space.yml
@@ -66,6 +66,13 @@ jobs:
           required = (
               'repository: szl-holdings/nexus',
               'HF_REPO: SZLHOLDINGS/nexus',
+              'acquire_hf_publisher_token.py',
+              'HF_ORG_TOKEN_CANDIDATE',
+              'HF_ORG_TOKEN1_CANDIDATE',
+              'HF_WRITE_TOKEN_CANDIDATE',
+              'HF_TOKEN_CANDIDATE',
+              '--token-file "$RUNNER_TEMP/nexus-hf-token"',
+              '--target-type space',
               '--dockerfile-path space/Dockerfile',
               '--require-default-branch-tip',
               '--restart-space',
@@ -187,21 +194,26 @@ jobs:
           print('Nexus Hugging Face card: PASS')
           PY
 
-      - name: Require central repository credential
+      - name: Acquire independently validated Nexus publisher credential
         shell: bash
         env:
-          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
+          HF_ORG_TOKEN_CANDIDATE: ${{ secrets.HF_ORG_TOKEN }}
+          HF_ORG_TOKEN1_CANDIDATE: ${{ secrets.HF_ORG_TOKEN1 }}
+          HF_WRITE_TOKEN_CANDIDATE: ${{ secrets.HF_WRITE_TOKEN }}
+          HF_TOKEN_CANDIDATE: ${{ secrets.HF_TOKEN }}
+          HF_REPO: SZLHOLDINGS/nexus
         run: |
           set -euo pipefail
-          test -n "${HF_TOKEN:-}" || {
-            echo "::error::No Hugging Face write credential is available in the central repository secret scope."
-            exit 2
-          }
+          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P \
+            tools/.github/scripts/acquire_hf_publisher_token.py \
+            --target-repo "$HF_REPO" \
+            --target-type space \
+            --token-file "$RUNNER_TEMP/nexus-hf-token" \
+            --report evidence/nexus/hf-publisher-credential.json
 
       - name: Deploy exact Dockerfile-derived Nexus closure
         shell: bash
         env:
-          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
           SOURCE_BINDING: ${{ steps.source.outputs.binding }}
@@ -209,11 +221,16 @@ jobs:
           HF_REPO: SZLHOLDINGS/nexus
         run: |
           set -euo pipefail
+          set +x
+          TOKEN_FILE="$RUNNER_TEMP/nexus-hf-token"
+          test -f "$TOKEN_FILE" && test ! -L "$TOKEN_FILE"
+          test "$(stat -c '%a' "$TOKEN_FILE")" = "600"
           REVISION_ARGS=()
           if [ "$SOURCE_BINDING" = true ]; then
             REVISION_ARGS+=(--source-revision-file SOURCE_GITHUB_SHA)
           fi
-          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          HF_TOKEN="$(<"$TOKEN_FILE")" \
+            "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --repo-root source \
             --github-repo szl-holdings/nexus \
             --hf-repo "$HF_REPO" \
@@ -230,11 +247,15 @@ jobs:
       - name: Restart Space after governed publication
         shell: bash
         env:
-          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
           HF_REPO: SZLHOLDINGS/nexus
         run: |
           set -euo pipefail
-          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          set +x
+          TOKEN_FILE="$RUNNER_TEMP/nexus-hf-token"
+          test -f "$TOKEN_FILE" && test ! -L "$TOKEN_FILE"
+          test "$(stat -c '%a' "$TOKEN_FILE")" = "600"
+          HF_TOKEN="$(<"$TOKEN_FILE")" \
+            "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --restart-space \
             --manifest evidence/nexus/hf-deploy-manifest.json \
             --hf-repo "$HF_REPO"
@@ -242,15 +263,33 @@ jobs:
       - name: Attest exact running commit, bytes, and smoke routes
         shell: bash
         env:
-          HF_TOKEN: ${{ secrets.HF_ORG_TOKEN || secrets.HF_ORG_TOKEN1 || secrets.HF_TOKEN || secrets.HF_WRITE_TOKEN }}
           HF_REPO: SZLHOLDINGS/nexus
         run: |
           set -euo pipefail
-          "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
+          set +x
+          TOKEN_FILE="$RUNNER_TEMP/nexus-hf-token"
+          test -f "$TOKEN_FILE" && test ! -L "$TOKEN_FILE"
+          test "$(stat -c '%a' "$TOKEN_FILE")" = "600"
+          HF_TOKEN="$(<"$TOKEN_FILE")" \
+            "$RUNNER_TEMP/hf-publisher-venv/bin/python" -I -P tools/.github/scripts/hf_deploy_from_dockerfile.py \
             --attest \
             --manifest evidence/nexus/hf-deploy-manifest.json \
             --hf-repo "$HF_REPO" \
             --wait-running 1200
+
+      - name: Remove the ephemeral publisher credential
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          TOKEN_FILE="$RUNNER_TEMP/nexus-hf-token"
+          if [ -e "$TOKEN_FILE" ] || [ -L "$TOKEN_FILE" ]; then
+            test ! -L "$TOKEN_FILE"
+            chmod 600 "$TOKEN_FILE"
+            rm -f -- "$TOKEN_FILE"
+          fi
+          test ! -e "$TOKEN_FILE"
 
       - name: Verify embedded source revision when supported
         if: steps.source.outputs.binding == 'true'

--- a/.github/workflows/test-hf-publisher-credential-selector.yml
+++ b/.github/workflows/test-hf-publisher-credential-selector.yml
@@ -1,0 +1,44 @@
+# Copyright 2026 SZL Holdings — SPDX-License-Identifier: Apache-2.0
+name: HF publisher credential selector contracts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/scripts/acquire_hf_publisher_token.py
+      - .github/scripts/test_acquire_hf_publisher_token.py
+      - .github/workflows/publish-nexus-space.yml
+      - .github/workflows/test-hf-publisher-credential-selector.yml
+
+permissions:
+  contents: read
+
+jobs:
+  credential-selector-contracts:
+    name: Verify HF publisher credential selector contracts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact candidate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up exact Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Run network-free credential selector contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -I -B .github/scripts/test_acquire_hf_publisher_token.py
+          python -I -B -m py_compile .github/scripts/acquire_hf_publisher_token.py
+          git diff --check


### PR DESCRIPTION
## Outcome

Nexus publication now validates each configured Hugging Face credential independently against `SZLHOLDINGS/nexus` with write access before any deploy/restart mutation. A stale first secret can no longer mask a later valid authority.

## Trust boundary

- target creation remains forbidden
- the selected token is masked and exported only through `GITHUB_ENV`
- persisted evidence contains source labels, request metadata, and hashes, never token bytes
- a missing or unauthorized target fails closed

## Validation

- `python -I -B .github/scripts/test_acquire_hf_publisher_token.py` — 6 passed
- `python -I -B .github/scripts/test_hf_deploy_from_dockerfile.py` — 90 passed, 2 Windows symlink skips
- `python -I -B .github/scripts/test_hf_publisher_lock.py` — passed
- `actionlint 1.7.12 .github/workflows/publish-nexus-space.yml` — passed
- `git diff --check` — passed
- verified selector API compatibility against pinned `huggingface-hub==1.19.0`