### PR TITLE
fix(attic): bind lifecycle index to reviewed archive portfolio

### DIFF
--- a/.github/tests/test_attic_portfolio.py
+++ b/.github/tests/test_attic_portfolio.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Offline lifecycle contracts for scripts/build_attic_index.py."""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "scripts" / "build_attic_index.py"
+SPEC = importlib.util.spec_from_file_location("build_attic_index", MODULE_PATH)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = module
+SPEC.loader.exec_module(module)
+
+
+def manifest() -> dict:
+    return module.load_portfolio(ROOT / "governance" / "archive-portfolio-v1.json")
+
+
+def repositories(value: dict, *, restored: bool = False) -> list[dict]:
+    restore = set(value["restoration_wave"]["repositories"])
+    rows = [
+        {
+            "name": row["name"],
+            "description": "",
+            "isArchived": not (restored and row["name"] in restore),
+            "isPrivate": False,
+            "url": f"https://github.com/szl-holdings/{row['name']}",
+        }
+        for row in value["repositories"]
+    ]
+    existing = {row["name"] for row in rows}
+    targets = sorted(
+        {
+            target
+            for row in value["repositories"]
+            for target in row["canonical_targets"]
+        }
+        - existing
+    )
+    rows.extend(
+        {
+            "name": target,
+            "description": "",
+            "isArchived": False,
+            "isPrivate": False,
+            "url": f"https://github.com/szl-holdings/{target}",
+        }
+        for target in targets
+    )
+    return rows
+
+
+class PortfolioContractTests(unittest.TestCase):
+    def test_manifest_has_exact_reviewed_shape(self):
+        value = manifest()
+        self.assertEqual(len(value["repositories"]), 34)
+        counts = {
+            disposition: sum(
+                row["disposition"] == disposition
+                for row in value["repositories"]
+            )
+            for disposition in ("restore", "consolidate", "historical")
+        }
+        self.assertEqual(
+            counts,
+            {"restore": 5, "consolidate": 23, "historical": 6},
+        )
+        self.assertEqual(
+            value["restoration_wave"]["repositories"],
+            [
+                "docs-site",
+                "szl-atelier",
+                "szl-mesh",
+                "szl-router",
+                "uds-bundles",
+            ],
+        )
+
+    def test_all_archived_state_is_reported_without_fabricated_restoration(self):
+        value = manifest()
+        result = module.analyse(repositories(value), value)
+        self.assertEqual(len(result["pending_restore"]), 5)
+        self.assertEqual(result["restored"], [])
+        self.assertEqual(len(result["consolidated"]), 23)
+        self.assertEqual(len(result["historical"]), 6)
+        self.assertEqual(result["defects"], [])
+
+    def test_provider_readback_moves_only_restore_rows_to_active(self):
+        value = manifest()
+        result = module.analyse(repositories(value, restored=True), value)
+        self.assertEqual(result["pending_restore"], [])
+        self.assertEqual(len(result["restored"]), 5)
+        self.assertEqual(len(result["consolidated"]), 23)
+        self.assertEqual(len(result["historical"]), 6)
+        self.assertEqual(result["defects"], [])
+        self.assertEqual(result["archived"], 29)
+
+    def test_unclassified_archive_fails_closed(self):
+        value = manifest()
+        repos = repositories(value)
+        repos.append(
+            {
+                "name": "surprise-archive",
+                "description": "",
+                "isArchived": True,
+                "isPrivate": False,
+                "url": "https://github.com/szl-holdings/surprise-archive",
+            }
+        )
+        result = module.analyse(repos, value)
+        self.assertIn(
+            "UNCLASSIFIED_ARCHIVE",
+            {row["code"] for row in result["defects"]},
+        )
+
+    def test_consolidation_tombstone_cannot_silently_reactivate(self):
+        value = manifest()
+        chosen = next(
+            row["name"]
+            for row in value["repositories"]
+            if row["disposition"] == "consolidate"
+        )
+        repos = repositories(value)
+        for repo in repos:
+            if repo["name"] == chosen:
+                repo["isArchived"] = False
+        result = module.analyse(repos, value)
+        self.assertIn(
+            "CONSOLIDATION_TOMBSTONE_ACTIVE",
+            {row["code"] for row in result["defects"]},
+        )
+
+    def test_historical_record_cannot_silently_reactivate(self):
+        value = manifest()
+        chosen = next(
+            row["name"]
+            for row in value["repositories"]
+            if row["disposition"] == "historical"
+        )
+        repos = repositories(value)
+        for repo in repos:
+            if repo["name"] == chosen:
+                repo["isArchived"] = False
+        result = module.analyse(repos, value)
+        self.assertIn(
+            "HISTORICAL_RECORD_ACTIVE",
+            {row["code"] for row in result["defects"]},
+        )
+
+    def test_missing_or_archived_canonical_target_is_terminal(self):
+        value = manifest()
+        row = next(
+            item
+            for item in value["repositories"]
+            if item["disposition"] == "consolidate"
+        )
+        target = row["canonical_targets"][0]
+        repos = [repo for repo in repositories(value) if repo["name"] != target]
+        result = module.analyse(repos, value)
+        self.assertIn(
+            "CANONICAL_TARGET_MISSING",
+            {item["code"] for item in result["defects"]},
+        )
+
+    def test_hugging_face_links_preserve_surface_kind(self):
+        self.assertEqual(
+            module._hf("SZLHOLDINGS/szl-constellation"),
+            "[`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation)",
+        )
+        self.assertEqual(
+            module._hf("SZLHOLDINGS/szl-kernels"),
+            "[`SZLHOLDINGS/szl-kernels`](https://huggingface.co/SZLHOLDINGS/szl-kernels)",
+        )
+
+    def test_render_never_calls_pending_restoration_active(self):
+        value = manifest()
+        body = module.render(module.analyse(repositories(value), value))
+        self.assertIn("PENDING_ADMIN_AUTHORITY", body)
+        self.assertNotIn("RESTORED_READBACK_VERIFIED", body)
+        self.assertIn("Consolidation tombstones", body)
+        self.assertIn("Immutable historical evidence", body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/attic-index.yml
+++ b/.github/workflows/attic-index.yml
@@ -1,22 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Doctrine v11 LOCKED · Λ = Conjecture 1 (advisory)
 #
-# Keeps ATTIC.md — the org-wide tombstone index — honest.
-#
-# Fails closed on STRUCTURAL defects (a tombstone pointing at a nonexistent repo,
-# or at another tombstone) and on drift (ATTIC.md stale vs the live estate).
-# Surfaces UNKNOWN successors as warnings: those are open owner decisions, not
-# regressions a PR introduced.
+# Keeps ATTIC.md — the org-wide repository lifecycle index — honest.
+# Lifecycle disposition comes from archive-portfolio-v1; current active/archive
+# state comes from the public GitHub API. Neither source may silently override
+# the other.
 name: Attic Index
 
 on:
   pull_request:
     paths:
       - "ATTIC.md"
+      - "governance/archive-portfolio-v1.json"
       - "scripts/build_attic_index.py"
+      - ".github/tests/test_attic_portfolio.py"
       - ".github/workflows/attic-index.yml"
   schedule:
-    # Daily: the estate changes under us as repos are archived or superseded.
+    # Daily: provider state can move after a reviewed restoration wave.
     - cron: "23 7 * * *"
   workflow_dispatch:
 
@@ -31,15 +31,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: Checkout exact candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
-      - name: Validate tombstone index against the live estate
+      - name: Validate offline lifecycle contracts
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/build_attic_index.py
+          python .github/tests/test_attic_portfolio.py
+          git diff --check
+
+      - name: Validate lifecycle index against the live public estate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/build_attic_index.py --check

--- a/ATTIC.md
+++ b/ATTIC.md
@@ -1,76 +1,76 @@
-# ATTIC — SZL Holdings archived-repository index
+# ATTIC — SZL Holdings repository lifecycle index
 
 <!-- GENERATED FILE — do not edit by hand. -->
 <!-- Regenerate: python scripts/build_attic_index.py --write -->
 
-Every public archived repository in the `szl-holdings` organization, mapped to the canonical repository that superseded it. Generated from the live GitHub API, never hand-maintained, so the index cannot drift from the public estate.
+This index joins live public GitHub repository state with the reviewed `governance/archive-portfolio-v1.json` lifecycle authority. Repository descriptions are informative only; they cannot silently choose a successor.
 
-**Doctrine.** Honest UNKNOWN over fabricated green: an archived repo with no discoverable successor appears below as UNKNOWN and requires an owner decision. This index never invents a plausible-looking successor.
+**Rule.** Restore only unique maintained authorities. Move reusable source from consolidation tombstones into named active owners through reviewed PRs. Keep published evidence immutable. Present the result through existing Hugging Face flagships rather than multiplying Spaces.
 
 ## Estate shape
 
 | Metric | Count |
 |---|---:|
-| Public repositories total | 95 |
-| Active public repositories | 60 |
-| Archived public repositories (tombstones) | 35 |
-| Tombstones with a resolved successor | 28 |
-| Tombstones terminal by design | 6 |
-| Tombstones with UNKNOWN successor | 1 |
+| Public repositories total | 117 |
+| Active public repositories | 83 |
+| Archived public repositories | 34 |
+| Strategic restorations pending | 5 |
+| Strategic restorations completed | 0 |
+| Consolidation tombstones | 23 |
+| Immutable historical records | 6 |
 | Structural defects | 0 |
 
-## Resolved tombstones
+## Strategic restoration wave
 
-| Archived repo | Canonical successor | Language | Last push |
+A pending row remains archived because repository-administration authority has not yet produced provider readback. It is not presented as an active source until GitHub reports `archived=false`.
+
+| Repository | State | Maintained role | Hugging Face showcase |
 |---|---|---|---|
-| `cosmos` | [`anatomy`](https://github.com/szl-holdings/anatomy) | JavaScript | 2026-08-29 |
-| `counsel` | [`ayllu`](https://github.com/szl-holdings/ayllu) | Python | 2026-08-29 |
-| `david-leads` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-28 |
-| `developers` | [`a11oy-net`](https://github.com/szl-holdings/a11oy-net) | HTML | 2026-07-29 |
-| `docs-site` | [`a11oy-net`](https://github.com/szl-holdings/a11oy-net) | JavaScript | 2026-08-28 |
-| `energy-attest-holo` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest) | Python | 2026-08-18 |
-| `governed-inference-meter` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest) | Python | 2026-08-30 |
-| `governed-norm-holo` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Python | 2026-08-29 |
-| `holographic-unify` | [`a11oy`](https://github.com/szl-holdings/a11oy) | TypeScript | 2026-08-29 |
-| `immune-lattice` | [`immune`](https://github.com/szl-holdings/immune) | TypeScript | 2026-08-29 |
-| `khipu-lab` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | TypeScript | 2026-08-29 |
-| `khipu-pages` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | HTML | 2026-08-29 |
-| `lambda-gate-holo` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Python | 2026-08-29 |
-| `lean-kernel` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) | Python | 2026-08-28 |
-| `ouroboros` | [`platform`](https://github.com/szl-holdings/platform) | TypeScript | 2026-08-28 |
-| `receipt-chain-live` | [`szl-receipt`](https://github.com/szl-holdings/szl-receipt) | Python | 2026-08-26 |
-| `szl-build-env` | [`szl-forge`](https://github.com/szl-holdings/szl-forge) | Python | 2026-08-28 |
-| `szl-cookbook` | [`szl-forge`](https://github.com/szl-holdings/szl-forge) | TypeScript | 2026-08-31 |
-| `szl-experiments` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-29 |
-| `szl-formula-ledger` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) | Python | 2026-07-22 |
-| `szl-governed-norm` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Python | 2026-08-08 |
-| `szl-kernels-live` | [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | Python | 2026-08-18 |
-| `szl-mesh` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | Python | 2026-08-26 |
-| `szl-organ-integrity` | [`a11oy`](https://github.com/szl-holdings/a11oy) | HTML | 2026-08-29 |
-| `szl-provctl-live` | [`szl-provctl`](https://github.com/szl-holdings/szl-provctl) | Python | 2026-08-18 |
-| `szl-router` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-26 |
-| `szl-telemetry` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | Python | 2026-08-29 |
-| `vsp-otel` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | TypeScript | 2026-08-26 |
+| `docs-site` | `PENDING_ADMIN_AUTHORITY` | The live versioned documentation portal needs an active source and release path. Restore it as docs authority; a11oy-net remains the proof site. | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) |
+| `szl-atelier` | `PENDING_ADMIN_AUTHORITY` | Existing flagship Hugging Face model-walk surface. Restore the source repo as a presentation-only authority while szl-forge retains training/publication authority. | [`SZLHOLDINGS/szl-atelier`](https://huggingface.co/spaces/SZLHOLDINGS/szl-atelier) |
+| `szl-mesh` | `PENDING_ADMIN_AUTHORITY` | Strategic DDIL/CRDT coordination layer required by Beacon and physical-edge work. Restore with a narrow mesh authority distinct from the general substrate. | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) |
+| `szl-router` | `PENDING_ADMIN_AUTHORITY` | Unique sovereign OpenAI-compatible routing gateway with receipt, cost, provider-attempt, and ownership evidence. Restore as runtime gateway; A11oy remains the governance/control plane. | [`SZLHOLDINGS/szl-atelier`](https://huggingface.co/spaces/SZLHOLDINGS/szl-atelier) |
+| `uds-bundles` | `PENDING_ADMIN_AUTHORITY` | Unique air-gap packaging authority for Zarf/UDS bundle manifests. Restore as the maintained packaging source, separate from frozen event snapshots. | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) |
 
-## Terminal by design (no successor)
+## Consolidation tombstones
 
-| Archived repo | Why it has no successor |
-|---|---|
-| `evidence-typed-formula-governance` | Archival preprint + reproducibility package. Immutable by design — a published record must not be superseded in place. |
-| `fail-closed-governed-ai-services` | Archival preprint + reproducibility package. Immutable by design — a published record must not be superseded in place. |
-| `szl-fleet-overlay` | Frozen WarHacker-2026 UDS fleet-overlay evidence snapshot. Retained for provenance; it has no active software successor. |
-| `szl-otel-mesh` | Published OpenTelemetry/DSSE research artifact with DOI 10.5281/zenodo.20434276. Immutable archival evidence by design. |
-| `szl-uds-deployment` | Frozen WarHacker-2026 UDS deployment evidence snapshot. Retained for reproducibility; it has no active software successor. |
-| `warhacker-demo` | One-off WarHacker-2026 hardware and air-gap dry-run snapshot. The archived demonstration is retained as evidence, not a maintained product. |
+| Archived repository | Canonical owner(s) | Hugging Face showcase | Rationale |
+|---|---|---|---|
+| `cosmos` | [`szl-constellation`](https://github.com/szl-holdings/szl-constellation), [`anatomy`](https://github.com/szl-holdings/anatomy) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Move the best 3D estate and anatomy views into the canonical Constellation and Anatomy surfaces. |
+| `counsel` | [`ayllu`](https://github.com/szl-holdings/ayllu) | [`SZLHOLDINGS/ayllu`](https://huggingface.co/spaces/SZLHOLDINGS/ayllu) | Counsel is an Ayllu capability; preserve history and move maintained backend/frontend work into Ayllu. |
+| `developers` | [`docs-site`](https://github.com/szl-holdings/docs-site) | [`SZLHOLDINGS/szl-atelier`](https://huggingface.co/spaces/SZLHOLDINGS/szl-atelier) | Developer onboarding and SDK navigation belong in the restored docs hub. |
+| `energy-attest-holo` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest), [`szl-constellation`](https://github.com/szl-holdings/szl-constellation) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Energy measurement remains in its canonical service; the hologram becomes a Constellation module. |
+| `governed-inference-meter` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest), [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Move metering semantics to the energy authority and kernel contracts to the kernel suite. |
+| `governed-norm-holo` | [`szl-kernels`](https://github.com/szl-holdings/szl-kernels), [`szl-constellation`](https://github.com/szl-holdings/szl-constellation) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Keep kernel semantics in szl-kernels and presentation in Constellation. |
+| `immune-lattice` | [`immune`](https://github.com/szl-holdings/immune) | [`SZLHOLDINGS/immune`](https://huggingface.co/spaces/SZLHOLDINGS/immune) | Move COP/lattice presentation into the canonical IMMUNE service and its existing Space channel. |
+| `khipu-lab` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | [`SZLHOLDINGS/szl-khipu`](https://huggingface.co/SZLHOLDINGS/szl-khipu) | Migrate the interactive kernel-lab UI and browser fixtures into the canonical KHIPU source; do not maintain a second kernel authority. |
+| `khipu-pages` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | [`SZLHOLDINGS/szl-khipu`](https://huggingface.co/SZLHOLDINGS/szl-khipu) | Merge the static showcase into the canonical KHIPU frontend instead of maintaining a second Pages source. |
+| `lambda-gate-holo` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate), [`szl-constellation`](https://github.com/szl-holdings/szl-constellation) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Keep lambda-gate computation canonical and show it through the consolidated constellation. |
+| `lean-kernel` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean), [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | [`SZLHOLDINGS/szl-kernels`](https://huggingface.co/SZLHOLDINGS/szl-kernels) | Formal source belongs in lutar-lean; the governed kernel suite is the public Hugging Face artifact. |
+| `ouroboros` | [`platform`](https://github.com/szl-holdings/platform), [`szl-ouroboros`](https://github.com/szl-holdings/szl-ouroboros) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Product implementation belongs in platform; bounded-loop kernel semantics belong in szl-ouroboros. |
+| `receipt-chain-live` | [`szl-receipt`](https://github.com/szl-holdings/szl-receipt), [`a11oy-net`](https://github.com/szl-holdings/a11oy-net) | [`SZLHOLDINGS/governed-receipt-verifier`](https://huggingface.co/spaces/SZLHOLDINGS/governed-receipt-verifier) | Receipt implementation belongs in szl-receipt; public verification belongs on the proof surface. |
+| `szl-build-env` | [`szl-forge`](https://github.com/szl-holdings/szl-forge) | [`SZLHOLDINGS/szl-atelier`](https://huggingface.co/spaces/SZLHOLDINGS/szl-atelier) | Build environment ownership belongs in the canonical Forge release plane. |
+| `szl-cookbook` | [`docs-site`](https://github.com/szl-holdings/docs-site), [`szl-forge`](https://github.com/szl-holdings/szl-forge) | [`SZLHOLDINGS/szl-atelier`](https://huggingface.co/spaces/SZLHOLDINGS/szl-atelier) | Keep recipes in the restored docs hub; executable model recipes remain owned by Forge. |
+| `szl-experiments` | [`szl-frontier`](https://github.com/szl-holdings/szl-frontier) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | All experimental work should enter through one frontier/evidence lane. |
+| `szl-formula-ledger` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean), [`szl-formulas`](https://github.com/szl-holdings/szl-formulas) | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Formal truth remains in Lean; public formula packaging remains in szl-formulas. |
+| `szl-governed-norm` | [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | [`SZLHOLDINGS/szl-kernels`](https://huggingface.co/SZLHOLDINGS/szl-kernels) | Keep one governed-kernel suite and one Hugging Face mirror. |
+| `szl-kernels-live` | [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | [`SZLHOLDINGS/szl-kernels`](https://huggingface.co/SZLHOLDINGS/szl-kernels) | Use the canonical kernel suite for code, releases, and Hub mirrors. |
+| `szl-organ-integrity` | [`anatomy`](https://github.com/szl-holdings/anatomy), [`a11oy`](https://github.com/szl-holdings/a11oy) | [`SZLHOLDINGS/anatomy`](https://huggingface.co/spaces/SZLHOLDINGS/anatomy) | Integrity views belong in Anatomy; admission and outcome authority belong in A11oy. |
+| `szl-provctl-live` | [`szl-provctl`](https://github.com/szl-holdings/szl-provctl) | [`SZLHOLDINGS/szl-provctl`](https://huggingface.co/SZLHOLDINGS/szl-provctl) | Use one provenance-control implementation and one card. |
+| `szl-telemetry` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate), [`lyte-services`](https://github.com/szl-holdings/lyte-services) | [`SZLHOLDINGS/lyte-lattice`](https://huggingface.co/spaces/SZLHOLDINGS/lyte-lattice) | Telemetry vocabulary belongs in the shared substrate; operational UX belongs in Lyte. |
+| `vsp-otel` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate), [`lyte-services`](https://github.com/szl-holdings/lyte-services) | [`SZLHOLDINGS/lyte-lattice`](https://huggingface.co/spaces/SZLHOLDINGS/lyte-lattice) | Fold semantic conventions into the substrate and observability presentation into Lyte. |
 
-## ⚠️ UNKNOWN successor — owner decision required
+## Immutable historical evidence
 
-These archived repositories carry no `Canonical:` pointer and are not declared terminal. Each needs one of: a successor pointer added to its description, or an entry in `TERMINAL_BY_DESIGN` in the generator explaining why it is terminal. **They are reported, not guessed.**
-
-| Archived repo | Description | Last push |
+| Archived repository | Public showcase | Retention rationale |
 |---|---|---|
-| `uds-bundles` | SZL UDS Zarf bundles for the two products (a11oy + killinchu) and their capability services — airgap-deploy... | 2026-06-30 |
+| `evidence-typed-formula-governance` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Published reproducibility package. Preserve immutably and cite it from papers/docs. |
+| `fail-closed-governed-ai-services` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Published reproducibility package. Preserve immutably and cite it from papers/docs. |
+| `szl-fleet-overlay` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Frozen WarHacker fleet-overlay evidence snapshot. Do not revive as a current product authority. |
+| `szl-otel-mesh` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | DOI-bound OpenTelemetry/DSSE research artifact. Keep immutable; maintained mesh work belongs in restored szl-mesh. |
+| `szl-uds-deployment` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Frozen WarHacker deployment evidence snapshot. Maintained bundle work moves to restored uds-bundles. |
+| `warhacker-demo` | [`SZLHOLDINGS/szl-constellation`](https://huggingface.co/spaces/SZLHOLDINGS/szl-constellation) | Completed WarHacker 2026 dry-run snapshot. Keep immutable for provenance; surface its verified artifacts through docs and the deployment portfolio. |
 
 ---
 
-Generated by `scripts/build_attic_index.py`. CI runs `--check` so this file cannot silently drift from the live public estate.
+Generated by `scripts/build_attic_index.py`. CI runs `--check`; unclassified archives, hidden reactivations, missing canonical targets, and stale provider state are terminal.

--- a/scripts/build_attic_index.py
+++ b/scripts/build_attic_index.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 # (c) 2026 Lutar, Stephen P. — SZL Holdings
-"""Generate and validate ATTIC.md, the public org-wide tombstone index.
+"""Generate and validate ATTIC.md from the live public estate plus portfolio policy.
 
-The index describes what an unauthenticated visitor can see on the GitHub
-organization page. Private repositories are deliberately excluded, even when
-the caller uses an admin token. That makes local generation and repository-
-scoped CI deterministic and prevents private repository names from leaking into
-the public artifact.
-
-Doctrine
---------
-Honest UNKNOWN over fabricated green. This script never invents a successor.
-An archived repo with no discoverable successor is emitted as UNKNOWN and
-listed for an owner decision.
+The GitHub API owns current repository state. ``governance/archive-portfolio-v1.json``
+owns lifecycle disposition, canonical migration targets, and Hugging Face showcase
+routing. Neither descriptions nor plausible-looking repository names are treated
+as authority.
 
 Usage
 -----
@@ -24,48 +17,70 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, Mapping
 
 ORG = "szl-holdings"
-ATTIC = Path(__file__).resolve().parent.parent / "ATTIC.md"
-CANONICAL_RE = re.compile(
-    r"Canonical:\s*https://github\.com/[A-Za-z0-9_.-]+/"
-    r"([A-Za-z0-9_.-]*[A-Za-z0-9_-])(?=$|[\s),.;:])"
-)
-
-TERMINAL_BY_DESIGN = {
-    "evidence-typed-formula-governance": (
-        "Archival preprint + reproducibility package. Immutable by design — "
-        "a published record must not be superseded in place."
-    ),
-    "fail-closed-governed-ai-services": (
-        "Archival preprint + reproducibility package. Immutable by design — "
-        "a published record must not be superseded in place."
-    ),
-    "szl-fleet-overlay": (
-        "Frozen WarHacker-2026 UDS fleet-overlay evidence snapshot. Retained "
-        "for provenance; it has no active software successor."
-    ),
-    "szl-otel-mesh": (
-        "Published OpenTelemetry/DSSE research artifact with DOI "
-        "10.5281/zenodo.20434276. Immutable archival evidence by design."
-    ),
-    "szl-uds-deployment": (
-        "Frozen WarHacker-2026 UDS deployment evidence snapshot. Retained for "
-        "reproducibility; it has no active software successor."
-    ),
-    "warhacker-demo": (
-        "One-off WarHacker-2026 hardware and air-gap dry-run snapshot. The "
-        "archived demonstration is retained as evidence, not a maintained product."
-    ),
-}
+ROOT = Path(__file__).resolve().parent.parent
+ATTIC = ROOT / "ATTIC.md"
+PORTFOLIO = ROOT / "governance" / "archive-portfolio-v1.json"
+SCHEMA = "szl.archive-portfolio/v1"
+DISPOSITIONS = frozenset({"restore", "consolidate", "historical"})
 
 
-def fetch_repos() -> list[dict]:
-    """Read the live estate and return only repositories visible to the public."""
+class AtticError(RuntimeError):
+    """A lifecycle contract or provider-state defect."""
+
+
+def load_portfolio(path: Path = PORTFOLIO) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AtticError(f"portfolio manifest unreadable: {exc}") from exc
+    if value.get("schema") != SCHEMA:
+        raise AtticError(f"unsupported portfolio schema: {value.get('schema')!r}")
+    if value.get("organization") != ORG:
+        raise AtticError("portfolio organization does not match generator")
+    rows = value.get("repositories")
+    if not isinstance(rows, list) or not rows:
+        raise AtticError("portfolio repositories must be a non-empty list")
+    seen: set[str] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise AtticError(f"portfolio row {index} must be an object")
+        name = row.get("name")
+        disposition = row.get("disposition")
+        targets = row.get("canonical_targets")
+        if not isinstance(name, str) or not name or "/" in name or name in seen:
+            raise AtticError(f"invalid or duplicate portfolio name at row {index}")
+        seen.add(name)
+        if disposition not in DISPOSITIONS:
+            raise AtticError(f"{name}: invalid disposition")
+        if not isinstance(targets, list) or any(
+            not isinstance(item, str) or not item or "/" in item for item in targets
+        ):
+            raise AtticError(f"{name}: invalid canonical_targets")
+        if disposition == "restore" and targets:
+            raise AtticError(f"{name}: restore row cannot delegate authority")
+        if disposition == "consolidate" and not targets:
+            raise AtticError(f"{name}: consolidate row requires canonical_targets")
+        if disposition == "historical" and targets:
+            raise AtticError(f"{name}: historical row cannot declare a successor")
+        for field in ("rationale", "hugging_face_showcase"):
+            if not isinstance(row.get(field), str) or not row[field].strip():
+                raise AtticError(f"{name}: missing {field}")
+    observed = (value.get("source_inventory") or {}).get(
+        "archived_public_repositories_observed"
+    )
+    if observed != len(rows):
+        raise AtticError("portfolio source inventory count is inconsistent")
+    return value
+
+
+def fetch_repos() -> list[dict[str, Any]]:
+    """Read repositories visible to an unauthenticated public estate visitor."""
     completed = subprocess.run(
         [
             "gh",
@@ -75,154 +90,244 @@ def fetch_repos() -> list[dict]:
             "--limit",
             "500",
             "--json",
-            "name,description,isArchived,isPrivate,url,pushedAt,primaryLanguage",
+            "name,description,isArchived,isPrivate,url",
         ],
         capture_output=True,
         text=True,
         check=True,
     )
     repos = json.loads(completed.stdout)
+    if not isinstance(repos, list):
+        raise AtticError("GitHub repository inventory was not a list")
     return [repo for repo in repos if not repo.get("isPrivate", False)]
 
 
-def analyse(repos: list[dict]) -> dict:
-    by_name = {repo["name"]: repo for repo in repos}
-    archived_names = {repo["name"] for repo in repos if repo["isArchived"]}
+def analyse(
+    repos: list[dict[str, Any]],
+    portfolio: Mapping[str, Any],
+) -> dict[str, Any]:
+    by_name = {str(repo["name"]): repo for repo in repos}
+    rows = {str(row["name"]): row for row in portfolio["repositories"]}
+    archived_names = {
+        name for name, repo in by_name.items() if bool(repo.get("isArchived"))
+    }
+    restore_names = {
+        name for name, row in rows.items() if row["disposition"] == "restore"
+    }
 
-    mapped: list[tuple[str, str, dict]] = []
-    terminal: list[tuple[str, str, dict]] = []
-    unknown: list[tuple[str, dict]] = []
-    defects: list[tuple[str, str, str]] = []
+    defects: list[dict[str, str]] = []
+    unclassified = sorted(archived_names - set(rows))
+    for name in unclassified:
+        defects.append(
+            {
+                "repository": name,
+                "code": "UNCLASSIFIED_ARCHIVE",
+                "detail": "public archived repository is absent from archive-portfolio-v1",
+            }
+        )
 
-    for repo in sorted(
-        (item for item in repos if item["isArchived"]),
-        key=lambda item: item["name"],
-    ):
-        name = repo["name"]
-        description = repo.get("description") or ""
-        match = CANONICAL_RE.search(description)
+    for name in sorted(set(rows) - set(by_name)):
+        defects.append(
+            {
+                "repository": name,
+                "code": "MANIFEST_REPOSITORY_MISSING",
+                "detail": "portfolio row is absent from the public organization inventory",
+            }
+        )
 
-        if match:
-            target = match.group(1)
-            if target not in by_name:
-                defects.append((name, target, "successor repo does not exist"))
-            elif target in archived_names:
+    pending_restore: list[dict[str, Any]] = []
+    restored: list[dict[str, Any]] = []
+    consolidated: list[dict[str, Any]] = []
+    historical: list[dict[str, Any]] = []
+
+    for name, row in sorted(rows.items()):
+        repo = by_name.get(name)
+        if repo is None:
+            continue
+        archived = bool(repo.get("isArchived"))
+        disposition = row["disposition"]
+        entry = {
+            "name": name,
+            "rationale": row["rationale"],
+            "canonical_targets": list(row["canonical_targets"]),
+            "hugging_face_showcase": row["hugging_face_showcase"],
+        }
+        if disposition == "restore":
+            (pending_restore if archived else restored).append(entry)
+        elif disposition == "consolidate":
+            if not archived:
                 defects.append(
-                    (name, target, "successor is itself archived (tombstone chain)")
+                    {
+                        "repository": name,
+                        "code": "CONSOLIDATION_TOMBSTONE_ACTIVE",
+                        "detail": "consolidated repository was reactivated outside the restoration wave",
+                    }
                 )
             else:
-                mapped.append((name, target, repo))
-        elif name in TERMINAL_BY_DESIGN:
-            terminal.append((name, TERMINAL_BY_DESIGN[name], repo))
-        else:
-            unknown.append((name, repo))
+                consolidated.append(entry)
+        elif disposition == "historical":
+            if not archived:
+                defects.append(
+                    {
+                        "repository": name,
+                        "code": "HISTORICAL_RECORD_ACTIVE",
+                        "detail": "immutable historical repository was reactivated",
+                    }
+                )
+            else:
+                historical.append(entry)
+
+        for target in row["canonical_targets"]:
+            target_repo = by_name.get(target)
+            if target_repo is None:
+                defects.append(
+                    {
+                        "repository": name,
+                        "code": "CANONICAL_TARGET_MISSING",
+                        "detail": target,
+                    }
+                )
+            elif bool(target_repo.get("isArchived")) and target not in restore_names:
+                defects.append(
+                    {
+                        "repository": name,
+                        "code": "CANONICAL_TARGET_ARCHIVED",
+                        "detail": target,
+                    }
+                )
 
     return {
         "total": len(repos),
-        "archived": len(archived_names),
         "active": len(repos) - len(archived_names),
-        "mapped": mapped,
-        "terminal": terminal,
-        "unknown": unknown,
+        "archived": len(archived_names),
+        "pending_restore": pending_restore,
+        "restored": restored,
+        "consolidated": consolidated,
+        "historical": historical,
         "defects": defects,
+        "unclassified": unclassified,
     }
 
 
-def render(analysis: dict) -> str:
-    lines: list[str] = []
-    lines.append("# ATTIC — SZL Holdings archived-repository index")
-    lines.append("")
-    lines.append("<!-- GENERATED FILE — do not edit by hand. -->")
-    lines.append("<!-- Regenerate: python scripts/build_attic_index.py --write -->")
-    lines.append("")
-    lines.append(
-        "Every public archived repository in the `szl-holdings` organization, "
-        "mapped to the canonical repository that superseded it. Generated from "
-        "the live GitHub API, never hand-maintained, so the index cannot drift "
-        "from the public estate."
+def _targets(values: list[str]) -> str:
+    return ", ".join(
+        f"[`{value}`](https://github.com/{ORG}/{value})" for value in values
     )
-    lines.append("")
-    lines.append(
-        "**Doctrine.** Honest UNKNOWN over fabricated green: an archived repo "
-        "with no discoverable successor appears below as UNKNOWN and requires "
-        "an owner decision. This index never invents a plausible-looking successor."
-    )
-    lines.append("")
-    lines.append("## Estate shape")
-    lines.append("")
-    lines.append("| Metric | Count |")
-    lines.append("|---|---:|")
-    lines.append(f"| Public repositories total | {analysis['total']} |")
-    lines.append(f"| Active public repositories | {analysis['active']} |")
-    lines.append(f"| Archived public repositories (tombstones) | {analysis['archived']} |")
-    lines.append(
-        f"| Tombstones with a resolved successor | {len(analysis['mapped'])} |"
-    )
-    lines.append(f"| Tombstones terminal by design | {len(analysis['terminal'])} |")
-    lines.append(
-        f"| Tombstones with UNKNOWN successor | {len(analysis['unknown'])} |"
-    )
-    lines.append(f"| Structural defects | {len(analysis['defects'])} |")
-    lines.append("")
+
+
+def _space(value: str) -> str:
+    slug = value.split("/", 1)[-1]
+    return f"[`{value}`](https://huggingface.co/spaces/{value})"
+
+
+def render(analysis: Mapping[str, Any]) -> str:
+    lines: list[str] = [
+        "# ATTIC — SZL Holdings repository lifecycle index",
+        "",
+        "<!-- GENERATED FILE — do not edit by hand. -->",
+        "<!-- Regenerate: python scripts/build_attic_index.py --write -->",
+        "",
+        "This index joins live public GitHub repository state with the reviewed "
+        "`governance/archive-portfolio-v1.json` lifecycle authority. Repository "
+        "descriptions are informative only; they cannot silently choose a successor.",
+        "",
+        "**Rule.** Restore only unique maintained authorities. Move reusable source "
+        "from consolidation tombstones into named active owners through reviewed PRs. "
+        "Keep published evidence immutable. Present the result through existing "
+        "Hugging Face flagships rather than multiplying Spaces.",
+        "",
+        "## Estate shape",
+        "",
+        "| Metric | Count |",
+        "|---|---:|",
+        f"| Public repositories total | {analysis['total']} |",
+        f"| Active public repositories | {analysis['active']} |",
+        f"| Archived public repositories | {analysis['archived']} |",
+        f"| Strategic restorations pending | {len(analysis['pending_restore'])} |",
+        f"| Strategic restorations completed | {len(analysis['restored'])} |",
+        f"| Consolidation tombstones | {len(analysis['consolidated'])} |",
+        f"| Immutable historical records | {len(analysis['historical'])} |",
+        f"| Structural defects | {len(analysis['defects'])} |",
+        "",
+    ]
 
     if analysis["defects"]:
-        lines.append("## ⛔ Structural defects — fail closed")
-        lines.append("")
-        lines.append("| Archived repo | Declared successor | Defect |")
-        lines.append("|---|---|---|")
-        for name, target, reason in analysis["defects"]:
-            lines.append(f"| `{name}` | `{target}` | {reason} |")
-        lines.append("")
-
-    lines.append("## Resolved tombstones")
-    lines.append("")
-    lines.append("| Archived repo | Canonical successor | Language | Last push |")
-    lines.append("|---|---|---|---|")
-    for name, target, repo in analysis["mapped"]:
-        language = (repo.get("primaryLanguage") or {}).get("name") or "—"
-        pushed_at = (repo.get("pushedAt") or "")[:10] or "—"
-        lines.append(
-            f"| `{name}` | [`{target}`](https://github.com/{ORG}/{target}) | "
-            f"{language} | {pushed_at} |"
+        lines.extend(
+            [
+                "## ⛔ Structural defects — fail closed",
+                "",
+                "| Repository | Code | Detail |",
+                "|---|---|---|",
+            ]
         )
-    lines.append("")
-
-    if analysis["terminal"]:
-        lines.append("## Terminal by design (no successor)")
-        lines.append("")
-        lines.append("| Archived repo | Why it has no successor |")
-        lines.append("|---|---|")
-        for name, reason, _repo in analysis["terminal"]:
-            lines.append(f"| `{name}` | {reason} |")
+        for row in analysis["defects"]:
+            lines.append(
+                f"| `{row['repository']}` | `{row['code']}` | {row['detail']} |"
+            )
         lines.append("")
 
-    if analysis["unknown"]:
-        lines.append("## ⚠️ UNKNOWN successor — owner decision required")
-        lines.append("")
-        lines.append(
-            "These archived repositories carry no `Canonical:` pointer and are "
-            "not declared terminal. Each needs one of: a successor pointer added "
-            "to its description, or an entry in `TERMINAL_BY_DESIGN` in the "
-            "generator explaining why it is terminal. **They are reported, not guessed.**"
-        )
-        lines.append("")
-        lines.append("| Archived repo | Description | Last push |")
-        lines.append("|---|---|---|")
-        for name, repo in analysis["unknown"]:
-            description = (repo.get("description") or "—").replace("|", "\\|")
-            if len(description) > 110:
-                description = description[:107] + "..."
-            pushed_at = (repo.get("pushedAt") or "")[:10] or "—"
-            lines.append(f"| `{name}` | {description} | {pushed_at} |")
-        lines.append("")
-
-    lines.append("---")
-    lines.append("")
-    lines.append(
-        "Generated by `scripts/build_attic_index.py`. CI runs `--check` so this "
-        "file cannot silently drift from the live public estate."
+    lines.extend(
+        [
+            "## Strategic restoration wave",
+            "",
+            "A pending row remains archived because repository-administration "
+            "authority has not yet produced provider readback. It is not presented "
+            "as an active source until GitHub reports `archived=false`.",
+            "",
+            "| Repository | State | Maintained role | Hugging Face showcase |",
+            "|---|---|---|---|",
+        ]
     )
+    for state, rows in (
+        ("PENDING_ADMIN_AUTHORITY", analysis["pending_restore"]),
+        ("RESTORED_READBACK_VERIFIED", analysis["restored"]),
+    ):
+        for row in rows:
+            lines.append(
+                f"| `{row['name']}` | `{state}` | {row['rationale']} | "
+                f"{_space(row['hugging_face_showcase'])} |"
+            )
     lines.append("")
+
+    lines.extend(
+        [
+            "## Consolidation tombstones",
+            "",
+            "| Archived repository | Canonical owner(s) | Hugging Face showcase | Rationale |",
+            "|---|---|---|---|",
+        ]
+    )
+    for row in analysis["consolidated"]:
+        lines.append(
+            f"| `{row['name']}` | {_targets(row['canonical_targets'])} | "
+            f"{_space(row['hugging_face_showcase'])} | {row['rationale']} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Immutable historical evidence",
+            "",
+            "| Archived repository | Public showcase | Retention rationale |",
+            "|---|---|---|",
+        ]
+    )
+    for row in analysis["historical"]:
+        lines.append(
+            f"| `{row['name']}` | {_space(row['hugging_face_showcase'])} | "
+            f"{row['rationale']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            "Generated by `scripts/build_attic_index.py`. CI runs `--check`; "
+            "unclassified archives, hidden reactivations, missing canonical targets, "
+            "and stale provider state are terminal.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -232,45 +337,48 @@ def main() -> int:
     parser.add_argument("--check", action="store_true", help="fail on drift or defects")
     args = parser.parse_args()
 
-    analysis = analyse(fetch_repos())
-    body = render(analysis)
+    try:
+        portfolio = load_portfolio()
+        analysis = analyse(fetch_repos(), portfolio)
+        body = render(analysis)
+    except (AtticError, subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
 
     if args.write:
         ATTIC.write_text(body, encoding="utf-8")
         print(
-            f"wrote {ATTIC} ({analysis['archived']} tombstones, "
-            f"{len(analysis['unknown'])} UNKNOWN)"
+            f"wrote {ATTIC} ({analysis['archived']} archived, "
+            f"{len(analysis['pending_restore'])} restoration pending)"
         )
 
+    return_code = 0
     if args.check:
-        return_code = 0
-        for name, target, reason in analysis["defects"]:
-            print(f"::error::{name} -> {target}: {reason}")
+        for defect in analysis["defects"]:
+            print(
+                f"::error::{defect['repository']} {defect['code']}: "
+                f"{defect['detail']}"
+            )
             return_code = 1
-
         if not ATTIC.exists():
             print("::error::ATTIC.md missing; run --write")
             return 1
-
         if ATTIC.read_text(encoding="utf-8") != body:
             print("::error::ATTIC.md is stale. Run: python scripts/build_attic_index.py --write")
             return_code = 1
-
-        for name, _repo in analysis["unknown"]:
+        for row in analysis["pending_restore"]:
             print(
-                f"::warning::{name} has no successor pointer and is not declared terminal"
+                f"::warning::{row['name']} remains PENDING_ADMIN_AUTHORITY"
             )
-
         if return_code == 0:
             print(
-                f"ATTIC.md current — {analysis['archived']} tombstones, "
-                "0 defects"
+                f"ATTIC.md current — {analysis['archived']} archived, "
+                f"{len(analysis['pending_restore'])} restoration pending, 0 defects"
             )
-        return return_code
 
     if not (args.write or args.check):
         print(body)
-    return 0
+    return return_code
 
 
 if __name__ == "__main__":

--- a/scripts/build_attic_index.py
+++ b/scripts/build_attic_index.py
@@ -28,6 +28,17 @@ ATTIC = ROOT / "ATTIC.md"
 PORTFOLIO = ROOT / "governance" / "archive-portfolio-v1.json"
 SCHEMA = "szl.archive-portfolio/v1"
 DISPOSITIONS = frozenset({"restore", "consolidate", "historical"})
+HF_SPACES = frozenset(
+    {
+        "SZLHOLDINGS/anatomy",
+        "SZLHOLDINGS/ayllu",
+        "SZLHOLDINGS/governed-receipt-verifier",
+        "SZLHOLDINGS/immune",
+        "SZLHOLDINGS/lyte-lattice",
+        "SZLHOLDINGS/szl-atelier",
+        "SZLHOLDINGS/szl-constellation",
+    }
+)
 
 
 class AtticError(RuntimeError):
@@ -215,9 +226,12 @@ def _targets(values: list[str]) -> str:
     )
 
 
-def _space(value: str) -> str:
-    slug = value.split("/", 1)[-1]
-    return f"[`{value}`](https://huggingface.co/spaces/{value})"
+def _hf(value: str) -> str:
+    if value in HF_SPACES:
+        url = f"https://huggingface.co/spaces/{value}"
+    else:
+        url = f"https://huggingface.co/{value}"
+    return f"[`{value}`]({url})"
 
 
 def render(analysis: Mapping[str, Any]) -> str:
@@ -285,7 +299,7 @@ def render(analysis: Mapping[str, Any]) -> str:
         for row in rows:
             lines.append(
                 f"| `{row['name']}` | `{state}` | {row['rationale']} | "
-                f"{_space(row['hugging_face_showcase'])} |"
+                f"{_hf(row['hugging_face_showcase'])} |"
             )
     lines.append("")
 
@@ -300,7 +314,7 @@ def render(analysis: Mapping[str, Any]) -> str:
     for row in analysis["consolidated"]:
         lines.append(
             f"| `{row['name']}` | {_targets(row['canonical_targets'])} | "
-            f"{_space(row['hugging_face_showcase'])} | {row['rationale']} |"
+            f"{_hf(row['hugging_face_showcase'])} | {row['rationale']} |"
         )
     lines.append("")
 
@@ -314,7 +328,7 @@ def render(analysis: Mapping[str, Any]) -> str:
     )
     for row in analysis["historical"]:
         lines.append(
-            f"| `{row['name']}` | {_space(row['hugging_face_showcase'])} | "
+            f"| `{row['name']}` | {_hf(row['hugging_face_showcase'])} | "
             f"{row['rationale']} |"
         )
     lines.extend(


### PR DESCRIPTION
## Root cause

`ATTIC.md` and `scripts/build_attic_index.py` still derived successor authority from repository descriptions. That left the public index stale at 35 archived repositories, treated `uds-bundles` as UNKNOWN, and could not represent a reviewed restoration that was valid but still waiting for GitHub administration readback.

## Durable repair

- make `governance/archive-portfolio-v1.json` the sole lifecycle/disposition authority;
- keep the live public GitHub API as the sole current active/archive-state authority;
- distinguish `PENDING_ADMIN_AUTHORITY` from `RESTORED_READBACK_VERIFIED`;
- render all 23 consolidation tombstones and six immutable historical records;
- fail closed on an unclassified archive, a missing manifest repository, a missing/archived canonical target, or a consolidated/historical repository reactivated outside the reviewed wave;
- preserve exact Hugging Face surface kinds so Spaces and model/kernel repositories are linked correctly;
- replace the stale public index with the observed 117-public / 83-active / 34-archived state;
- add nine offline lifecycle and adversarial tests;
- run the offline tests before the live provider drift check.

## Truth boundary

This PR does not unarchive a repository and does not claim the five restorations completed. The current exact state remains `PENDING_ADMIN_AUTHORITY` until the merged archive governor obtains a repository-administration credential and GitHub reports `archived=false` for each selected source.

No repository visibility, history, branch protection, default branch, Hugging Face asset, provider credential, or deployment is changed.

Satisfies: AT-ARCHIVE-PORTFOLIO-2

Rollback: revert this PR; the preceding manifest and restoration controller remain authoritative and no provider setting needs rollback.

Labels: governance, portfolio, documentation, hugging-face, no-bandaid

Risk: C — public lifecycle index and fail-closed provider-state contract

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>