### PR TITLE
fix(ci-health): make the 123-repository sweep rate-budget aware

### DIFF
--- a/.github/scripts/ci_health_digest_http.py
+++ b/.github/scripts/ci_health_digest_http.py
@@ -5,12 +5,20 @@
 A credential is selected only after it proves the complete organization
 inventory against GitHub's authoritative public/private repository totals and
 can read Actions metadata. Candidate values are never included in receipts.
+
+The estate sweep contains nested repository and workflow concurrency. All HTTP
+traffic therefore passes through one process-wide semaphore and one shared
+rate-budget coordinator. Primary and secondary rate limits are retried only
+within explicit wait and workflow deadlines; ordinary authorization failures
+remain terminal.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -21,7 +29,11 @@ ORG = "szl-holdings"
 TRANSIENT_HTTP = {429, 500, 502, 503, 504}
 CANDIDATE_ENVIRONMENT = (
     ("github_app", "qillqaq_app_installation", "DIGEST_APP_TOKEN"),
-    ("governed_pat_fallback", "ORG_REPO_WORKFLOW_TOKEN", "ORG_REPO_WORKFLOW_TOKEN"),
+    (
+        "governed_pat_fallback",
+        "ORG_REPO_WORKFLOW_TOKEN",
+        "ORG_REPO_WORKFLOW_TOKEN",
+    ),
     ("governed_pat_fallback", "SZL_ORG_PAT", "SZL_ORG_PAT"),
     ("governed_pat_fallback", "SZL_GITHUB_PAT", "SZL_GITHUB_PAT"),
     ("governed_pat_fallback", "GH_PAT", "GH_PAT"),
@@ -29,7 +41,11 @@ CANDIDATE_ENVIRONMENT = (
     ("governed_pat_fallback", "GITHUB_PAT", "GITHUB_PAT"),
     ("governed_pat_fallback", "GH_TOKEN", "GH_TOKEN"),
     ("governed_pat_fallback", "SZL_GITHUB_TOKEN", "SZL_GITHUB_TOKEN"),
-    ("repository_token_probe", "repository_github_token", "REPOSITORY_GITHUB_TOKEN"),
+    (
+        "repository_token_probe",
+        "repository_github_token",
+        "REPOSITORY_GITHUB_TOKEN",
+    ),
 )
 
 
@@ -47,7 +63,14 @@ class ReaderSelectionError(DigestError):
 
 
 class ApiError(DigestError):
-    def __init__(self, *, operation: str, status: int, detail_class: str) -> None:
+    def __init__(
+        self,
+        *,
+        operation: str,
+        status: int,
+        detail_class: str,
+        retry_after_seconds: int | None = None,
+    ) -> None:
         super().__init__(
             f"GitHub API operation {operation!r} failed: "
             f"HTTP {status} ({detail_class})"
@@ -55,6 +78,7 @@ class ApiError(DigestError):
         self.operation = operation
         self.status = status
         self.detail_class = detail_class
+        self.retry_after_seconds = retry_after_seconds
 
 
 @dataclass(frozen=True)
@@ -66,19 +90,143 @@ class ReaderSelection:
     attempts: tuple[dict[str, Any], ...]
 
 
+def _positive_environment_number(name: str, default: float) -> float:
+    raw = str(os.environ.get(name) or str(default)).strip()
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise DigestError(f"{name} is not numeric") from exc
+    if not math.isfinite(value) or value <= 0:
+        raise DigestError(f"{name} must be positive")
+    return value
+
+
+def _http_concurrency() -> int:
+    value = _positive_environment_number("CI_HEALTH_HTTP_CONCURRENCY", 3)
+    if value != int(value):
+        raise DigestError("CI_HEALTH_HTTP_CONCURRENCY must be an integer")
+    return int(value)
+
+
+_PROCESS_STARTED = time.monotonic()
+_HTTP_SEMAPHORE = threading.BoundedSemaphore(_http_concurrency())
+_RATE_LIMIT_LOCK = threading.Lock()
+_RATE_LIMIT_BLOCK_UNTIL = 0.0
+
+
+def _workflow_deadline_remaining() -> float:
+    total = _positive_environment_number("CI_HEALTH_DEADLINE_SECONDS", 5400)
+    elapsed = max(0.0, time.monotonic() - _PROCESS_STARTED)
+    return max(0.0, total - elapsed)
+
+
+def _maximum_rate_limit_wait() -> float:
+    return _positive_environment_number(
+        "CI_HEALTH_MAX_RATE_LIMIT_WAIT_SECONDS",
+        3900,
+    )
+
+
+def _header(headers: Any, name: str) -> str:
+    if headers is None:
+        return ""
+    try:
+        value = headers.get(name)
+    except (AttributeError, TypeError):
+        return ""
+    return str(value or "").strip()
+
+
 def classify_http_detail(value: object) -> str:
     text = str(value or "").lower()
     if "bad credentials" in text or "requires authentication" in text:
         return "unauthenticated"
+    if "rate limit" in text or "abuse detection" in text:
+        return "rate_limited"
     if "resource not accessible" in text or "forbidden" in text:
         return "unauthorized"
-    if "rate limit" in text:
-        return "rate_limited"
     if "not found" in text:
         return "not_found_or_hidden"
     if not text:
         return "empty_error_body"
     return "api_error"
+
+
+def _rate_limit_delay(headers: Any, attempt: int) -> float:
+    retry_after = _header(headers, "Retry-After")
+    if retry_after:
+        try:
+            value = float(retry_after)
+        except ValueError:
+            value = 0.0
+        if math.isfinite(value) and value > 0:
+            return value
+
+    reset = _header(headers, "X-RateLimit-Reset")
+    if reset:
+        try:
+            reset_epoch = float(reset)
+        except ValueError:
+            reset_epoch = 0.0
+        if math.isfinite(reset_epoch) and reset_epoch > 0:
+            return max(1.0, reset_epoch - time.time() + 2.0)
+
+    return min(float(2 ** max(attempt - 1, 0)), 60.0)
+
+
+def _is_rate_limited(status: int, detail_class: str, headers: Any) -> bool:
+    return (
+        status == 429
+        or detail_class == "rate_limited"
+        or _header(headers, "X-RateLimit-Remaining") == "0"
+    )
+
+
+def _publish_rate_limit_delay(
+    delay: float,
+    *,
+    operation: str,
+    status: int,
+) -> None:
+    bounded = max(0.0, delay)
+    maximum = _maximum_rate_limit_wait()
+    remaining = _workflow_deadline_remaining()
+    if bounded > maximum or bounded >= remaining:
+        raise ApiError(
+            operation=operation,
+            status=status,
+            detail_class="rate_limit_wait_exceeded",
+            retry_after_seconds=int(math.ceil(bounded)),
+        )
+    global _RATE_LIMIT_BLOCK_UNTIL
+    with _RATE_LIMIT_LOCK:
+        _RATE_LIMIT_BLOCK_UNTIL = max(
+            _RATE_LIMIT_BLOCK_UNTIL,
+            time.monotonic() + bounded,
+        )
+
+
+def _wait_for_shared_rate_budget(operation: str) -> None:
+    while True:
+        with _RATE_LIMIT_LOCK:
+            delay = _RATE_LIMIT_BLOCK_UNTIL - time.monotonic()
+        if delay <= 0:
+            return
+        if delay >= _workflow_deadline_remaining():
+            raise ApiError(
+                operation=operation,
+                status=429,
+                detail_class="rate_limit_wait_exceeded",
+                retry_after_seconds=int(math.ceil(delay)),
+            )
+        time.sleep(delay)
+
+
+def _reset_rate_limit_state_for_tests() -> None:
+    """Reset process-global coordination for deterministic unit tests."""
+    global _RATE_LIMIT_BLOCK_UNTIL
+    with _RATE_LIMIT_LOCK:
+        _RATE_LIMIT_BLOCK_UNTIL = 0.0
 
 
 def request_json(
@@ -89,21 +237,26 @@ def request_json(
     body: Mapping[str, Any] | None = None,
     operation: str,
     expected: set[int] | None = None,
-    attempts: int = 4,
+    attempts: int = 8,
 ) -> tuple[int, Any]:
     if not token:
         raise DigestError(f"no credential supplied for {operation}")
+    if attempts < 1:
+        raise DigestError("request attempts must be positive")
     expected = expected or {200}
     data = json.dumps(body).encode("utf-8") if body is not None else None
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "szl-ci-health-digest/3",
+        "User-Agent": "szl-ci-health-digest/4",
     }
     last_status = 0
     last_detail = "request_failed"
+    last_retry_after: int | None = None
+
     for attempt in range(1, attempts + 1):
+        _wait_for_shared_rate_budget(operation)
         request = urllib.request.Request(
             url,
             data=data,
@@ -111,50 +264,80 @@ def request_json(
             headers=headers,
         )
         try:
-            with urllib.request.urlopen(request, timeout=45) as response:
-                status = int(response.status)
-                raw = response.read()
-                payload = json.loads(raw) if raw else {}
-                if status not in expected:
-                    raise ApiError(
-                        operation=operation,
-                        status=status,
-                        detail_class="unexpected_success_status",
-                    )
-                return status, payload
+            with _HTTP_SEMAPHORE:
+                with urllib.request.urlopen(request, timeout=45) as response:
+                    status = int(response.status)
+                    raw = response.read()
+                    payload = json.loads(raw) if raw else {}
+                    response_headers = response.headers
+            if status not in expected:
+                raise ApiError(
+                    operation=operation,
+                    status=status,
+                    detail_class="unexpected_success_status",
+                )
+            if _header(response_headers, "X-RateLimit-Remaining") == "0":
+                delay = _rate_limit_delay(response_headers, attempt)
+                _publish_rate_limit_delay(
+                    delay,
+                    operation=operation,
+                    status=429,
+                )
+            return status, payload
         except urllib.error.HTTPError as exc:
             last_status = int(exc.code)
             raw = exc.read()[:1000].decode("utf-8", errors="replace")
             last_detail = classify_http_detail(raw)
-            if last_status in TRANSIENT_HTTP and attempt < attempts:
-                retry_after = exc.headers.get("Retry-After") if exc.headers else None
-                delay = (
-                    float(retry_after)
-                    if retry_after and retry_after.isdigit()
-                    else 2 ** (attempt - 1)
-                )
-                time.sleep(min(delay, 15.0))
+            rate_limited = _is_rate_limited(
+                last_status,
+                last_detail,
+                exc.headers,
+            )
+            if rate_limited:
+                last_detail = "rate_limited"
+                delay = _rate_limit_delay(exc.headers, attempt)
+                last_retry_after = int(math.ceil(delay))
+                if attempt < attempts:
+                    _publish_rate_limit_delay(
+                        delay,
+                        operation=operation,
+                        status=last_status,
+                    )
+                    continue
+            elif last_status in TRANSIENT_HTTP and attempt < attempts:
+                time.sleep(min(float(2 ** (attempt - 1)), 15.0))
                 continue
             raise ApiError(
                 operation=operation,
                 status=last_status,
                 detail_class=last_detail,
+                retry_after_seconds=last_retry_after,
             ) from exc
+        except ApiError:
+            raise
         except (urllib.error.URLError, TimeoutError) as exc:
             last_status = 0
             last_detail = type(exc).__name__
             if attempt < attempts:
-                time.sleep(min(2 ** (attempt - 1), 15))
+                time.sleep(min(float(2 ** (attempt - 1)), 15.0))
                 continue
             raise ApiError(
                 operation=operation,
                 status=0,
                 detail_class=last_detail,
             ) from exc
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ApiError(
+                operation=operation,
+                status=last_status,
+                detail_class="invalid_json",
+            ) from exc
+
     raise ApiError(
         operation=operation,
         status=last_status,
         detail_class=last_detail,
+        retry_after_seconds=last_retry_after,
     )
 
 
@@ -206,7 +389,9 @@ def _paginated_list(
 
 def _nonnegative_integer(value: Any, label: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise DigestError(f"authoritative {label} repository total is unavailable")
+        raise DigestError(
+            f"authoritative {label} repository total is unavailable"
+        )
     return value
 
 
@@ -215,7 +400,6 @@ def validate_authoritative_inventory(
     repositories: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
     """Prove exact public/private inventory equality without admin-only coupling."""
-
     _, metadata = request_json(
         token,
         f"https://api.github.com/orgs/{ORG}",
@@ -224,7 +408,10 @@ def validate_authoritative_inventory(
     if not isinstance(metadata, dict):
         raise DigestError("organization metadata payload is malformed")
 
-    public_total = _nonnegative_integer(metadata.get("public_repos"), "public")
+    public_total = _nonnegative_integer(
+        metadata.get("public_repos"),
+        "public",
+    )
     private_value = metadata.get("total_private_repos")
     if private_value is None:
         private_value = metadata.get("owned_private_repos")
@@ -243,7 +430,8 @@ def validate_authoritative_inventory(
         full_name = str(item.get("full_name") or "").strip()
         if not full_name.startswith(f"{ORG}/"):
             raise DigestError(
-                f"organization inventory contains foreign or empty identity: {full_name!r}"
+                "organization inventory contains foreign or empty identity: "
+                f"{full_name!r}"
             )
         identities.append(full_name)
         if item.get("private") is True or item.get("visibility") in {
@@ -253,15 +441,19 @@ def validate_authoritative_inventory(
             observed_private += 1
 
     if len(identities) != len(set(identities)):
-        raise DigestError("organization inventory contains duplicate repositories")
+        raise DigestError(
+            "organization inventory contains duplicate repositories"
+        )
     if len(repositories) != authoritative_total:
         raise DigestError(
-            "organization repository listing does not match authoritative totals: "
+            "organization repository listing does not match authoritative "
+            "totals: "
             f"listed={len(repositories)} authoritative={authoritative_total}"
         )
     if observed_private != private_total:
         raise DigestError(
-            "organization private repository listing does not match authoritative total: "
+            "organization private repository listing does not match "
+            "authoritative total: "
             f"listed={observed_private} authoritative={private_total}"
         )
 
@@ -277,16 +469,23 @@ def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
     repositories = list(
         _paginated_list(
             token,
-            f"https://api.github.com/orgs/{ORG}/repos?type=all&sort=full_name&direction=asc",
+            (
+                f"https://api.github.com/orgs/{ORG}/repos?"
+                "type=all&sort=full_name&direction=asc"
+            ),
             operation="list organization repositories",
         )
     )
     seen: set[str] = set()
     for item in repositories:
         name = str(item.get("name") or "").strip()
-        full_name = str(item.get("full_name") or f"{ORG}/{name}").strip()
+        full_name = str(
+            item.get("full_name") or f"{ORG}/{name}"
+        ).strip()
         if not name or not full_name:
-            raise DigestError("organization repository entry has no identity")
+            raise DigestError(
+                "organization repository entry has no identity"
+            )
         if full_name in seen:
             raise DigestError(
                 f"duplicate repository returned by GitHub: {full_name}"
@@ -299,13 +498,18 @@ def list_repositories(token: str) -> tuple[dict[str, Any], ...]:
             "organization repository coverage below reviewed floor: "
             f"observed={len(repositories)} floor={floor}"
         )
-    active = [item for item in repositories if not item.get("archived")]
+    active = [
+        item for item in repositories if not item.get("archived")
+    ]
     if not active:
-        raise DigestError("organization listing contains no active repositories")
+        raise DigestError(
+            "organization listing contains no active repositories"
+        )
     for item in active:
         if not str(item.get("default_branch") or "").strip():
             raise DigestError(
-                f"active repository {item.get('name')!r} lacks a default branch"
+                f"active repository {item.get('name')!r} "
+                "lacks a default branch"
             )
     validate_authoritative_inventory(token, repositories)
     return tuple(repositories)
@@ -344,7 +548,9 @@ def select_reader() -> ReaderSelection:
         try:
             repositories = list_repositories(token)
             active_probe = next(
-                item for item in repositories if not item.get("archived")
+                item
+                for item in repositories
+                if not item.get("archived")
             )
             _, actions_payload = request_json(
                 token,
@@ -358,10 +564,12 @@ def select_reader() -> ReaderSelection:
                 ),
             )
             if not isinstance(actions_payload, dict) or not isinstance(
-                actions_payload.get("workflows"), list
+                actions_payload.get("workflows"),
+                list,
             ):
                 raise DigestError(
-                    "Actions-read capability probe returned a malformed payload"
+                    "Actions-read capability probe returned a malformed "
+                    "payload"
                 )
         except Exception as exc:  # noqa: BLE001
             attempts.append(

--- a/.github/scripts/test_ci_health_digest_rate_budget.py
+++ b/.github/scripts/test_ci_health_digest_rate_budget.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import io
+import json
+import os
+from email.message import Message
+from pathlib import Path
+import sys
+import unittest
+import urllib.error
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+import ci_health_digest_http as http
+
+
+class Response:
+    def __init__(self, payload, *, status=200, headers=None):
+        self.status = status
+        self.headers = headers or Message()
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return self._raw
+
+
+def error(status: int, body: str, headers=None):
+    return urllib.error.HTTPError(
+        "https://api.github.com/example",
+        status,
+        body,
+        headers or Message(),
+        io.BytesIO(body.encode("utf-8")),
+    )
+
+
+class RateBudgetTests(unittest.TestCase):
+    def setUp(self):
+        http._reset_rate_limit_state_for_tests()
+
+    def tearDown(self):
+        http._reset_rate_limit_state_for_tests()
+
+    def test_rate_limit_classification_precedes_generic_forbidden(self):
+        self.assertEqual(
+            http.classify_http_detail("API rate limit exceeded for user"),
+            "rate_limited",
+        )
+        self.assertEqual(
+            http.classify_http_detail("Resource not accessible by integration"),
+            "unauthorized",
+        )
+
+    def test_retry_after_is_authoritative(self):
+        headers = Message()
+        headers["Retry-After"] = "17"
+        headers["X-RateLimit-Reset"] = "9999999999"
+        self.assertEqual(http._rate_limit_delay(headers, 1), 17.0)
+
+    def test_primary_reset_wait_includes_clock_cushion(self):
+        headers = Message()
+        headers["X-RateLimit-Reset"] = "1060"
+        with patch.object(http.time, "time", return_value=1000.0):
+            self.assertEqual(http._rate_limit_delay(headers, 1), 62.0)
+
+    def test_wait_beyond_reviewed_deadline_fails_closed(self):
+        with patch.dict(
+            os.environ,
+            {
+                "CI_HEALTH_MAX_RATE_LIMIT_WAIT_SECONDS": "10",
+                "CI_HEALTH_DEADLINE_SECONDS": "100",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(http.ApiError) as raised:
+                http._publish_rate_limit_delay(
+                    11.0,
+                    operation="bounded probe",
+                    status=429,
+                )
+        self.assertEqual(
+            raised.exception.detail_class,
+            "rate_limit_wait_exceeded",
+        )
+        self.assertEqual(raised.exception.retry_after_seconds, 11)
+
+    def test_retryable_403_rate_limit_reaches_second_attempt(self):
+        headers = Message()
+        headers["Retry-After"] = "1"
+        first = error(403, "API rate limit exceeded", headers)
+        second = Response({"ok": True})
+        with patch.object(
+            http.urllib.request,
+            "urlopen",
+            side_effect=[first, second],
+        ) as opener, patch.object(
+            http,
+            "_wait_for_shared_rate_budget",
+        ), patch.object(
+            http,
+            "_publish_rate_limit_delay",
+        ) as publish:
+            status, payload = http.request_json(
+                "secret-not-recorded",
+                "https://api.github.com/example",
+                operation="rate-limited fixture",
+                attempts=2,
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"ok": True})
+        self.assertEqual(opener.call_count, 2)
+        publish.assert_called_once_with(
+            1.0,
+            operation="rate-limited fixture",
+            status=403,
+        )
+
+    def test_ordinary_403_is_terminal_and_not_retried(self):
+        first = error(403, "Resource not accessible by integration")
+        with patch.object(
+            http.urllib.request,
+            "urlopen",
+            side_effect=first,
+        ) as opener, patch.object(
+            http,
+            "_wait_for_shared_rate_budget",
+        ):
+            with self.assertRaises(http.ApiError) as raised:
+                http.request_json(
+                    "secret-not-recorded",
+                    "https://api.github.com/example",
+                    operation="unauthorized fixture",
+                    attempts=8,
+                )
+        self.assertEqual(opener.call_count, 1)
+        self.assertEqual(raised.exception.detail_class, "unauthorized")
+
+    def test_success_with_exhausted_primary_budget_coordinates_next_call(self):
+        headers = Message()
+        headers["X-RateLimit-Remaining"] = "0"
+        headers["X-RateLimit-Reset"] = "1010"
+        response = Response({"ok": True}, headers=headers)
+        with patch.object(
+            http.urllib.request,
+            "urlopen",
+            return_value=response,
+        ), patch.object(
+            http,
+            "_wait_for_shared_rate_budget",
+        ), patch.object(
+            http,
+            "_publish_rate_limit_delay",
+        ) as publish, patch.object(http.time, "time", return_value=1000.0):
+            status, payload = http.request_json(
+                "secret-not-recorded",
+                "https://api.github.com/example",
+                operation="last-budget fixture",
+            )
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"ok": True})
+        publish.assert_called_once_with(
+            12.0,
+            operation="last-budget fixture",
+            status=429,
+        )
+
+
+class WorkflowRateBudgetContractTests(unittest.TestCase):
+    def test_workflow_is_deadline_bounded_and_app_mint_is_least_privilege(self):
+        source = (ROOT / ".github/workflows/ci-health-digest.yml").read_text(
+            encoding="utf-8"
+        )
+        for marker in (
+            'CI_HEALTH_HTTP_CONCURRENCY: "3"',
+            'CI_HEALTH_MAX_RATE_LIMIT_WAIT_SECONDS: "3900"',
+            'CI_HEALTH_DEADLINE_SECONDS: "5400"',
+            "test_ci_health_digest_rate_budget.py",
+            "timeout-minutes: 100",
+        ):
+            self.assertIn(marker, source)
+
+        app_step = source.split(
+            "- name: Mint preferred qillqaq organization reader",
+            1,
+        )[1].split(
+            "- name: Sweep the verified organization estate",
+            1,
+        )[0]
+        self.assertIn("permission-actions: read", app_step)
+        self.assertIn("permission-contents: read", app_step)
+        self.assertNotIn(
+            "permission-organization-administration: read",
+            app_step,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_ci_health_digest_rate_budget.py
+++ b/.github/scripts/test_ci_health_digest_rate_budget.py
@@ -59,7 +59,9 @@ class RateBudgetTests(unittest.TestCase):
             "rate_limited",
         )
         self.assertEqual(
-            http.classify_http_detail("Resource not accessible by integration"),
+            http.classify_http_detail(
+                "Resource not accessible by integration"
+            ),
             "unauthorized",
         )
 
@@ -118,8 +120,7 @@ class RateBudgetTests(unittest.TestCase):
                 operation="rate-limited fixture",
                 attempts=2,
             )
-        self.assertEqual(status, 200)
-        self.assertEqual(payload, {"ok": True})
+        self.assertEqual((status, payload), (200, {"ok": True}))
         self.assertEqual(opener.call_count, 2)
         publish.assert_called_once_with(
             1.0,
@@ -147,7 +148,7 @@ class RateBudgetTests(unittest.TestCase):
         self.assertEqual(opener.call_count, 1)
         self.assertEqual(raised.exception.detail_class, "unauthorized")
 
-    def test_success_with_exhausted_primary_budget_coordinates_next_call(self):
+    def test_success_at_zero_remaining_coordinates_next_call(self):
         headers = Message()
         headers["X-RateLimit-Remaining"] = "0"
         headers["X-RateLimit-Reset"] = "1010"
@@ -168,8 +169,7 @@ class RateBudgetTests(unittest.TestCase):
                 "https://api.github.com/example",
                 operation="last-budget fixture",
             )
-        self.assertEqual(status, 200)
-        self.assertEqual(payload, {"ok": True})
+        self.assertEqual((status, payload), (200, {"ok": True}))
         publish.assert_called_once_with(
             12.0,
             operation="last-budget fixture",
@@ -178,7 +178,7 @@ class RateBudgetTests(unittest.TestCase):
 
 
 class WorkflowRateBudgetContractTests(unittest.TestCase):
-    def test_workflow_is_deadline_bounded_and_app_mint_is_least_privilege(self):
+    def test_workflow_is_bounded_and_app_profile_is_exact(self):
         source = (ROOT / ".github/workflows/ci-health-digest.yml").read_text(
             encoding="utf-8"
         )
@@ -188,6 +188,7 @@ class WorkflowRateBudgetContractTests(unittest.TestCase):
             'CI_HEALTH_DEADLINE_SECONDS: "5400"',
             "test_ci_health_digest_rate_budget.py",
             "timeout-minutes: 100",
+            "vars.QILLQAQ_ORG_ADMIN_GRANTED == 'true'",
         ):
             self.assertIn(marker, source)
 
@@ -200,8 +201,12 @@ class WorkflowRateBudgetContractTests(unittest.TestCase):
         )[0]
         self.assertIn("permission-actions: read", app_step)
         self.assertIn("permission-contents: read", app_step)
-        self.assertNotIn(
+        self.assertIn(
             "permission-organization-administration: read",
+            app_step,
+        )
+        self.assertIn(
+            "vars.QILLQAQ_ORG_ADMIN_GRANTED == 'true'",
             app_step,
         )
 

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -4,9 +4,13 @@ name: CI Health Digest
 # migration-safe, and fail-closed. Every configured reader is independently
 # validated against GitHub's authoritative public/private repository totals,
 # the complete paginated organization inventory, and Actions-read capability.
-# A stale or partial credential cannot mask a later complete reader. The
-# ephemeral workflow token writes only issue #158 (or its exact-title
-# replacement) in this repository.
+# A stale or partial credential cannot mask a later complete reader.
+#
+# The qillqaq mint deliberately omits
+# `permission-organization-administration: read`: that permission is not granted
+# to the installation. The selector accepts the App only when its actual API
+# responses still prove the private inventory; otherwise it continues to the
+# complete governed PAT. The inventory contract itself is never weakened.
 #
 # Default-branch evidence boundary: GitHub's Actions registry can retain workflow
 # entries from feature or closed-PR branches. The digest proves every inspected
@@ -25,6 +29,7 @@ on:
       - .github/scripts/ci_health_digest_sweep.py
       - .github/scripts/test_ci_health_digest.py
       - .github/scripts/test_ci_health_digest_reader_inventory.py
+      - .github/scripts/test_ci_health_digest_rate_budget.py
       - .github/scripts/test_ci_health_digest_default_branch.py
       - .github/workflows/ci-health-digest.yml
       - .github/workflows/ci-health-digest-default-branch-pr.yml
@@ -41,12 +46,16 @@ concurrency:
 env:
   REPORT_PATH: reports/ci-health-digest.json
   ORG_REPOSITORY_FLOOR: "123"
+  CI_HEALTH_HTTP_CONCURRENCY: "3"
+  CI_HEALTH_MAX_RATE_LIMIT_WAIT_SECONDS: "3900"
+  CI_HEALTH_DEADLINE_SECONDS: "5400"
+  PYTHONDONTWRITEBYTECODE: "1"
 
 jobs:
   digest:
     name: Authenticated organization sweep and rolling evidence issue
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 100
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -73,9 +82,11 @@ jobs:
             .github/scripts/ci_health_digest_sweep.py \
             .github/scripts/test_ci_health_digest.py \
             .github/scripts/test_ci_health_digest_reader_inventory.py \
+            .github/scripts/test_ci_health_digest_rate_budget.py \
             .github/scripts/test_ci_health_digest_default_branch.py
           python .github/scripts/test_ci_health_digest.py
           python .github/scripts/test_ci_health_digest_reader_inventory.py
+          python .github/scripts/test_ci_health_digest_rate_budget.py
           python .github/scripts/test_ci_health_digest_default_branch.py
           git diff --check
 
@@ -90,7 +101,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-actions: read
           permission-contents: read
-          permission-organization-administration: read
 
       - name: Sweep the verified organization estate and publish issue evidence
         id: digest

--- a/.github/workflows/ci-health-digest.yml
+++ b/.github/workflows/ci-health-digest.yml
@@ -6,11 +6,11 @@ name: CI Health Digest
 # the complete paginated organization inventory, and Actions-read capability.
 # A stale or partial credential cannot mask a later complete reader.
 #
-# The qillqaq mint deliberately omits
-# `permission-organization-administration: read`: that permission is not granted
-# to the installation. The selector accepts the App only when its actual API
-# responses still prove the private inventory; otherwise it continues to the
-# complete governed PAT. The inventory contract itself is never weakened.
+# Qillqaq's governance-approved token profile includes
+# `permission-organization-administration: read`. The action runs only when the
+# installation has been explicitly confirmed to hold that permission; otherwise
+# the selector proceeds to the independently validated complete PAT instead of
+# generating a known 422. The inventory contract is never weakened.
 #
 # Default-branch evidence boundary: GitHub's Actions registry can retain workflow
 # entries from feature or closed-PR branches. The digest proves every inspected
@@ -92,7 +92,7 @@ jobs:
 
       - name: Mint preferred qillqaq organization reader
         id: app-token
-        if: vars.QILLQAQ_CLIENT_ID != ''
+        if: vars.QILLQAQ_CLIENT_ID != '' && vars.QILLQAQ_ORG_ADMIN_GRANTED == 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -101,6 +101,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-actions: read
           permission-contents: read
+          permission-organization-administration: read
 
       - name: Sweep the verified organization estate and publish issue evidence
         id: digest


### PR DESCRIPTION
## Measured failure

The source-valid CI Health Digest selected `SZL_GITHUB_TOKEN`, proved exact parity with the current **123-repository** estate, and passed its complete local contract suite. The protected-main run then failed during the Actions sweep with a typed `ApiError` classified `rate_limited`. The prior client issued nested repository/workflow requests with up to 64 concurrent callers, retried a secondary limit for only 1/2/4 seconds, and ignored `X-RateLimit-Reset`. The rolling issue remained correctly open and the failed receipt was retained.

## Durable repair

- place every GitHub API request behind one process-wide three-request semaphore, regardless of nested executor width;
- distinguish retryable 403/429 rate limiting from ordinary 403 authorization failure;
- honor numeric `Retry-After` first and primary `X-RateLimit-Reset` second;
- coordinate one shared block-until instant so workers do not stampede the API after a limit response;
- allow up to 3,900 seconds for a reviewed reset, bounded by a 5,400-second process deadline and a 100-minute job timeout;
- retry transport and 5xx failures separately with bounded exponential backoff;
- retain secret-free typed failures and never record credential values, prefixes, hashes, or headers;
- preserve qillqaq’s governance-approved Actions/content/organization-administration read profile, but mint only after `QILLQAQ_ORG_ADMIN_GRANTED=true` explicitly confirms the installation has that authority;
- otherwise proceed directly to the independently validated complete PAT instead of generating a known App-token 422;
- preserve exact 120-public plus 3-private inventory reconciliation and the Actions-read capability probe;
- add network-free regressions for primary and secondary limits, wait ceilings, ordinary authorization failure, proactive last-request exhaustion, and the App authority guard.

## Acceptance

All exact-head tests, FORGE-9, doctrine, security, organization-control, provenance, and production-readiness checks must pass. After merge, the push-triggered digest must either finish the complete default-branch Actions sweep and close #158 automatically, or retain a typed fail-closed receipt naming the remaining class. No issue is closed manually and no result is represented as current until that run succeeds.

Satisfies: C-158
Rollback: revert this PR; the complete-reader selection and prior fail-closed receipt remain intact.
Labels: ci-health, reliability, rate-limit, organization-inventory
Risk: D — protected organization-wide CI evidence control plane
Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen P. Lutar <stephenlutar2@gmail.com>