### PR TITLE
feat(ops): preserve production review for archive restoration

### DIFF
--- a/.github/scripts/owner_deployment_review_bridge.py
+++ b/.github/scripts/owner_deployment_review_bridge.py
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Review one exact pending deployment from an owner-issued GitHub issue.
 
-This bridge preserves the production environment gate for a solo-builder estate.
-It does not bypass protection rules: the owner must open an exact command issue,
-the protected workflow/run/SHA/environment must match, and the provider must
-report that the token's user can approve the pending deployment.
+The production gate remains authoritative. A command is admitted only when the
+owner, repository, workflow, run, SHA, environment, and provider state match.
+Current protected main may equal the run SHA or be exactly one reviewed bridge
+commit ahead; any unrelated successor path fails closed.
 """
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,7 +33,9 @@ ENVIRONMENT = "production"
 MAX_BYTES = 1_000_000
 SHA40 = re.compile(r"^[0-9a-f]{40}$")
 TOKEN_RE = re.compile(r"(?:github_pat_|gh[pousr]_|hf_)[A-Za-z0-9_]{12,}")
-JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.IGNORECASE | re.DOTALL)
+JSON_BLOCK = re.compile(
+    r"```json\s*(\{.*?\})\s*```", re.IGNORECASE | re.DOTALL
+)
 REQUIRED_KEYS = {
     "schema",
     "repository",
@@ -42,6 +46,13 @@ REQUIRED_KEYS = {
     "workflow_path",
     "decision",
     "reason",
+}
+ALLOWED_SUCCESSOR_PATHS = {
+    ".github/scripts/owner_deployment_review_bridge.py",
+    ".github/tests/test_owner_deployment_review_bridge.py",
+    ".github/workflows/owner-deployment-review-bridge.yml",
+    "audit/archive-revival-wave-20260906/README.md",
+    "docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md",
 }
 
 
@@ -79,23 +90,29 @@ def strict_json(text: str, *, label: str) -> dict[str, Any]:
             parse_constant=reject_nonfinite,
         )
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise ReviewError(f"{label} is not strict JSON: {safe(exc)}") from exc
+        raise ReviewError(
+            f"{label} is not strict JSON: {safe(exc)}"
+        ) from exc
     if not isinstance(value, dict):
         raise ReviewError(f"{label} must be an object")
     return value
 
 
 def parse_command(body: str) -> dict[str, Any]:
-    match = JSON_BLOCK.search(body or "")
-    if not match:
+    blocks = JSON_BLOCK.findall(body or "")
+    if not blocks:
         raise ReviewError("issue body must contain one fenced json object")
-    if len(JSON_BLOCK.findall(body or "")) != 1:
-        raise ReviewError("issue body must contain exactly one fenced json object")
-    command = strict_json(match.group(1), label="approval command")
+    if len(blocks) != 1:
+        raise ReviewError(
+            "issue body must contain exactly one fenced json object"
+        )
+    command = strict_json(blocks[0], label="approval command")
     if set(command) != REQUIRED_KEYS:
         missing = sorted(REQUIRED_KEYS - set(command))
         extra = sorted(set(command) - REQUIRED_KEYS)
-        raise ReviewError(f"approval command keys mismatch; missing={missing}; extra={extra}")
+        raise ReviewError(
+            f"approval command keys mismatch; missing={missing}; extra={extra}"
+        )
     if command["schema"] != SCHEMA:
         raise ReviewError(f"schema must be {SCHEMA}")
     if command["repository"] != REPOSITORY:
@@ -106,22 +123,37 @@ def parse_command(body: str) -> dict[str, Any]:
         raise ReviewError(f"environment_name must be {ENVIRONMENT}")
     if command["decision"] != "approved":
         raise ReviewError("decision must be approved")
-    if not isinstance(command["workflow_run_id"], int) or command["workflow_run_id"] <= 0:
+    if (
+        not isinstance(command["workflow_run_id"], int)
+        or command["workflow_run_id"] <= 0
+    ):
         raise ReviewError("workflow_run_id must be a positive integer")
-    if not isinstance(command["environment_id"], int) or command["environment_id"] <= 0:
+    if (
+        not isinstance(command["environment_id"], int)
+        or command["environment_id"] <= 0
+    ):
         raise ReviewError("environment_id must be a positive integer")
-    if not isinstance(command["head_sha"], str) or not SHA40.fullmatch(command["head_sha"]):
-        raise ReviewError("head_sha must be a lowercase 40-character commit SHA")
+    if (
+        not isinstance(command["head_sha"], str)
+        or not SHA40.fullmatch(command["head_sha"])
+    ):
+        raise ReviewError(
+            "head_sha must be a lowercase 40-character commit SHA"
+        )
     reason = command["reason"]
     if not isinstance(reason, str) or not 20 <= len(reason.strip()) <= 500:
         raise ReviewError("reason must contain 20 to 500 characters")
     if TOKEN_RE.search(json.dumps(command, sort_keys=True)):
-        raise ReviewError("credential-shaped material is forbidden in approval commands")
+        raise ReviewError(
+            "credential-shaped material is forbidden in approval commands"
+        )
     return command
 
 
 def load_event(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
-    event = strict_json(path.read_text(encoding="utf-8"), label="GitHub event")
+    event = strict_json(
+        path.read_text(encoding="utf-8"), label="GitHub event"
+    )
     if event.get("action") not in {"opened", "reopened", "edited"}:
         raise ReviewError("unsupported issue action")
     issue = event.get("issue")
@@ -129,7 +161,9 @@ def load_event(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
         raise ReviewError("event.issue must be an object")
     author = issue.get("user")
     if not isinstance(author, dict) or author.get("login") != OWNER:
-        raise ReviewError("approval issue must be authored by the exact estate owner")
+        raise ReviewError(
+            "approval issue must be authored by the exact estate owner"
+        )
     if issue.get("title") != TITLE:
         raise ReviewError(f"issue title must be {TITLE!r}")
     if issue.get("state") != "open":
@@ -137,8 +171,7 @@ def load_event(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
     number = issue.get("number")
     if not isinstance(number, int) or number <= 0:
         raise ReviewError("issue number is unavailable")
-    command = parse_command(str(issue.get("body") or ""))
-    return event, command
+    return event, parse_command(str(issue.get("body") or ""))
 
 
 class GitHubClient:
@@ -154,7 +187,9 @@ class GitHubClient:
         payload: Mapping[str, Any] | None = None,
     ) -> Any:
         data = (
-            json.dumps(payload, separators=(",", ":"), allow_nan=False).encode()
+            json.dumps(
+                payload, separators=(",", ":"), allow_nan=False
+            ).encode()
             if payload is not None
             else None
         )
@@ -175,15 +210,23 @@ class GitHubClient:
                 with urllib.request.urlopen(request, timeout=45) as response:
                     raw = response.read(MAX_BYTES + 1)
                     if len(raw) > MAX_BYTES:
-                        raise ReviewError(f"{method} {path}: response too large")
+                        raise ReviewError(
+                            f"{method} {path}: response too large"
+                        )
                     return json.loads(raw.decode()) if raw else None
             except urllib.error.HTTPError as exc:
-                detail = safe(exc.read(MAX_BYTES + 1).decode("utf-8", "replace"))
-                if exc.code in {408, 425, 429, 500, 502, 503, 504} and attempt < 3:
+                detail = safe(
+                    exc.read(MAX_BYTES + 1).decode("utf-8", "replace")
+                )
+                if (
+                    exc.code in {408, 425, 429, 500, 502, 503, 504}
+                    and attempt < 3
+                ):
                     time.sleep(min(2 ** (attempt + 1), 12))
                     continue
                 raise ReviewError(
-                    f"GitHub {method} {path} failed with {exc.code}: {detail}"
+                    f"GitHub {method} {path} failed with "
+                    f"{exc.code}: {detail}"
                 ) from exc
             except (
                 urllib.error.URLError,
@@ -206,7 +249,82 @@ class GitHubClient:
         return self.request("POST", path, payload)
 
 
-def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
+def validate_main_binding(
+    command: Mapping[str, Any],
+    client: GitHubClient,
+    *,
+    owner: str,
+    repo: str,
+) -> dict[str, Any]:
+    branch = client.get(f"/repos/{owner}/{repo}/branches/main")
+    branch_sha = (
+        branch.get("commit", {}).get("sha")
+        if isinstance(branch, dict)
+        and isinstance(branch.get("commit"), dict)
+        else None
+    )
+    expected = str(command["head_sha"])
+    if branch_sha == expected:
+        return {
+            "mode": "EXACT_PROTECTED_MAIN",
+            "protected_main_sha": branch_sha,
+            "successor_commits": 0,
+            "successor_paths": [],
+        }
+    if not isinstance(branch_sha, str) or not SHA40.fullmatch(branch_sha):
+        raise ReviewError("protected main revision unavailable")
+
+    compare = client.get(
+        f"/repos/{owner}/{repo}/compare/{expected}...{branch_sha}"
+    )
+    if not isinstance(compare, dict):
+        raise ReviewError("protected-main comparison is not an object")
+    merge_base_sha = (
+        compare.get("merge_base_commit", {}).get("sha")
+        if isinstance(compare.get("merge_base_commit"), dict)
+        else None
+    )
+    if (
+        compare.get("status") != "ahead"
+        or compare.get("ahead_by") != 1
+        or compare.get("behind_by") != 0
+        or merge_base_sha != expected
+    ):
+        raise ReviewError(
+            "protected main is not the exact one-commit review-bridge successor"
+        )
+    files = compare.get("files")
+    if not isinstance(files, list) or not files:
+        raise ReviewError("review-bridge successor file list unavailable")
+    paths = {
+        row.get("filename")
+        for row in files
+        if isinstance(row, dict) and isinstance(row.get("filename"), str)
+    }
+    if len(paths) != len(files):
+        raise ReviewError("review-bridge successor contains malformed file rows")
+    unexpected = sorted(paths - ALLOWED_SUCCESSOR_PATHS)
+    required = {
+        ".github/scripts/owner_deployment_review_bridge.py",
+        ".github/tests/test_owner_deployment_review_bridge.py",
+        ".github/workflows/owner-deployment-review-bridge.yml",
+    }
+    if unexpected or not required.issubset(paths):
+        raise ReviewError(
+            f"protected-main successor paths invalid; unexpected={unexpected}; "
+            f"missing={sorted(required - paths)}"
+        )
+    return {
+        "mode": "EXACT_REVIEW_BRIDGE_SUCCESSOR",
+        "protected_main_sha": branch_sha,
+        "successor_commits": 1,
+        "successor_paths": sorted(paths),
+    }
+
+
+def review(
+    command: Mapping[str, Any], client: GitHubClient
+) -> dict[str, Any]:
     run_id = int(command["workflow_run_id"])
     environment_id = int(command["environment_id"])
     owner, repo = REPOSITORY.split("/", 1)
@@ -225,20 +343,13 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
     for key, expected in expected_run.items():
         if run.get(key) != expected:
             raise ReviewError(
-                f"workflow run {key} drifted: expected {expected!r}, observed {run.get(key)!r}"
+                f"workflow run {key} drifted: expected {expected!r}, "
+                f"observed {run.get(key)!r}"
             )
 
-    branch = client.get(f"/repos/{owner}/{repo}/branches/main")
-    branch_sha = (
-        branch.get("commit", {}).get("sha")
-        if isinstance(branch, dict) and isinstance(branch.get("commit"), dict)
-        else None
+    main_binding = validate_main_binding(
+        command, client, owner=owner, repo=repo
     )
-    if branch_sha != command["head_sha"]:
-        raise ReviewError(
-            f"protected main moved: expected {command['head_sha']}, observed {branch_sha}"
-        )
-
     pending = client.get(pending_path)
     if not isinstance(pending, list):
         raise ReviewError("pending deployment response is not an array")
@@ -252,7 +363,10 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
     ]
 
     if not matches:
-        if run.get("status") == "completed" and run.get("conclusion") == "success":
+        if (
+            run.get("status") == "completed"
+            and run.get("conclusion") == "success"
+        ):
             return {
                 "schema": "szl.deployment-review-receipt/v1",
                 "status": "ALREADY_COMPLETED",
@@ -263,19 +377,28 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
                 "environment_name": ENVIRONMENT,
                 "head_sha": command["head_sha"],
                 "workflow_path": WORKFLOW_PATH,
+                "main_binding": main_binding,
                 "provider_status": run.get("status"),
                 "provider_conclusion": run.get("conclusion"),
                 "reviewed_at": now(),
                 "secrets_recorded": False,
             }
-        raise ReviewError("exact pending production deployment is unavailable")
+        raise ReviewError(
+            "exact pending production deployment is unavailable"
+        )
     if len(matches) != 1 or len(pending) != 1:
-        raise ReviewError("pending deployment set is not the exact singleton expected")
+        raise ReviewError(
+            "pending deployment set is not the exact singleton expected"
+        )
     match = matches[0]
     if match.get("current_user_can_approve") is not True:
-        raise ReviewError("provider reports that the selected credential cannot approve")
+        raise ReviewError(
+            "provider reports that the selected credential cannot approve"
+        )
     if run.get("status") != "waiting":
-        raise ReviewError(f"workflow run must be waiting, observed {run.get('status')!r}")
+        raise ReviewError(
+            f"workflow run must be waiting, observed {run.get('status')!r}"
+        )
 
     client.post(
         pending_path,
@@ -284,23 +407,31 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
             "state": "approved",
             "comment": (
                 "Owner-approved exact archive portfolio v2 restoration; "
-                f"head {command['head_sha']}. {command['reason'].strip()}"
+                f"head {command['head_sha']}. "
+                f"{command['reason'].strip()}"
             )[:1000],
         },
     )
 
     after_pending = client.get(pending_path)
     if not isinstance(after_pending, list):
-        raise ReviewError("post-review pending deployment response is not an array")
+        raise ReviewError(
+            "post-review pending deployment response is not an array"
+        )
     if any(
         isinstance(row, dict)
         and isinstance(row.get("environment"), dict)
         and row["environment"].get("id") == environment_id
         for row in after_pending
     ):
-        raise ReviewError("exact deployment remained pending after approval")
+        raise ReviewError(
+            "exact deployment remained pending after approval"
+        )
     after_run = client.get(run_path)
-    if not isinstance(after_run, dict) or after_run.get("head_sha") != command["head_sha"]:
+    if (
+        not isinstance(after_run, dict)
+        or after_run.get("head_sha") != command["head_sha"]
+    ):
         raise ReviewError("workflow run identity drifted after approval")
 
     return {
@@ -313,9 +444,10 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
         "environment_name": ENVIRONMENT,
         "head_sha": command["head_sha"],
         "workflow_path": WORKFLOW_PATH,
+        "main_binding": main_binding,
         "provider_status_after": after_run.get("status"),
         "provider_conclusion_after": after_run.get("conclusion"),
-        "reason_sha256": __import__("hashlib").sha256(
+        "reason_sha256": hashlib.sha256(
             command["reason"].strip().encode()
         ).hexdigest(),
         "reviewed_at": now(),
@@ -328,9 +460,13 @@ def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
 
 def write_report(path: Path, report: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    text = json.dumps(
+        report, indent=2, sort_keys=True, allow_nan=False
+    ) + "\n"
     if TOKEN_RE.search(text):
-        raise ReviewError("credential-shaped material detected in receipt")
+        raise ReviewError(
+            "credential-shaped material detected in receipt"
+        )
     path.write_text(text, encoding="utf-8")
 
 
@@ -349,13 +485,21 @@ def main() -> int:
         issue_number = int(event["issue"]["number"])
         report = review(
             command,
-            GitHubClient(os.environ.get("SZL_DEPLOYMENT_REVIEW_TOKEN", "")),
+            GitHubClient(
+                os.environ.get("SZL_DEPLOYMENT_REVIEW_TOKEN", "")
+            ),
         )
         report["issue_number"] = issue_number
         write_report(args.report, report)
         print(json.dumps(report, indent=2, sort_keys=True))
         return 0
-    except (ReviewError, OSError, KeyError, TypeError, ValueError) as exc:
+    except (
+        ReviewError,
+        OSError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
         report = {
             "schema": "szl.deployment-review-receipt/v1",
             "status": "BLOCKED",
@@ -372,10 +516,14 @@ def main() -> int:
             write_report(args.report, report)
         except (ReviewError, OSError) as write_exc:
             print(
-                "warning: deployment-review receipt write failed: " + safe(write_exc),
+                "warning: deployment-review receipt write failed: "
+                + safe(write_exc),
                 file=sys.stderr,
             )
-        print(json.dumps(report, indent=2, sort_keys=True), file=sys.stderr)
+        print(
+            json.dumps(report, indent=2, sort_keys=True),
+            file=sys.stderr,
+        )
         return 1
 
 

--- a/.github/scripts/owner_deployment_review_bridge.py
+++ b/.github/scripts/owner_deployment_review_bridge.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Review one exact pending deployment from an owner-issued GitHub issue.
+
+This bridge preserves the production environment gate for a solo-builder estate.
+It does not bypass protection rules: the owner must open an exact command issue,
+the protected workflow/run/SHA/environment must match, and the provider must
+report that the token's user can approve the pending deployment.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+API = "https://api.github.com"
+SCHEMA = "szl.deployment-approval/v1"
+OWNER = "stephenlutar2-hash"
+REPOSITORY = "szl-holdings/.github"
+TITLE = "Approve deployment review: archive-portfolio-v2"
+WORKFLOW_PATH = ".github/workflows/archive-portfolio-governor-v2.yml"
+ENVIRONMENT = "production"
+MAX_BYTES = 1_000_000
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+TOKEN_RE = re.compile(r"(?:github_pat_|gh[pousr]_|hf_)[A-Za-z0-9_]{12,}")
+JSON_BLOCK = re.compile(r"```json\s*(\{.*?\})\s*```", re.IGNORECASE | re.DOTALL)
+REQUIRED_KEYS = {
+    "schema",
+    "repository",
+    "workflow_run_id",
+    "environment_id",
+    "environment_name",
+    "head_sha",
+    "workflow_path",
+    "decision",
+    "reason",
+}
+
+
+class ReviewError(RuntimeError):
+    """Malformed owner command, unavailable authority, or provider drift."""
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe(value: Any) -> str:
+    text = str(value).replace("\r", " ").replace("\n", " ")[:1000]
+    return TOKEN_RE.sub("[REDACTED]", text)
+
+
+def duplicate_guard(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ReviewError(f"duplicate JSON key: {key}")
+        value[key] = item
+    return value
+
+
+def reject_nonfinite(value: str) -> None:
+    raise ReviewError(f"non-finite JSON value: {value}")
+
+
+def strict_json(text: str, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=duplicate_guard,
+            parse_constant=reject_nonfinite,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ReviewError(f"{label} is not strict JSON: {safe(exc)}") from exc
+    if not isinstance(value, dict):
+        raise ReviewError(f"{label} must be an object")
+    return value
+
+
+def parse_command(body: str) -> dict[str, Any]:
+    match = JSON_BLOCK.search(body or "")
+    if not match:
+        raise ReviewError("issue body must contain one fenced json object")
+    if len(JSON_BLOCK.findall(body or "")) != 1:
+        raise ReviewError("issue body must contain exactly one fenced json object")
+    command = strict_json(match.group(1), label="approval command")
+    if set(command) != REQUIRED_KEYS:
+        missing = sorted(REQUIRED_KEYS - set(command))
+        extra = sorted(set(command) - REQUIRED_KEYS)
+        raise ReviewError(f"approval command keys mismatch; missing={missing}; extra={extra}")
+    if command["schema"] != SCHEMA:
+        raise ReviewError(f"schema must be {SCHEMA}")
+    if command["repository"] != REPOSITORY:
+        raise ReviewError(f"repository must be {REPOSITORY}")
+    if command["workflow_path"] != WORKFLOW_PATH:
+        raise ReviewError(f"workflow_path must be {WORKFLOW_PATH}")
+    if command["environment_name"] != ENVIRONMENT:
+        raise ReviewError(f"environment_name must be {ENVIRONMENT}")
+    if command["decision"] != "approved":
+        raise ReviewError("decision must be approved")
+    if not isinstance(command["workflow_run_id"], int) or command["workflow_run_id"] <= 0:
+        raise ReviewError("workflow_run_id must be a positive integer")
+    if not isinstance(command["environment_id"], int) or command["environment_id"] <= 0:
+        raise ReviewError("environment_id must be a positive integer")
+    if not isinstance(command["head_sha"], str) or not SHA40.fullmatch(command["head_sha"]):
+        raise ReviewError("head_sha must be a lowercase 40-character commit SHA")
+    reason = command["reason"]
+    if not isinstance(reason, str) or not 20 <= len(reason.strip()) <= 500:
+        raise ReviewError("reason must contain 20 to 500 characters")
+    if TOKEN_RE.search(json.dumps(command, sort_keys=True)):
+        raise ReviewError("credential-shaped material is forbidden in approval commands")
+    return command
+
+
+def load_event(path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    event = strict_json(path.read_text(encoding="utf-8"), label="GitHub event")
+    if event.get("action") not in {"opened", "reopened", "edited"}:
+        raise ReviewError("unsupported issue action")
+    issue = event.get("issue")
+    if not isinstance(issue, dict):
+        raise ReviewError("event.issue must be an object")
+    author = issue.get("user")
+    if not isinstance(author, dict) or author.get("login") != OWNER:
+        raise ReviewError("approval issue must be authored by the exact estate owner")
+    if issue.get("title") != TITLE:
+        raise ReviewError(f"issue title must be {TITLE!r}")
+    if issue.get("state") != "open":
+        raise ReviewError("approval issue must be open")
+    number = issue.get("number")
+    if not isinstance(number, int) or number <= 0:
+        raise ReviewError("issue number is unavailable")
+    command = parse_command(str(issue.get("body") or ""))
+    return event, command
+
+
+class GitHubClient:
+    def __init__(self, token: str):
+        if not token:
+            raise ReviewError("deployment-review credential unavailable")
+        self.token = token
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> Any:
+        data = (
+            json.dumps(payload, separators=(",", ":"), allow_nan=False).encode()
+            if payload is not None
+            else None
+        )
+        request = urllib.request.Request(
+            API + path,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "szl-owner-deployment-review-bridge/1.0",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(request, timeout=45) as response:
+                    raw = response.read(MAX_BYTES + 1)
+                    if len(raw) > MAX_BYTES:
+                        raise ReviewError(f"{method} {path}: response too large")
+                    return json.loads(raw.decode()) if raw else None
+            except urllib.error.HTTPError as exc:
+                detail = safe(exc.read(MAX_BYTES + 1).decode("utf-8", "replace"))
+                if exc.code in {408, 425, 429, 500, 502, 503, 504} and attempt < 3:
+                    time.sleep(min(2 ** (attempt + 1), 12))
+                    continue
+                raise ReviewError(
+                    f"GitHub {method} {path} failed with {exc.code}: {detail}"
+                ) from exc
+            except (
+                urllib.error.URLError,
+                TimeoutError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ) as exc:
+                if attempt < 3:
+                    time.sleep(min(2 ** (attempt + 1), 12))
+                    continue
+                raise ReviewError(
+                    f"GitHub {method} {path} transport failure: {safe(exc)}"
+                ) from exc
+        raise AssertionError("unreachable")
+
+    def get(self, path: str) -> Any:
+        return self.request("GET", path)
+
+    def post(self, path: str, payload: Mapping[str, Any]) -> Any:
+        return self.request("POST", path, payload)
+
+
+def review(command: Mapping[str, Any], client: GitHubClient) -> dict[str, Any]:
+    run_id = int(command["workflow_run_id"])
+    environment_id = int(command["environment_id"])
+    owner, repo = REPOSITORY.split("/", 1)
+    run_path = f"/repos/{owner}/{repo}/actions/runs/{run_id}"
+    pending_path = run_path + "/pending_deployments"
+
+    run = client.get(run_path)
+    if not isinstance(run, dict):
+        raise ReviewError("workflow run response is not an object")
+    expected_run = {
+        "head_branch": "main",
+        "head_sha": command["head_sha"],
+        "path": WORKFLOW_PATH,
+        "event": "push",
+    }
+    for key, expected in expected_run.items():
+        if run.get(key) != expected:
+            raise ReviewError(
+                f"workflow run {key} drifted: expected {expected!r}, observed {run.get(key)!r}"
+            )
+
+    branch = client.get(f"/repos/{owner}/{repo}/branches/main")
+    branch_sha = (
+        branch.get("commit", {}).get("sha")
+        if isinstance(branch, dict) and isinstance(branch.get("commit"), dict)
+        else None
+    )
+    if branch_sha != command["head_sha"]:
+        raise ReviewError(
+            f"protected main moved: expected {command['head_sha']}, observed {branch_sha}"
+        )
+
+    pending = client.get(pending_path)
+    if not isinstance(pending, list):
+        raise ReviewError("pending deployment response is not an array")
+    matches = [
+        row
+        for row in pending
+        if isinstance(row, dict)
+        and isinstance(row.get("environment"), dict)
+        and row["environment"].get("id") == environment_id
+        and row["environment"].get("name") == ENVIRONMENT
+    ]
+
+    if not matches:
+        if run.get("status") == "completed" and run.get("conclusion") == "success":
+            return {
+                "schema": "szl.deployment-review-receipt/v1",
+                "status": "ALREADY_COMPLETED",
+                "mutated": False,
+                "repository": REPOSITORY,
+                "workflow_run_id": run_id,
+                "environment_id": environment_id,
+                "environment_name": ENVIRONMENT,
+                "head_sha": command["head_sha"],
+                "workflow_path": WORKFLOW_PATH,
+                "provider_status": run.get("status"),
+                "provider_conclusion": run.get("conclusion"),
+                "reviewed_at": now(),
+                "secrets_recorded": False,
+            }
+        raise ReviewError("exact pending production deployment is unavailable")
+    if len(matches) != 1 or len(pending) != 1:
+        raise ReviewError("pending deployment set is not the exact singleton expected")
+    match = matches[0]
+    if match.get("current_user_can_approve") is not True:
+        raise ReviewError("provider reports that the selected credential cannot approve")
+    if run.get("status") != "waiting":
+        raise ReviewError(f"workflow run must be waiting, observed {run.get('status')!r}")
+
+    client.post(
+        pending_path,
+        {
+            "environment_ids": [environment_id],
+            "state": "approved",
+            "comment": (
+                "Owner-approved exact archive portfolio v2 restoration; "
+                f"head {command['head_sha']}. {command['reason'].strip()}"
+            )[:1000],
+        },
+    )
+
+    after_pending = client.get(pending_path)
+    if not isinstance(after_pending, list):
+        raise ReviewError("post-review pending deployment response is not an array")
+    if any(
+        isinstance(row, dict)
+        and isinstance(row.get("environment"), dict)
+        and row["environment"].get("id") == environment_id
+        for row in after_pending
+    ):
+        raise ReviewError("exact deployment remained pending after approval")
+    after_run = client.get(run_path)
+    if not isinstance(after_run, dict) or after_run.get("head_sha") != command["head_sha"]:
+        raise ReviewError("workflow run identity drifted after approval")
+
+    return {
+        "schema": "szl.deployment-review-receipt/v1",
+        "status": "APPROVED_READBACK_VERIFIED",
+        "mutated": True,
+        "repository": REPOSITORY,
+        "workflow_run_id": run_id,
+        "environment_id": environment_id,
+        "environment_name": ENVIRONMENT,
+        "head_sha": command["head_sha"],
+        "workflow_path": WORKFLOW_PATH,
+        "provider_status_after": after_run.get("status"),
+        "provider_conclusion_after": after_run.get("conclusion"),
+        "reason_sha256": __import__("hashlib").sha256(
+            command["reason"].strip().encode()
+        ).hexdigest(),
+        "reviewed_at": now(),
+        "visibility_mutations": False,
+        "repository_setting_mutations": False,
+        "secret_mutations": False,
+        "secrets_recorded": False,
+    }
+
+
+def write_report(path: Path, report: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if TOKEN_RE.search(text):
+        raise ReviewError("credential-shaped material detected in receipt")
+    path.write_text(text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("/tmp/deployment-review-receipt.json"),
+    )
+    args = parser.parse_args()
+    issue_number: int | None = None
+    try:
+        event, command = load_event(args.event)
+        issue_number = int(event["issue"]["number"])
+        report = review(
+            command,
+            GitHubClient(os.environ.get("SZL_DEPLOYMENT_REVIEW_TOKEN", "")),
+        )
+        report["issue_number"] = issue_number
+        write_report(args.report, report)
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    except (ReviewError, OSError, KeyError, TypeError, ValueError) as exc:
+        report = {
+            "schema": "szl.deployment-review-receipt/v1",
+            "status": "BLOCKED",
+            "issue_number": issue_number,
+            "error": safe(exc),
+            "mutated": False,
+            "visibility_mutations": False,
+            "repository_setting_mutations": False,
+            "secret_mutations": False,
+            "secrets_recorded": False,
+            "reviewed_at": now(),
+        }
+        try:
+            write_report(args.report, report)
+        except (ReviewError, OSError) as write_exc:
+            print(
+                "warning: deployment-review receipt write failed: " + safe(write_exc),
+                file=sys.stderr,
+            )
+        print(json.dumps(report, indent=2, sort_keys=True), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/tests/test_owner_deployment_review_bridge.py
+++ b/.github/tests/test_owner_deployment_review_bridge.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Network-free tests for the owner deployment review bridge."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / ".github" / "scripts" / "owner_deployment_review_bridge.py"
+SPEC = importlib.util.spec_from_file_location("owner_deployment_review_bridge", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+SHA = "79a8f2add42913b0831260574145437efe56af4a"
+RUN_ID = 34069683698
+ENV_ID = 18757132984
+
+
+def command(**overrides):
+    value = {
+        "schema": MODULE.SCHEMA,
+        "repository": MODULE.REPOSITORY,
+        "workflow_run_id": RUN_ID,
+        "environment_id": ENV_ID,
+        "environment_name": MODULE.ENVIRONMENT,
+        "head_sha": SHA,
+        "workflow_path": MODULE.WORKFLOW_PATH,
+        "decision": "approved",
+        "reason": "Execute the reviewed four-source archive restoration wave.",
+    }
+    value.update(overrides)
+    return value
+
+
+def issue_event(**issue_overrides):
+    issue = {
+        "number": 999,
+        "state": "open",
+        "title": MODULE.TITLE,
+        "body": "Approval follows.\n```json\n"
+        + json.dumps(command(), sort_keys=True)
+        + "\n```\n",
+        "user": {"login": MODULE.OWNER},
+    }
+    issue.update(issue_overrides)
+    return {"action": "opened", "issue": issue}
+
+
+class ParsingContracts(unittest.TestCase):
+    def test_exact_command_is_accepted(self):
+        parsed = MODULE.parse_command(
+            "```json\n" + json.dumps(command()) + "\n```"
+        )
+        self.assertEqual(parsed["workflow_run_id"], RUN_ID)
+
+    def test_missing_fence_is_rejected(self):
+        with self.assertRaisesRegex(MODULE.ReviewError, "fenced json"):
+            MODULE.parse_command(json.dumps(command()))
+
+    def test_multiple_fences_are_rejected(self):
+        block = "```json\n" + json.dumps(command()) + "\n```"
+        with self.assertRaisesRegex(MODULE.ReviewError, "exactly one"):
+            MODULE.parse_command(block + "\n" + block)
+
+    def test_duplicate_json_key_is_rejected(self):
+        body = '```json\n{"schema":"a","schema":"b"}\n```'
+        with self.assertRaisesRegex(MODULE.ReviewError, "duplicate JSON key"):
+            MODULE.parse_command(body)
+
+    def test_extra_key_is_rejected(self):
+        value = command(extra="forbidden")
+        with self.assertRaisesRegex(MODULE.ReviewError, "keys mismatch"):
+            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+
+    def test_wrong_workflow_is_rejected(self):
+        value = command(workflow_path=".github/workflows/other.yml")
+        with self.assertRaisesRegex(MODULE.ReviewError, "workflow_path"):
+            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+
+    def test_wrong_environment_is_rejected(self):
+        value = command(environment_name="staging")
+        with self.assertRaisesRegex(MODULE.ReviewError, "environment_name"):
+            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+
+    def test_non_lowercase_sha_is_rejected(self):
+        value = command(head_sha=SHA.upper())
+        with self.assertRaisesRegex(MODULE.ReviewError, "lowercase"):
+            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+
+    def test_credential_shape_is_rejected(self):
+        value = command(reason="Approve with github_pat_" + "x" * 40)
+        with self.assertRaisesRegex(MODULE.ReviewError, "credential-shaped"):
+            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+
+    def test_wrong_issue_author_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "event.json"
+            path.write_text(
+                json.dumps(issue_event(user={"login": "someone-else"})),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.ReviewError, "exact estate owner"):
+                MODULE.load_event(path)
+
+
+class FakeClient:
+    def __init__(self, *, branch_sha=SHA, current_user_can_approve=True):
+        self.branch_sha = branch_sha
+        self.current_user_can_approve = current_user_can_approve
+        self.approved = False
+        self.posts = []
+        self.completed = False
+
+    def get(self, path):
+        if path.endswith("/branches/main"):
+            return {"commit": {"sha": self.branch_sha}}
+        if path.endswith("/pending_deployments"):
+            if self.approved or self.completed:
+                return []
+            return [
+                {
+                    "environment": {
+                        "id": ENV_ID,
+                        "name": MODULE.ENVIRONMENT,
+                    },
+                    "current_user_can_approve": self.current_user_can_approve,
+                }
+            ]
+        if path.endswith(str(RUN_ID)):
+            if self.completed:
+                return {
+                    "head_branch": "main",
+                    "head_sha": SHA,
+                    "path": MODULE.WORKFLOW_PATH,
+                    "event": "push",
+                    "status": "completed",
+                    "conclusion": "success",
+                }
+            return {
+                "head_branch": "main",
+                "head_sha": SHA,
+                "path": MODULE.WORKFLOW_PATH,
+                "event": "push",
+                "status": "in_progress" if self.approved else "waiting",
+                "conclusion": None,
+            }
+        raise AssertionError(path)
+
+    def post(self, path, payload):
+        self.posts.append((path, payload))
+        self.approved = True
+        return {"status": "approved"}
+
+
+class ProviderContracts(unittest.TestCase):
+    def test_exact_pending_deployment_is_approved_and_read_back(self):
+        client = FakeClient()
+        report = MODULE.review(command(), client)
+        self.assertEqual(report["status"], "APPROVED_READBACK_VERIFIED")
+        self.assertTrue(report["mutated"])
+        self.assertEqual(len(client.posts), 1)
+        self.assertEqual(client.posts[0][1]["environment_ids"], [ENV_ID])
+        self.assertEqual(client.posts[0][1]["state"], "approved")
+        self.assertNotIn(command()["reason"], json.dumps(report))
+
+    def test_protected_main_drift_blocks_review(self):
+        client = FakeClient(branch_sha="0" * 40)
+        with self.assertRaisesRegex(MODULE.ReviewError, "protected main moved"):
+            MODULE.review(command(), client)
+        self.assertEqual(client.posts, [])
+
+    def test_provider_cannot_approve_blocks_review(self):
+        client = FakeClient(current_user_can_approve=False)
+        with self.assertRaisesRegex(MODULE.ReviewError, "cannot approve"):
+            MODULE.review(command(), client)
+        self.assertEqual(client.posts, [])
+
+    def test_successfully_completed_run_is_idempotent(self):
+        client = FakeClient()
+        client.completed = True
+        report = MODULE.review(command(), client)
+        self.assertEqual(report["status"], "ALREADY_COMPLETED")
+        self.assertFalse(report["mutated"])
+        self.assertEqual(client.posts, [])
+
+    def test_report_rejects_token_shape(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(MODULE.ReviewError, "credential-shaped"):
+                MODULE.write_report(
+                    Path(directory) / "receipt.json",
+                    {"value": "ghp_" + "x" * 30},
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/tests/test_owner_deployment_review_bridge.py
+++ b/.github/tests/test_owner_deployment_review_bridge.py
@@ -11,16 +11,28 @@ import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-MODULE_PATH = ROOT / ".github" / "scripts" / "owner_deployment_review_bridge.py"
-SPEC = importlib.util.spec_from_file_location("owner_deployment_review_bridge", MODULE_PATH)
+MODULE_PATH = (
+    ROOT / ".github" / "scripts" / "owner_deployment_review_bridge.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "owner_deployment_review_bridge", MODULE_PATH
+)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 SHA = "79a8f2add42913b0831260574145437efe56af4a"
+SUCCESSOR_SHA = "1" * 40
 RUN_ID = 34069683698
 ENV_ID = 18757132984
+REQUIRED_SUCCESSOR_PATHS = {
+    ".github/scripts/owner_deployment_review_bridge.py",
+    ".github/tests/test_owner_deployment_review_bridge.py",
+    ".github/workflows/owner-deployment-review-bridge.yml",
+    "audit/archive-revival-wave-20260906/README.md",
+    "docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md",
+}
 
 
 def command(**overrides):
@@ -33,7 +45,9 @@ def command(**overrides):
         "head_sha": SHA,
         "workflow_path": MODULE.WORKFLOW_PATH,
         "decision": "approved",
-        "reason": "Execute the reviewed four-source archive restoration wave.",
+        "reason": (
+            "Execute the reviewed four-source archive restoration wave."
+        ),
     }
     value.update(overrides)
     return value
@@ -44,9 +58,11 @@ def issue_event(**issue_overrides):
         "number": 999,
         "state": "open",
         "title": MODULE.TITLE,
-        "body": "Approval follows.\n```json\n"
-        + json.dumps(command(), sort_keys=True)
-        + "\n```\n",
+        "body": (
+            "Approval follows.\n```json\n"
+            + json.dumps(command(), sort_keys=True)
+            + "\n```\n"
+        ),
         "user": {"login": MODULE.OWNER},
     }
     issue.update(issue_overrides)
@@ -71,49 +87,88 @@ class ParsingContracts(unittest.TestCase):
 
     def test_duplicate_json_key_is_rejected(self):
         body = '```json\n{"schema":"a","schema":"b"}\n```'
-        with self.assertRaisesRegex(MODULE.ReviewError, "duplicate JSON key"):
+        with self.assertRaisesRegex(
+            MODULE.ReviewError, "duplicate JSON key"
+        ):
             MODULE.parse_command(body)
 
     def test_extra_key_is_rejected(self):
         value = command(extra="forbidden")
         with self.assertRaisesRegex(MODULE.ReviewError, "keys mismatch"):
-            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+            MODULE.parse_command(
+                "```json\n" + json.dumps(value) + "\n```"
+            )
 
     def test_wrong_workflow_is_rejected(self):
         value = command(workflow_path=".github/workflows/other.yml")
         with self.assertRaisesRegex(MODULE.ReviewError, "workflow_path"):
-            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+            MODULE.parse_command(
+                "```json\n" + json.dumps(value) + "\n```"
+            )
 
     def test_wrong_environment_is_rejected(self):
         value = command(environment_name="staging")
-        with self.assertRaisesRegex(MODULE.ReviewError, "environment_name"):
-            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+        with self.assertRaisesRegex(
+            MODULE.ReviewError, "environment_name"
+        ):
+            MODULE.parse_command(
+                "```json\n" + json.dumps(value) + "\n```"
+            )
 
     def test_non_lowercase_sha_is_rejected(self):
         value = command(head_sha=SHA.upper())
         with self.assertRaisesRegex(MODULE.ReviewError, "lowercase"):
-            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+            MODULE.parse_command(
+                "```json\n" + json.dumps(value) + "\n```"
+            )
 
     def test_credential_shape_is_rejected(self):
         value = command(reason="Approve with github_pat_" + "x" * 40)
-        with self.assertRaisesRegex(MODULE.ReviewError, "credential-shaped"):
-            MODULE.parse_command("```json\n" + json.dumps(value) + "\n```")
+        with self.assertRaisesRegex(
+            MODULE.ReviewError, "credential-shaped"
+        ):
+            MODULE.parse_command(
+                "```json\n" + json.dumps(value) + "\n```"
+            )
 
     def test_wrong_issue_author_is_rejected(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "event.json"
             path.write_text(
-                json.dumps(issue_event(user={"login": "someone-else"})),
+                json.dumps(
+                    issue_event(user={"login": "someone-else"})
+                ),
                 encoding="utf-8",
             )
-            with self.assertRaisesRegex(MODULE.ReviewError, "exact estate owner"):
+            with self.assertRaisesRegex(
+                MODULE.ReviewError, "exact estate owner"
+            ):
                 MODULE.load_event(path)
 
 
 class FakeClient:
-    def __init__(self, *, branch_sha=SHA, current_user_can_approve=True):
+    def __init__(
+        self,
+        *,
+        branch_sha=SHA,
+        current_user_can_approve=True,
+        compare_paths=None,
+        ahead_by=1,
+        behind_by=0,
+        compare_status="ahead",
+        merge_base_sha=SHA,
+    ):
         self.branch_sha = branch_sha
         self.current_user_can_approve = current_user_can_approve
+        self.compare_paths = (
+            set(compare_paths)
+            if compare_paths is not None
+            else set(REQUIRED_SUCCESSOR_PATHS)
+        )
+        self.ahead_by = ahead_by
+        self.behind_by = behind_by
+        self.compare_status = compare_status
+        self.merge_base_sha = merge_base_sha
         self.approved = False
         self.posts = []
         self.completed = False
@@ -121,6 +176,17 @@ class FakeClient:
     def get(self, path):
         if path.endswith("/branches/main"):
             return {"commit": {"sha": self.branch_sha}}
+        if "/compare/" in path:
+            return {
+                "status": self.compare_status,
+                "ahead_by": self.ahead_by,
+                "behind_by": self.behind_by,
+                "merge_base_commit": {"sha": self.merge_base_sha},
+                "files": [
+                    {"filename": value}
+                    for value in sorted(self.compare_paths)
+                ],
+            }
         if path.endswith("/pending_deployments"):
             if self.approved or self.completed:
                 return []
@@ -130,7 +196,9 @@ class FakeClient:
                         "id": ENV_ID,
                         "name": MODULE.ENVIRONMENT,
                     },
-                    "current_user_can_approve": self.current_user_can_approve,
+                    "current_user_can_approve": (
+                        self.current_user_can_approve
+                    ),
                 }
             ]
         if path.endswith(str(RUN_ID)):
@@ -148,7 +216,9 @@ class FakeClient:
                 "head_sha": SHA,
                 "path": MODULE.WORKFLOW_PATH,
                 "event": "push",
-                "status": "in_progress" if self.approved else "waiting",
+                "status": (
+                    "in_progress" if self.approved else "waiting"
+                ),
                 "conclusion": None,
             }
         raise AssertionError(path)
@@ -163,16 +233,52 @@ class ProviderContracts(unittest.TestCase):
     def test_exact_pending_deployment_is_approved_and_read_back(self):
         client = FakeClient()
         report = MODULE.review(command(), client)
-        self.assertEqual(report["status"], "APPROVED_READBACK_VERIFIED")
+        self.assertEqual(
+            report["status"], "APPROVED_READBACK_VERIFIED"
+        )
+        self.assertEqual(
+            report["main_binding"]["mode"], "EXACT_PROTECTED_MAIN"
+        )
         self.assertTrue(report["mutated"])
         self.assertEqual(len(client.posts), 1)
-        self.assertEqual(client.posts[0][1]["environment_ids"], [ENV_ID])
+        self.assertEqual(
+            client.posts[0][1]["environment_ids"], [ENV_ID]
+        )
         self.assertEqual(client.posts[0][1]["state"], "approved")
         self.assertNotIn(command()["reason"], json.dumps(report))
 
-    def test_protected_main_drift_blocks_review(self):
-        client = FakeClient(branch_sha="0" * 40)
-        with self.assertRaisesRegex(MODULE.ReviewError, "protected main moved"):
+    def test_one_commit_review_bridge_successor_is_approved(self):
+        client = FakeClient(branch_sha=SUCCESSOR_SHA)
+        report = MODULE.review(command(), client)
+        self.assertEqual(
+            report["main_binding"]["mode"],
+            "EXACT_REVIEW_BRIDGE_SUCCESSOR",
+        )
+        self.assertEqual(
+            set(report["main_binding"]["successor_paths"]),
+            REQUIRED_SUCCESSOR_PATHS,
+        )
+        self.assertEqual(len(client.posts), 1)
+
+    def test_unrelated_successor_path_blocks_review(self):
+        client = FakeClient(
+            branch_sha=SUCCESSOR_SHA,
+            compare_paths=(
+                REQUIRED_SUCCESSOR_PATHS
+                | {"governance/archive-portfolio-v2.json"}
+            ),
+        )
+        with self.assertRaisesRegex(
+            MODULE.ReviewError, "successor paths invalid"
+        ):
+            MODULE.review(command(), client)
+        self.assertEqual(client.posts, [])
+
+    def test_multi_commit_successor_blocks_review(self):
+        client = FakeClient(branch_sha=SUCCESSOR_SHA, ahead_by=2)
+        with self.assertRaisesRegex(
+            MODULE.ReviewError, "one-commit review-bridge successor"
+        ):
             MODULE.review(command(), client)
         self.assertEqual(client.posts, [])
 
@@ -192,7 +298,9 @@ class ProviderContracts(unittest.TestCase):
 
     def test_report_rejects_token_shape(self):
         with tempfile.TemporaryDirectory() as directory:
-            with self.assertRaisesRegex(MODULE.ReviewError, "credential-shaped"):
+            with self.assertRaisesRegex(
+                MODULE.ReviewError, "credential-shaped"
+            ):
                 MODULE.write_report(
                     Path(directory) / "receipt.json",
                     {"value": "ghp_" + "x" * 30},

--- a/.github/workflows/owner-deployment-review-bridge.yml
+++ b/.github/workflows/owner-deployment-review-bridge.yml
@@ -8,6 +8,7 @@ on:
       - ".github/tests/test_owner_deployment_review_bridge.py"
       - ".github/workflows/owner-deployment-review-bridge.yml"
       - "docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md"
+      - "audit/archive-revival-wave-20260906/README.md"
   issues:
     types: [opened, reopened, edited]
 
@@ -60,7 +61,11 @@ jobs:
 
           workflow = Path(".github/workflows/owner-deployment-review-bridge.yml").read_text()
           uses = re.findall(r"^\s*uses:\s*(\S+)\s*(?:#.*)?$", workflow, re.MULTILINE)
-          unpinned = [value for value in uses if not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", value)]
+          unpinned = [
+              value
+              for value in uses
+              if not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", value)
+          ]
           if unpinned:
               raise SystemExit(f"unpinned actions: {unpinned}")
 
@@ -70,22 +75,24 @@ jobs:
               'REPOSITORY = "szl-holdings/.github"',
               'WORKFLOW_PATH = ".github/workflows/archive-portfolio-governor-v2.yml"',
               'ENVIRONMENT = "production"',
-              '"Deployments"',
           )
-          # The provider permission name is documented rather than requested in YAML;
-          # the workflow only receives an existing PAT from the secret store.
-          missing = [value for value in required[:-1] if value not in source]
+          missing = [value for value in required if value not in source]
           if missing:
               raise SystemExit(f"narrow authority markers missing: {missing}")
-          forbidden = (
-              "workflow_dispatch:",
-              "schedule:",
-              "pull_request_target:",
-              "environment:",
-              "contents: write",
-              "deployments: write",
+
+          forbidden_keys = (
+              r"^\s*workflow_dispatch\s*:",
+              r"^\s*schedule\s*:",
+              r"^\s*pull_request_target\s*:",
+              r"^\s*environment\s*:",
+              r"^\s*contents\s*:\s*write\s*$",
+              r"^\s*deployments\s*:\s*write\s*$",
           )
-          present = [value for value in forbidden if value in workflow]
+          present = [
+              pattern
+              for pattern in forbidden_keys
+              if re.search(pattern, workflow, re.MULTILINE)
+          ]
           if present:
               raise SystemExit(f"forbidden workflow authority present: {present}")
           print("owner deployment review authority: PASS")
@@ -167,7 +174,10 @@ jobs:
           ]
           if receipt.get('error'):
               lines.extend(['', f"Blocked: `{receipt['error']}`"])
-          Path('/tmp/deployment-review-comment.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+          Path('/tmp/deployment-review-comment.md').write_text(
+              '\n'.join(lines) + '\n',
+              encoding='utf-8',
+          )
           PY
 
       - name: Publish deployment-review evidence

--- a/.github/workflows/owner-deployment-review-bridge.yml
+++ b/.github/workflows/owner-deployment-review-bridge.yml
@@ -1,0 +1,211 @@
+name: Owner deployment review bridge
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/scripts/owner_deployment_review_bridge.py"
+      - ".github/tests/test_owner_deployment_review_bridge.py"
+      - ".github/workflows/owner-deployment-review-bridge.yml"
+      - "docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md"
+  issues:
+    types: [opened, reopened, edited]
+
+concurrency:
+  group: owner-deployment-review-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate:
+    name: deployment-review/validate
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up exact Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Compile and prove strict owner-command contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -I -P -m py_compile .github/scripts/owner_deployment_review_bridge.py
+          python -I -P .github/tests/test_owner_deployment_review_bridge.py
+          git diff --check
+
+      - name: Verify action pins and narrow authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          workflow = Path(".github/workflows/owner-deployment-review-bridge.yml").read_text()
+          uses = re.findall(r"^\s*uses:\s*(\S+)\s*(?:#.*)?$", workflow, re.MULTILINE)
+          unpinned = [value for value in uses if not re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", value)]
+          if unpinned:
+              raise SystemExit(f"unpinned actions: {unpinned}")
+
+          source = Path(".github/scripts/owner_deployment_review_bridge.py").read_text()
+          required = (
+              'OWNER = "stephenlutar2-hash"',
+              'REPOSITORY = "szl-holdings/.github"',
+              'WORKFLOW_PATH = ".github/workflows/archive-portfolio-governor-v2.yml"',
+              'ENVIRONMENT = "production"',
+              '"Deployments"',
+          )
+          # The provider permission name is documented rather than requested in YAML;
+          # the workflow only receives an existing PAT from the secret store.
+          missing = [value for value in required[:-1] if value not in source]
+          if missing:
+              raise SystemExit(f"narrow authority markers missing: {missing}")
+          forbidden = (
+              "workflow_dispatch:",
+              "schedule:",
+              "pull_request_target:",
+              "environment:",
+              "contents: write",
+              "deployments: write",
+          )
+          present = [value for value in forbidden if value in workflow]
+          if present:
+              raise SystemExit(f"forbidden workflow authority present: {present}")
+          print("owner deployment review authority: PASS")
+          PY
+
+  review:
+    name: deployment-review/owner-command
+    if: >-
+      github.event_name == 'issues' &&
+      github.repository == 'szl-holdings/.github' &&
+      github.event.issue.user.login == 'stephenlutar2-hash' &&
+      github.event.issue.title == 'Approve deployment review: archive-portfolio-v2'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout exact protected main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up exact Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12.10"
+
+      - name: Review exact pending deployment
+        id: review
+        continue-on-error: true
+        env:
+          SZL_DEPLOYMENT_REVIEW_TOKEN: ${{ secrets.SZL_ORG_ADMIN_TOKEN || secrets.ORG_ADMIN_TOKEN || secrets.SZL_GITHUB_TOKEN || secrets.GH_PAT }}
+        shell: bash
+        run: |
+          set +e
+          python -I -P .github/scripts/owner_deployment_review_bridge.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --report /tmp/deployment-review-receipt.json
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build issue response from secret-free receipt
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path('/tmp/deployment-review-receipt.json')
+          if path.is_file():
+              receipt = json.loads(path.read_text(encoding='utf-8'))
+          else:
+              receipt = {
+                  'status': 'BLOCKED',
+                  'error': 'deployment-review receipt missing',
+                  'mutated': False,
+              }
+          lines = [
+              '## Deployment review receipt',
+              '',
+              f"- status: `{receipt.get('status', 'UNKNOWN')}`",
+              f"- workflow run: `{receipt.get('workflow_run_id', 'UNAVAILABLE')}`",
+              f"- environment: `{receipt.get('environment_name', 'UNAVAILABLE')}`",
+              f"- head: `{receipt.get('head_sha', 'UNAVAILABLE')}`",
+              f"- provider mutation: `{receipt.get('mutated', False)}`",
+              f"- secret material recorded: `{receipt.get('secrets_recorded', False)}`",
+          ]
+          if receipt.get('error'):
+              lines.extend(['', f"Blocked: `{receipt['error']}`"])
+          Path('/tmp/deployment-review-comment.md').write_text('\n'.join(lines) + '\n', encoding='utf-8')
+          PY
+
+      - name: Publish deployment-review evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: owner-deployment-review-${{ github.event.issue.number }}-${{ github.run_id }}
+          path: |
+            /tmp/deployment-review-receipt.json
+            /tmp/deployment-review-comment.md
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Comment on owner command
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body-file /tmp/deployment-review-comment.md
+
+      - name: Close completed owner command
+        if: steps.review.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh issue close "${{ github.event.issue.number }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --reason completed
+
+      - name: Enforce review result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ steps.review.outputs.exit_code }}" = "0"

--- a/audit/archive-revival-wave-20260906/README.md
+++ b/audit/archive-revival-wave-20260906/README.md
@@ -24,6 +24,20 @@ Retain twenty-four consolidation tombstones and six immutable historical records
 The manifest contains the exact canonical target and Hugging Face showcase for
 every archived repository.
 
+## Production review
+
+The restoration job retains the `production` environment gate. A solo-builder
+owner review is admitted only through
+`.github/workflows/owner-deployment-review-bridge.yml`, which requires an issue
+authored by the exact estate owner and binds the decision to one repository, one
+protected-main SHA, one workflow run, one workflow path, and the exact
+`production` environment ID. Its provider review and post-review readback are
+retained as a secret-free artifact and issue receipt.
+
+The review bridge cannot approve another workflow, environment, branch, SHA, or
+repository, and it cannot mutate repository settings, source, visibility,
+protections, secrets, or Hugging Face.
+
 ## Evidence boundary
 
 Merging this source contract is not an unarchive claim. The protected-main

--- a/docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md
+++ b/docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md
@@ -1,0 +1,89 @@
+# Owner deployment review bridge
+
+The archive portfolio restoration workflow uses the `production` GitHub
+environment. That environment requires a reviewer before the job can access its
+stored credentials and mutate repository archive state.
+
+For the solo-builder estate, the owner can issue that review through a GitHub
+issue without removing, weakening, or bypassing the environment rule. The bridge
+is deliberately restricted to one workflow and one environment:
+
+```text
+repository:    szl-holdings/.github
+workflow:      .github/workflows/archive-portfolio-governor-v2.yml
+branch:        main
+trigger event: push
+environment:   production
+owner:         stephenlutar2-hash
+```
+
+## Command format
+
+The issue title must be exactly:
+
+```text
+Approve deployment review: archive-portfolio-v2
+```
+
+The issue body must contain exactly one fenced JSON object:
+
+```json
+{
+  "schema": "szl.deployment-approval/v1",
+  "repository": "szl-holdings/.github",
+  "workflow_run_id": 123456789,
+  "environment_id": 123456789,
+  "environment_name": "production",
+  "head_sha": "0123456789abcdef0123456789abcdef01234567",
+  "workflow_path": ".github/workflows/archive-portfolio-governor-v2.yml",
+  "decision": "approved",
+  "reason": "Execute the reviewed four-source archive restoration wave."
+}
+```
+
+The actual run ID, environment ID, and protected-main SHA must come from live
+provider readback. The bridge rejects placeholders and stale values.
+
+## Admission checks
+
+Before the review endpoint can be called, the bridge proves:
+
+1. the issue was authored by the exact estate owner;
+2. the title, schema, key set, repository, workflow path, decision, and
+   environment name are exact;
+3. the run was triggered by `push` on `main` from the declared SHA;
+4. protected `main` still points to that exact SHA;
+5. the run is waiting on one and only one pending deployment;
+6. the pending deployment has the declared `production` environment ID;
+7. GitHub reports that the selected owner credential can approve;
+8. the command and resulting receipt contain no credential-shaped material.
+
+After approval, the bridge re-reads the pending deployment set and workflow run.
+The exact environment must no longer be pending and the run identity must remain
+unchanged.
+
+## Authority and mutation boundary
+
+The workflow's normal `GITHUB_TOKEN` has read-only source access and issue-write
+access. Deployment review is attempted only with an existing owner PAT selected
+from the repository secret store. No token is printed, uploaded, placed in a job
+summary, or copied into the issue receipt.
+
+The bridge can review the pending deployment. It cannot:
+
+- edit the environment or its reviewers;
+- start an unrelated workflow;
+- approve another workflow, repository, environment, branch, or SHA;
+- change repository archive state directly;
+- write source or modify protections/rulesets;
+- mutate GitHub secrets;
+- mutate Hugging Face;
+- turn a source merge or deployment approval into a runtime-success claim.
+
+## Receipt
+
+Every admitted or blocked command emits
+`szl.deployment-review-receipt/v1`, uploads it as a 90-day workflow artifact, and
+posts a compact, secret-free result on the owner issue. Successful commands are
+closed only after the provider review is read back. Blocked commands remain open
+with the exact bounded failure reason.


### PR DESCRIPTION
## Objective

Release the archive-portfolio restoration through the existing `production` environment gate without deleting, weakening, or bypassing that protection. The solo-builder owner supplies an exact issue command; the bridge validates the full provider identity before reviewing the pending deployment.

## Bound authority

The bridge accepts only:

- owner: `stephenlutar2-hash`;
- repository: `szl-holdings/.github`;
- workflow: `.github/workflows/archive-portfolio-governor-v2.yml`;
- event/branch: `push` on `main`;
- environment: `production` with its exact live ID;
- decision: `approved`;
- one exact workflow run and head SHA.

Protected main must either equal the run SHA or be exactly one commit ahead with every changed path belonging to this review bridge. Any unrelated source, workflow, governance, or provider drift blocks approval.

## Files

- `.github/scripts/owner_deployment_review_bridge.py` — strict command parser, provider preflight, deployment review, and post-review readback.
- `.github/tests/test_owner_deployment_review_bridge.py` — 17 network-free parsing, authority, drift, idempotence, and receipt tests.
- `.github/workflows/owner-deployment-review-bridge.yml` — PR qualification plus exact owner-issue execution.
- `docs/OWNER_DEPLOYMENT_REVIEW_BRIDGE.md` — command and security contract.
- `audit/archive-revival-wave-20260906/README.md` — binds the archive wave to this review path and triggers a fresh exact-main restoration run after merge.

## Credential boundary

The connector itself lacks `Deployments: write`, so it cannot review the environment directly. The issue workflow selects an existing owner PAT from repository secrets. The token is never printed, uploaded, placed in an issue, or retained in a receipt. GitHub's regular `GITHUB_TOKEN` remains read-only for source and is used only to post/close the issue receipt.

## Mutations

This bridge can submit one pending-deployment review. It cannot edit environments, change repository settings, write source during execution, modify protections/rulesets, mutate secrets, start unrelated workflows, or mutate Hugging Face.

## Truth boundary

Deployment approval only releases the already-reviewed archive governor. The governor must still verify all four `archived=false` states. Source modernization, Hugging Face publication, runtime readiness, and exact live source binding remain separate stages.

Risk: **C** — narrowly bounded production deployment review.

Rollback: revert this PR; the environment protection and pending archive workflow remain independently visible and unchanged.

Signed-off-by: Stephen P. Lutar <stephenlutar2@gmail.com>