### PR TITLE
fix(sre): revalidate incident authority at every write

### DIFF
--- a/.github/scripts/estate_deadman.py
+++ b/.github/scripts/estate_deadman.py
@@ -692,8 +692,9 @@ def validate_run_rows(runs: Sequence[Mapping[str, Any]]) -> None:
         )
         require(run_id not in ids, "workflow run ids repeat")
         ids.add(run_id)
+        created_time = parse_time(item.get("created_at"))
         require(
-            parse_time(item.get("created_at")) is not None,
+            created_time is not None,
             f"workflow run {run_id} creation timestamp is invalid",
         )
         status = item.get("status")
@@ -704,9 +705,14 @@ def validate_run_rows(runs: Sequence[Mapping[str, Any]]) -> None:
                 conclusion in RUN_CONCLUSIONS,
                 f"workflow run {run_id} conclusion is invalid",
             )
+            updated_time = parse_time(item.get("updated_at"))
             require(
-                parse_time(item.get("updated_at")) is not None,
+                updated_time is not None,
                 f"workflow run {run_id} terminal update timestamp is invalid",
+            )
+            require(
+                updated_time >= created_time,
+                f"workflow run {run_id} terminal update precedes creation",
             )
         else:
             require(
@@ -1066,6 +1072,8 @@ def reconcile_incident(
     policy: Mapping[str, Any],
     report: Mapping[str, Any],
     _now: dt.datetime,
+    *,
+    before_mutation: Callable[[], None],
 ) -> dict[str, Any]:
     repository = policy["controller_repository"]
     title = policy["incident"]["title"]
@@ -1092,11 +1100,13 @@ def reconcile_incident(
             return {"action": "none", "ok": True}
         number = current.get("number")
         require(isinstance(number, int), "incident number is invalid")
+        before_mutation()
         api.add_comment(
             repository,
             number,
             f"Independent scheduled-control evidence recovered at `{report['generated_at']}`. Closing automatically.",
         )
+        before_mutation()
         api.update_issue(repository, number, state="closed")
         prove_readback(number, state="closed")
         return {"action": "closed", "ok": True, "issue_number": number}
@@ -1106,6 +1116,7 @@ def reconcile_incident(
 
     body = issue_body(report)
     if current is None:
+        before_mutation()
         created = api.create_issue(repository, title, body)
         number = created.get("number")
         require(isinstance(number, int), "created incident number is invalid")
@@ -1117,6 +1128,7 @@ def reconcile_incident(
         }
     number = current.get("number")
     require(isinstance(number, int), "incident number is invalid")
+    before_mutation()
     api.update_issue(repository, number, body=body)
     prove_readback(number, state="open", body=body)
     return {"action": "refreshed", "ok": True, "issue_number": number}
@@ -1240,7 +1252,9 @@ def run_live(
         },
         "secret_values_recorded": False,
     }
-    try:
+
+    def reverify_controller_tip() -> None:
+        report["authority"]["controller_tip_reverified"] = False
         current_controller_tip = read_api.verified_branch_tip(
             policy["controller_repository"], policy["controller_branch"]
         )
@@ -1249,15 +1263,24 @@ def run_live(
             "controller authority changed during observation",
         )
         report["authority"]["controller_tip_reverified"] = True
+
+    try:
+        reverify_controller_tip()
         report["evidence_sha256"] = sha256_hex(canonical_json(report))
         report["incident"] = reconcile_incident(
             incident_api,
             policy,
             report,
             dt.datetime.now(dt.timezone.utc),
+            before_mutation=reverify_controller_tip,
         )
     except Exception as exc:
-        report.setdefault("evidence_sha256", sha256_hex(canonical_json(report)))
+        final_evidence = {
+            key: value
+            for key, value in report.items()
+            if key not in {"evidence_sha256", "incident"}
+        }
+        report["evidence_sha256"] = sha256_hex(canonical_json(final_evidence))
         report["incident"] = {
             "action": "failed",
             "ok": False,
@@ -1268,7 +1291,7 @@ def run_live(
     output.with_suffix(output.suffix + ".sha256").write_text(
         receipt_file_sha256 + "\n", encoding="ascii"
     )
-    return 0 if confirmation_state == "HEALTHY" else 2
+    return 0 if confirmed_healthy and report["incident"]["ok"] else 2
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/docs/estate-deadman.md
+++ b/docs/estate-deadman.md
@@ -16,6 +16,9 @@ newer red run. Active runs are accepted only inside their bounded duration and
 only when backed by a fresh success or a newly installed workflow's first-run
 grace period.
 
+Completed runs must have a terminal update time at or after their creation time.
+An impossible timestamp sequence is rejected before it can influence health.
+
 A suspected failure is sampled twice, sixty seconds apart. Only the same target
 failing both samples creates or refreshes the single `[ESTATE-DEADMAN]`
 incident. Alternating or recovered samples are `INCONCLUSIVE`, fail the run,
@@ -27,6 +30,18 @@ with an immutable provider-authenticated scheduled workflow attempt. It does
 not claim causal authorship because same-repository workflows using the built-in
 Actions identity can also write issues; every confirmed cycle overwrites the
 reserved issue with current evidence.
+
+The controller checks the protected branch revision again after incident
+discovery and immediately before every create, comment, refresh, or close.
+If the branch changes between a recovery comment and closing the issue, the
+close is withheld and the receipt records the failed reconciliation.
+
+Legacy incident records that predate run-bound markers are not trusted as
+current incidents. An operator can preserve the original body and open state,
+retitle the record outside the exact reserved title, and document the migration.
+The next scheduled cycle creates current evidence under the reserved title if
+failure is confirmed. Migration never supplies a synthetic run marker or claims
+that the underlying outage recovered.
 
 Each cycle writes a JSON receipt and a `.sha256` sidecar containing the SHA-256
 of the exact emitted JSON file bytes. The receipt contains public

--- a/tests/test_estate_deadman.py
+++ b/tests/test_estate_deadman.py
@@ -4,6 +4,8 @@ import ast
 import datetime as dt
 import hashlib
 import io
+import json
+import os
 import sys
 import tempfile
 import unittest
@@ -11,7 +13,7 @@ from contextlib import redirect_stderr
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any, Mapping
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 ROOT = Path(__file__).resolve().parents[1]
 MODULE_PATH = ROOT / ".github" / "scripts" / "estate_deadman.py"
@@ -310,7 +312,7 @@ class EvaluationTests(unittest.TestCase):
                     status="completed",
                     conclusion="success",
                     created_minutes_ago=-5,
-                    completed_minutes_ago=-4,
+                    completed_minutes_ago=-6,
                 )
             ]
         )
@@ -332,6 +334,19 @@ class EvaluationTests(unittest.TestCase):
         )
         self.assertFalse(observed.healthy)
         self.assertEqual(observed.state, "STALE_SUCCESS")
