### PR TITLE
fix(anatomy): bind drift watcher to live HF origin

### DIFF
--- a/.github/data/anatomy_map_registry.json
+++ b/.github/data/anatomy_map_registry.json
@@ -1,12 +1,12 @@
 {
   "schema": 3,
-  "_comment": "Active Living Anatomy evidence registry after the 2026-09-03 source-bound restoration. GitHub szl-holdings/anatomy is authoritative; the public SZLHOLDINGS/anatomy Hugging Face Space is an active Docker deployment mirror; a-11-oy.com is the product entry point. All public checks are credential-free and fail closed. Every invariant surface must preserve exactly the canonical locked-8 {F1,F4,F7,F11,F12,F18,F19,F22} and the Lambda=Conjecture-1 honesty label. Marker-block sources are additionally compared capability-for-capability. The HF runtime also exposes exact Anatomy and Second Brain source revisions, 575 public handles, handles-only retrieval, zero private graph nodes, and read-only authority through its version, evidence, and Brain contracts.",
+  "_comment": "Active Living Anatomy evidence registry after the source-bound restoration. GitHub szl-holdings/anatomy is authoritative; betterwithage/anatomy is the active public Docker deployment mirror; a-11-oy.com is the product entry point. The retired SZLHOLDINGS/anatomy origin is not an active surface. All public checks are credential-free and fail closed. Every invariant surface must preserve exactly the canonical locked-8 {F1,F4,F7,F11,F12,F18,F19,F22} and the Lambda=Conjecture-1 honesty label. Marker-block sources are additionally compared capability-for-capability. The HF runtime also exposes exact Anatomy and Second Brain source revisions, public handles, handles-only retrieval, zero private graph nodes, and read-only authority through its version, evidence, and Brain contracts.",
   "canonical_locked": ["F1", "F4", "F7", "F11", "F12", "F18", "F19", "F22"],
   "surfaces": [
     { "id": "a11oy-console",         "kind": "github", "repo": "szl-holdings/a11oy",     "path": "pages/console.html",         "extract": "marker_block" },
     { "id": "killinchu-elite",       "kind": "github", "repo": "szl-holdings/killinchu", "path": "killinchu_elite_console.py", "extract": "marker_block" },
     { "id": "anatomy-src",           "kind": "github", "repo": "szl-holdings/anatomy",   "paths": ["data.js", "index.html"],   "extract": "invariant_scan" },
-    { "id": "hf-anatomy",            "kind": "url",    "urls": ["https://szlholdings-anatomy.hf.space/data.js", "https://szlholdings-anatomy.hf.space/index.html"], "extract": "invariant_scan" },
+    { "id": "hf-anatomy",            "kind": "url",    "urls": ["https://betterwithage-anatomy.hf.space/data.js", "https://betterwithage-anatomy.hf.space/index.html"], "extract": "invariant_scan" },
     { "id": "a11oy-anatomy-product", "kind": "url",    "urls": ["https://a-11-oy.com/anatomy-map/data.js"], "extract": "invariant_scan" }
   ]
 }

--- a/.github/scripts/test_anatomy_product_contract.py
+++ b/.github/scripts/test_anatomy_product_contract.py
@@ -15,6 +15,8 @@ _ACTIVE_WORKFLOWS = (
     _WORKFLOW_DIR / "anatomy-map-product-drift.yml",
     _WORKFLOW_DIR / "reusable-anatomy-map-drift.yml",
 )
+_CANONICAL_HF_HOST = "betterwithage-anatomy.hf.space"
+_RETIRED_HF_HOST = "szlholdings-anatomy.hf.space"
 
 
 class TestAnatomyProductContract(unittest.TestCase):
@@ -39,14 +41,15 @@ class TestAnatomyProductContract(unittest.TestCase):
         self.assertEqual(
             urls,
             [
-                "https://szlholdings-anatomy.hf.space/data.js",
-                "https://szlholdings-anatomy.hf.space/index.html",
+                f"https://{_CANONICAL_HF_HOST}/data.js",
+                f"https://{_CANONICAL_HF_HOST}/index.html",
             ],
         )
         for url in urls:
             parsed = urlsplit(url)
             self.assertEqual(parsed.scheme, "https")
-            self.assertEqual(parsed.hostname, "szlholdings-anatomy.hf.space")
+            self.assertEqual(parsed.hostname, _CANONICAL_HF_HOST)
+            self.assertNotEqual(parsed.hostname, _RETIRED_HF_HOST)
             self.assertIsNone(parsed.username)
             self.assertIsNone(parsed.password)
 


### PR DESCRIPTION
## Root cause

The Living Anatomy cross-surface guard was still treating `SZLHOLDINGS/anatomy` / `https://szlholdings-anatomy.hf.space` as the active Docker mirror. That Space no longer resolves through the Hub, and `/data.js` returns 404.

Current provider readback identifies `betterwithage/anatomy` as the live Docker Space, updated today. The Anatomy source also declares `SPACE_ID = "betterwithage/anatomy"`, and `data.js` remains a source-owned artifact served from the repository root by the hardened Python runtime.

## Repair

- Point the `hf-anatomy` invariant surface at:
  - `https://betterwithage-anatomy.hf.space/data.js`
  - `https://betterwithage-anatomy.hf.space/index.html`
- Update the registry's architecture note to distinguish the live creator-profile Space from the retired org origin.
- Add a network-free regression that requires the canonical creator-profile hostname and explicitly rejects the retired `szlholdings-anatomy.hf.space` hostname.

## Boundary

This does not skip the HF runtime, weaken fail-closed behavior, add credentials, mutate Hugging Face, or change product authority. It corrects the public origin that the existing cross-surface verifier must fetch.