### PR TITLE
fix(profile): restore the source-bound public inventory contract

### DIFF
--- a/.github/scripts/test_profile_inventory_contract.py
+++ b/.github/scripts/test_profile_inventory_contract.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COUNT_LINE = re.compile(
+    r"(?P<spaces>[0-9]+) public Spaces, "
+    r"(?P<models>[0-9]+) models, "
+    r"(?P<datasets>[0-9]+) datasets\."
+)
+
+
+class PublicInventoryContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.contract = json.loads(
+            (ROOT / "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        snapshot = self.contract["huggingface_inventory_snapshot"]
+        self.expected = {
+            "spaces": int(snapshot["public_space_count"]),
+            "models": int(snapshot["model_count"]),
+            "datasets": int(snapshot["dataset_count"]),
+        }
+        self.documents = {
+            "profile": ROOT / "profile/README.md",
+            "hub_card": ROOT / "huggingface/org-card/README.md",
+        }
+
+    def test_both_front_doors_publish_the_exact_public_inventory(self) -> None:
+        for name, path in self.documents.items():
+            with self.subTest(document=name):
+                source = path.read_text(encoding="utf-8")
+                match = COUNT_LINE.search(source)
+                self.assertIsNotNone(match)
+                observed = {
+                    key: int(value)
+                    for key, value in match.groupdict().items()
+                }
+                self.assertEqual(observed, self.expected)
+                self.assertIn("16 portfolio Spaces", source)
+                self.assertIn("1 inventory-only Space", source)
+                self.assertIn("Yarqa", source)
+                self.assertIn("governedKeep=false", source)
+
+    def test_public_markdown_has_no_hidden_control_characters(self) -> None:
+        for name, path in self.documents.items():
+            with self.subTest(document=name):
+                source = path.read_text(encoding="utf-8")
+                offenders = sorted(
+                    {
+                        ord(character)
+                        for character in source
+                        if ord(character) < 32
+                        and character not in {"\n", "\r", "\t"}
+                    }
+                )
+                self.assertEqual(offenders, [])
+                self.assertNotIn("¡", source)
+
+    def test_profile_keeps_all_public_navigation_paths_well_formed(self) -> None:
+        source = self.documents["profile"].read_text(encoding="utf-8")
+        required = (
+            "[**Product**](https://a-11-oy.com)",
+            "[**Proof**](https://a11oy.net)",
+            "[**GitHub**](https://github.com/szl-holdings)",
+            "[**Hugging Face**](https://huggingface.co/SZLHOLDINGS)",
+            "[Channel A](https://huggingface.co/spaces/SZLHOLDINGS/immune)",
+            "[Channel B](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice)",
+        )
+        for marker in required:
+            self.assertIn(marker, source)
+        self.assertNotIn("·`[Channel B]", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/hf-org-card-deploy.yml
+++ b/.github/workflows/hf-org-card-deploy.yml
@@ -8,6 +8,7 @@ on:
       - "huggingface/org-card/**"
       - "huggingface/org-card.manifest.json"
       - "docs/ESTATE_ALIGNMENT_CONTRACT_V1.json"
+      - "profile/README.md"
       - "profile/assets/**"
       - "profile/assets/evidence-lattice-v2.webp"
       - ".github/scripts/hf_static_space_deploy.py"
@@ -18,6 +19,7 @@ on:
       - ".github/scripts/test_hf_org_card_embed_check.py"
       - ".github/scripts/test_hf_static_space_deploy.py"
       - ".github/scripts/test_public_front_door_check.py"
+      - ".github/scripts/test_profile_inventory_contract.py"
       - ".github/workflows/hf-org-card-deploy.yml"
       - ".github/workflows/hf-org-card-embed-check.yml"
 
@@ -67,6 +69,12 @@ jobs:
           python -m unittest discover
           -s .github/scripts
           -p test_public_front_door_check.py
+
+      - name: Test public inventory and text integrity
+        run: >-
+          python -m unittest discover
+          -s .github/scripts
+          -p test_profile_inventory_contract.py
 
       - name: Test org-card embed contract
         run: >-

--- a/huggingface/org-card/README.md
+++ b/huggingface/org-card/README.md
@@ -49,9 +49,9 @@ Five public domain bodies: **Terra, Killinchu, PRISM Counsel, PURIQ Finance, LYT
 
 Six internal engines: **Sentra, Lyte, Killinchu, Finance, Terra, Counsel**.
 
-**16 portfolio Spaces · 45 models · 34 datasets.**
+**17 public Spaces, 45 models, 34 datasets.**
 
-**1 inventory-only Space: Yarqa · governedKeep=false ·disposition=FOLD.**
+Portfolio authority is narrower: **16 portfolio Spaces** plus **1 inventory-only Space**, Yarqa, with `governedKeep=false` and disposition `FOLD`.
 
 Hub inventory is registry-only—not availability, operational readiness, or publication policy. KEEP authority: [`docs/CANONICAL_FLEET.md`](https://github.com/szl-holdings/.github/blob/main/docs/CANONICAL_FLEET.md).
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -35,18 +35,18 @@ Five public domain bodies: **Terra, Killinchu, PRISM Counsel, PURIQ Finance, LYT
 
 Six internal engines: **Sentra, Lyte, Killinchu, Finance, Terra, Counsel**.
 
-**16 portfolio Spaces · 45 models · 34 datasets.**
+**17 public Spaces, 45 models, 34 datasets.**
 
-**1 inventory-only Space: Yarqa · governedKeep=false ·disposition=FOLD.**
+Portfolio authority is narrower: **16 portfolio Spaces** plus **1 inventory-only Space**, Yarqa, with `governedKeep=false` and disposition `FOLD`.
 
 Hub inventory is registry-only—not availability, operational readiness, or publication policy. KEEP authority: [`docs/CANONICAL_FLEET.md`](https://github.com/szl-holdings/.github/blob/main/docs/CANONICAL_FLEET.md).
 
 ## Public paths
 
-- **A11oy** ¡ [product](https://a-11-oy.com) · [source](https://github.com/szl-holdings/a11oy)
+- **A11oy** · [product](https://a-11-oy.com) · [source](https://github.com/szl-holdings/a11oy)
 - **Proof registry** · [a11oy.net](https://a11oy.net) for diligence and atlas evidence
-- **Artifacts** ¡ [Hugging Face](https://huggingface.co/SZLHOLDINGS)
-- **IMMUNE** · [product tab](https://a-11-oy.com/immune) · [Channel A](https://huggingface.co/spaces/SZLHOLDINGS/immune) ·`[Channel B](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice)
+- **Artifacts** · [Hugging Face](https://huggingface.co/SZLHOLDINGS)
+- **IMMUNE** · [product tab](https://a-11-oy.com/immune) · [Channel A](https://huggingface.co/spaces/SZLHOLDINGS/immune) · [Channel B](https://huggingface.co/spaces/SZLHOLDINGS/immune-lattice)
 - **Security** · [policy](https://github.com/szl-holdings/.github/security/policy) · [trust boundary](https://github.com/szl-holdings/.github/blob/main/TRUST.md)
 
 NEXUS is an internal IMMUNE capability plane, not a second product. Do not mint `SZLHOLDINGS/nexus`.
@@ -55,16 +55,17 @@ NEXUS is an internal IMMUNE capability plane, not a second product. Do not mint 
 
 - A11oy publishes bounded kernel evidence; λ remains a conjecture.
 - Killinchu public actuation is **SIMULATED** unless a separately authorized effector proves otherwise.
-- [`SzlHOLDINGS/SZLHOLDINGS`](https://huggingface.co/datasets/SZLHOLDINGS/SZLHOLDINGS) is a **HISTORICAL** dataset mirror.
+- [`SZLHOLDINGS/SZLHOLDINGS`](https://huggingface.co/datasets/SZLHOLDINGS/SZLHOLDINGS) is a **HISTORICAL** dataset mirror.
 - A signature proves integrity and origin within scope—not accuracy, safety, performance, compliance, or deployment authorization.
 - Estate is **not READY**. Research-only and quarantined artifacts are not production SKUs.
 
 This profile claims no regulatory approval, universal safety, customer adoption, or investment outcome. An HTTP 200 response is not a production certificate.
----
+
+---
 
 <div align="center">
 
-**Govern ¡ execute · prove**
+**Govern · execute · prove**
 
 [a-11-oy.com](https://a-11-oy.com) · [a11oy.net](https://a11oy.net)
 


### PR DESCRIPTION
## Measured failure

The latest A11oy estate-release artifact observed **17 public Spaces, 45 models, and 34 datasets**, exactly matching `docs/huggingface-ecosystem-manifest.json`. The release still remained divergent because the GitHub profile’s `declared_counts` was `null`: it split the Space total into `16 portfolio Spaces` and `1 inventory-only Space`, while the verifier consumes one canonical public-inventory sentence. The profile also contained a hidden control character, corrupted `¡` separators, and a malformed IMMUNE Channel B link.

## Durable repair

- publish one exact machine-readable statement on both public cards: `17 public Spaces, 45 models, 34 datasets.`;
- preserve the narrower authority boundary as 16 portfolio Spaces plus one inventory-only Yarqa Space with `governedKeep=false` and disposition `FOLD`;
- repair the corrupted A11oy, artifact, footer, and IMMUNE navigation text without changing destinations;
- remove hidden C0 control characters from the GitHub profile;
- add a contract that derives expected counts from `docs/ESTATE_ALIGNMENT_CONTRACT_V1.json`, validates both cards, preserves the portfolio/inventory distinction, checks every public path, and rejects future control-character corruption;
- run that contract inside the canonical source-bound Hugging Face organization-card publication workflow;
- add `profile/README.md` to the publication trigger so the visible GitHub and Hub front doors cannot silently diverge.

## Acceptance

All exact-head workflow, governance, security, public-front-door, and production-readiness checks must pass. After merge, the source-bound organization-card publisher must read back the exact served revision. The A11oy estate-release train must then be rerun and may clear `HF_INVENTORY_COUNT_MISMATCH_OR_UNAVAILABLE` only when its new artifact reports `declared_counts == observed_counts == manifest_counts`.

Satisfies: C-2010
Rollback: revert this PR; the prior front-door documents and fail-closed release-train receipt remain recoverable.
Labels: public-experience, hugging-face, inventory, reliability
Risk: D — protected public-card publication workflow and organization profile
Solo-Operator-Authorization: confirmed

Signed-off-by: Stephen P. Lutar <stephenlutar2@gmail.com>