### PR TITLE
fix(alignment): bind Constellation to restored source authority

### DIFF
--- a/.github/tests/test_holographic_spaces_v2.py
+++ b/.github/tests/test_holographic_spaces_v2.py
@@ -192,7 +192,7 @@ class ControllerSafetyContract(unittest.TestCase):
         self.assertEqual(mapping["immune"], "szl-holdings/immune")
         self.assertEqual(mapping["immune-lattice"], "szl-holdings/immune")
         self.assertEqual(mapping["szl-command-lab"], "szl-holdings/szl-command-lab")
-        self.assertEqual(mapping["szl-constellation"], "szl-holdings/holographic-unify")
+        self.assertEqual(mapping["szl-constellation"], "szl-holdings/szl-constellation")
         self.assertEqual(mapping["ayllu"], "szl-holdings/ayllu")
         self.assertEqual(mapping["yarqa"], "szl-holdings/yarqa")
         self.assertEqual(len(mapping), 15)

--- a/design/responsive-v3/flagship-space-sources.json
+++ b/design/responsive-v3/flagship-space-sources.json
@@ -76,9 +76,10 @@
     },
     {
       "space": "szl-constellation",
-      "repo": "szl-holdings/holographic-unify",
-      "source_root": "space/index.html",
-      "ownership": "source-owned-lab-surface"
+      "repo": "szl-holdings/szl-constellation",
+      "source_root": "space/app.py",
+      "ownership": "source-owned-lab-surface",
+      "supersedes": "szl-holdings/holographic-unify as the GitHub-to-Hub source authority"
     },
     {
       "space": "ayllu",

--- a/docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
+++ b/docs/ESTATE_ALIGNMENT_CONTRACT_V1.json
@@ -194,8 +194,8 @@
       {
         "repo_id": "SZLHOLDINGS/szl-constellation",
         "class": "lab_surface",
-        "canonical_source": "szl-holdings/holographic-unify",
-        "deployment_source": "szl-holdings/holographic-unify"
+        "canonical_source": "szl-holdings/szl-constellation",
+        "deployment_source": "szl-holdings/szl-constellation"
       },
       {
         "repo_id": "SZLHOLDINGS/szl-frontier",


### PR DESCRIPTION
## Root cause

The exact provider source for `SZLHOLDINGS/szl-constellation` was restored into `szl-holdings/szl-constellation` and that repository now owns the only source-bound GitHub→Hub publisher. The organization source map and estate contract still named archived `szl-holdings/holographic-unify`, so the rollout controller could edit or attest the wrong repository.

## Permanent reconciliation

- point the protected public-Space source map to `szl-holdings/szl-constellation`;
- bind the reviewed runtime entrypoint to `space/app.py`;
- record that this source supersedes `holographic-unify` as the GitHub-to-Hub authority;
- align the estate contract’s canonical and deployment source fields;
- update the network-free rollout contract so heuristic or stale provider metadata cannot send Constellation work back to the archived repository.

This changes source authority only. It does not claim that the latest GitHub source has published: the current Constellation publication run failed closed because no repository secret was present and its Hugging Face Trusted Publisher exchange did not match. Provider publication and exact live readback remain separate acceptance gates.

No product taxonomy, Space visibility, model, dataset, DNS, credential, branch protection, direct main write, duplicate publisher, or provider mutation is introduced.

Signed-off-by: Stephen P. Lutar <stephenlutar2@gmail.com>