### PR TITLE
fix(alignment): reject explicit invalid source identities

### DIFF
--- a/.github/scripts/estate_alignment_contract.py
+++ b/.github/scripts/estate_alignment_contract.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import time
 import urllib.error
 import urllib.parse
@@ -808,11 +809,39 @@ def validate_live(contract: Mapping[str, Any]) -> tuple[list[str], dict[str, Any
     }
 
 
+def checked_out_revision(root: Path) -> str:
+    """Read the actual checkout, not a PR event's synthetic GITHUB_SHA.
+
+    This only reads local Git metadata. It neither fetches nor changes refs.
+    A missing or invalid checkout identity is not replaced with an environment
+    value that could describe a different source tree.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--verify", "HEAD^{commit}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        raise AlignmentError("checked-out Git source identity unavailable") from None
+    revision = result.stdout.strip()
+    if SHA40.fullmatch(revision) is None:
+        raise AlignmentError("checked-out Git source identity is not an exact commit")
+    return revision
+
+
 def build_receipt(root: Path, *, live: bool) -> dict[str, Any]:
     contract_path = root / "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json"
     contract = load_json(contract_path)
     failures = validate_contract(contract)
     failures.extend(validate_documents(root, contract))
+    try:
+        checkout_revision = checked_out_revision(root)
+    except AlignmentError as exc:
+        checkout_revision = "UNAVAILABLE"
+        failures.append(str(exc))
     live_observation: dict[str, Any] | None = None
     if live:
         try:
@@ -825,7 +854,7 @@ def build_receipt(root: Path, *, live: bool) -> dict[str, Any]:
         "observed_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
         "state": "ALIGNED" if not failures else "DIVERGENT",
         "contract_sha256": sha256_bytes(contract_path.read_bytes()),
-        "source_revision": os.getenv("GITHUB_SHA", "UNAVAILABLE"),
+        "source_revision": checkout_revision,
         "live_requested": live,
         "live_observation": live_observation,
         "failures": failures,

--- a/.github/scripts/estate_alignment_contract.py
+++ b/.github/scripts/estate_alignment_contract.py
@@ -436,20 +436,31 @@ def source_revision(payload: Any) -> str | None:
 
 
 def reported_source_repository(payload: Any) -> str | None:
+    """Distinguish absent identity from an explicit invalid or conflicting claim.
+
+    Origin inference is allowed only when no repository field was supplied.
+    Check every supported envelope; a valid sibling cannot hide an invalid one.
+    Do not reflect untrusted field values into retained errors or receipts.
+    """
     if not isinstance(payload, Mapping):
         return None
-    candidates = [payload.get("source_repository"), payload.get("repository")]
+    envelopes = [payload]
     for name in ("build", "source", "deployment", "runtime"):
         nested = payload.get(name)
         if isinstance(nested, Mapping):
-            candidates.extend(
-                (nested.get("source_repository"), nested.get("repository"))
-            )
-    repositories = {
-        source_repository(candidate)
-        for candidate in candidates
-        if isinstance(candidate, str) and candidate.startswith("szl-holdings/")
-    }
+            envelopes.append(nested)
+    repositories: set[str] = set()
+    for envelope in envelopes:
+        for key in ("source_repository", "repository"):
+            if key not in envelope:
+                continue
+            candidate = envelope[key]
+            if not isinstance(candidate, str) or re.fullmatch(
+                r"szl-holdings/[A-Za-z0-9_.-]+(?::[A-Za-z0-9_./-]+)?",
+                candidate,
+            ) is None:
+                raise AlignmentError("runtime binding reports invalid source repository")
+            repositories.add(source_repository(candidate))
     if len(repositories) > 1:
         raise AlignmentError("runtime binding reports conflicting source repositories")
     return next(iter(repositories), None)

--- a/.github/scripts/test_estate_alignment_identity.py
+++ b/.github/scripts/test_estate_alignment_identity.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 import estate_alignment_contract as alignment
 
@@ -13,6 +16,7 @@ REVISION = "a" * 40
 ROW = {"repo_id": "SZLHOLDINGS/a11oy", "deployment_source": REPOSITORY}
 ENVELOPES = (None, "build", "source", "deployment", "runtime")
 FIELDS = ("repository", "source_repository")
+ROOT = Path(__file__).resolve().parents[2]
 
 
 def envelope(name: str | None, key: str, value: object) -> dict:
@@ -134,6 +138,59 @@ class ExplicitSourceIdentityTests(unittest.TestCase):
         self.assertFalse(result["matched"])
         self.assertNotIn(sentinel, json.dumps(result))
         self.assertNotIn("DO_NOT_RECORD", json.dumps(result))
+
+
+class CheckedOutReceiptIdentityTests(unittest.TestCase):
+    def test_event_merge_sha_cannot_replace_checked_out_commit(self) -> None:
+        result = subprocess.CompletedProcess(["git"], 0, stdout=REVISION + "\n")
+        with patch.dict(alignment.os.environ, {"GITHUB_SHA": "b" * 40}), patch.object(
+            alignment.subprocess, "run", return_value=result
+        ) as run:
+            receipt = alignment.build_receipt(ROOT, live=False)
+        self.assertEqual(receipt["source_revision"], REVISION)
+        self.assertEqual(receipt["state"], "ALIGNED")
+        run.assert_called_once_with(
+            ["git", "-C", str(ROOT), "rev-parse", "--verify", "HEAD^{commit}"],
+            capture_output=True, text=True, check=True, timeout=10,
+        )
+
+    def test_actual_git_checkout_is_read_not_environment_hint(self) -> None:
+        expected = subprocess.run(
+            ["git", "-C", str(ROOT), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+        with patch.dict(alignment.os.environ, {"GITHUB_SHA": "b" * 40}):
+            self.assertEqual(alignment.checked_out_revision(ROOT), expected)
+
+    def test_git_failure_retains_failed_receipt_without_error_values(self) -> None:
+        error = subprocess.CalledProcessError(1, ["git"], stderr="DO_NOT_RECORD")
+        with patch.object(alignment.subprocess, "run", side_effect=error):
+            receipt = alignment.build_receipt(ROOT, live=False)
+        self.assertEqual(receipt["state"], "DIVERGENT")
+        self.assertEqual(receipt["source_revision"], "UNAVAILABLE")
+        self.assertIn("checked-out Git source identity unavailable", receipt["failures"])
+        self.assertNotIn("DO_NOT_RECORD", json.dumps(receipt))
+
+    def test_invalid_commit_output_is_not_an_identity(self) -> None:
+        for value in ("main", "", "a" * 39, "A" * 40, REVISION + "\n" + REVISION):
+            result = subprocess.CompletedProcess(["git"], 0, stdout=value)
+            with self.subTest(value=value), patch.object(
+                alignment.subprocess, "run", return_value=result
+            ), self.assertRaises(alignment.AlignmentError):
+                alignment.checked_out_revision(ROOT)
+
+    def test_git_timeout_is_bounded_and_does_not_use_event_fallback(self) -> None:
+        with patch.dict(alignment.os.environ, {"GITHUB_SHA": REVISION}), patch.object(
+            alignment.subprocess, "run", side_effect=subprocess.TimeoutExpired(["git"], 10)
+        ), self.assertRaisesRegex(alignment.AlignmentError, "unavailable"):
+            alignment.checked_out_revision(ROOT)
+
+    def test_missing_git_cannot_become_a_source_claim(self) -> None:
+        with patch.object(alignment.subprocess, "run", side_effect=FileNotFoundError("DO_NOT_RECORD")):
+            receipt = alignment.build_receipt(ROOT, live=False)
+        self.assertEqual(receipt["state"], "DIVERGENT")
+        self.assertEqual(receipt["source_revision"], "UNAVAILABLE")
+        self.assertNotIn("DO_NOT_RECORD", json.dumps(receipt))
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_estate_alignment_identity.py
+++ b/.github/scripts/test_estate_alignment_identity.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Offline source-identity regressions against the actual alignment validator."""
+from __future__ import annotations
+
+import json
+import unittest
+
+import estate_alignment_contract as alignment
+
+REPOSITORY = "szl-holdings/a11oy"
+REVISION = "a" * 40
+ROW = {"repo_id": "SZLHOLDINGS/a11oy", "deployment_source": REPOSITORY}
+ENVELOPES = (None, "build", "source", "deployment", "runtime")
+FIELDS = ("repository", "source_repository")
+
+
+def envelope(name: str | None, key: str, value: object) -> dict:
+    field = {key: value}
+    return field if name is None else {name: field}
+
+
+class ExplicitSourceIdentityTests(unittest.TestCase):
+    def bind(self, payload: dict) -> tuple[dict, list[str]]:
+        calls: list[str] = []
+
+        def fetch(url: str, **kwargs: object) -> bytes:
+            calls.append(url)
+            self.assertEqual(kwargs["required_origin"], "https://szlholdings-a11oy.hf.space")
+            self.assertNotIn("token", kwargs)
+            return json.dumps(payload).encode("utf-8")
+
+        return alignment.runtime_source_binding(ROW, REVISION, fetch=fetch), calls
+
+    def test_absence_remains_distinct_from_a_reported_repository(self) -> None:
+        payload = {"source_revision": REVISION, "runtime": {"stage": "RUNNING"}}
+        self.assertIsNone(alignment.reported_source_repository(payload))
+        result, calls = self.bind(payload)
+        self.assertTrue(result["matched"])
+        self.assertIsNone(result["observed_source"])
+        self.assertEqual(result["source_evidence"], "contract-bound-origin")
+        self.assertEqual(len(calls), alignment.RUNTIME_OBSERVATIONS)
+
+    def test_valid_fields_in_every_supported_envelope(self) -> None:
+        for name in ENVELOPES:
+            for key in FIELDS:
+                with self.subTest(name=name, key=key):
+                    payload = {"source_revision": REVISION, **envelope(name, key, REPOSITORY)}
+                    result, _ = self.bind(payload)
+                    self.assertTrue(result["matched"])
+                    self.assertEqual(result["observed_source"], REPOSITORY)
+                    self.assertEqual(result["source_evidence"], "reported")
+
+    def test_foreign_repository_is_rejected_in_every_envelope(self) -> None:
+        for name in ENVELOPES:
+            for key in FIELDS:
+                with self.subTest(name=name, key=key):
+                    payload = {"source_revision": REVISION, **envelope(name, key, "other-org/other-repo")}
+                    with self.assertRaises(alignment.AlignmentError):
+                        alignment.reported_source_repository(payload)
+                    result, calls = self.bind(payload)
+                    self.assertFalse(result["matched"])
+                    self.assertEqual(len(calls), 1)
+                    self.assertIn("invalid source repository", result["attempts"][0]["observations"][0]["error"])
+
+    def test_explicit_null_empty_and_wrong_types_are_not_absence(self) -> None:
+        for value in (None, "", " ", False, 0, [], {}, [REPOSITORY]):
+            for name in ENVELOPES:
+                for key in FIELDS:
+                    with self.subTest(value=value, name=name, key=key):
+                        payload = envelope(name, key, value)
+                        with self.assertRaises(alignment.AlignmentError):
+                            alignment.reported_source_repository(payload)
+
+    def test_malformed_strings_cannot_be_normalized_to_origin_evidence(self) -> None:
+        for value in ("https://github.com/" + REPOSITORY, REPOSITORY + " ", " " + REPOSITORY,
+                      "szl-holdings/", REPOSITORY + "\n", REPOSITORY + "?token=sentinel",
+                      REPOSITORY + ":", REPOSITORY + ":bad?token=sentinel"):
+            with self.subTest(value=value), self.assertRaises(alignment.AlignmentError):
+                alignment.reported_source_repository({"repository": value})
+
+    def test_valid_outer_identity_cannot_hide_invalid_nested_identity(self) -> None:
+        for name in ENVELOPES[1:]:
+            for key in FIELDS:
+                with self.subTest(name=name, key=key):
+                    result, calls = self.bind({"source_revision": REVISION,
+                                              "repository": REPOSITORY,
+                                              **envelope(name, key, "other-org/other-repo")})
+                    self.assertFalse(result["matched"])
+                    self.assertEqual(len(calls), 1)
+
+    def test_valid_nested_identity_cannot_hide_invalid_outer_identity(self) -> None:
+        result, calls = self.bind({"source_revision": REVISION, "repository": None,
+                                  "build": {"source_repository": REPOSITORY}})
+        self.assertFalse(result["matched"])
+        self.assertEqual(len(calls), 1)
+
+    def test_distinct_valid_repository_claims_conflict(self) -> None:
+        payload = {"source_revision": REVISION, "repository": REPOSITORY,
+                   "deployment": {"source_repository": "szl-holdings/killinchu"}}
+        with self.assertRaisesRegex(alignment.AlignmentError, "conflicting"):
+            alignment.reported_source_repository(payload)
+        self.assertFalse(self.bind(payload)[0]["matched"])
+
+    def test_consistent_repeated_claims_preserve_compatibility(self) -> None:
+        payload = {"repository": REPOSITORY, "source_repository": REPOSITORY,
+                   "build": {"repository": REPOSITORY}}
+        self.assertEqual(alignment.reported_source_repository(payload), REPOSITORY)
+        self.assertEqual(alignment.reported_source_repository(
+            {"repository": "szl-holdings/a11oy:verticals/counsel"}), REPOSITORY)
+
+    def test_wrong_but_valid_owner_repository_does_not_match(self) -> None:
+        result, _ = self.bind({"source_revision": REVISION, "repository": "szl-holdings/killinchu"})
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["source_evidence"], "conflicting")
+
+    def test_invalid_second_observation_cannot_fall_back_to_success(self) -> None:
+        calls: list[str] = []
+
+        def fetch(url: str, **kwargs: object) -> bytes:
+            calls.append(url)
+            value = REPOSITORY if len(calls) == 1 else "other-org/other-repo"
+            return json.dumps({"source_revision": REVISION, "repository": value}).encode()
+
+        result = alignment.runtime_source_binding(ROW, REVISION, fetch=fetch)
+        self.assertFalse(result["matched"])
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(all("/api/build-info?" in url for url in calls))
+        self.assertEqual(result["attempts"][0]["observations"][0]["observed_source"], REPOSITORY)
+
+    def test_untrusted_values_are_not_reflected_into_retained_errors(self) -> None:
+        sentinel = "foreign/private-name?credential=DO_NOT_RECORD"
+        result, _ = self.bind({"source_revision": REVISION, "repository": sentinel})
+        self.assertFalse(result["matched"])
+        self.assertNotIn(sentinel, json.dumps(result))
+        self.assertNotIn("DO_NOT_RECORD", json.dumps(result))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/estate-one-fabric-alignment.yml
+++ b/.github/workflows/estate-one-fabric-alignment.yml
@@ -11,6 +11,7 @@ on:
       - .github/scripts/estate_alignment_contract.py
       - .github/scripts/test_estate_alignment_contract.py
       - .github/scripts/test_estate_alignment_org_card.py