+
+    def test_completed_run_cannot_finish_before_it_was_created(self) -> None:
+        impossible = run(
+            run_id=10,
+            status="completed",
+            conclusion="success",
+            created_minutes_ago=5,
+            completed_minutes_ago=6,
+        )
+        with self.assertRaisesRegex(ContractError, "terminal update precedes creation"):
+            self.observe([impossible])
+        impossible["updated_at"] = impossible["created_at"]
+        self.assertTrue(self.observe([impossible]).healthy)
 
     def test_malformed_newest_run_cannot_hide_behind_older_green(self) -> None:
         malformed = run(
@@ -708,9 +723,159 @@ class IncidentContractTests(unittest.TestCase):
                 }
 
         api = ReconcileApi()
-        result = reconcile_incident(api, policy(), report(), NOW)
+        result = reconcile_incident(
+            api, policy(), report(), NOW, before_mutation=lambda: None
+        )
         self.assertEqual(result["action"], "refreshed")
         self.assertTrue(api.updated)
+
+    def test_reconciliation_rechecks_authority_before_every_write(self) -> None:
+        class RecordingApi:
+            def __init__(self, exists: bool) -> None:
+                self.exists = exists
+                self.events: list[str] = []
+                self.body = ""
+                self.state = "open"
+
+            def find_incident(self, repository: str, title: str) -> Any:
+                self.events.append("discovery")
+                return {"number": 42} if self.exists else None
+
+            def create_issue(self, repository: str, title: str, body: str) -> Any:
+                self.events.append("create")
+                self.body = body
+                return {"number": 42}
+
+            def add_comment(self, repository: str, number: int, body: str) -> None:
+                self.events.append("comment")
+
+            def update_issue(self, repository: str, number: int, **values: Any) -> Any:
+                self.events.append("close" if "state" in values else "refresh")
+                self.body = values.get("body", self.body)
+                self.state = values.get("state", self.state)
+                return {"number": number}
+
+            def issue(self, repository: str, number: int) -> Any:
+                self.events.append("readback")
+                return {
+                    "number": number,
+                    "title": policy()["incident"]["title"],
+                    "state": self.state,
+                    "body": self.body,
+                }
+
+        scenarios = (
+            (False, False, ["create"]),
+            (True, False, ["refresh"]),
+            (True, True, ["comment", "close"]),
+        )
+        for exists, healthy, writes in scenarios:
+            for blocked_at in range(len(writes) + 1):
+                with self.subTest(
+                    exists=exists, healthy=healthy, blocked_at=blocked_at
+                ):
+                    api = RecordingApi(exists)
+                    rechecks = 0
+
+                    def check_authority() -> None:
+                        nonlocal rechecks
+                        rechecks += 1
+                        api.events.append("recheck")
+                        if blocked_at and rechecks == blocked_at:
+                            raise ContractError("controller authority changed")
+
+                    def reconcile() -> None:
+                        reconcile_incident(
+                            api,
+                            policy(),
+                            report(healthy=healthy),
+                            NOW,
+                            before_mutation=check_authority,
+                        )
+
+                    if blocked_at:
+                        with self.assertRaisesRegex(ContractError, "authority changed"):
+                            reconcile()
+                        expected = ["discovery"]
+                        for write in writes[: blocked_at - 1]:
+                            expected.extend(("recheck", write))
+                        expected.append("recheck")
+                    else:
+                        reconcile()
+                        expected = ["discovery"]
+                        for write in writes:
+                            expected.extend(("recheck", write))
+                        expected.append("readback")
+                    self.assertEqual(api.events, expected)
+
+    def test_late_authority_failure_keeps_receipt_digest_consistent(self) -> None:
+        for healthy in (False, True):
+            with (
+                self.subTest(healthy=healthy),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                read_api = Mock()
+                read_api.verified_branch_tip.side_effect = (
+                    ["a" * 40, "a" * 40, "a" * 40, "b" * 40]
+                    if healthy
+                    else ["a" * 40, "a" * 40, "b" * 40]
+                )
+                incident_api = Mock()
+                incident_api.find_incident.return_value = (
+                    {"number": 42} if healthy else None
+                )
+                output = Path(directory) / "receipt.json"
+                environment = {
+                    "ESTATE_READ_TOKEN": "offline-test",
+                    "GITHUB_TOKEN": "offline-test",
+                    "GITHUB_REPOSITORY": "szl-holdings/.github",
+                    "GITHUB_SHA": "a" * 40,
+                    "GITHUB_RUN_ID": "123",
+                    "GITHUB_RUN_ATTEMPT": "1",
+                }
+                with (
+                    patch.dict(os.environ, environment, clear=True),
+                    patch.object(
+                        estate_deadman,
+                        "GitHubApi",
+                        side_effect=[read_api, incident_api],
+                    ),
+                    patch.object(
+                        estate_deadman,
+                        "observe_all",
+                        return_value=[
+                            observation("autonomic-public-estate-sre", healthy)
+                        ],
+                    ),
+                ):
+                    result = estate_deadman.run_live(
+                        policy(), "c" * 64, output, sleep_fn=lambda _: None
+                    )
+                receipt = json.loads(output.read_text(encoding="utf-8"))
+                projection = {
+                    key: value
+                    for key, value in receipt.items()
+                    if key not in {"incident", "evidence_sha256"}
+                }
+                self.assertEqual(result, 2)
+                self.assertFalse(receipt["authority"]["controller_tip_reverified"])
+                self.assertFalse(receipt["incident"]["ok"])
+                self.assertEqual(
+                    receipt["evidence_sha256"],
+                    estate_deadman.sha256_hex(
+                        estate_deadman.canonical_json(projection)
+                    ),
+                )
+                self.assertEqual(
+                    output.with_suffix(".json.sha256").read_text().strip(),
+                    hashlib.sha256(output.read_bytes()).hexdigest(),
+                )
+                incident_api.create_issue.assert_not_called()
+                incident_api.update_issue.assert_not_called()
+                if healthy:
+                    incident_api.add_comment.assert_called_once()
+                else:
+                    incident_api.add_comment.assert_not_called()
 
     def test_workflow_permissions_are_exact_and_structural(self) -> None:
         source = (ROOT / ".github" / "workflows" / "estate-deadman.yml").read_text(


### PR DESCRIPTION
Incident discovery performs network reads, so the controller branch could change after the original authority check but before an issue write. The supervisor now checks the protected revision immediately before every create, recovery comment, refresh, and close. A revision change after the recovery comment withholds closure and produces a failed receipt.

The repair also rejects completed runs whose terminal update predates creation. When a late authority check fails, the evidence digest is recomputed from the final recorded observations and authority state; the file sidecar continues to cover the entire emitted receipt. The CLI returns failure when incident reconciliation fails, including otherwise healthy observations.

The three-file change addresses both post-merge findings on #648. Tests cover branch changes during discovery and between comment and close, no subsequent writes after rejection, consistent evidence/file digests, and impossible run timestamp ordering. All 39 deadman contracts, Ruff, the workflow authority validator, actionlint, and diff checks pass. Independent review found no remaining P0-P2 issue.

Base: `373d45f774a61dcfdff7366029721f9560f6ca14`. Signed source head: `c157f3bb36896bc45f7b356421c6c190cd2f7215`.

Operational evidence: the legacy #647 body and open state were preserved under a historical title. A real scheduled cycle created #684 and subsequent cycles refresh it. The census remains degraded; this source repair does not claim recovery or invent a production signing identity.
