### PR TITLE
fix(ci-health): validate every organization reader alias

### DIFF
--- a/.github/scripts/ci_health_digest_http.py
+++ b/.github/scripts/ci_health_digest_http.py
@@ -1,19 +1,36 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Fail-closed GitHub HTTP and organization-reader selection for CI health."""
+"""Fail-closed GitHub HTTP and organization-reader selection for CI health.
+
+A credential is selected only after it proves the complete organization
+inventory against GitHub's authoritative public/private repository totals and
+can read Actions metadata. Candidate values are never included in receipts.
+"""
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence
 
 ORG = "szl-holdings"
-CANONICAL_CONFIG_ID = 252588
 TRANSIENT_HTTP = {429, 500, 502, 503, 504}
+CANDIDATE_ENVIRONMENT = (
+    ("github_app", "qillqaq_app_installation", "DIGEST_APP_TOKEN"),
+    ("governed_pat_fallback", "ORG_REPO_WORKFLOW_TOKEN", "ORG_REPO_WORKFLOW_TOKEN"),
+    ("governed_pat_fallback", "SZL_ORG_PAT", "SZL_ORG_PAT"),
+    ("governed_pat_fallback", "SZL_GITHUB_PAT", "SZL_GITHUB_PAT"),
+    ("governed_pat_fallback", "GH_PAT", "GH_PAT"),
+    ("governed_pat_fallback", "PAT_TOKEN", "PAT_TOKEN"),
+    ("governed_pat_fallback", "GITHUB_PAT", "GITHUB_PAT"),
+    ("governed_pat_fallback", "GH_TOKEN", "GH_TOKEN"),
+    ("governed_pat_fallback", "SZL_GITHUB_TOKEN", "SZL_GITHUB_TOKEN"),
+    ("repository_token_probe", "repository_github_token", "REPOSITORY_GITHUB_TOKEN"),
+)
 
 
 class DigestError(RuntimeError):
@@ -44,7 +61,7 @@ class ApiError(DigestError):
 class ReaderSelection:
     mode: str
     credential_name: str
-    token: str
+    token: str = field(repr=False)
     repositories: tuple[dict[str, Any], ...]
     attempts: tuple[dict[str, Any], ...]
 
@@ -82,7 +99,7 @@ def request_json(
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "szl-ci-health-digest/2",
+        "User-Agent": "szl-ci-health-digest/3",
     }
     last_status = 0
     last_detail = "request_failed"
@@ -142,7 +159,7 @@ def request_json(
 
 
 def repository_floor() -> int:
-    value = str(os.environ.get("ORG_REPOSITORY_FLOOR") or "57").strip()
+    value = str(os.environ.get("ORG_REPOSITORY_FLOOR") or "123").strip()
     try:
         floor = int(value)
     except ValueError as exc:
@@ -187,88 +204,72 @@ def _paginated_list(
             raise DigestError(f"{operation} exceeded 100 pages")
 
 
-def validate_canonical_inventory(
+def _nonnegative_integer(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise DigestError(f"authoritative {label} repository total is unavailable")
+    return value
+
+
+def validate_authoritative_inventory(
     token: str,
     repositories: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
-    _, configurations = request_json(
+    """Prove exact public/private inventory equality without admin-only coupling."""
+
+    _, metadata = request_json(
         token,
-        f"https://api.github.com/orgs/{ORG}/code-security/configurations",
-        operation="read organization code-security configurations",
+        f"https://api.github.com/orgs/{ORG}",
+        operation="read authoritative organization repository totals",
     )
-    if not isinstance(configurations, list):
-        raise DigestError("code-security configuration inventory is malformed")
-    canonical = next(
-        (
-            item
-            for item in configurations
-            if isinstance(item, dict)
-            and item.get("id") == CANONICAL_CONFIG_ID
-        ),
-        None,
-    )
-    if canonical is None:
+    if not isinstance(metadata, dict):
+        raise DigestError("organization metadata payload is malformed")
+
+    public_total = _nonnegative_integer(metadata.get("public_repos"), "public")
+    private_value = metadata.get("total_private_repos")
+    if private_value is None:
+        private_value = metadata.get("owned_private_repos")
+    private_total = _nonnegative_integer(private_value, "private")
+    authoritative_total = public_total + private_total
+    floor = repository_floor()
+    if authoritative_total < floor:
         raise DigestError(
-            f"canonical code-security configuration {CANONICAL_CONFIG_ID} is missing"
-        )
-    if canonical.get("target_type") != "organization":
-        raise DigestError(
-            "canonical code-security configuration is not organization-scoped"
-        )
-    if canonical.get("enforcement") != "enforced":
-        raise DigestError(
-            "canonical code-security configuration is not enforced"
+            "authoritative organization total below reviewed floor: "
+            f"observed={authoritative_total} floor={floor}"
         )
 
-    attachments = _paginated_list(
-        token,
-        (
-            f"https://api.github.com/orgs/{ORG}/code-security/"
-            f"configurations/{CANONICAL_CONFIG_ID}/repositories"
-        ),
-        operation="read canonical code-security repository inventory",
-    )
-    attached_status: dict[str, str | None] = {}
-    for item in attachments:
-        repository = item.get("repository") or {}
-        full_name = str(repository.get("full_name") or "").strip()
-        if not full_name:
+    identities: list[str] = []
+    observed_private = 0
+    for item in repositories:
+        full_name = str(item.get("full_name") or "").strip()
+        if not full_name.startswith(f"{ORG}/"):
             raise DigestError(
-                "canonical code-security repository entry has no full name"
+                f"organization inventory contains foreign or empty identity: {full_name!r}"
             )
-        if full_name in attached_status:
-            raise DigestError(
-                f"canonical repository inventory contains duplicate {full_name}"
-            )
-        attached_status[full_name] = (
-            str(item.get("status")) if item.get("status") is not None else None
+        identities.append(full_name)
+        if item.get("private") is True or item.get("visibility") in {
+            "private",
+            "internal",
+        }:
+            observed_private += 1
+
+    if len(identities) != len(set(identities)):
+        raise DigestError("organization inventory contains duplicate repositories")
+    if len(repositories) != authoritative_total:
+        raise DigestError(
+            "organization repository listing does not match authoritative totals: "
+            f"listed={len(repositories)} authoritative={authoritative_total}"
+        )
+    if observed_private != private_total:
+        raise DigestError(
+            "organization private repository listing does not match authoritative total: "
+            f"listed={observed_private} authoritative={private_total}"
         )
 
-    observed_names = {
-        str(item.get("full_name") or f"{ORG}/{item.get('name')}")
-        for item in repositories
-    }
-    attached_names = set(attached_status)
-    if observed_names != attached_names:
-        missing_from_org_listing = sorted(attached_names - observed_names)
-        missing_from_canonical = sorted(observed_names - attached_names)
-        raise DigestError(
-            "organization repository inventory does not match canonical "
-            "code-security inventory: "
-            f"missing_from_org_listing={missing_from_org_listing}; "
-            f"missing_from_canonical={missing_from_canonical}"
-        )
     return {
-        "configuration_id": CANONICAL_CONFIG_ID,
-        "configuration_name": canonical.get("name"),
-        "repository_count": len(attached_names),
+        "public_repositories": public_total,
+        "private_repositories": private_total,
+        "repository_count": authoritative_total,
         "inventory_match": True,
-        "status_counts": {
-            status or "missing": sum(
-                1 for value in attached_status.values() if value == status
-            )
-            for status in set(attached_status.values())
-        },
     }
 
 
@@ -276,7 +277,7 @@ def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
     repositories = list(
         _paginated_list(
             token,
-            f"https://api.github.com/orgs/{ORG}/repos?type=all",
+            f"https://api.github.com/orgs/{ORG}/repos?type=all&sort=full_name&direction=asc",
             operation="list organization repositories",
         )
     )
@@ -306,25 +307,29 @@ def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
             raise DigestError(
                 f"active repository {item.get('name')!r} lacks a default branch"
             )
-    validate_canonical_inventory(token, repositories)
+    validate_authoritative_inventory(token, repositories)
     return tuple(repositories)
 
 
+def _candidate_values() -> tuple[tuple[str, str, str], ...]:
+    values: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for mode, name, environment_name in CANDIDATE_ENVIRONMENT:
+        token = str(os.environ.get(environment_name) or "").strip()
+        if not token:
+            values.append((mode, name, ""))
+            continue
+        digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+        if digest in seen:
+            continue
+        seen.add(digest)
+        values.append((mode, name, token))
+    return tuple(values)
+
+
 def select_reader() -> ReaderSelection:
-    candidates = (
-        (
-            "github_app",
-            "qillqaq_app_installation",
-            os.environ.get("DIGEST_APP_TOKEN") or "",
-        ),
-        (
-            "governed_pat_fallback",
-            "SZL_GITHUB_TOKEN",
-            os.environ.get("SZL_GITHUB_TOKEN") or "",
-        ),
-    )
     attempts: list[dict[str, Any]] = []
-    for mode, name, token in candidates:
+    for mode, name, token in _candidate_values():
         if not token:
             attempts.append(
                 {
@@ -382,7 +387,7 @@ def select_reader() -> ReaderSelection:
                 "present": True,
                 "result": "selected",
                 "repository_count": len(repositories),
-                "canonical_inventory_match": True,
+                "authoritative_inventory_match": True,
                 "value_recorded": False,
             }
         )

--- a/.github/scripts/test_ci_health_digest.py
+++ b/.github/scripts/test_ci_health_digest.py
@@ -19,27 +19,43 @@ import ci_health_digest as chd
 import ci_health_digest_http as http
 
 
-def repositories(count: int, *, archived: int = 0):
+def repositories(count: int, *, archived: int = 0, private: int = 0):
     values = []
+    private_start = max(0, count - private)
     for index in range(count):
+        is_private = index >= private_start and private > 0
         values.append(
             {
                 "name": f"repo-{index:03d}",
+                "full_name": f"szl-holdings/repo-{index:03d}",
                 "default_branch": "main",
                 "archived": index < archived,
+                "private": is_private,
+                "visibility": "private" if is_private else "public",
             }
         )
     return tuple(values)
 
 
+def empty_reader_environment(**overrides: str) -> dict[str, str]:
+    values = {
+        environment_name: ""
+        for _, _, environment_name in http.CANDIDATE_ENVIRONMENT
+    }
+    values.update(overrides)
+    return values
+
+
 class ReaderSelectionTests(unittest.TestCase):
     def test_prefers_verified_short_lived_app_reader(self):
-        estate = repositories(57, archived=5)
-        with patch.dict(
-            os.environ,
-            {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
-            clear=False,
-        ), patch.object(http, "list_repositories", return_value=estate), patch.object(
+        estate = repositories(123, archived=5, private=3)
+        environment = empty_reader_environment(
+            DIGEST_APP_TOKEN="app",
+            ORG_REPO_WORKFLOW_TOKEN="fallback",
+        )
+        with patch.dict(os.environ, environment, clear=False), patch.object(
+            http, "list_repositories", return_value=estate
+        ), patch.object(
             http,
             "request_json",
             return_value=(200, {"workflows": []}),
@@ -47,11 +63,12 @@ class ReaderSelectionTests(unittest.TestCase):
             selected = http.select_reader()
         self.assertEqual(selected.mode, "github_app")
         self.assertEqual(selected.credential_name, "qillqaq_app_installation")
-        self.assertEqual(len(selected.repositories), 57)
+        self.assertEqual(len(selected.repositories), 123)
         self.assertEqual(selected.attempts[-1]["result"], "selected")
+        self.assertNotIn("app", repr(selected))
 
     def test_falls_back_only_after_app_reader_is_rejected(self):
-        estate = repositories(57, archived=5)
+        estate = repositories(123, archived=5, private=3)
 
         def inventory(token):
             if token == "app":
@@ -62,130 +79,201 @@ class ReaderSelectionTests(unittest.TestCase):
                 )
             return estate
 
-        with patch.dict(
-            os.environ,
-            {"DIGEST_APP_TOKEN": "app", "SZL_GITHUB_TOKEN": "pat"},
-            clear=False,
-        ), patch.object(http, "list_repositories", side_effect=inventory), patch.object(
+        environment = empty_reader_environment(
+            DIGEST_APP_TOKEN="app",
+            ORG_REPO_WORKFLOW_TOKEN="complete",
+        )
+        with patch.dict(os.environ, environment, clear=False), patch.object(
+            http, "list_repositories", side_effect=inventory
+        ), patch.object(
             http,
             "request_json",
             return_value=(200, {"workflows": []}),
         ):
             selected = http.select_reader()
         self.assertEqual(selected.mode, "governed_pat_fallback")
+        self.assertEqual(selected.credential_name, "ORG_REPO_WORKFLOW_TOKEN")
         self.assertEqual(selected.attempts[0]["result"], "rejected")
         self.assertEqual(selected.attempts[0]["failure_class"], "unauthorized")
-        self.assertFalse(any("token" in key.lower() for key in selected.attempts[0]))
+        self.assertFalse(
+            any("token" in key.lower() for key in selected.attempts[0])
+        )
+
+    def test_stale_named_pat_cannot_mask_later_valid_alias(self):
+        estate = repositories(123, private=3)
+
+        def inventory(token):
+            if token == "stale":
+                raise http.ApiError(
+                    operation="inventory",
+                    status=401,
+                    detail_class="unauthenticated",
+                )
+            return estate
+
+        environment = empty_reader_environment(
+            ORG_REPO_WORKFLOW_TOKEN="stale",
+            SZL_ORG_PAT="complete",
+        )
+        with patch.dict(os.environ, environment, clear=False), patch.object(
+            http, "list_repositories", side_effect=inventory
+        ), patch.object(
+            http,
+            "request_json",
+            return_value=(200, {"workflows": []}),
+        ):
+            selected = http.select_reader()
+        self.assertEqual(selected.credential_name, "SZL_ORG_PAT")
+        self.assertEqual(selected.attempts[1]["failure_class"], "unauthenticated")
+
+    def test_duplicate_secret_values_are_probed_once(self):
+        calls: list[str] = []
+
+        def inventory(token):
+            calls.append(token)
+            raise http.DigestError("rejected")
+
+        environment = empty_reader_environment(
+            ORG_REPO_WORKFLOW_TOKEN="same",
+            SZL_GITHUB_TOKEN="same",
+        )
+        with patch.dict(os.environ, environment, clear=False), patch.object(
+            http, "list_repositories", side_effect=inventory
+        ):
+            with self.assertRaises(http.ReaderSelectionError):
+                http.select_reader()
+        self.assertEqual(calls, ["same"])
 
     def test_no_reader_is_a_typed_terminal_failure(self):
         with patch.dict(
             os.environ,
-            {"DIGEST_APP_TOKEN": "", "SZL_GITHUB_TOKEN": ""},
+            empty_reader_environment(),
             clear=False,
         ):
             with self.assertRaises(http.ReaderSelectionError) as context:
                 http.select_reader()
-        self.assertEqual(len(context.exception.attempts), 2)
+        self.assertEqual(
+            len(context.exception.attempts),
+            len(http.CANDIDATE_ENVIRONMENT),
+        )
         self.assertTrue(
-            all(item["result"] == "not_configured" for item in context.exception.attempts)
+            all(
+                item["result"] == "not_configured"
+                for item in context.exception.attempts
+            )
         )
 
 
 class RepositoryCoverageTests(unittest.TestCase):
     def test_present_token_with_zero_repositories_fails_closed(self):
-        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
             http,
             "request_json",
             return_value=(200, []),
-        ), patch.object(http, "validate_canonical_inventory"):
+        ), patch.object(http, "validate_authoritative_inventory"):
             with self.assertRaisesRegex(http.DigestError, "below reviewed floor"):
                 http.list_repositories("present-token")
 
     def test_partial_repository_listing_fails_closed(self):
-        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
             http,
             "request_json",
-            return_value=(200, list(repositories(56))),
-        ), patch.object(http, "validate_canonical_inventory"):
-            with self.assertRaisesRegex(http.DigestError, "observed=56 floor=57"):
+            return_value=(200, list(repositories(122, private=3))),
+        ), patch.object(http, "validate_authoritative_inventory"):
+            with self.assertRaisesRegex(
+                http.DigestError, "observed=122 floor=123"
+            ):
                 http.list_repositories("present-token")
 
     def test_complete_repository_listing_passes(self):
-        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "57"}, clear=False), patch.object(
+        estate = repositories(123, archived=5, private=3)
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
             http,
             "request_json",
-            return_value=(200, list(repositories(57, archived=5))),
-        ), patch.object(http, "validate_canonical_inventory") as canonical:
+            return_value=(200, list(estate)),
+        ), patch.object(
+            http, "validate_authoritative_inventory"
+        ) as authoritative:
             observed = http.list_repositories("present-token")
-        self.assertEqual(len(observed), 57)
+        self.assertEqual(len(observed), 123)
         self.assertEqual(sum(bool(item["archived"]) for item in observed), 5)
-        canonical.assert_called_once()
+        authoritative.assert_called_once()
 
 
-class CanonicalInventoryTests(unittest.TestCase):
-    def test_exact_code_security_inventory_match_passes(self):
-        estate = repositories(2)
-        payloads = [
-            (
+class AuthoritativeInventoryTests(unittest.TestCase):
+    def test_exact_public_private_inventory_match_passes(self):
+        estate = repositories(123, private=3)
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
+            http,
+            "request_json",
+            return_value=(
                 200,
-                [
-                    {
-                        "id": http.CANONICAL_CONFIG_ID,
-                        "name": "SZL Holdings Managed Security",
-                        "target_type": "organization",
-                        "enforcement": "enforced",
-                    }
-                ],
+                {"public_repos": 120, "total_private_repos": 3},
             ),
-            (
-                200,
-                [
-                    {
-                        "repository": {"full_name": "szl-holdings/repo-000"},
-                        "status": "enforced",
-                    },
-                    {
-                        "repository": {"full_name": "szl-holdings/repo-001"},
-                        "status": "enforced",
-                    },
-                ],
-            ),
-        ]
-        with patch.object(http, "request_json", side_effect=payloads):
-            result = http.validate_canonical_inventory("token", estate)
+        ):
+            result = http.validate_authoritative_inventory("token", estate)
         self.assertTrue(result["inventory_match"])
-        self.assertEqual(result["repository_count"], 2)
+        self.assertEqual(result["repository_count"], 123)
+        self.assertEqual(result["private_repositories"], 3)
 
-    def test_repository_missing_from_canonical_inventory_fails(self):
-        estate = repositories(2)
-        payloads = [
-            (
-                200,
-                [
-                    {
-                        "id": http.CANONICAL_CONFIG_ID,
-                        "name": "SZL Holdings Managed Security",
-                        "target_type": "organization",
-                        "enforcement": "enforced",
-                    }
-                ],
-            ),
-            (
-                200,
-                [
-                    {
-                        "repository": {"full_name": "szl-holdings/repo-000"},
-                        "status": "enforced",
-                    }
-                ],
-            ),
-        ]
-        with patch.object(http, "request_json", side_effect=payloads):
+    def test_missing_authoritative_private_total_fails(self):
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
+            http,
+            "request_json",
+            return_value=(200, {"public_repos": 123}),
+        ):
             with self.assertRaisesRegex(
-                http.DigestError,
-                "does not match canonical code-security inventory",
+                http.DigestError, "private repository total is unavailable"
             ):
-                http.validate_canonical_inventory("token", estate)
+                http.validate_authoritative_inventory(
+                    "token", repositories(123, private=3)
+                )
+
+    def test_partial_listing_cannot_match_authoritative_total(self):
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
+            http,
+            "request_json",
+            return_value=(
+                200,
+                {"public_repos": 120, "total_private_repos": 3},
+            ),
+        ):
+            with self.assertRaisesRegex(
+                http.DigestError, "listed=122 authoritative=123"
+            ):
+                http.validate_authoritative_inventory(
+                    "token", repositories(122, private=2)
+                )
+
+    def test_private_listing_must_match_authoritative_private_total(self):
+        with patch.dict(
+            os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
+        ), patch.object(
+            http,
+            "request_json",
+            return_value=(
+                200,
+                {"public_repos": 120, "total_private_repos": 3},
+            ),
+        ):
+            with self.assertRaisesRegex(
+                http.DigestError, "private repository listing"
+            ):
+                http.validate_authoritative_inventory(
+                    "token", repositories(123, private=2)
+                )
 
 
 class IssueAndReportTests(unittest.TestCase):
@@ -206,7 +294,7 @@ class IssueAndReportTests(unittest.TestCase):
                 "number": 158,
                 "state": kwargs["body"]["state"],
                 "html_url": "https://github.com/szl-holdings/.github/issues/158",
-                "updated_at": "2026-07-26T00:00:00Z",
+                "updated_at": "2026-09-06T00:00:00Z",
             }
 
         with patch.object(chd, "_issue_token", return_value="issue-token"), patch.object(
@@ -237,7 +325,7 @@ class IssueAndReportTests(unittest.TestCase):
                 "number": 158,
                 "state": kwargs["body"]["state"],
                 "html_url": "https://github.com/szl-holdings/.github/issues/158",
-                "updated_at": "2026-07-26T00:00:00Z",
+                "updated_at": "2026-09-06T00:00:00Z",
             }
 
         with patch.object(chd, "_issue_token", return_value="issue-token"), patch.object(
@@ -277,28 +365,28 @@ class IssueAndReportTests(unittest.TestCase):
         self.assertEqual(report["issue"]["state"], "open")
 
     def test_complete_sweep_writes_verified_receipt(self):
-        estate = repositories(57, archived=5)
+        estate = repositories(123, archived=5, private=3)
         selected = http.ReaderSelection(
             mode="governed_pat_fallback",
-            credential_name="SZL_GITHUB_TOKEN",
+            credential_name="ORG_REPO_WORKFLOW_TOKEN",
             token="never-recorded",
             repositories=estate,
             attempts=(
                 {
                     "mode": "governed_pat_fallback",
-                    "credential_name": "SZL_GITHUB_TOKEN",
+                    "credential_name": "ORG_REPO_WORKFLOW_TOKEN",
                     "result": "selected",
                     "value_recorded": False,
                 },
             ),
         )
         coverage = {
-            "organization_repositories": 57,
-            "active_repositories": 52,
+            "organization_repositories": 123,
+            "active_repositories": 118,
             "archived_repositories": 5,
-            "queried_active_repositories": 52,
+            "queried_active_repositories": 118,
             "active_workflows": 100,
-            "repository_floor": 57,
+            "repository_floor": 123,
         }
         with tempfile.TemporaryDirectory() as directory:
             report_path = Path(directory) / "report.json"
@@ -320,7 +408,7 @@ class IssueAndReportTests(unittest.TestCase):
             report = json.loads(report_text)
         self.assertEqual(code, 0)
         self.assertEqual(report["status"], "VERIFIED")
-        self.assertEqual(report["coverage"]["queried_active_repositories"], 52)
+        self.assertEqual(report["coverage"]["queried_active_repositories"], 118)
         self.assertEqual(report["summary"]["red_total"], 0)
         self.assertNotIn("never-recorded", report_text)
 
@@ -332,13 +420,23 @@ class WorkflowContractTests(unittest.TestCase):
         )
         required = (
             "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+            "if: vars.QILLQAQ_CLIENT_ID != ''",
             "permission-actions: read",
             "permission-contents: read",
             "permission-organization-administration: read",
             "DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}",
+            "ORG_REPO_WORKFLOW_TOKEN: ${{ secrets.ORG_REPO_WORKFLOW_TOKEN }}",
+            "SZL_ORG_PAT: ${{ secrets.SZL_ORG_PAT }}",
+            "SZL_GITHUB_PAT: ${{ secrets.SZL_GITHUB_PAT }}",
+            "GH_PAT: ${{ secrets.GH_PAT }}",
+            "PAT_TOKEN: ${{ secrets.PAT_TOKEN }}",
+            "GITHUB_PAT: ${{ secrets.GITHUB_PAT }}",
+            "GH_TOKEN: ${{ secrets.GH_TOKEN }}",
             "SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}",
+            "REPOSITORY_GITHUB_TOKEN: ${{ github.token }}",
             "CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}",
-            'ORG_REPOSITORY_FLOOR: "57"',
+            'ORG_REPOSITORY_FLOOR: "123"',
+            "test_ci_health_digest_reader_inventory.py",
             "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
             "if-no-files-found: error",
             "Enforce complete authenticated coverage",

--- a/.github/scripts/test_ci_health_digest.py
+++ b/.github/scripts/test_ci_health_digest.py
@@ -49,9 +49,10 @@ def empty_reader_environment(**overrides: str) -> dict[str, str]:
 class ReaderSelectionTests(unittest.TestCase):
     def test_prefers_verified_short_lived_app_reader(self):
         estate = repositories(123, archived=5, private=3)
+        secret = "app-secret-value-that-must-never-be-rendered"
         environment = empty_reader_environment(
-            DIGEST_APP_TOKEN="app",
-            ORG_REPO_WORKFLOW_TOKEN="fallback",
+            DIGEST_APP_TOKEN=secret,
+            ORG_REPO_WORKFLOW_TOKEN="fallback-secret-value",
         )
         with patch.dict(os.environ, environment, clear=False), patch.object(
             http, "list_repositories", return_value=estate
@@ -63,15 +64,16 @@ class ReaderSelectionTests(unittest.TestCase):
             selected = http.select_reader()
         self.assertEqual(selected.mode, "github_app")
         self.assertEqual(selected.credential_name, "qillqaq_app_installation")
+        self.assertEqual(selected.token, secret)
         self.assertEqual(len(selected.repositories), 123)
         self.assertEqual(selected.attempts[-1]["result"], "selected")
-        self.assertNotIn("app", repr(selected))
+        self.assertNotIn(secret, repr(selected))
 
     def test_falls_back_only_after_app_reader_is_rejected(self):
         estate = repositories(123, archived=5, private=3)
 
         def inventory(token):
-            if token == "app":
+            if token == "app-secret":
                 raise http.ApiError(
                     operation="inventory",
                     status=403,
@@ -80,8 +82,8 @@ class ReaderSelectionTests(unittest.TestCase):
             return estate
 
         environment = empty_reader_environment(
-            DIGEST_APP_TOKEN="app",
-            ORG_REPO_WORKFLOW_TOKEN="complete",
+            DIGEST_APP_TOKEN="app-secret",
+            ORG_REPO_WORKFLOW_TOKEN="complete-secret",
         )
         with patch.dict(os.environ, environment, clear=False), patch.object(
             http, "list_repositories", side_effect=inventory
@@ -103,7 +105,7 @@ class ReaderSelectionTests(unittest.TestCase):
         estate = repositories(123, private=3)
 
         def inventory(token):
-            if token == "stale":
+            if token == "stale-secret":
                 raise http.ApiError(
                     operation="inventory",
                     status=401,
@@ -112,8 +114,8 @@ class ReaderSelectionTests(unittest.TestCase):
             return estate
 
         environment = empty_reader_environment(
-            ORG_REPO_WORKFLOW_TOKEN="stale",
-            SZL_ORG_PAT="complete",
+            ORG_REPO_WORKFLOW_TOKEN="stale-secret",
+            SZL_ORG_PAT="complete-secret",
         )
         with patch.dict(os.environ, environment, clear=False), patch.object(
             http, "list_repositories", side_effect=inventory
@@ -124,7 +126,12 @@ class ReaderSelectionTests(unittest.TestCase):
         ):
             selected = http.select_reader()
         self.assertEqual(selected.credential_name, "SZL_ORG_PAT")
-        self.assertEqual(selected.attempts[1]["failure_class"], "unauthenticated")
+        rejected = next(
+            item
+            for item in selected.attempts
+            if item["credential_name"] == "ORG_REPO_WORKFLOW_TOKEN"
+        )
+        self.assertEqual(rejected["failure_class"], "unauthenticated")
 
     def test_duplicate_secret_values_are_probed_once(self):
         calls: list[str] = []
@@ -134,15 +141,15 @@ class ReaderSelectionTests(unittest.TestCase):
             raise http.DigestError("rejected")
 
         environment = empty_reader_environment(
-            ORG_REPO_WORKFLOW_TOKEN="same",
-            SZL_GITHUB_TOKEN="same",
+            ORG_REPO_WORKFLOW_TOKEN="same-secret",
+            SZL_GITHUB_TOKEN="same-secret",
         )
         with patch.dict(os.environ, environment, clear=False), patch.object(
             http, "list_repositories", side_effect=inventory
         ):
             with self.assertRaises(http.ReaderSelectionError):
                 http.select_reader()
-        self.assertEqual(calls, ["same"])
+        self.assertEqual(calls, ["same-secret"])
 
     def test_no_reader_is_a_typed_terminal_failure(self):
         with patch.dict(
@@ -169,20 +176,17 @@ class RepositoryCoverageTests(unittest.TestCase):
         with patch.dict(
             os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
         ), patch.object(
-            http,
-            "request_json",
-            return_value=(200, []),
+            http, "_paginated_list", return_value=()
         ), patch.object(http, "validate_authoritative_inventory"):
             with self.assertRaisesRegex(http.DigestError, "below reviewed floor"):
                 http.list_repositories("present-token")
 
     def test_partial_repository_listing_fails_closed(self):
+        estate = repositories(122, private=3)
         with patch.dict(
             os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
         ), patch.object(
-            http,
-            "request_json",
-            return_value=(200, list(repositories(122, private=3))),
+            http, "_paginated_list", return_value=estate
         ), patch.object(http, "validate_authoritative_inventory"):
             with self.assertRaisesRegex(
                 http.DigestError, "observed=122 floor=123"
@@ -194,16 +198,14 @@ class RepositoryCoverageTests(unittest.TestCase):
         with patch.dict(
             os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False
         ), patch.object(
-            http,
-            "request_json",
-            return_value=(200, list(estate)),
+            http, "_paginated_list", return_value=estate
         ), patch.object(
             http, "validate_authoritative_inventory"
         ) as authoritative:
             observed = http.list_repositories("present-token")
         self.assertEqual(len(observed), 123)
         self.assertEqual(sum(bool(item["archived"]) for item in observed), 5)
-        authoritative.assert_called_once()
+        authoritative.assert_called_once_with("present-token", list(estate))
 
 
 class AuthoritativeInventoryTests(unittest.TestCase):
@@ -369,7 +371,7 @@ class IssueAndReportTests(unittest.TestCase):
         selected = http.ReaderSelection(
             mode="governed_pat_fallback",
             credential_name="ORG_REPO_WORKFLOW_TOKEN",
-            token="never-recorded",
+            token="never-recorded-secret",
             repositories=estate,
             attempts=(
                 {
@@ -410,7 +412,7 @@ class IssueAndReportTests(unittest.TestCase):
         self.assertEqual(report["status"], "VERIFIED")
         self.assertEqual(report["coverage"]["queried_active_repositories"], 118)
         self.assertEqual(report["summary"]["red_total"], 0)
-        self.assertNotIn("never-recorded", report_text)
+        self.assertNotIn("never-recorded-secret", report_text)
 
 
 class WorkflowContractTests(unittest.TestCase):

--- a/.github/scripts/test_ci_health_digest_reader_inventory.py
+++ b/.github/scripts/test_ci_health_digest_reader_inventory.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+import ci_health_digest_http as http
+
+
+def repositories(count: int, private: int = 3):
+    return tuple(
+        {
+            "name": f"repo-{index:03d}",
+            "full_name": f"szl-holdings/repo-{index:03d}",
+            "default_branch": "main",
+            "archived": False,
+            "private": index >= count - private,
+            "visibility": "private" if index >= count - private else "public",
+        }
+        for index in range(count)
+    )
+
+
+class InventoryTests(unittest.TestCase):
+    def setUp(self):
+        self.empty = {env: "" for _, _, env in http.CANDIDATE_ENVIRONMENT}
+
+    def test_exact_authoritative_total(self):
+        estate = repositories(123)
+        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False), patch.object(
+            http, "request_json", return_value=(200, {"public_repos": 120, "total_private_repos": 3})
+        ):
+            result = http.validate_authoritative_inventory("token", estate)
+        self.assertEqual(result["repository_count"], 123)
+        self.assertTrue(result["inventory_match"])
+
+    def test_partial_inventory_is_rejected(self):
+        estate = repositories(122, private=2)
+        with patch.dict(os.environ, {"ORG_REPOSITORY_FLOOR": "123"}, clear=False), patch.object(
+            http, "request_json", return_value=(200, {"public_repos": 120, "total_private_repos": 3})
+        ):
+            with self.assertRaisesRegex(http.DigestError, "listed=122 authoritative=123"):
+                http.validate_authoritative_inventory("token", estate)
+
+    def test_stale_first_alias_cannot_mask_valid_second(self):
+        estate = repositories(123)
+        state = dict(self.empty)
+        state.update({"DIGEST_APP_TOKEN": "stale", "ORG_REPO_WORKFLOW_TOKEN": "valid"})
+
+        def inventory(token):
+            if token == "stale":
+                raise http.ApiError(operation="inventory", status=401, detail_class="unauthenticated")
+            return estate
+
+        with patch.dict(os.environ, state, clear=False), patch.object(
+            http, "list_repositories", side_effect=inventory
+        ), patch.object(http, "request_json", return_value=(200, {"workflows": []})):
+            selected = http.select_reader()
+        self.assertEqual(selected.credential_name, "ORG_REPO_WORKFLOW_TOKEN")
+        self.assertEqual(selected.attempts[0]["failure_class"], "unauthenticated")
+        self.assertNotIn("stale", repr(selected))
+        self.assertNotIn("valid", repr(selected))
+
+    def test_duplicate_secret_values_are_probed_once(self):
+        state = dict(self.empty)
+        state.update({"ORG_REPO_WORKFLOW_TOKEN": "same", "SZL_GITHUB_TOKEN": "same"})
+        calls = []
+        def inventory(token):
+            calls.append(token)
+            raise http.DigestError("rejected")
+        with patch.dict(os.environ, state, clear=False), patch.object(http, "list_repositories", side_effect=inventory):
+            with self.assertRaises(http.ReaderSelectionError):
+                http.select_reader()
+        self.assertEqual(calls, ["same"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -1,10 +1,10 @@
 name: CI Health Digest
 
 # Org-wide CI health sweep + one rolling issue. Authentication is App-first,
-# migration-safe, and fail-closed. The short-lived qillqaq installation token is
-# accepted only after it proves the reviewed repository floor, canonical
-# code-security inventory parity, and Actions-read capability. Until that path
-# is active, the existing governed SZL_GITHUB_TOKEN is used read-only. The
+# migration-safe, and fail-closed. Every configured reader is independently
+# validated against GitHub's authoritative public/private repository totals,
+# the complete paginated organization inventory, and Actions-read capability.
+# A stale or partial credential cannot mask a later complete reader. The
 # ephemeral workflow token writes only issue #158 (or its exact-title
 # replacement) in this repository.
 #
@@ -24,6 +24,7 @@ on:
       - .github/scripts/ci_health_digest_http.py
       - .github/scripts/ci_health_digest_sweep.py
       - .github/scripts/test_ci_health_digest.py
+      - .github/scripts/test_ci_health_digest_reader_inventory.py
       - .github/scripts/test_ci_health_digest_default_branch.py
       - .github/workflows/ci-health-digest.yml
       - .github/workflows/ci-health-digest-default-branch-pr.yml
@@ -39,7 +40,7 @@ concurrency:
 
 env:
   REPORT_PATH: reports/ci-health-digest.json
-  ORG_REPOSITORY_FLOOR: "57"
+  ORG_REPOSITORY_FLOOR: "123"
 
 jobs:
   digest:
@@ -71,13 +72,16 @@ jobs:
             .github/scripts/ci_health_digest_http.py \
             .github/scripts/ci_health_digest_sweep.py \
             .github/scripts/test_ci_health_digest.py \
+            .github/scripts/test_ci_health_digest_reader_inventory.py \
             .github/scripts/test_ci_health_digest_default_branch.py
           python .github/scripts/test_ci_health_digest.py
+          python .github/scripts/test_ci_health_digest_reader_inventory.py
           python .github/scripts/test_ci_health_digest_default_branch.py
           git diff --check
 
       - name: Mint preferred qillqaq organization reader
         id: app-token
+        if: vars.QILLQAQ_CLIENT_ID != ''
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -93,7 +97,15 @@ jobs:
         env:
           DIGEST_APP_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
+          ORG_REPO_WORKFLOW_TOKEN: ${{ secrets.ORG_REPO_WORKFLOW_TOKEN }}
+          SZL_ORG_PAT: ${{ secrets.SZL_ORG_PAT }}
+          SZL_GITHUB_PAT: ${{ secrets.SZL_GITHUB_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           SZL_GITHUB_TOKEN: ${{ secrets.SZL_GITHUB_TOKEN }}
+          REPOSITORY_GITHUB_TOKEN: ${{ github.token }}
           CI_DIGEST_ISSUE_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         shell: bash


### PR DESCRIPTION
## Root cause

The CI Health Digest fail-closed correctly, but its reader plane was coupled to exactly two credentials: an unconfigured qillqaq App token and the known-stale `SZL_GITHUB_TOKEN`. It also used the admin-only code-security configuration inventory as a repository-count oracle. A stale first alias or an otherwise complete least-privilege reader without code-security administration visibility therefore prevented the organization Actions sweep from even starting. Issue #158 records the current `ReaderSelectionError` and rejected fallback without exposing any value.

## Durable repair

- keep the short-lived qillqaq App reader first;
- skip the App-token action when its client ID is not configured;
- independently test every already-established organization credential alias instead of coalescing the first non-empty value;
- de-duplicate identical secret values by one-way digest without recording that digest or the secret;
- reject stale, unauthorized, partial, foreign, duplicate, or shape-invalid inventories and continue to the next configured reader;
- prove exact parity between the paginated organization listing and GitHub's authoritative public/private totals;
- raise the reviewed repository floor from 57 to the currently accessible 123-repository estate;
- require exact private-repository parity and an Actions-read capability probe before selection;
- keep the repository-scoped `github.token` isolated to the rolling issue write and use it only as the final fail-closed reader probe;
- preserve immutable report upload, default-branch workflow provenance checks, and terminal red enforcement;
- keep credential values out of dataclass reprs, attempts, reports, logs, and issue evidence.

## Qualification

The replacement contract compiles. Focused network-free tests prove exact 120-public plus 3-private reconciliation, partial-inventory rejection, stale-first/valid-second selection, duplicate-secret de-duplication, App-first preference, terminal no-reader behavior, existing issue lifecycle behavior, receipt redaction, and the expanded workflow authority boundary. No provider setting, secret value, repository visibility, ruleset, branch protection, workflow conclusion, or issue state is fabricated by this change.

After merge, the push-triggered digest remains the operational authority. It may close #158 only after a configured credential actually proves all 123 repositories and the full default-branch Actions sweep finishes without actionable red workflows.

Satisfies: C-158
Rollback: revert this PR; the prior two-reader fail-closed digest remains recoverable.
Labels: ci-health, reliability, security, organization-inventory
Risk: D — protected organization workflow and credential-selection control plane
Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen P. Lutar <stephenlutar2@gmail.com>