+      - .github/scripts/test_estate_alignment_identity.py
       - .github/workflows/estate-one-fabric-alignment.yml
   push:
     branches: [main]
@@ -22,6 +23,7 @@ on:
       - .github/scripts/estate_alignment_contract.py
       - .github/scripts/test_estate_alignment_contract.py
       - .github/scripts/test_estate_alignment_org_card.py
+      - .github/scripts/test_estate_alignment_identity.py
       - .github/workflows/estate-one-fabric-alignment.yml
   workflow_run:
     workflows: ["Hugging Face organization front door"]
@@ -68,11 +70,13 @@ jobs:
           .github/scripts/estate_alignment_contract.py
           .github/scripts/test_estate_alignment_contract.py
           .github/scripts/test_estate_alignment_org_card.py
+          .github/scripts/test_estate_alignment_identity.py
 
       - name: Prove exact one-fabric contract offline
         run: |
           python .github/scripts/test_estate_alignment_contract.py
           python .github/scripts/test_estate_alignment_org_card.py
+          python .github/scripts/test_estate_alignment_identity.py
 
       - name: Emit secret-free source receipt
         env:


### PR DESCRIPTION
## Permanent source-identity corrections

Follow-through on the source-identity review of merged #693, with a second defect caught by independently verifying the hosted artifact before merge.

