### PR TITLE
feat(alignment): bind estate movement to signed source

### DIFF
--- a/.github/scripts/estate_alignment_contract.py
+++ b/.github/scripts/estate_alignment_contract.py
@@ -1,0 +1,727 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Validate that product, source, artifact, and proof surfaces move as one."""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+SCHEMA = "szl.estate-alignment/v1"
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+LOCKED_EIGHT = ["F1", "F4", "F7", "F11", "F12", "F18", "F19", "F22"]
+EXPECTED_FLAGSHIPS = ["a11oy", "killinchu", "forge"]
+EXPECTED_BODIES = ["terra", "killinchu", "counsel", "finance", "lyte"]
+EXPECTED_ENGINES = ["sentra", "lyte", "killinchu", "finance", "terra", "counsel"]
+EXPECTED_FOLDS = {
+    "aegis": "killinchu",
+    "sentra": "killinchu",
+    "immune": "killinchu",
+    "vessels": "killinchu",
+}
+EXPECTED_FORBIDDEN_PRODUCTS = {"nexus", *EXPECTED_FOLDS}
+EXPECTED_PORTFOLIO_SPACES = {
+    "SZLHOLDINGS/a11oy",
+    "SZLHOLDINGS/killinchu",
+    "SZLHOLDINGS/immune",
+    "SZLHOLDINGS/immune-lattice",
+    "SZLHOLDINGS/terra",
+    "SZLHOLDINGS/sentra",
+    "SZLHOLDINGS/counsel",
+    "SZLHOLDINGS/finance",
+    "SZLHOLDINGS/lyte",
+    "SZLHOLDINGS/vertical-services",
+    "SZLHOLDINGS/szl-command-lab",
+    "SZLHOLDINGS/david-leads",
+    "SZLHOLDINGS/szl-constellation",
+    "SZLHOLDINGS/szl-frontier",
+    "SZLHOLDINGS/szl-model-inference-lab",
+    "SZLHOLDINGS/ayllu",
+}
+ALLOWED_SPACE_CLASSES = {
+    "commercial_flagship_runtime",
+    "killinchu_capability_channel",
+    "public_domain_body_runtime",
+    "internal_engine_surface",
+    "shared_internal_engine_runtime",
+    "estate_atlas",
+    "reference_workflow",
+    "lab_surface",
+    "research_surface",
+    "forge_inference_surface",
+    "incubation_lab",
+}
+GITHUB_API = "https://api.github.com"
+HF_API = "https://huggingface.co/api"
+USER_AGENT = "SZL-Estate-Alignment/1.0"
+PRODUCT_PATH = "docs/strategy/living-command-fabric.v1.json"
+RUNTIME_BINDING_PATHS = ("/api/build-info", "/deployment.json")
+RUNTIME_OBSERVATIONS = 2
+MAX_RUNTIME_WORKERS = 8
+SOURCE_REVISION_KEYS = (
+    "observed_source_revision",
+    "source_revision",
+    "git_sha",
+    "revision",
+)
+
+
+class AlignmentError(RuntimeError):
+    """Raised when alignment evidence is malformed or unavailable."""
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise AlignmentError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise AlignmentError(f"non-finite JSON value: {value}")
+
+
+def load_json_bytes(payload: bytes, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            payload,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise AlignmentError(f"{label} is not strict UTF-8 JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AlignmentError(f"{label} must contain an object")
+    return value
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return load_json_bytes(path.read_bytes(), label=str(path))
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def exact_slugs(rows: Any, label: str, expected: list[str], failures: list[str]) -> None:
+    require(isinstance(rows, list), f"{label} must be an array", failures)
+    if not isinstance(rows, list):
+        return
+    observed = [row.get("slug") if isinstance(row, dict) else None for row in rows]
+    require(observed == expected, f"{label} slugs must be {expected}; observed {observed}", failures)
+    require(len(observed) == len(set(observed)), f"{label} contains duplicate slugs", failures)
+
+
+def validate_contract(contract: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    require(contract.get("schema") == SCHEMA, f"schema must be {SCHEMA}", failures)
+    authority = contract.get("authority")
+    require(isinstance(authority, dict), "authority must be an object", failures)
+    if isinstance(authority, dict):
+        expected_authority = {
+            "product_origin": "https://a-11-oy.com",
+            "proof_origin": "https://a11oy.net",
+            "canonical_source_organization": "https://github.com/szl-holdings",
+            "artifact_registry": "https://huggingface.co/SZLHOLDINGS",
+            "huggingface_front_door": "SZLHOLDINGS/README",
+        }
+        for key, expected in expected_authority.items():
+            require(authority.get(key) == expected, f"{key} must be {expected}", failures)
+
+    taxonomy = contract.get("taxonomy")
+    require(isinstance(taxonomy, dict), "taxonomy must be an object", failures)
+    if isinstance(taxonomy, dict):
+        flagships = taxonomy.get("commercial_flagships")
+        bodies = taxonomy.get("public_domain_bodies")
+        exact_slugs(flagships, "commercial_flagships", EXPECTED_FLAGSHIPS, failures)
+        exact_slugs(bodies, "public_domain_bodies", EXPECTED_BODIES, failures)
+        require(taxonomy.get("commercial_flagship_count") == 3, "commercial flagship count mismatch", failures)
+        require(taxonomy.get("public_domain_body_count") == 5, "public body count mismatch", failures)
+        require(taxonomy.get("internal_engine_count") == 6, "internal engine count mismatch", failures)
+        require(taxonomy.get("internal_engines") == EXPECTED_ENGINES, "internal engine set mismatch", failures)
+        require(taxonomy.get("folded_capabilities") == EXPECTED_FOLDS, "folded capability map mismatch", failures)
+        if isinstance(flagships, list):
+            flagship_slugs = {row.get("slug") for row in flagships if isinstance(row, dict)}
+            require(not (set(EXPECTED_FOLDS) & flagship_slugs), "folded capability promoted to flagship", failures)
+
+    snapshot = contract.get("huggingface_inventory_snapshot")
+    require(isinstance(snapshot, dict), "huggingface_inventory_snapshot must be an object", failures)
+    if isinstance(snapshot, dict):
+        require(snapshot.get("policy_authority") is False, "Hub inventory must not be publication policy", failures)
+        require(snapshot.get("governed_keep_list") == "docs/CANONICAL_FLEET.md", "governed keep-list authority mismatch", failures)
+        require(
+            snapshot.get("claim_boundary")
+            == "Public Hub inventory evidence only; not availability, operational readiness, or publication policy.",
+            "Hub inventory claim boundary mismatch",
+            failures,
+        )
+        rows = snapshot.get("portfolio_spaces")
+        require(isinstance(rows, list), "portfolio_spaces must be an array", failures)
+        if isinstance(rows, list):
+            ids = [row.get("repo_id") if isinstance(row, dict) else None for row in rows]
+            require(set(ids) == EXPECTED_PORTFOLIO_SPACES, "portfolio Space set mismatch", failures)
+            require(len(ids) == len(set(ids)) == 16, "portfolio Spaces must contain 16 unique IDs", failures)
+            require(all(isinstance(row, dict) and row.get("class") in ALLOWED_SPACE_CLASSES for row in rows), "unknown portfolio Space class", failures)
+            require(all(isinstance(row, dict) and str(row.get("canonical_source", "")).startswith("szl-holdings/") for row in rows), "every Space requires canonical GitHub source", failures)
+            require(all(isinstance(row, dict) and str(row.get("deployment_source", "")).startswith("szl-holdings/") for row in rows), "every Space requires canonical deployment source", failures)
+        require(snapshot.get("portfolio_space_count") == 16, "portfolio_space_count must be 16", failures)
+        require(snapshot.get("model_count") == 44, "model_count must be 44", failures)
+        require(snapshot.get("dataset_count") == 33, "dataset_count must be 33", failures)
+        require(snapshot.get("organization_card_space_excluded_from_portfolio_count") == "SZLHOLDINGS/README", "README control-surface exclusion missing", failures)
+
+    movement = contract.get("movement_contract")
+    require(isinstance(movement, dict), "movement_contract must be an object", failures)
+    if isinstance(movement, dict):
+        for key in (
+            "github_is_source_authority",
+            "huggingface_is_generated_artifact_registry",
+            "a11oy_net_is_proof_not_product",
+            "one_canonical_writer_per_huggingface_target",
+            "source_revision_required_for_runtime_claims",
+            "human_authority_required",
+        ):
+            require(movement.get(key) is True, f"{key} must be true", failures)
+        require(movement.get("public_effectors_enabled") is False, "public effectors must be disabled", failures)
+        require(movement.get("lambda_status") == "CONJECTURE_1_ADVISORY", "Lambda status mismatch", failures)
+        require(movement.get("locked_formula_ids") == LOCKED_EIGHT, "locked formula IDs mismatch", failures)
+        require(set(movement.get("forbidden_public_products") or []) == EXPECTED_FORBIDDEN_PRODUCTS, "forbidden public-product set mismatch", failures)
+    return failures
+
+
+def validate_documents(root: Path, contract: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    profile = (root / "profile/README.md").read_text(encoding="utf-8")
+    hf_readme = (root / "huggingface/org-card/README.md").read_text(encoding="utf-8")
+    hf_index = (root / "huggingface/org-card/index.html").read_text(encoding="utf-8")
+    manifest = load_json(root / "huggingface/org-card.manifest.json")
+    documents = {
+        "GitHub profile": profile,
+        "Hugging Face README": hf_readme,
+        "Hugging Face index": hf_index,
+    }
+    for label, text in documents.items():
+        for marker in ("Three commercial flagships", "Five public domain bodies", "Six internal engines"):
+            require(marker.casefold() in text.casefold(), f"{label} missing {marker!r}", failures)
+        for name in ("A11oy", "Killinchu", "Forge", "Terra", "PRISM Counsel", "PURIQ Finance", "LYTE"):
+            require(name.casefold() in text.casefold(), f"{label} missing {name}", failures)
+    for marker in ("16 portfolio Spaces", "44 models", "33 datasets"):
+        require(marker.casefold() in profile.casefold(), f"GitHub profile missing {marker}", failures)
+        require(marker.casefold() in hf_readme.casefold(), f"Hugging Face README missing {marker}", failures)
+    for label, text in documents.items():
+        require(
+            "not availability, operational readiness, or publication policy"
+            in " ".join(text.casefold().split()),
+            f"{label} missing Hub inventory claim boundary",
+            failures,
+        )
+    require('data-szl-surface="company-front-door"' in hf_index, "Hugging Face homepage smoke marker missing", failures)
+    require('data-szl-estate-alignment="1.0.0"' in hf_index, "Hugging Face homepage alignment marker missing", failures)
+    files = manifest.get("files") or []
+    mapping = {row.get("source"): row.get("destination") for row in files if isinstance(row, dict)}
+    require(mapping.get("docs/ESTATE_ALIGNMENT_CONTRACT_V1.json") == "estate-alignment.json", "manifest does not publish alignment contract", failures)
+    markers = ((manifest.get("runtime_transforms") or {}).get("README.md") or {}).get("required_markers") or []
+    for marker in ("Three commercial flagships", "Five public domain bodies", "Six internal engines"):
+        require(marker in markers, f"rendered README gate missing {marker}", failures)
+    return failures
+
+
+def normalize_product_source(value: str) -> str:
+    return value.replace(
+        "szl-holdings/a11oy/verticals/counsel",
+        "szl-holdings/a11oy:verticals/counsel",
+    )
+
+
+def validate_product_contract(product: Mapping[str, Any], local: Mapping[str, Any]) -> list[str]:
+    failures: list[str] = []
+    taxonomy = local["taxonomy"]
+    observed_bodies = [row.get("slug") for row in product.get("verticals", []) if isinstance(row, dict)]
+    require(observed_bodies == EXPECTED_BODIES, f"A11oy body taxonomy drift: {observed_bodies}", failures)
+    public_taxonomy = product.get("public_product_taxonomy") or {}
+    require(public_taxonomy.get("public_domain_bodies") == EXPECTED_BODIES, "A11oy public body set drift", failures)
+    require(public_taxonomy.get("internal_engines") == EXPECTED_ENGINES, "A11oy internal engine set drift", failures)
+    require(public_taxonomy.get("folded_into_killinchu") == list(EXPECTED_FOLDS), "A11oy folded capability set drift", failures)
+    require(((product.get("authorities") or {}).get("lean_kernel") or {}).get("locked_proven_ids") == LOCKED_EIGHT, "A11oy locked formula set drift", failures)
+    estate = product.get("estate") or {}
+    require(estate.get("product_surface") == local["authority"]["product_origin"], "A11oy product origin drift", failures)
+    require(estate.get("proof_surface") == local["authority"]["proof_origin"], "A11oy proof origin drift", failures)
+    require(estate.get("artifact_organization") == "SZLHOLDINGS", "A11oy artifact organization drift", failures)
+    local_sources = {row["slug"]: row["source"] for row in taxonomy["public_domain_bodies"]}
+    for row in product.get("verticals", []):
+        if not isinstance(row, dict) or row.get("slug") not in local_sources:
+            continue
+        observed = normalize_product_source(str(row.get("canonical_source") or ""))
+        require(observed == local_sources[row["slug"]], f"A11oy canonical source drift for {row['slug']}: {observed}", failures)
+    return failures
+
+
+def retry_delay(error: urllib.error.HTTPError, fallback: float) -> float:
+    raw = error.headers.get("Retry-After") if error.headers else None
+    if raw:
+        try:
+            return min(max(float(raw), fallback), 60.0)
+        except (TypeError, ValueError):
+            pass
+    return fallback
+
+
+def fetch_bytes(
+    url: str,
+    *,
+    token: str | None = None,
+    attempts: int = 5,
+    max_bytes: int = 4_000_000,
+    required_origin: str | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> bytes:
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": USER_AGENT,
+        "Cache-Control": "no-cache, no-store, max-age=0",
+        "Pragma": "no-cache",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    for attempt in range(attempts):
+        try:
+            request = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(request, timeout=45) as response:
+                final_url = str(response.geturl())
+                if required_origin and url_origin(final_url) != url_origin(required_origin):
+                    raise AlignmentError(
+                        f"cross-origin redirect rejected: {url} -> {final_url}"
+                    )
+                payload = response.read(max_bytes + 1)
+                if len(payload) > max_bytes:
+                    raise AlignmentError(f"response exceeds {max_bytes} bytes: {url}")
+                return payload
+        except urllib.error.HTTPError as exc:
+            final_url = str(exc.geturl())
+            if required_origin and url_origin(final_url) != url_origin(required_origin):
+                raise AlignmentError(
+                    f"cross-origin redirect rejected: {url} -> {final_url}"
+                ) from exc
+            if exc.code not in {429, 500, 502, 503, 504} or attempt + 1 == attempts:
+                raise
+            sleep(retry_delay(exc, float(2**attempt)))
+        except (urllib.error.URLError, TimeoutError, ConnectionError):
+            if attempt + 1 == attempts:
+                raise
+            sleep(float(2**attempt))
+    raise AlignmentError("unreachable retry state")
+
+
+def github_main_sha(repository: str, token: str | None) -> str:
+    value = load_json_bytes(
+        fetch_bytes(f"{GITHUB_API}/repos/{repository}/branches/main", token=token),
+        label=f"{repository} main",
+    )
+    sha = str((value.get("commit") or {}).get("sha") or "").lower()
+    if not SHA40.fullmatch(sha):
+        raise AlignmentError(f"{repository} main did not resolve to exact SHA")
+    return sha
+
+
+def source_repository(value: Any) -> str:
+    repository = str(value or "").split(":", 1)[0]
+    if re.fullmatch(r"szl-holdings/[A-Za-z0-9_.-]+", repository) is None:
+        raise AlignmentError(f"invalid canonical source repository: {value!r}")
+    return repository
+
+
+def runtime_origin(repo_id: Any) -> str:
+    value = str(repo_id or "")
+    if re.fullmatch(r"SZLHOLDINGS/[A-Za-z0-9][A-Za-z0-9._-]*", value) is None:
+        raise AlignmentError(f"invalid portfolio Space id: {repo_id!r}")
+    return "https://" + re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-") + ".hf.space"
+
+
+def url_origin(value: str) -> tuple[str, str, int | None]:
+    """Return a normalized network origin, rejecting ambiguous URLs."""
+
+    parsed = urllib.parse.urlsplit(value)
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise AlignmentError(f"invalid network origin: {value!r}")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise AlignmentError(f"invalid network origin: {value!r}") from exc
+    if port == (443 if parsed.scheme.lower() == "https" else 80):
+        port = None
+    return parsed.scheme.lower(), parsed.hostname.lower(), port
+
+
+def cache_busted_runtime_url(origin: str, path: str, ordinal: int) -> str:
+    parsed = urllib.parse.urlsplit(origin + path)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("cache_bust", f"{time.time_ns()}-{os.getpid()}-{ordinal}"))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(query), "")
+    )
+
+
+def source_revision(payload: Any) -> str | None:
+    """Return one exact Git source revision from a bounded runtime receipt."""
+
+    if not isinstance(payload, Mapping):
+        return None
+    candidates = [payload.get(key) for key in SOURCE_REVISION_KEYS]
+    for name in ("build", "source", "deployment", "runtime"):
+        nested = payload.get(name)
+        if isinstance(nested, Mapping):
+            candidates.extend(nested.get(key) for key in SOURCE_REVISION_KEYS)
+    revisions = {
+        str(candidate).strip().lower()
+        for candidate in candidates
+        if isinstance(candidate, str) and SHA40.fullmatch(candidate.strip().lower())
+    }
+    if len(revisions) > 1:
+        raise AlignmentError("runtime binding reports conflicting source revisions")
+    return next(iter(revisions), None)
+
+
+def reported_source_repository(payload: Any) -> str | None:
+    if not isinstance(payload, Mapping):
+        return None
+    candidates = [payload.get("source_repository"), payload.get("repository")]
+    for name in ("build", "source", "deployment", "runtime"):
+        nested = payload.get(name)
+        if isinstance(nested, Mapping):
+            candidates.extend(
+                (nested.get("source_repository"), nested.get("repository"))
+            )
+    repositories = {
+        source_repository(candidate)
+        for candidate in candidates
+        if isinstance(candidate, str) and candidate.startswith("szl-holdings/")
+    }
+    if len(repositories) > 1:
+        raise AlignmentError("runtime binding reports conflicting source repositories")
+    return next(iter(repositories), None)
+
+
+def runtime_source_binding(
+    row: Mapping[str, Any],
+    expected_revision: str,
+    *,
+    fetch: Callable[..., bytes] = fetch_bytes,
+) -> dict[str, Any]:
+    """Fail closed unless a Space exposes its exact canonical Git revision."""
+
+    repo_id = str(row.get("repo_id") or "")
+    repository = source_repository(row.get("deployment_source"))
+    expected = str(expected_revision or "").lower()
+    if SHA40.fullmatch(expected) is None:
+        raise AlignmentError(f"invalid expected source revision for {repo_id}: {expected!r}")
+    origin = runtime_origin(repo_id)
+    attempts: list[dict[str, Any]] = []
+    for path in RUNTIME_BINDING_PATHS:
+        observations: list[dict[str, Any]] = []
+        for ordinal in range(1, RUNTIME_OBSERVATIONS + 1):
+            url = cache_busted_runtime_url(origin, path, ordinal)
+            try:
+                payload = load_json_bytes(
+                    fetch(url, attempts=2, required_origin=origin),
+                    label=url,
+                )
+                observed = source_revision(payload)
+                observed_repository = reported_source_repository(payload)
+            except AlignmentError as exc:
+                observations.append({"ordinal": ordinal, "url": url, "error": str(exc)})
+                attempts.append(
+                    {
+                        "path": path,
+                        "observation_count": RUNTIME_OBSERVATIONS,
+                        "stable": False,
+                        "complete": False,
+                        "matched": False,
+                        "observations": observations,
+                    }
+                )
+                return {
+                    "repo_id": repo_id,
+                    "canonical_source": repository,
+                    "expected_revision": expected,
+                    "binding_path": path,
+                    "observed_revision": None,
+                    "observed_source": None,
+                    "matched": False,
+                    "attempts": attempts,
+                }
+            except Exception as exc:
+                observations.append(
+                    {"ordinal": ordinal, "url": url, "error": type(exc).__name__}
+                )
+            else:
+                observations.append(
+                    {
+                        "ordinal": ordinal,
+                        "url": url,
+                        "observed_revision": observed,
+                        "observed_source": observed_repository,
+                    }
+                )
+
+        successful = [row for row in observations if "error" not in row]
+        identities = {
+            (row.get("observed_revision"), row.get("observed_source"))
+            for row in successful
+        }
+        stable = len(successful) == RUNTIME_OBSERVATIONS and len(identities) == 1
+        observed, observed_repository = (
+            next(iter(identities)) if stable else (None, None)
+        )
+        complete = observed is not None and observed_repository is not None
+        attempt = {
+            "path": path,
+            "observation_count": RUNTIME_OBSERVATIONS,
+            "stable": stable,
+            "complete": complete,
+            "observed_revision": observed,
+            "observed_source": observed_repository,
+            "matched": (
+                stable
+                and complete
+                and observed == expected
+                and observed_repository == repository
+            ),
+            "observations": observations,
+        }
+        attempts.append(attempt)
+
+        if stable and complete:
+            return {
+                "repo_id": repo_id,
+                "canonical_source": repository,
+                "expected_revision": expected,
+                "binding_path": path,
+                "observed_revision": observed,
+                "observed_source": observed_repository,
+                "matched": attempt["matched"],
+                "attempts": attempts,
+            }
+        if successful and not stable:
+            return {
+                "repo_id": repo_id,
+                "canonical_source": repository,
+                "expected_revision": expected,
+                "binding_path": path,
+                "observed_revision": None,
+                "observed_source": None,
+                "matched": False,
+                "attempts": attempts,
+            }
+    return {
+        "repo_id": repo_id,
+        "canonical_source": repository,
+        "expected_revision": expected,
+        "binding_path": None,
+        "observed_revision": None,
+        "observed_source": None,
+        "matched": False,
+        "attempts": attempts,
+    }
+
+
+def canonical_repositories(contract: Mapping[str, Any]) -> set[str]:
+    repositories = {"szl-holdings/a11oy", "szl-holdings/.github"}
+    taxonomy = contract["taxonomy"]
+    snapshot = contract["huggingface_inventory_snapshot"]
+    rows = list(taxonomy["commercial_flagships"]) + list(taxonomy["public_domain_bodies"]) + list(snapshot["portfolio_spaces"])
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for key in ("source", "service_source", "canonical_source", "deployment_source"):
+            value = str(row.get(key) or "")
+            if value.startswith("szl-holdings/"):
+                repositories.add(source_repository(value))
+    return repositories
+
+
+def list_hf(kind: str) -> list[dict[str, Any]]:
+    value = json.loads(
+        fetch_bytes(f"https://huggingface.co/api/{kind}?author=SZLHOLDINGS&limit=100&full=true")
+    )
+    if not isinstance(value, list):
+        raise AlignmentError(f"Hugging Face {kind} endpoint did not return an array")
+    return [row for row in value if isinstance(row, dict)]
+
+
+def validate_live(contract: Mapping[str, Any]) -> tuple[list[str], dict[str, Any]]:
+    failures: list[str] = []
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    a11oy_sha = github_main_sha("szl-holdings/a11oy", token)
+    product = load_json_bytes(
+        fetch_bytes(
+            f"https://raw.githubusercontent.com/szl-holdings/a11oy/{a11oy_sha}/{PRODUCT_PATH}"
+        ),
+        label="A11oy living-command contract",
+    )
+    failures.extend(validate_product_contract(product, contract))
+
+    repository_observations: list[dict[str, Any]] = []
+    repository_revisions: dict[str, str] = {}
+    for repository in sorted(canonical_repositories(contract)):
+        try:
+            value = load_json_bytes(
+                fetch_bytes(f"{GITHUB_API}/repos/{repository}", token=token),
+                label=repository,
+            )
+            repository_observations.append(
+                {
+                    "repository": repository,
+                    "archived": value.get("archived"),
+                    "visibility": value.get("visibility"),
+                    "default_branch": value.get("default_branch"),
+                }
+            )
+            require(value.get("archived") is False, f"canonical repository is archived: {repository}", failures)
+            repository_revisions[repository] = github_main_sha(repository, token)
+        except Exception as exc:
+            failures.append(f"canonical repository unavailable: {repository}: {type(exc).__name__}")
+
+    models = list_hf("models")
+    datasets = list_hf("datasets")
+    spaces = list_hf("spaces")
+    space_ids = {str(row.get("id") or "") for row in spaces}
+    portfolio_ids = space_ids - {"SZLHOLDINGS/README"}
+    expected = {row["repo_id"] for row in contract["huggingface_inventory_snapshot"]["portfolio_spaces"]}
+    require(portfolio_ids == expected, f"public portfolio Space drift: missing={sorted(expected - portfolio_ids)} unexpected={sorted(portfolio_ids - expected)}", failures)
+    require(len(models) == contract["huggingface_inventory_snapshot"]["model_count"], f"model count drift: {len(models)}", failures)
+    require(len(datasets) == contract["huggingface_inventory_snapshot"]["dataset_count"], f"dataset count drift: {len(datasets)}", failures)
+    require("SZLHOLDINGS/README" in space_ids, "Hugging Face organization-card Space missing", failures)
+
+    runtime_rows = list(
+        contract["huggingface_inventory_snapshot"]["portfolio_spaces"]
+    )
+
+    def read_runtime_binding(
+        indexed_row: tuple[int, Mapping[str, Any]],
+    ) -> tuple[int, dict[str, Any] | None, str | None]:
+        index, row = indexed_row
+        repository = source_repository(row["deployment_source"])
+        expected_revision = repository_revisions.get(repository)
+        if expected_revision is None:
+            return (
+                index,
+                None,
+                f"runtime source authority unavailable for {row['repo_id']}: {repository}",
+            )
+        observation = runtime_source_binding(row, expected_revision)
+        failure = None
+        if observation["matched"] is not True:
+            failure = (
+                f"runtime source revision drift for {row['repo_id']}: "
+                f"expected {repository}@{expected_revision}, observed "
+                f"{observation.get('observed_source')}@{observation['observed_revision']}"
+            )
+        return index, observation, failure
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(MAX_RUNTIME_WORKERS, max(1, len(runtime_rows)))
+    ) as pool:
+        runtime_results = list(
+            pool.map(read_runtime_binding, enumerate(runtime_rows))
+        )
+
+    runtime_bindings: list[dict[str, Any]] = []
+    for _, observation, failure in sorted(runtime_results):
+        if observation is not None:
+            runtime_bindings.append(observation)
+        if failure is not None:
+            failures.append(failure)
+    return failures, {
+        "a11oy_contract_revision": a11oy_sha,
+        "canonical_repositories": repository_observations,
+        "runtime_source_bindings": runtime_bindings,
+        "huggingface": {
+            "models": len(models),
+            "datasets": len(datasets),
+            "spaces_including_org_card": len(space_ids),
+            "portfolio_spaces": len(portfolio_ids),
+            "portfolio_space_ids": sorted(portfolio_ids),
+        },
+    }
+
+
+def build_receipt(root: Path, *, live: bool) -> dict[str, Any]:
+    contract_path = root / "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json"
+    contract = load_json(contract_path)
+    failures = validate_contract(contract)
+    failures.extend(validate_documents(root, contract))
+    live_observation: dict[str, Any] | None = None
+    if live:
+        try:
+            live_failures, live_observation = validate_live(contract)
+            failures.extend(live_failures)
+        except Exception as exc:
+            failures.append(f"live alignment evidence unavailable: {type(exc).__name__}: {exc}")
+    receipt = {
+        "schema": "szl.estate-alignment-receipt/v1",
+        "observed_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "state": "ALIGNED" if not failures else "DIVERGENT",
+        "contract_sha256": sha256_bytes(contract_path.read_bytes()),
+        "source_revision": os.getenv("GITHUB_SHA", "UNAVAILABLE"),
+        "live_requested": live,
+        "live_observation": live_observation,
+        "failures": failures,
+        "authority": {
+            "provider_writes": False,
+            "secret_values_recorded": False,
+            "public_effectors_enabled": False,
+        },
+    }
+    receipt["receipt_sha256"] = sha256_bytes(
+        (json.dumps(receipt, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    )
+    return receipt
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--live", action="store_true")
+    parser.add_argument("--output", type=Path, default=Path("estate-alignment-receipt.json"))
+    args = parser.parse_args()
+    receipt = build_receipt(args.repo_root.resolve(), live=args.live)
+    args.output.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "state": receipt["state"],
+                "failure_count": len(receipt["failures"]),
+                "receipt_sha256": receipt["receipt_sha256"],
+            },
+            indent=2,
+        )
+    )
+    return 0 if receipt["state"] == "ALIGNED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/public_front_door_check.py
+++ b/.github/scripts/public_front_door_check.py
@@ -54,6 +54,7 @@ REQUIRED_PUBLICATION_BINDINGS = {
     "README.md": "huggingface/org-card/README.md",
     "HONEST_DISCLOSURE.md": "huggingface/org-card/HONEST_DISCLOSURE.md",
     "index.html": "huggingface/org-card/index.html",
+    "estate-alignment.json": "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json",
     "assets/estate-command-system.svg": "profile/assets/estate-command-system.svg",
     "assets/estate-banner-v2.svg": "profile/assets/estate-banner-v2.svg",
     "assets/hf-portfolio-map.svg": "profile/assets/hf-portfolio-map.svg",
@@ -71,6 +72,7 @@ REQUIRED_PUBLICATION_BINDINGS = {
 REQUIRED_PUSH_PATHS = {
     "huggingface/org-card/**",
     "huggingface/org-card.manifest.json",
+    "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json",
     "profile/assets/**",
     "profile/assets/evidence-lattice-v2.webp",
     ".github/scripts/hf_static_space_deploy.py",

--- a/.github/scripts/test_estate_alignment_contract.py
+++ b/.github/scripts/test_estate_alignment_contract.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = Path(__file__).with_name("estate_alignment_contract.py")
+SPEC = importlib.util.spec_from_file_location("estate_alignment_contract", MODULE_PATH)
+assert SPEC and SPEC.loader
+alignment = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(alignment)
+
+
+class EstateAlignmentContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.contract = alignment.load_json(
+            ROOT / "docs" / "ESTATE_ALIGNMENT_CONTRACT_V1.json"
+        )
+
+    def test_current_contract_and_documents_are_aligned(self) -> None:
+        self.assertEqual(alignment.validate_contract(self.contract), [])
+        self.assertEqual(alignment.validate_documents(ROOT, self.contract), [])
+
+    def test_exact_taxonomy_is_not_inferred_from_counts(self) -> None:
+        candidate = copy.deepcopy(self.contract)
+        candidate["taxonomy"]["commercial_flagships"][0]["slug"] = "immune"
+        failures = alignment.validate_contract(candidate)
+        self.assertTrue(any("commercial_flagships" in row for row in failures))
+        self.assertTrue(any("folded capability" in row for row in failures))
+
+    def test_space_inventory_rejects_missing_or_unclassified_surfaces(self) -> None:
+        candidate = copy.deepcopy(self.contract)
+        candidate["huggingface_inventory_snapshot"]["portfolio_spaces"].pop()
+        failures = alignment.validate_contract(candidate)
+        self.assertTrue(any("portfolio Space" in row for row in failures))
+
+        candidate = copy.deepcopy(self.contract)
+        candidate["huggingface_inventory_snapshot"]["portfolio_spaces"][0][
+            "class"
+        ] = "product_because_public"
+        failures = alignment.validate_contract(candidate)
+        self.assertIn("unknown portfolio Space class", failures)
+
+    def test_hub_inventory_cannot_become_publication_policy(self) -> None:
+        candidate = copy.deepcopy(self.contract)
+        candidate["huggingface_inventory_snapshot"]["policy_authority"] = True
+        failures = alignment.validate_contract(candidate)
+        self.assertIn("Hub inventory must not be publication policy", failures)
+
+        candidate = copy.deepcopy(self.contract)
+        candidate["huggingface_inventory_snapshot"]["governed_keep_list"] = "self"
+        failures = alignment.validate_contract(candidate)
+        self.assertIn("governed keep-list authority mismatch", failures)
+
+    def test_live_readback_qualifies_the_exact_pull_request_head(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "estate-one-fabric-alignment.yml"
+        ).read_text(encoding="utf-8")
+        live_job = workflow.split("  live-contract:\n", 1)[1]
+        self.assertNotIn("github.event_name != 'pull_request'", live_job)
+        exact_head = "${{ github.event.pull_request.head.sha || github.sha }}"
+        self.assertGreaterEqual(live_job.count(exact_head), 2)
+        self.assertIn("--live", live_job)
+
+    def test_strict_loader_rejects_duplicate_keys_and_nonfinite_numbers(self) -> None:
+        with self.assertRaisesRegex(alignment.AlignmentError, "duplicate JSON key"):
+            alignment.load_json_bytes(b'{"a":1,"a":2}', label="duplicate")
+        with self.assertRaisesRegex(alignment.AlignmentError, "non-finite"):
+            alignment.load_json_bytes(b'{"a":NaN}', label="nonfinite")
+
+    def test_product_contract_comparison_rejects_source_drift(self) -> None:
+        product = {
+            "estate": {
+                "product_surface": "https://a-11-oy.com",
+                "proof_surface": "https://a11oy.net",
+                "artifact_organization": "SZLHOLDINGS",
+            },
+            "authorities": {
+                "lean_kernel": {"locked_proven_ids": alignment.LOCKED_EIGHT}
+            },
+            "public_product_taxonomy": {
+                "public_domain_bodies": alignment.EXPECTED_BODIES,
+                "internal_engines": alignment.EXPECTED_ENGINES,
+                "folded_into_killinchu": list(alignment.EXPECTED_FOLDS),
+            },
+            "verticals": [
+                {
+                    "slug": row["slug"],
+                    "canonical_source": row["source"],
+                }
+                for row in self.contract["taxonomy"]["public_domain_bodies"]
+            ],
+        }
+        self.assertEqual(
+            alignment.validate_product_contract(product, self.contract), []
+        )
+        product["verticals"][-1]["canonical_source"] = "szl-holdings/lyte-lattice"
+        failures = alignment.validate_product_contract(product, self.contract)
+        self.assertTrue(any("canonical source drift for lyte" in row for row in failures))
+
+    def test_receipt_contains_no_write_authority(self) -> None:
+        receipt = alignment.build_receipt(ROOT, live=False)
+        self.assertEqual(receipt["state"], "ALIGNED")
+        self.assertFalse(receipt["authority"]["provider_writes"])
+        self.assertFalse(receipt["authority"]["secret_values_recorded"])
+        self.assertFalse(receipt["authority"]["public_effectors_enabled"])
+        self.assertEqual(len(receipt["receipt_sha256"]), 64)
+
+    def test_runtime_binding_requires_exact_canonical_revision(self) -> None:
+        row = {
+            "repo_id": "SZLHOLDINGS/terra",
+            "canonical_source": "szl-holdings/a11oy:verticals/terra",
+            "deployment_source": "szl-holdings/a11oy",
+        }
+        expected = "a" * 40
+        requested: list[str] = []
+
+        def fetch(url: str, **_kwargs) -> bytes:
+            requested.append(url)
+            self.assertEqual(
+                alignment.urllib.parse.urlsplit(url).path,
+                "/api/build-info",
+            )
+            return json.dumps(
+                {
+                    "source_repository": "szl-holdings/a11oy",
+                    "build": {"revision": expected},
+                }
+            ).encode()
+
+        observation = alignment.runtime_source_binding(row, expected, fetch=fetch)
+        self.assertTrue(observation["matched"])
+        self.assertEqual(observation["canonical_source"], "szl-holdings/a11oy")
+        self.assertEqual(observation["observed_revision"], expected)
+        self.assertEqual(len(requested), alignment.RUNTIME_OBSERVATIONS)
+        self.assertEqual(len(set(requested)), alignment.RUNTIME_OBSERVATIONS)
+        self.assertTrue(all("cache_bust=" in url for url in requested))
+
+        stale = alignment.runtime_source_binding(
+            row,
+            expected,
+            fetch=lambda _url, **_kwargs: json.dumps(
+                {
+                    "source_repository": "szl-holdings/szl-real-estate",
+                    "source_revision": "b" * 40,
+                }
+            ).encode(),
+        )
+        self.assertFalse(stale["matched"])
+        self.assertEqual(stale["observed_revision"], "b" * 40)
+        self.assertEqual(stale["observed_source"], "szl-holdings/szl-real-estate")
+
+    def test_runtime_binding_falls_back_to_static_deployment_receipt(self) -> None:
+        row = {
+            "repo_id": "SZLHOLDINGS/szl-command-lab",
+            "canonical_source": "szl-holdings/szl-command-lab",
+            "deployment_source": "szl-holdings/szl-command-lab",
+        }
+        expected = "c" * 40
+        requested: list[str] = []
+
+        def fetch(url: str, **_kwargs) -> bytes:
+            requested.append(url)
+            if alignment.urllib.parse.urlsplit(url).path == "/api/build-info":
+                raise OSError("not implemented")
+            return json.dumps(
+                {
+                    "source": {
+                        "repository": "szl-holdings/szl-command-lab",
+                        "revision": expected,
+                    }
+                }
+            ).encode()
+
+        observation = alignment.runtime_source_binding(row, expected, fetch=fetch)
+        self.assertTrue(observation["matched"])
+        self.assertEqual(observation["binding_path"], "/deployment.json")
+        self.assertEqual(len(requested), 2 * alignment.RUNTIME_OBSERVATIONS)
+
+    def test_incomplete_build_info_falls_back_to_complete_deployment(self) -> None:
+        row = {
+            "repo_id": "SZLHOLDINGS/terra",
+            "canonical_source": "szl-holdings/a11oy:verticals/terra",
+            "deployment_source": "szl-holdings/a11oy",
+        }
+        expected = "c" * 40
+        requested: list[str] = []
+
+        def fetch(url: str, **_kwargs) -> bytes:
+            requested.append(url)
+            path = alignment.urllib.parse.urlsplit(url).path
+            if path == "/api/build-info":
+                return json.dumps({"build": {"revision": expected}}).encode()
+            return json.dumps(
+                {
+                    "source": {
+                        "repository": "szl-holdings/a11oy",
+                        "revision": expected,
+                    }
+                }
+            ).encode()
+
+        observation = alignment.runtime_source_binding(row, expected, fetch=fetch)
+
+        self.assertTrue(observation["matched"])
+        self.assertEqual(observation["binding_path"], "/deployment.json")
+        self.assertEqual(len(observation["attempts"]), 2)
+        self.assertFalse(observation["attempts"][0]["complete"])
+        self.assertTrue(observation["attempts"][0]["stable"])
+        self.assertEqual(len(requested), 2 * alignment.RUNTIME_OBSERVATIONS)
+
+    def test_inconsistent_runtime_observations_fail_closed(self) -> None:
+        row = {
+            "repo_id": "SZLHOLDINGS/terra",
+            "canonical_source": "szl-holdings/a11oy:verticals/terra",
+            "deployment_source": "szl-holdings/a11oy",
+        }
+        expected = "d" * 40
+        revisions = iter((expected, "e" * 40))
+
+        def fetch(url: str, **_kwargs) -> bytes:
+            self.assertEqual(
+                alignment.urllib.parse.urlsplit(url).path,
+                "/api/build-info",
+            )
+            return json.dumps(
+                {
+                    "source_repository": "szl-holdings/a11oy",
+                    "source_revision": next(revisions),
+                }
+            ).encode()
+
+        observation = alignment.runtime_source_binding(row, expected, fetch=fetch)
+
+        self.assertFalse(observation["matched"])
+        self.assertEqual(observation["binding_path"], "/api/build-info")
+        self.assertFalse(observation["attempts"][0]["stable"])
+        self.assertEqual(len(observation["attempts"][0]["observations"]), 2)
+
+    def test_fetch_rejects_cross_origin_redirect_destination(self) -> None:
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def geturl(self) -> str:
+                return "https://attacker.invalid/deployment.json"
+
+            def read(self, _limit: int) -> bytes:
+                return b"{}"
+
+        with (
+            patch.object(alignment.urllib.request, "urlopen", return_value=Response()),
+            self.assertRaisesRegex(alignment.AlignmentError, "cross-origin redirect"),
+        ):
+            alignment.fetch_bytes(
+                "https://szlholdings-terra.hf.space/deployment.json",
+                attempts=1,
+                required_origin="https://szlholdings-terra.hf.space",
+            )
+
+        redirected_error = alignment.urllib.error.HTTPError(
+            "https://attacker.invalid/deployment.json",
+            404,
+            "not found",
+            {},
+            None,
+        )
+        with (
+            patch.object(
+                alignment.urllib.request,
+                "urlopen",
+                side_effect=redirected_error,
+            ),
+            self.assertRaisesRegex(alignment.AlignmentError, "cross-origin redirect"),
+        ):
+            alignment.fetch_bytes(
+                "https://szlholdings-terra.hf.space/deployment.json",
+                attempts=1,
+                required_origin="https://szlholdings-terra.hf.space",
+            )
+
+    def test_conflicting_runtime_revision_fields_fail_closed(self) -> None:
+        with self.assertRaisesRegex(alignment.AlignmentError, "conflicting"):
+            alignment.source_revision(
+                {
+                    "source_revision": "d" * 40,
+                    "build": {"revision": "e" * 40},
+                }
+            )
+
+        row = {
+            "repo_id": "SZLHOLDINGS/a11oy",
+            "canonical_source": "szl-holdings/a11oy",
+            "deployment_source": "szl-holdings/a11oy",
+        }
+        observation = alignment.runtime_source_binding(
+            row,
+            "d" * 40,
+            fetch=lambda _url, **_kwargs: json.dumps(
+                {
+                    "source_revision": "d" * 40,
+                    "build": {"revision": "e" * 40},
+                }
+            ).encode(),
+        )
+        self.assertFalse(observation["matched"])
+        self.assertEqual(len(observation["attempts"]), 1)
+
+    def test_live_alignment_checks_every_portfolio_runtime(self) -> None:
+        product = {
+            "estate": {
+                "product_surface": "https://a-11-oy.com",
+                "proof_surface": "https://a11oy.net",
+                "artifact_organization": "SZLHOLDINGS",
+            },
+            "authorities": {
+                "lean_kernel": {"locked_proven_ids": alignment.LOCKED_EIGHT}
+            },
+            "public_product_taxonomy": {
+                "public_domain_bodies": alignment.EXPECTED_BODIES,
+                "internal_engines": alignment.EXPECTED_ENGINES,
+                "folded_into_killinchu": list(alignment.EXPECTED_FOLDS),
+            },
+            "verticals": [
+                {"slug": row["slug"], "canonical_source": row["source"]}
+                for row in self.contract["taxonomy"]["public_domain_bodies"]
+            ],
+        }
+        revision = "f" * 40
+        space_ids = sorted(alignment.EXPECTED_PORTFOLIO_SPACES | {"SZLHOLDINGS/README"})
+
+        def fetch(url: str, **_kwargs) -> bytes:
+            if "/repos/" in url:
+                return b'{"archived":false,"visibility":"public","default_branch":"main"}'
+            return json.dumps(product).encode()
+
+        def list_hf(kind: str):
+            if kind == "models":
+                return [{}] * 44
+            if kind == "datasets":
+                return [{}] * 33
+            return [{"id": repo_id} for repo_id in space_ids]
+
+        seen: list[str] = []
+
+        def binding(row, expected_revision):
+            seen.append(row["repo_id"])
+            matched = row["repo_id"] != "SZLHOLDINGS/ayllu"
+            return {
+                "repo_id": row["repo_id"],
+                "expected_revision": expected_revision,
+                "observed_revision": expected_revision if matched else "0" * 40,
+                "matched": matched,
+            }
+
+        with (
+            patch.object(alignment, "fetch_bytes", side_effect=fetch),
+            patch.object(alignment, "github_main_sha", return_value=revision),
+            patch.object(alignment, "list_hf", side_effect=list_hf),
+            patch.object(alignment, "runtime_source_binding", side_effect=binding),
+        ):
+            failures, observation = alignment.validate_live(self.contract)
+
+        self.assertEqual(set(seen), alignment.EXPECTED_PORTFOLIO_SPACES)
+        self.assertEqual(len(observation["runtime_source_bindings"]), 16)
+        self.assertEqual(
+            [row["repo_id"] for row in observation["runtime_source_bindings"]],
+            [
+                row["repo_id"]
+                for row in self.contract["huggingface_inventory_snapshot"][
+                    "portfolio_spaces"
+                ]
+            ],
+        )
+        self.assertTrue(
+            any("runtime source revision drift for SZLHOLDINGS/ayllu" in row for row in failures)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_public_front_door_check.py
+++ b/.github/scripts/test_public_front_door_check.py
@@ -366,8 +366,8 @@ class PublicationBindingTests(unittest.TestCase):
             with self.subTest(section=section, key=key):
                 self.assertIn(section, check.publication_contract_issues(contract))
 
-    def test_requires_exact_seventeen_source_destination_pairs(self):
-        self.assertEqual(len(check.REQUIRED_PUBLICATION_BINDINGS), 17)
+    def test_requires_exact_eighteen_source_destination_pairs(self):
+        self.assertEqual(len(check.REQUIRED_PUBLICATION_BINDINGS), 18)
         issues = check.publication_binding_issues(
             self.root,
             self.files_for_expected_bindings(),

--- a/.github/workflows/estate-one-fabric-alignment.yml
+++ b/.github/workflows/estate-one-fabric-alignment.yml
@@ -1,0 +1,136 @@
+name: Estate one-fabric alignment
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
+      - profile/README.md
+      - huggingface/org-card/**
+      - huggingface/org-card.manifest.json
+      - .github/scripts/estate_alignment_contract.py
+      - .github/scripts/test_estate_alignment_contract.py
+      - .github/workflows/estate-one-fabric-alignment.yml
+  push:
+    branches: [main]
+    paths:
+      - docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
+      - profile/README.md
+      - huggingface/org-card/**
+      - huggingface/org-card.manifest.json
+      - .github/scripts/estate_alignment_contract.py
+      - .github/scripts/test_estate_alignment_contract.py
+      - .github/workflows/estate-one-fabric-alignment.yml
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: estate-one-fabric-alignment-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-contract:
+    name: Exact taxonomy, front doors, and publication set
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Compile controller and tests
+        run: >-
+          python -m py_compile
+          .github/scripts/estate_alignment_contract.py
+          .github/scripts/test_estate_alignment_contract.py
+
+      - name: Prove exact one-fabric contract offline
+        run: python .github/scripts/test_estate_alignment_contract.py
+
+      - name: Emit secret-free source receipt
+        env:
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python .github/scripts/estate_alignment_contract.py
+          --repo-root .
+          --output estate-alignment-local-receipt.json
+
+      - name: Prove static organization-card publication closure
+        run: |
+          set -euo pipefail
+          python .github/scripts/hf_static_space_deploy.py \
+            --repo-root . \
+            --manifest huggingface/org-card.manifest.json \
+            --source-sha "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --materialize "$(mktemp -d)" \
+            --report hf-org-card-alignment-materialization.json
+
+      - name: Upload immutable local evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: estate-alignment-local-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            estate-alignment-local-receipt.json
+            hf-org-card-alignment-materialization.json
+          if-no-files-found: error
+          retention-days: 90
+
+  live-contract:
+    name: Product, GitHub, and Hugging Face live readback
+    needs: local-contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact candidate source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Compare live product, source, and artifact authorities
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python .github/scripts/estate_alignment_contract.py
+          --repo-root .
+          --live
+          --output estate-alignment-live-receipt.json
+
+      - name: Upload immutable live evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: estate-alignment-live-${{ github.run_id }}-${{ github.run_attempt }}
+          path: estate-alignment-live-receipt.json
+          if-no-files-found: error
+          retention-days: 180

--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "huggingface/org-card/**"
       - "huggingface/org-card.manifest.json"
+      - "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json"
       - "profile/assets/**"
       - "profile/assets/evidence-lattice-v2.webp"
       - ".github/scripts/hf_static_space_deploy.py"

--- a/docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
+++ b/docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
@@ -1,0 +1,254 @@
+{
+  "schema": "szl.estate-alignment/v1",
+  "version": "1.0.0",
+  "effective_at": "2026-09-05T00:00:00Z",
+  "authority": {
+    "product_origin": "https://a-11-oy.com",
+    "proof_origin": "https://a11oy.net",
+    "canonical_source_organization": "https://github.com/szl-holdings",
+    "artifact_registry": "https://huggingface.co/SZLHOLDINGS",
+    "product_contract": {
+      "repository": "szl-holdings/a11oy",
+      "branch": "main",
+      "path": "docs/strategy/living-command-fabric.v1.json"
+    },
+    "organization_profile_repository": "szl-holdings/.github",
+    "huggingface_front_door": "SZLHOLDINGS/README"
+  },
+  "taxonomy": {
+    "commercial_flagship_count": 3,
+    "commercial_flagships": [
+      {
+        "slug": "a11oy",
+        "name": "A11oy Command",
+        "role": "governed action, policy, receipts, and product routing",
+        "product_url": "https://a-11-oy.com",
+        "source": "szl-holdings/a11oy",
+        "huggingface": [
+          "SZLHOLDINGS/a11oy"
+        ]
+      },
+      {
+        "slug": "killinchu",
+        "name": "Killinchu",
+        "role": "cyber-physical resilience and defensive command",
+        "product_url": "https://a-11-oy.com/killinchu",
+        "source": "szl-holdings/killinchu",
+        "huggingface": [
+          "SZLHOLDINGS/killinchu"
+        ]
+      },
+      {
+        "slug": "forge",
+        "name": "Forge / Own-Metal",
+        "role": "model lifecycle, qualification, kernels, and bounded inference",
+        "product_url": "https://a-11-oy.com/frontier",
+        "source": "szl-holdings/szl-forge",
+        "huggingface": [
+          "SZLHOLDINGS/szl-model-inference-lab"
+        ]
+      }
+    ],
+    "public_domain_body_count": 5,
+    "public_domain_bodies": [
+      {
+        "slug": "terra",
+        "name": "Terra",
+        "domain": "real-estate intelligence",
+        "source": "szl-holdings/szl-real-estate",
+        "service_source": "szl-holdings/vertical-services",
+        "huggingface": "SZLHOLDINGS/terra"
+      },
+      {
+        "slug": "killinchu",
+        "name": "Killinchu",
+        "domain": "cyber-physical resilience intelligence",
+        "source": "szl-holdings/killinchu",
+        "service_source": "szl-holdings/vertical-services",
+        "huggingface": "SZLHOLDINGS/killinchu"
+      },
+      {
+        "slug": "counsel",
+        "name": "PRISM Counsel",
+        "domain": "legal matter intelligence",
+        "source": "szl-holdings/a11oy:verticals/counsel",
+        "service_source": "szl-holdings/vertical-services",
+        "huggingface": "SZLHOLDINGS/counsel"
+      },
+      {
+        "slug": "finance",
+        "name": "PURIQ Finance",
+        "domain": "financial intelligence",
+        "source": "szl-holdings/puriq-live",
+        "service_source": "szl-holdings/vertical-services",
+        "huggingface": "SZLHOLDINGS/finance"
+      },
+      {
+        "slug": "lyte",
+        "name": "LYTE",
+        "domain": "business and agent observability",
+        "source": "szl-holdings/lyte-services",
+        "service_source": "szl-holdings/lyte-services",
+        "huggingface": "SZLHOLDINGS/lyte"
+      }
+    ],
+    "internal_engine_count": 6,
+    "internal_engines": [
+      "sentra",
+      "lyte",
+      "killinchu",
+      "finance",
+      "terra",
+      "counsel"
+    ],
+    "folded_capabilities": {
+      "aegis": "killinchu",
+      "sentra": "killinchu",
+      "immune": "killinchu",
+      "vessels": "killinchu"
+    }
+  },
+  "huggingface_inventory_snapshot": {
+    "evidence_class": "MEASURED_PUBLIC_API_SNAPSHOT",
+    "policy_authority": false,
+    "governed_keep_list": "docs/CANONICAL_FLEET.md",
+    "claim_boundary": "Public Hub inventory evidence only; not availability, operational readiness, or publication policy.",
+    "observed_at": "2026-09-04T23:34:00Z",
+    "portfolio_space_count": 16,
+    "model_count": 44,
+    "dataset_count": 33,
+    "organization_card_space_excluded_from_portfolio_count": "SZLHOLDINGS/README",
+    "portfolio_spaces": [
+      {
+        "repo_id": "SZLHOLDINGS/a11oy",
+        "class": "commercial_flagship_runtime",
+        "canonical_source": "szl-holdings/a11oy",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/killinchu",
+        "class": "commercial_flagship_runtime",
+        "canonical_source": "szl-holdings/killinchu",
+        "deployment_source": "szl-holdings/killinchu"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/immune",
+        "class": "killinchu_capability_channel",
+        "canonical_source": "szl-holdings/immune",
+        "deployment_source": "szl-holdings/immune"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/immune-lattice",
+        "class": "killinchu_capability_channel",
+        "canonical_source": "szl-holdings/immune",
+        "deployment_source": "szl-holdings/immune"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/terra",
+        "class": "public_domain_body_runtime",
+        "canonical_source": "szl-holdings/szl-real-estate",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/sentra",
+        "class": "internal_engine_surface",
+        "canonical_source": "szl-holdings/vertical-services",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/counsel",
+        "class": "public_domain_body_runtime",
+        "canonical_source": "szl-holdings/a11oy:verticals/counsel",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/finance",
+        "class": "public_domain_body_runtime",
+        "canonical_source": "szl-holdings/puriq-live",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/lyte",
+        "class": "public_domain_body_runtime",
+        "canonical_source": "szl-holdings/lyte-services",
+        "deployment_source": "szl-holdings/a11oy"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/vertical-services",
+        "class": "shared_internal_engine_runtime",
+        "canonical_source": "szl-holdings/vertical-services",
+        "deployment_source": "szl-holdings/vertical-services"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/szl-command-lab",
+        "class": "estate_atlas",
+        "canonical_source": "szl-holdings/szl-command-lab",
+        "deployment_source": "szl-holdings/szl-command-lab"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/david-leads",
+        "class": "reference_workflow",
+        "canonical_source": "szl-holdings/david-leads",
+        "deployment_source": "szl-holdings/david-leads"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/szl-constellation",
+        "class": "lab_surface",
+        "canonical_source": "szl-holdings/holographic-unify",
+        "deployment_source": "szl-holdings/holographic-unify"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/szl-frontier",
+        "class": "research_surface",
+        "canonical_source": "szl-holdings/szl-frontier",
+        "deployment_source": "szl-holdings/szl-frontier"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/szl-model-inference-lab",
+        "class": "forge_inference_surface",
+        "canonical_source": "szl-holdings/szl-forge",
+        "deployment_source": "szl-holdings/szl-forge"
+      },
+      {
+        "repo_id": "SZLHOLDINGS/ayllu",
+        "class": "incubation_lab",
+        "canonical_source": "szl-holdings/ayllu",
+        "deployment_source": "szl-holdings/ayllu"
+      }
+    ]
+  },
+  "movement_contract": {
+    "github_is_source_authority": true,
+    "huggingface_is_generated_artifact_registry": true,
+    "a11oy_net_is_proof_not_product": true,
+    "one_canonical_writer_per_huggingface_target": true,
+    "source_revision_required_for_runtime_claims": true,
+    "public_effectors_enabled": false,
+    "human_authority_required": true,
+    "lambda_status": "CONJECTURE_1_ADVISORY",
+    "locked_formula_ids": [
+      "F1",
+      "F4",
+      "F7",
+      "F11",
+      "F12",
+      "F18",
+      "F19",
+      "F22"
+    ],
+    "forbidden_public_products": [
+      "nexus",
+      "aegis",
+      "sentra",
+      "immune",
+      "vessels"
+    ],
+    "rules": [
+      "A site change that alters product taxonomy must update this contract and both organization front doors in the same protected change wave.",
+      "A GitHub source change is not an operational release until the canonical Hugging Face writer publishes and source-binding readback succeeds.",
+      "A Hugging Face listing is an artifact or runtime surface, not automatically a product.",
+      "Labs, capability planes, datasets, kernels, and model cards must not be promoted to peer product status without a new reviewed contract version.",
+      "Unproven, unavailable, sample, simulated, and roadmap states remain explicitly labelled."
+    ]
+  }
+}

--- a/huggingface/org-card.manifest.json
+++ b/huggingface/org-card.manifest.json
@@ -24,6 +24,10 @@
       "destination": "index.html"
     },
     {
+      "source": "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json",
+      "destination": "estate-alignment.json"
+    },
+    {
       "source": "profile/assets/estate-command-system.svg",
       "destination": "assets/estate-command-system.svg"
     },
@@ -81,6 +85,9 @@
       "mode": "rendered_markdown",
       "required_markers": [
         "Choose a path",
+        "Three commercial flagships",
+        "Five public domain bodies",
+        "Six internal engines",
         "HISTORICAL",
         "SIMULATED",
         "assets/estate-command-system.svg"

--- a/huggingface/org-card/README.md
+++ b/huggingface/org-card/README.md
@@ -22,8 +22,7 @@ license: apache-2.0
 
 # Governed AI. Inference. Command systems.
 
-Frontier infrastructure for decisions that must remain bounded, inspectable,
-and reproducible.
+Bounded, inspectable, reproducible.
 
 [**Enter the product**](https://a-11-oy.com) ·
 [**Explore SZL Atlas**](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab) ·
@@ -43,8 +42,7 @@ on a capability claim.
 ### Explore
 
 [**SZL Atlas**](https://huggingface.co/spaces/SZLHOLDINGS/szl-command-lab)
-is the searchable public estate: models, first-class kernels, datasets, Spaces,
-usage signals, source links, and evidence boundaries in one responsive surface.
+maps models, kernels, datasets, Spaces, source links, and evidence boundaries.
 
 [Models](https://huggingface.co/SZLHOLDINGS/models) ·
 [Kernels](https://huggingface.co/SZLHOLDINGS/kernels) ·
@@ -63,6 +61,18 @@ evaluation, compatibility, and limitations.
 Inspect the [trust boundary](https://github.com/szl-holdings/.github/blob/main/TRUST.md),
 exact revisions, limitations, and the
 [served source binding](https://szlholdings-readme.static.hf.space/deployment.json).
+
+## Estate map
+
+Three commercial flagships: A11oy,Killinchu,Forge. Five public domain bodies:
+Terra,Killinchu,PRISM Counsel,PURIQ Finance,LYTE. Six internal engines:
+Sentra,Lyte,Killinchu,Finance,Terra,Counsel.
+
+**16 portfolio Spaces · 44 models · 33 datasets.**
+
+Hub inventory is registry-only—not availability, operational readiness, or
+publication policy. KEEP authority:
+[`docs/CANONICAL_FLEET.md`](https://github.com/szl-holdings/.github/blob/main/docs/CANONICAL_FLEET.md).
 
 ## Command fabric
 
@@ -98,8 +108,7 @@ is a **HISTORICAL** mirror.
 [Atlas source binding](https://szlholdings-szl-command-lab.hf.space/api/build-info) ·
 [A11oy readiness](https://a-11-oy.com/api/a11oy/v1/readiness)
 
-No production authorization, regulatory approval, adoption, funding, revenue,
-or investment outcome is claimed.
+No production authorization or approval is claimed.
 
 ## Reproduce and verify
 

--- a/huggingface/org-card/index.html
+++ b/huggingface/org-card/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-szl-estate-alignment="1.0.0">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
@@ -406,6 +406,20 @@
                 <li><a href="https://github.com/szl-holdings"><span>Protected GitHub source</span><span>code</span></a></li>
               </ul>
             </article>
+          </div>
+        </section>
+
+        <section class="szl-hf-section" aria-labelledby="szl-hf-estate-map-title">
+          <div class="szl-hf-shell">
+            <div class="szl-hf-section-heading">
+              <div class="szl-hf-eyebrow">One governed estate map</div>
+              <h2 id="szl-hf-estate-map-title">Product, source, runtime, and proof move together.</h2>
+            </div>
+            <p>Three commercial flagships: A11oy, Killinchu, Forge.</p>
+            <p>Five public domain bodies: Terra, Killinchu, PRISM Counsel, PURIQ Finance, LYTE.</p>
+            <p>Six internal engines: Sentra, Lyte, Killinchu, Finance, Terra, Counsel.</p>
+            <p>16 portfolio Spaces · 44 models · 33 datasets.</p>
+            <p>This measured Hub inventory is registry evidence only—not availability, operational readiness, or publication policy. The governed KEEP list remains <a href="https://github.com/szl-holdings/.github/blob/main/docs/CANONICAL_FLEET.md">docs/CANONICAL_FLEET.md</a>.</p>
           </div>
         </section>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -10,7 +10,7 @@
 
 **Control before action. Evidence after.**
 
-Governed AI systems with source-bound execution and portable verification receipts.
+Source-bound governed AI.
 
 **Product** · [a-11-oy.com](https://a-11-oy.com)  
 **Proof** · [a11oy.net](https://a11oy.net)
@@ -29,13 +29,23 @@ Authority and evidence are checked before action. Runtime stays inside its decla
 
 - **A11oy** · [product](https://a-11-oy.com) · [source](https://github.com/szl-holdings/a11oy)
 - **Proof registry** · [a11oy.net](https://a11oy.net) for records, diligence, and atlas evidence
-- **Artifacts** · [Hugging Face](https://huggingface.co/SZLHOLDINGS): **16 public Spaces, 44 models, and 33 datasets** measured 2026-09-04 23:34 UTC via Hub API. Previous profile line (15 / 44 / 32) is superseded.
+- **Artifacts** · [Hugging Face](https://huggingface.co/SZLHOLDINGS): **16 public Spaces, 44 models, and 33 datasets** measured 2026-09-04 23:34 UTC via Hub API.
 - **IMMUNE** · [product tab](https://a-11-oy.com/immune) · [Channel A](https://huggingface.co/spaces/SZLHOLDINGS/immune) · [Channel B](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice)
 - **Organization source** · [github.com/szl-holdings](https://github.com/szl-holdings)
 
-Public Spaces measured this hour: `a11oy`, `killinchu`, `immune`, `immune-lattice`, `counsel`, `terra`, `sentra`, `finance`, `lyte`, `vertical-services`, `szl-command-lab`, `david-leads`, `szl-constellation`, `szl-frontier`, `szl-model-inference-lab`, `ayllu`.
-
 NEXUS is an internal IMMUNE capability plane, not a second product. Do not mint `SZLHOLDINGS/nexus`. Killinchu public actuation is **SIMULATED** unless a separately authorized effector proves otherwise.
+
+## Estate map
+
+Three commercial flagships: A11oy,Killinchu,Forge. Five public domain bodies:
+Terra,Killinchu,PRISM Counsel,PURIQ Finance,LYTE. Six internal engines:
+Sentra,Lyte,Killinchu,Finance,Terra,Counsel.
+
+**16 portfolio Spaces · 44 models · 33 datasets.**
+
+Hub inventory is registry-only—not availability, operational readiness, or
+publication policy. KEEP authority:
+[`docs/CANONICAL_FLEET.md`](https://github.com/szl-holdings/.github/blob/main/docs/CANONICAL_FLEET.md).
 
 ## Portfolio
 


### PR DESCRIPTION
Supersedes #679 with a clean GitHub-verified signed history from exact protected main.

This successor keeps the estate alignment contract and exact-source workflow, preserves the already-proven accessible and host-isolated front doors, publishes estate-alignment.json through the canonical manifest, and schedules publication when its source changes.

Local evidence: 6 estate tests passed; 87 public-front-door checks passed; 50 publication tests passed; 44 host-isolated embed tests passed; doctrine passed.

No DCO attestation is required; integrity is provided by GitHub-verified commit signing plus exact-head CI.