### PR TITLE
fix(hf): harden lifecycle receipts and final state preflight

### DIFF
--- a/.github/scripts/hf_space_lifecycle_reconcile.py
+++ b/.github/scripts/hf_space_lifecycle_reconcile.py
@@ -150,7 +150,7 @@ def normalize_revision(value: Any) -> str:
     revision = str(value or "").strip().lower()
     if not EXACT_REVISION.fullmatch(revision):
         raise LifecycleError(
-            f"Hugging Face Space revision is not an exact 40-hex SHA: {revision!r}"
+            "Hugging Face Space revision must be an exact 40-hex SHA"
         )
     return revision
 
@@ -526,6 +526,41 @@ def error_record(exc: Exception) -> dict[str, Any]:
     return record
 
 
+def validate_dispatch_inputs(
+    *,
+    target: str,
+    mode: str,
+    requested_transition: str,
+    expected_policy_sha256: str | None,
+    expected_visibility: str | None,
+    expected_runtime_stage: str | None,
+    expected_revision: str | None,
+) -> dict[str, Any]:
+    """Validate before retaining dispatch values or contacting either provider."""
+
+    if mode not in {"plan", "apply"}:
+        raise LifecycleError("unsupported mode")
+    if requested_transition not in {"inspect", "private-to-public"}:
+        raise LifecycleError("unsupported transition")
+    if target not in ALLOWED_REPO_IDS:
+        raise LifecycleError("target is not in the fixed inventory")
+    visibility = _optional_visibility(expected_visibility)
+    stage = _optional_stage(expected_runtime_stage)
+    revision = _optional_revision(expected_revision)
+    digest = _optional_policy_sha256(expected_policy_sha256)
+    return {
+        "mode": mode,
+        "target": target,
+        "requested_transition": requested_transition,
+        "expected_policy_sha256": digest,
+        "expected_before": {
+            "visibility": visibility,
+            "runtime_stage": stage,
+            "revision": revision,
+        },
+    }
+
+
 def reconcile(
     *,
     client: HubSpaceClient,
@@ -549,15 +584,6 @@ def reconcile(
         "schema": RECEIPT_SCHEMA,
         "generated_at": utc_now(),
         "organization": ORGANIZATION,
-        "mode": mode,
-        "target": target,
-        "requested_transition": requested_transition,
-        "expected_policy_sha256": expected_policy_sha256,
-        "expected_before": {
-            "visibility": expected_visibility,
-            "runtime_stage": expected_runtime_stage,
-            "revision": expected_revision,
-        },
         "controller": {
             "repository": environ.get("GITHUB_REPOSITORY") or CONTROL_REPOSITORY,
             "ref": environ.get("GITHUB_REF") or "LOCAL_UNBOUND",
@@ -571,6 +597,8 @@ def reconcile(
             "At most one private-to-public transition is applied.",
             "Private, archive, pause, restart, upload, hardware, storage, variable, and secret writes are impossible through this controller.",
             "RUNNING is provider-stage evidence, not product correctness or uptime proof.",
+            "Expected-state checks are optimistic: the provider visibility write has no atomic compare-and-set precondition.",
+            "A plan receipt is not consumed or replay-protected by this controller.",
         ],
         "provider_request": {
             "attempted": False,
@@ -581,12 +609,20 @@ def reconcile(
         "readbacks": [],
     }
     try:
-        if mode not in {"plan", "apply"}:
-            raise LifecycleError(f"unsupported mode: {mode!r}")
-        if requested_transition not in {"inspect", "private-to-public"}:
-            raise LifecycleError(f"unsupported transition: {requested_transition!r}")
-        if target not in ALLOWED_REPO_IDS:
-            raise LifecycleError(f"target is not in the fixed inventory: {target!r}")
+        validated = validate_dispatch_inputs(
+            target=target,
+            mode=mode,
+            requested_transition=requested_transition,
+            expected_policy_sha256=expected_policy_sha256,
+            expected_visibility=expected_visibility,
+            expected_runtime_stage=expected_runtime_stage,
+            expected_revision=expected_revision,
+        )
+        receipt.update(validated)
+        expected_policy_sha256 = validated["expected_policy_sha256"]
+        expected_visibility = validated["expected_before"]["visibility"]
+        expected_runtime_stage = validated["expected_before"]["runtime_stage"]
+        expected_revision = validated["expected_before"]["revision"]
 
         policy, targets = load_policy(policy_path)
         digest = policy_digest(policy)
@@ -649,6 +685,16 @@ def reconcile(
 
         control_revision = main_guard(environ)
         receipt["controller"]["live_default_before"] = control_revision
+        # This narrows the race window; update_repo_settings has no atomic CAS.
+        final_before = client.read(target)
+        receipt["prewrite"] = {
+            "observed_at": utc_now(),
+            "state": asdict(final_before),
+            "matches_initial_observation": final_before == before,
+            "check_semantics": "OPTIMISTIC_NON_ATOMIC",
+        }
+        if final_before != before:
+            raise LifecycleError("provider state changed before the publication write")
         receipt["provider_request"] = {
             "attempted": True,
             "method": transition.method,
@@ -722,69 +768,125 @@ def reconcile(
         return receipt, 2
 
 
-def _optional_visibility(value: str) -> str | None:
+def _optional_visibility(value: str | None) -> str | None:
     if not value or value == "unspecified":
         return None
     if value not in {"public", "private"}:
-        raise argparse.ArgumentTypeError("visibility must be unspecified, public, or private")
+        raise LifecycleError("visibility must be unspecified, public, or private")
     return value
 
 
-def _optional_stage(value: str) -> str | None:
-    return normalize_stage(value) if value else None
+def _optional_stage(value: str | None) -> str | None:
+    if not value:
+        return None
+    stage = value.strip().upper()
+    if stage not in {
+        "NO_APP_FILE", "CONFIG_ERROR", "BUILDING", "BUILD_ERROR", "RUNNING",
+        "RUNNING_BUILDING", "RUNTIME_ERROR", "DELETING", "PAUSED", "SLEEPING",
+    }:
+        raise LifecycleError("expected runtime stage is not a supported provider stage")
+    return stage
 
 
-def _optional_revision(value: str) -> str | None:
+def _optional_revision(value: str | None) -> str | None:
     return normalize_revision(value) if value else None
 
 
-def _optional_policy_sha256(value: str) -> str | None:
+def _optional_policy_sha256(value: str | None) -> str | None:
     return normalize_policy_sha256(value) if value else None
 
 
+class ReceiptArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        # argparse includes raw argument values in errors; retain neither.
+        raise LifecycleError("invalid lifecycle command-line arguments")
+
+
+def dispatch_values(args: argparse.Namespace) -> dict[str, Any]:
+    """Read Actions inputs from its event file without placing them in logs."""
+
+    fields = {
+        "target": "repo_id",
+        "mode": "mode",
+        "requested_transition": "transition",
+        "expected_policy_sha256": "expected_policy_sha256",
+        "expected_visibility": "expected_visibility",
+        "expected_runtime_stage": "expected_stage",
+        "expected_revision": "expected_revision",
+    }
+    cli = {
+        "target": args.target,
+        "mode": args.mode,
+        "requested_transition": args.transition,
+        "expected_policy_sha256": args.expected_policy_sha256,
+        "expected_visibility": args.expected_visibility,
+        "expected_runtime_stage": args.expected_stage,
+        "expected_revision": args.expected_revision,
+    }
+    if args.dispatch_event is None:
+        cli["mode"] = "plan" if cli["mode"] is None else cli["mode"]
+        cli["requested_transition"] = (
+            "inspect" if cli["requested_transition"] is None
+            else cli["requested_transition"]
+        )
+        return cli
+    if any(value is not None for value in cli.values()):
+        raise LifecycleError("dispatch event inputs cannot be mixed with CLI inputs")
+    try:
+        event = json.loads(args.dispatch_event.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        raise LifecycleError("cannot read lifecycle dispatch event") from None
+    inputs = event.get("inputs") if isinstance(event, dict) else None
+    if (
+        not isinstance(inputs, dict)
+        or set(inputs) - set(fields.values())
+        or not all(isinstance(value, str) for value in inputs.values())
+    ):
+        raise LifecycleError("lifecycle dispatch inputs must be a supported string mapping")
+    return {key: inputs.get(event_key) for key, event_key in fields.items()}
+
+
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = ReceiptArgumentParser(description=__doc__, allow_abbrev=False)
     parser.add_argument(
         "--policy",
         type=Path,
         default=Path(".github/data/hf-space-lifecycle-policy.json"),
     )
-    parser.add_argument("--target", required=True, choices=sorted(ALLOWED_REPO_IDS))
-    parser.add_argument("--mode", choices=("plan", "apply"), default="plan")
+    parser.add_argument("--dispatch-event", type=Path)
+    parser.add_argument("--target")
+    parser.add_argument("--mode")
+    parser.add_argument("--transition")
+    parser.add_argument("--expected-policy-sha256")
+    parser.add_argument("--expected-visibility")
+    parser.add_argument("--expected-stage")
+    parser.add_argument("--expected-revision")
     parser.add_argument(
-        "--transition", choices=("inspect", "private-to-public"), default="inspect"
+        "--report", type=Path,
+        default=Path(os.environ.get("REPORT_PATH", "reports/hf-space-lifecycle/receipt.json")),
     )
-    parser.add_argument("--expected-policy-sha256", type=_optional_policy_sha256)
-    parser.add_argument(
-        "--expected-visibility", type=_optional_visibility, default=None
-    )
-    parser.add_argument("--expected-stage", type=_optional_stage, default=None)
-    parser.add_argument("--expected-revision", type=_optional_revision, default=None)
-    parser.add_argument(
-        "--report", type=Path, default=Path("reports/hf-space-lifecycle/receipt.json")
-    )
-    args = parser.parse_args(argv)
-    args.report.parent.mkdir(parents=True, exist_ok=True)
-
-    token = os.environ.get("HF_ORG_TOKEN")
-    if not token:
-        report = {
-            "schema": RECEIPT_SCHEMA,
-            "generated_at": utc_now(),
-            "organization": ORGANIZATION,
-            "mode": args.mode,
-            "target": args.target,
-            "requested_transition": args.transition,
-            "result": "FAILED_BEFORE_ATTEMPT",
-            "error": {
-                "class": "LifecycleError",
-                "detail": "authenticated plan/apply requires the fixed HF_ORG_TOKEN secret",
-            },
-            "exit_code": 2,
-        }
-        exit_code = 2
-    else:
-        try:
+    args = argparse.Namespace()
+    report: dict[str, Any] = {
+        "schema": RECEIPT_SCHEMA,
+        "generated_at": utc_now(),
+        "organization": ORGANIZATION,
+        "provider_request": {"attempted": False},
+    }
+    try:
+        parser.parse_args(argv, namespace=args)
+        report.update(validate_dispatch_inputs(**dispatch_values(args)))
+        token = os.environ.get("HF_ORG_TOKEN")
+        if not token:
+            report.update({
+                "result": "FAILED_BEFORE_ATTEMPT",
+                "error": {
+                    "class": "LifecycleError",
+                    "detail": "authenticated plan/apply requires the fixed HF_ORG_TOKEN secret",
+                },
+                "exit_code": 2,
+            })
+            exit_code = 2
+        else:
             # Do not expose the provider credential to a feature-branch copy.
             require_current_protected_main(os.environ)
             import httpx
@@ -798,33 +900,28 @@ def main(argv: list[str] | None = None) -> int:
                     HfApi(endpoint=HUGGING_FACE_ENDPOINT, token=token)
                 ),
                 policy_path=args.policy,
-                target=args.target,
-                mode=args.mode,
-                requested_transition=args.transition,
-                expected_policy_sha256=args.expected_policy_sha256,
-                expected_visibility=args.expected_visibility,
-                expected_runtime_stage=args.expected_stage,
-                expected_revision=args.expected_revision,
+                target=report["target"],
+                mode=report["mode"],
+                requested_transition=report["requested_transition"],
+                expected_policy_sha256=report["expected_policy_sha256"],
+                expected_visibility=report["expected_before"]["visibility"],
+                expected_runtime_stage=report["expected_before"]["runtime_stage"],
+                expected_revision=report["expected_before"]["revision"],
                 environ=os.environ,
             )
-        except Exception as exc:
-            report = {
-                "schema": RECEIPT_SCHEMA,
-                "generated_at": utc_now(),
-                "organization": ORGANIZATION,
-                "mode": args.mode,
-                "target": args.target,
-                "requested_transition": args.transition,
-                "result": (
-                    "BLOCKED_PRECONDITION"
-                    if isinstance(exc, LifecycleError)
-                    else "FAILED_BEFORE_ATTEMPT"
-                ),
-                "error": error_record(exc),
-                "exit_code": 2,
-            }
-            exit_code = 2
+    except Exception as exc:
+        report.update({
+            "result": (
+                "BLOCKED_PRECONDITION"
+                if isinstance(exc, LifecycleError)
+                else "FAILED_BEFORE_ATTEMPT"
+            ),
+            "error": error_record(exc),
+            "exit_code": 2,
+        })
+        exit_code = 2
 
+    args.report.parent.mkdir(parents=True, exist_ok=True)
     args.report.write_text(
         json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )

--- a/.github/scripts/test_hf_space_lifecycle_reconcile.py
+++ b/.github/scripts/test_hf_space_lifecycle_reconcile.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import copy
+import contextlib
 import importlib.util
+import io
 import json
 import re
 import sys
@@ -12,6 +14,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -406,6 +409,8 @@ class LifecycleTests(unittest.TestCase):
         )
         self.assertEqual(code, 0)
         self.assertEqual(report["result"], "VERIFIED")
+        self.assertTrue(report["prewrite"]["matches_initial_observation"])
+        self.assertEqual(report["prewrite"]["check_semantics"], "OPTIMISTIC_NON_ATOMIC")
         self.assertEqual(
             api.mutations,
             [
@@ -415,6 +420,169 @@ class LifecycleTests(unittest.TestCase):
                 )
             ],
         )
+
+    def test_provider_drift_during_main_guard_blocks_final_write(self) -> None:
+        repo_id = "SZLHOLDINGS/szl-khipu"
+        current = state(repo_id, "private")
+        changed_states = {
+            "visibility": state(repo_id, "public"),
+            "stage": state(repo_id, "private", stage="PAUSED"),
+            "revision": state(repo_id, "private", revision="d" * 40),
+            "sdk": state(repo_id, "private", sdk="static"),
+        }
+        for field, changed in changed_states.items():
+            with self.subTest(field=field):
+                api = FakeApi({repo_id: current})
+
+                def changing_guard(_env: object) -> str:
+                    api.states[repo_id] = changed
+                    return MAIN_SHA
+
+                report, code, _ = self.run_controller(
+                    repo_id, current, mode="apply", transition="private-to-public",
+                    expected=True, expected_policy=True, api=api, guard=changing_guard,
+                )
+                self.assertEqual(code, 2)
+                self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
+                self.assertFalse(report["provider_request"]["attempted"])
+                self.assertFalse(report["prewrite"]["matches_initial_observation"])
+                self.assertEqual(api.mutations, [])
+
+    def test_failed_final_provider_read_blocks_write_without_raw_error(self) -> None:
+        repo_id = "SZLHOLDINGS/szl-khipu"
+        current = state(repo_id, "private")
+
+        class FinalReadDeniedApi(FakeApi):
+            reads = 0
+
+            def space_info(self, *, repo_id: str, expand: list[str]) -> SimpleNamespace:
+                self.reads += 1
+                if self.reads == 2:
+                    raise RuntimeError("raw-provider-response-do-not-retain")
+                return super().space_info(repo_id=repo_id, expand=expand)
+
+        api = FinalReadDeniedApi({repo_id: current})
+        report, code, _ = self.run_controller(
+            repo_id, current, mode="apply", transition="private-to-public",
+            expected=True, expected_policy=True, api=api,
+        )
+        self.assertEqual(code, 2)
+        self.assertEqual(report["result"], "FAILED_BEFORE_ATTEMPT")
+        self.assertFalse(report["provider_request"]["attempted"])
+        self.assertEqual(api.mutations, [])
+        self.assertNotIn("raw-provider-response", json.dumps(report))
+
+    def test_cli_invalid_dispatch_emits_safe_receipt_before_provider_access(self) -> None:
+        invalid = "raw-invalid-dispatch-value-do-not-retain"
+        fields = (
+            "target", "mode", "transition", "expected-policy-sha256",
+            "expected-visibility", "expected-stage", "expected-revision",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "receipt.json"
+            for field in fields:
+                with self.subTest(field=field):
+                    argv = ["--target=SZLHOLDINGS/a11oy", f"--report={report_path}"]
+                    argv.append(f"--{field}={invalid}")
+                    output, errors = io.StringIO(), io.StringIO()
+                    with (
+                        patch.dict(module.os.environ, {"HF_ORG_TOKEN": "fake-test-only"}),
+                        patch.object(module, "require_current_protected_main") as guard,
+                        contextlib.redirect_stdout(output),
+                        contextlib.redirect_stderr(errors),
+                    ):
+                        code = module.main(argv)
+                    self.assertEqual(code, 2)
+                    guard.assert_not_called()
+                    report = json.loads(report_path.read_text(encoding="utf-8"))
+                    self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
+                    self.assertFalse(report["provider_request"]["attempted"])
+                    self.assertNotIn(invalid, json.dumps(report))
+                    self.assertNotIn(invalid, output.getvalue() + errors.getvalue())
+
+    def test_cli_syntax_error_emits_run_scoped_receipt_without_raw_arguments(self) -> None:
+        invalid = "raw-invalid-cli-option-do-not-retain"
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "run-evidence.json"
+            output, errors = io.StringIO(), io.StringIO()
+            with (
+                patch.dict(module.os.environ, {"REPORT_PATH": str(report_path)}),
+                patch.object(module, "require_current_protected_main") as guard,
+                contextlib.redirect_stdout(output),
+                contextlib.redirect_stderr(errors),
+            ):
+                code = module.main(["--target=SZLHOLDINGS/a11oy", f"--{invalid}"])
+            self.assertEqual(code, 2)
+            guard.assert_not_called()
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
+            self.assertFalse(report["provider_request"]["attempted"])
+            self.assertNotIn(invalid, output.getvalue() + errors.getvalue())
+
+    def test_event_inputs_are_validated_without_logging_raw_values(self) -> None:
+        invalid = "raw-event-value-do-not-retain"
+        base = {"repo_id": "SZLHOLDINGS/a11oy", "mode": "plan", "transition": "inspect"}
+        cases = [
+            {"inputs": {**base, field: invalid}}
+            for field in (
+                "repo_id", "mode", "transition", "expected_policy_sha256",
+                "expected_visibility", "expected_stage", "expected_revision", "unknown",
+            )
+        ]
+        cases.extend([
+            {"inputs": {**base, "mode": {"raw": invalid}}},
+            {"inputs": None},
+            [],
+        ])
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            report_path = Path(directory) / "receipt.json"
+            for event in cases:
+                with self.subTest(event=event):
+                    event_path.write_text(json.dumps(event), encoding="utf-8")
+                    output, errors = io.StringIO(), io.StringIO()
+                    with (
+                        patch.dict(module.os.environ, {"HF_ORG_TOKEN": "fake-test-only"}),
+                        patch.object(module, "require_current_protected_main") as guard,
+                        contextlib.redirect_stdout(output),
+                        contextlib.redirect_stderr(errors),
+                    ):
+                        code = module.main([
+                            f"--dispatch-event={event_path}", f"--report={report_path}",
+                        ])
+                    self.assertEqual(code, 2)
+                    guard.assert_not_called()
+                    report = json.loads(report_path.read_text(encoding="utf-8"))
+                    self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
+                    self.assertFalse(report["provider_request"]["attempted"])
+                    self.assertNotIn(invalid, json.dumps(report))
+                    self.assertNotIn(invalid, output.getvalue() + errors.getvalue())
+
+    def test_event_inputs_retain_valid_identity_and_reject_cli_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            report_path = Path(directory) / "receipt.json"
+            event_path.write_text(json.dumps({"inputs": {
+                "repo_id": "SZLHOLDINGS/a11oy", "mode": "plan", "transition": "inspect",
+                "expected_visibility": "unspecified", "expected_stage": "",
+                "expected_revision": "", "expected_policy_sha256": "",
+            }}), encoding="utf-8")
+            argv = [f"--dispatch-event={event_path}", f"--report={report_path}"]
+            with (
+                patch.dict(module.os.environ, {}, clear=True),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(module.main(argv), 2)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["result"], "FAILED_BEFORE_ATTEMPT")
+            self.assertEqual(report["target"], "SZLHOLDINGS/a11oy")
+            self.assertEqual(report["mode"], "plan")
+            self.assertIsNone(report["expected_before"]["revision"])
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(module.main([*argv, "--target=SZLHOLDINGS/nexus"]), 2)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["result"], "BLOCKED_PRECONDITION")
+            self.assertFalse(report["provider_request"]["attempted"])
 
     def test_public_apply_is_precondition_failure(self) -> None:
         repo_id = "SZLHOLDINGS/a11oy"
@@ -582,7 +750,9 @@ class LifecycleTests(unittest.TestCase):
         for block in step_blocks:
             if block is not controller_steps[0]:
                 self.assertNotIn("HF_ORG_TOKEN", block)
-        self.assertIn("--expected-policy-sha256", workflow)
+        self.assertIn('--dispatch-event "$GITHUB_EVENT_PATH"', workflow)
+        self.assertNotIn("${{ inputs.", workflow)
+        self.assertNotIn("INPUT_EXPECTED_", workflow)
         self.assertIn("--require-hashes", workflow)
         self.assertIn("persist-credentials: false", workflow)
         uses = re.findall(r"uses:\s+[^@\s]+@([^\s]+)", workflow)

--- a/.github/workflows/hf-space-lifecycle-reconcile.yml
+++ b/.github/workflows/hf-space-lifecycle-reconcile.yml
@@ -95,29 +95,22 @@ on:
 permissions:
   contents: read
 
-# A single organization-wide key prevents two instances of this controller
-# from crossing provider writes. Other legacy HF writers remain separately
-# governed and must not be dispatched during an apply.
+# GitHub concurrency is repository-scoped. This key serializes participating
+# workflows here, but does not lock writers in other repositories or clients.
+# Other HF writers must be coordinated separately before an apply.
 concurrency:
   group: hf-provider-mutation-szlholdings
   cancel-in-progress: false
 
 jobs:
   reconcile:
-    name: Plan or publish one exact Space with compare-and-set evidence
+    name: Plan or publish one Space with optimistic expected-state evidence
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production
     env:
       GITHUB_TOKEN: ${{ github.token }}
       HF_HUB_DISABLE_PROGRESS_BARS: "1"
-      INPUT_REPO_ID: ${{ inputs.repo_id }}
-      INPUT_MODE: ${{ inputs.mode }}
-      INPUT_TRANSITION: ${{ inputs.transition }}
-      INPUT_EXPECTED_POLICY_SHA256: ${{ inputs.expected_policy_sha256 }}
-      INPUT_EXPECTED_VISIBILITY: ${{ inputs.expected_visibility }}
-      INPUT_EXPECTED_STAGE: ${{ inputs.expected_stage }}
-      INPUT_EXPECTED_REVISION: ${{ inputs.expected_revision }}
       REPORT_PATH: reports/hf-space-lifecycle/evidence-${{ github.run_id }}-${{ github.run_attempt }}.json
     steps:
       - name: Harden runner
@@ -172,14 +165,6 @@ jobs:
             'from importlib.metadata import version; assert version("huggingface-hub") == "1.19.0"'
           echo "python=$VENV/bin/python" >> "$GITHUB_OUTPUT"
 
-      - name: Bind safe run-scoped evidence identity
-        id: evidence
-        shell: bash
-        run: |
-          set -euo pipefail
-          SAFE_TARGET="${INPUT_REPO_ID//\//-}"
-          echo "safe_target=$SAFE_TARGET" >> "$GITHUB_OUTPUT"
-
       - name: Plan or apply one expected-state publication
         env:
           HF_ORG_TOKEN: ${{ secrets.HF_ORG_TOKEN }}
@@ -189,20 +174,14 @@ jobs:
           "${{ steps.runtime.outputs.python }}" -I -P \
             .github/scripts/hf_space_lifecycle_reconcile.py \
             --policy .github/data/hf-space-lifecycle-policy.json \
-            --target "$INPUT_REPO_ID" \
-            --mode "$INPUT_MODE" \
-            --transition "$INPUT_TRANSITION" \
-            --expected-policy-sha256 "$INPUT_EXPECTED_POLICY_SHA256" \
-            --expected-visibility "$INPUT_EXPECTED_VISIBILITY" \
-            --expected-stage "$INPUT_EXPECTED_STAGE" \
-            --expected-revision "$INPUT_EXPECTED_REVISION" \
+            --dispatch-event "$GITHUB_EVENT_PATH" \
             --report "$REPORT_PATH"
 
       - name: Upload run-scoped lifecycle evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: hf-space-lifecycle-${{ steps.evidence.outputs.safe_target }}-${{ inputs.transition }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: hf-space-lifecycle-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ env.REPORT_PATH }}
           if-no-files-found: error
           retention-days: 90

--- a/huggingface/SPACE_LIFECYCLE.md
+++ b/huggingface/SPACE_LIFECYCLE.md
@@ -3,7 +3,7 @@
 **Status:** protected source policy. A source merge is not a provider mutation,
 and a provider `RUNNING` stage is not end-to-end product proof.
 
-## Current authenticated authority
+## Historical authenticated policy authority
 
 The policy is bound to the supported-API inventory at protected `.github/main`:
 
@@ -16,6 +16,11 @@ The policy is bound to the supported-API inventory at protected `.github/main`:
 - Authenticated role: SZLHOLDINGS organization admin
 - Counts: 44 models, 37 datasets, 46 Spaces, 14 Kernels, 18 collections,
   and 6 buckets
+
+This fixed policy is based on the August 31 inventory; it is not a current
+estate census and does not admit every Space that may exist today. Deleted
+targets fail provider reads, and new targets require a separate policy review.
+The lifecycle hardening does not refresh the inventory or change visibility.
 
 The immutable inventory enumerated 46 existing Spaces and all 46 were public
 and enabled. A later bounded runtime census observed 27 `RUNNING` and 19
@@ -30,7 +35,7 @@ inventory as public. New repositories do not match a wildcard and require a new
 protected policy revision with content, privacy, license, and source review.
 
 The desired runtime stage is `RUNNING` for every admitted Space. This first
-controller reports runtime drift but cannot repair it. At the current census,
+controller reports runtime drift but cannot repair it. At the August 31 census,
 the following 19 public Spaces were paused:
 
 - `a11oy-factory`
@@ -61,7 +66,9 @@ and source/runtime identity checks. A blanket restart is not encoded here.
 
 `HF Space Lifecycle Reconcile` is manual, protected-main-only, serialized on
 `hf-provider-mutation-szlholdings`, and gated by the GitHub `production`
-environment. Only the controller step receives the fixed `HF_ORG_TOKEN`
+environment. GitHub concurrency only serializes participating workflows in
+this repository; it is not an organization-wide or provider-side lock.
+Only the controller step receives the fixed `HF_ORG_TOKEN`
 secret. Without logging identity or token material, it verifies user identity
 and an unambiguous SZLHOLDINGS admin role, then performs a separate,
 non-mutating `HfApi.auth_check(..., repo_type="space", write=True)` against the
@@ -78,7 +85,7 @@ HfApi.update_repo_settings(
 )
 ```
 
-An apply requires all of the following from an immediately preceding plan:
+An operator must obtain all of the following from a fresh plan for an apply:
 
 1. Exact 64-hex policy digest.
 2. Exact observed visibility.
@@ -86,11 +93,30 @@ An apply requires all of the following from an immediately preceding plan:
 4. Exact 40-hex Hub revision.
 5. The precise `private-to-public` transition.
 
-The controller rechecks the live provider state and protected-main identity,
-attempts at most one call, retries authenticated reads only, and verifies that
+The controller checks provider state and protected-main identity, then reads
+provider state again immediately before attempting the write. Any change in
+Space identity, visibility, revision, runtime stage, or SDK between those two
+reads blocks the write. It attempts at most one call, retries authenticated
+reads only, and verifies that
 visibility changed while revision, runtime stage, and SDK did not. If the call
 may have escaped but readback cannot prove the result, the receipt is
 `UNKNOWN_AFTER_ATTEMPT` and the job fails. It must not be retried blindly.
+
+These checks are optimistic, not atomic compare-and-set (CAS). The supported
+visibility API does not accept an expected revision or other atomic state
+precondition, so a competing writer can still act between the final read and
+the write. Expected values supplied by an operator are not a signed plan
+receipt, and the controller does not check plan age or consume a receipt once.
+Matching readback proves the observed state, not sole authorship of the change.
+Coordinate all competing writers before applying; this patch does not provide
+provider-wide serialization or replay protection.
+
+Malformed dispatch values fail with a receipt and exit code 2 before provider
+access. Actions passes its event-file path to the controller; it does not bind
+raw inputs into step environments or commands that the runner prints.
+Receipts and CLI errors exclude invalid input values. Artifact names
+use only the GitHub run ID and attempt, so invalid targets or transitions are
+not copied into workflow outputs or artifact names.
 
 The controller cannot:
 
@@ -108,10 +134,10 @@ to merge as an operator. It can log an `archived` readback without asserting
 that the state became true, can leave some failed reads green, selects the first
 token that answers `whoami` without proving SZLHOLDINGS manage authority, has a
 two-target partial-write group, and has no exact-policy digest, expected-state
-CAS, production environment, protected-main recheck, or immutable receipt.
+checks, production environment, protected-main recheck, or immutable receipt.
 
 It also implements an older consolidation snapshot that conflicts with the
-current authenticated fact that all 46 Spaces are public. It must be closed as
+August 31 authenticated snapshot in which all 46 Spaces were public. It must be closed as
 superseded, not dispatched or merged.
 
 ## Private datasets and buckets remain gated


### PR DESCRIPTION
## Summary

Harden the single-Space visibility controller without changing its admitted inventory or granting new mutation capabilities.

- Validate dispatch/CLI values before provider access or receipt retention and emit a sanitized run-scoped failure receipt for malformed inputs.
- Read Actions inputs from its event file so raw dispatch values are not interpolated into runner-logged commands, environment bindings, or artifact names.
- Re-read exact provider identity, visibility, stage, revision, and SDK immediately before the one permitted visibility write; block if any field drifted.
- Describe expected-state checks as optimistic and non-atomic, document repository-scoped concurrency and absent replay protection, and label the August 31 inventory historical.

## Verification

- 24 lifecycle unittest tests passed, including malformed-input receipts, event-file inputs, final-read drift, failed reads, and existing before/after mutation checks.
- actionlint 1.7.12 passed for the changed workflow.
- git diff --check passed.
- Independent local code review found no merge-blocking defect; its stale documentation observation was corrected.

## Boundaries

No Hugging Face provider mutation, visibility change, restart, upload, hardware change, secret change, or policy-inventory refresh was performed. This patch does not implement provider-wide locking, atomic compare-and-set, signed plan admission, or replay prevention. Source CI, protected merge, provider publication, and runtime correctness remain separate evidence layers.