1. `reported_source_repository()` now distinguishes absent fields from explicit null, empty, wrong-type, foreign, malformed, and conflicting claims. Every supported nested envelope participates; a valid sibling cannot hide an invalid one. Errors never reflect supplied field values. Existing truly absent-field origin inference and valid component-qualified identities remain supported.
2. `build_receipt()` now obtains the source revision from the actual checked-out Git commit using a bounded, read-only local Git command. It no longer trusts reserved `GITHUB_SHA`, which can identify the PR event's synthetic merge rather than the exact source checked out by the workflow. Missing/invalid local identity produces a retained failed receipt, not an environment fallback.

## Observed defect evidence

First hosted run `34033177923` on head `2feec065a7fcefdcc91f72ace97b9465aab91415` passed 20 existing alignment tests, 6 org-card tests, and 12 new identity tests. All latest 29 check observations were success/skipped (25/4).

Downloaded artifact `9989291367` independently verified ZIP SHA-256 `d7141a83ce6e6886822e71b68efd079885e0a78505ac863b8b9454aed3d6d384` and receipt digest `deed35bb8846363ccd73cb7b1272b60d66c1dc326289dcc58303d6743151446b`. Its local receipt nevertheless named synthetic merge `37abaf952c1b20691d0dc147ebffcef457aa7ffc`, while the materialized card named the actual checked-out head. That is why the candidate was returned to draft and corrected instead of calling a green job sufficient proof.

## Current qualification

Current head `b3fa81e54a4fe6038b649dd0bc92d8bc0a461ad0` adds six checkout-identity regressions (18 new test methods total), including a real local-Git comparison, event/head divergence, malformed Git output, missing Git, timeout, and value-free retained failure receipts. The existing canonical workflow runs this suite; no new workflow or publisher is introduced. Fresh exact-head hosted tests and the downloaded final receipt must agree on the actual checkout before protected squash merge.

## Boundaries

No inventory changes, Space creation, provider write, duplicate publisher, credential readback, direct-main write, temporary shim, self-modifying controller, force push, or branch-protection change. Live deployment acceptance and authenticated private-file coverage remain separate from local source validation.