### PR TITLE
fix(experience): validate reviewed target asset paths

### DIFF
--- a/.github/scripts/holographic_target_contract.py
+++ b/.github/scripts/holographic_target_contract.py
@@ -4,11 +4,29 @@ from __future__ import annotations
 
 import json
 import textwrap
-from typing import Any
+from typing import Any, Sequence
 
 
-def target_contract(entrypoint: str | None) -> str:
-    """Return a dependency-light target repository GitHub Actions contract."""
+def target_contract(
+    entrypoint: str | None,
+    asset_paths: Sequence[str] = (),
+) -> str:
+    """Return a dependency-light target repository GitHub Actions contract.
+
+    The rollout planner already knows the exact reviewed asset host it is
+    changing. Carry those repository-relative paths into the target gate rather
+    than rediscovering one hard-coded filename family inside the candidate
+    checkout. This preserves product-owned hosts such as ``szl-holo-v2.*``
+    without weakening the responsive, local-asset, or source-binding checks.
+    """
+
+    declared_assets = sorted(
+        {
+            str(path)
+            for path in asset_paths
+            if str(path).lower().endswith((".css", ".js"))
+        }
+    )
     template = r'''
 name: SZL Public Experience v3 Contract
 
@@ -45,10 +63,18 @@ jobs:
           import py_compile
           import subprocess
 
-          css_files = sorted(
-              path for path in Path('.').rglob('szl-space-hologram.css')
-              if '.git' not in path.parts
-          )
+          raw_asset_paths = __ASSET_PATHS__
+          asset_paths = []
+          for raw in raw_asset_paths:
+              path = Path(raw)
+              if path.is_absolute() or '\\' in raw or '..' in path.parts:
+                  raise SystemExit(f'unsafe declared holographic asset path: {raw}')
+              asset_paths.append(path)
+          missing_assets = [str(path) for path in asset_paths if not path.is_file()]
+          if missing_assets:
+              raise SystemExit(f'missing declared holographic assets: {missing_assets}')
+
+          css_files = sorted(path for path in asset_paths if path.suffix.lower() == '.css')
           if not css_files:
               raise SystemExit('missing holographic CSS')
           css_required = (
@@ -78,10 +104,7 @@ jobs:
               if text.count('{') != text.count('}'):
                   raise SystemExit(f'{path}: unbalanced CSS braces')
 
-          js_files = sorted(
-              path for path in Path('.').rglob('szl-space-hologram.js')
-              if '.git' not in path.parts
-          )
+          js_files = sorted(path for path in asset_paths if path.suffix.lower() == '.js')
           prohibited_js = (
               'fetch(', 'XMLHttpRequest', 'sendBeacon', 'localStorage',
               'sessionStorage', 'document.cookie',
@@ -119,17 +142,23 @@ jobs:
               if not target.is_file():
                   raise SystemExit(f'missing entrypoint: {entrypoint}')
               text = target.read_text(encoding='utf-8')
-              if not any(marker in text for marker in (
+              source_markers = (
                   'szl-space-hologram',
                   'SZL Holographic Space Fabric v2',
                   'szl_hologram',
-              )):
+                  'data-szl-holo-space-v2',
+              )
+              asset_names = tuple(path.name for path in asset_paths)
+              if not any(marker in text for marker in (*source_markers, *asset_names)):
                   raise SystemExit(f'{entrypoint}: source binding missing')
           PY
           git diff --check
 '''
