### PR TITLE
test(hf): prove TraceLease managed-source additions

### DIFF
--- a/.github/scripts/test_hf_candidate_plan.py
+++ b/.github/scripts/test_hf_candidate_plan.py
@@ -190,6 +190,51 @@ class TestExactCandidatePlan(CandidatePlanTestCase):
         ).encode()
         self.assertEqual(digest, hashlib.sha256(canonical_bytes).hexdigest())
 
+    def test_tracelease_managed_additions_are_planned_without_allowlist(self) -> None:
+        fixture = self.fixture()
+        candidate = fixture.commit(
+            "add TraceLease managed modules",
+            {
+                "Dockerfile": (
+                    "FROM python:3.12-slim\n"
+                    "COPY app/ /app/\n"
+                    "COPY szl_tracelease_durable.py szl_tracelease_routes.py ./\n"
+                ),
+                "szl_tracelease_durable.py": "DURABLE = True\n",
+                "szl_tracelease_routes.py": "ROUTES = True\n",
+            },
+        )
+
+        first = fixture.plan(candidate)
+        second = fixture.plan(candidate)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["canonical_sha256"], second["canonical_sha256"])
+        self.assertNotIn("szl_tracelease_durable.py", first["baseline"]["files"])
+        self.assertNotIn("szl_tracelease_routes.py", first["baseline"]["files"])
+        for path in (
+            "szl_tracelease_durable.py",
+            "szl_tracelease_routes.py",
+        ):
+            self.assertEqual(
+                first["candidate"]["source_files"][path],
+                first["candidate"]["files"][path]["oid"],
+            )
+        self.assertEqual(
+            [
+                (delta["path"], delta["kind"])
+                for delta in first["deltas"]
+            ],
+            [
+                ("Dockerfile", "modified"),
+                ("szl_tracelease_durable.py", "managed-added"),
+                ("szl_tracelease_routes.py", "managed-added"),
+            ],
+        )
+        self.assertEqual(first["delta_count"], 3)
+        self.assertEqual(first["network_requests"], 0)
+        self.assertFalse(first["allowlist_used"])
+
     def test_directory_copy_recurses_through_git_tree(self) -> None:
         fixture = self.fixture(
             extra_files={


### PR DESCRIPTION
## Root cause

The provider-free candidate planner supports new Docker-managed files, but its regression suite did not cover the exact two-module TraceLease transition. Add one regression that verifies baseline absence, exact Git object identity, the three expected file deltas, deterministic plan/digest, zero network requests, and no allowlist.

Only `.github/scripts/test_hf_candidate_plan.py` changes. Publisher code, workflows, credentials, and provider state are untouched. A11oy retains its existing reviewed publisher pins; this shared regression does not qualify a new A11oy deployment controller.

## Satisfies and section reference

TraceLease source-derived publication contract: the reviewed local split handoff dated 2026-09-04, amended after the current A11oy protected-base lifecycle audit. No FORGE-9 acceptance-test identifier is assigned to this narrow regression.

## Labels and risk

LOCAL_TESTED. Risk A: one offline regression only; no runtime behavior change, external calls, or evidence promotion.

## Tests executed

| Test | Result |
| --- | --- |
| Full candidate planner suite | 33 tests passed |
| Full publisher suite | 93 tests run, OK; two Windows symlink cases skipped |
| `git diff --check` | Passed |
| SSH commit signature and Signed-off-by trailer | Verified locally on the submitted commit |

Protected CI, hosted provenance, and merge results remain pending until recorded by GitHub. Local actionlint is unavailable; this PR changes no workflow. No UI, theorem, schema, or production capability claim changes.

## Rollback

If the regression itself is incorrect, revert the single test commit through a new protected PR. No provider rollback is needed because the change has no provider side effects.

## Known limitations and doctrine

The synthetic planner fixture proves managed-file selection and deterministic provenance, not a Hugging Face upload or runtime deployment. Windows symlink branches remain for Linux CI. Doctrine and existing build/security gates remain unchanged; no force push, bypass, or safeguard reduction is requested.