-    return textwrap.dedent(template).lstrip().replace(
-        "__ENTRYPOINT__", json.dumps(entrypoint or "")
+    return (
+        textwrap.dedent(template)
+        .lstrip()
+        .replace("__ENTRYPOINT__", json.dumps(entrypoint or ""))
+        .replace("__ASSET_PATHS__", json.dumps(declared_assets))
     )
 
 
@@ -143,7 +172,14 @@ def install(core: Any) -> None:
         plan = original(*args, **kwargs)
         if plan.status == "planned":
             workflow_path = ".github/workflows/szl-holographic-space-v2.yml"
-            rendered = target_contract(plan.entrypoint)
+            asset_paths = sorted(
+                {
+                    change.path
+                    for change in plan.changes
+                    if change.path.lower().endswith((".css", ".js"))
+                }
+            )
+            rendered = target_contract(plan.entrypoint, asset_paths)
             existing = next(
                 (change for change in plan.changes if change.path == workflow_path),
                 None,

--- a/.github/tests/test_holographic_target_contract.py
+++ b/.github/tests/test_holographic_target_contract.py
@@ -19,9 +19,10 @@ spec.loader.exec_module(targets)
 
 class TargetContractTests(unittest.TestCase):
     def test_contract_is_validly_scoped_local_and_responsive(self) -> None:
-        workflow = targets.target_contract("app.py")
+        workflow = targets.target_contract("app.py", ["public/szl-space-hologram.css"])
         self.assertIn("name: SZL Public Experience v3 Contract", workflow)
         self.assertIn('SZL_HOLO_ENTRYPOINT: "app.py"', workflow)
+        self.assertIn('raw_asset_paths = ["public/szl-space-hologram.css"]', workflow)
         self.assertIn("node', '--check", workflow)
         self.assertIn("py_compile.compile", workflow)
         for marker in (
@@ -46,9 +47,33 @@ class TargetContractTests(unittest.TestCase):
         self.assertNotIn("curl ", workflow)
         self.assertNotIn("wget ", workflow)
 
-    def test_entrypoint_is_json_escaped(self) -> None:
-        workflow = targets.target_contract('path/with"quote.py')
+    def test_entrypoint_and_assets_are_json_escaped(self) -> None:
+        workflow = targets.target_contract(
+            'path/with"quote.py',
+            ['assets/with"quote.css'],
+        )
         self.assertIn('SZL_HOLO_ENTRYPOINT: "path/with\\"quote.py"', workflow)
+        self.assertIn('raw_asset_paths = ["assets/with\\"quote.css"]', workflow)
+
+    def test_reviewed_custom_asset_host_is_declared_exactly(self) -> None:
+        workflow = targets.target_contract(
+            "frontend/index.html",
+            ["frontend/szl-holo-v2.css", "frontend/szl-holo-v2.js"],
+        )
+        self.assertIn(
+            'raw_asset_paths = ["frontend/szl-holo-v2.css", "frontend/szl-holo-v2.js"]',
+            workflow,
+        )
+        self.assertIn("data-szl-holo-space-v2", workflow)
+        self.assertIn("asset_names = tuple(path.name for path in asset_paths)", workflow)
+        self.assertNotIn("rglob('szl-space-hologram.css')", workflow)
+        self.assertNotIn("rglob('szl-space-hologram.js')", workflow)
+
+    def test_declared_asset_paths_fail_closed_on_unsafe_shapes(self) -> None:
+        workflow = targets.target_contract("index.html", ["../outside.css"])
+        self.assertIn("path.is_absolute()", workflow)
+        self.assertIn("'..' in path.parts", workflow)
+        self.assertIn('raw_asset_paths = ["../outside.css"]', workflow)
 
     def test_install_wraps_exactly_once(self) -> None:
         class Change:
@@ -71,6 +96,33 @@ class TargetContractTests(unittest.TestCase):
         second = core.plan_repository("y")
         self.assertEqual(len(second.changes), 1)
         self.assertEqual(len(calls), 2)
+
+    def test_install_carries_reviewed_asset_paths_into_gate(self) -> None:
+        class Change:
+            def __init__(self, path, content):
+                self.path = path
+                self.content = content
+
+        core = SimpleNamespace(
+            plan_repository=lambda *args, **kwargs: SimpleNamespace(
+                status="planned",
+                entrypoint="frontend/index.html",
+                changes=[
+                    Change("frontend/szl-holo-v2.css", "css"),
+                    Change("frontend/szl-holo-v2.js", "js"),
+                ],
+            ),
+            Change=Change,
+        )
+        targets.install(core)
+        plan = core.plan_repository()
+        workflow = next(
+            change.content
+            for change in plan.changes
+            if change.path == ".github/workflows/szl-holographic-space-v2.yml"
+        )
+        self.assertIn("frontend/szl-holo-v2.css", workflow)
+        self.assertIn("frontend/szl-holo-v2.js", workflow)
 
     def test_existing_workflow_is_replaced_not_duplicated(self) -> None:
         class Change:


### PR DESCRIPTION
## Reproduced failure

The first source PR created by the repaired Public Experience rollout, `szl-holdings/immune#130`, correctly refreshed IMMUNE's existing reviewed asset host at `frontend/szl-holo-v2.css` and `.js`. Its generated target contract nevertheless searched only for files literally named `szl-space-hologram.css` and `.js`, producing `missing holographic CSS` even though the intended responsive bytes were present.

## Permanent correction

- carry the exact CSS and JavaScript change paths from the rollout plan into the generated target workflow;
- validate those declared repository-relative assets rather than rediscovering a hard-coded filename family;
- reject absolute paths, backslashes, traversal, missing declared files, malformed CSS, external runtime imports, prohibited client behavior, and invalid JavaScript syntax;
- accept reviewed existing-host source markers such as `data-szl-holo-space-v2` and exact declared asset filenames;
- retain Python helper and Python entrypoint compilation;
- preserve the existing read-only workflow permissions and `git diff --check` boundary;
- add network-free tests for JSON escaping, custom IMMUNE-style hosts, unsafe paths, and exact plan-to-gate propagation.

This corrects the gate, not the product standard. Responsive markers, accessibility tokens, local-only assets, reduced motion, contrast, forced colors, zoom/reflow, and print requirements remain mandatory.

No default-branch write, force push, protection change, provider mutation, secret readback, Space setting, model, dataset, DNS, or runtime claim is introduced.

Signed-off-by: Stephen Lutar <stephenlutar2@gmail.com>