### PR TITLE
fix(hf): project dated public inventory into organization card

### DIFF
--- a/huggingface/org-card/README.md
+++ b/huggingface/org-card/README.md
@@ -54,11 +54,15 @@ Five public domain bodies: **Terra, Killinchu, PRISM Counsel, PURIQ Finance, LYT
 
 Six internal engines: **Sentra, Lyte, Killinchu, Finance, Terra, Counsel**.
 
-**17 public Spaces, 45 models, 34 datasets.** Portfolio authority is narrower: **16 portfolio Spaces** plus **1 inventory-only Space**.
+**HISTORICAL estate-alignment v1 snapshot:** **17 public Spaces, 45 models, 34 datasets.** Portfolio authority was narrower: **16 portfolio Spaces** plus **1 inventory-only Space**. These figures remain provenance for that contract and do not override the current dated public observation below.
 
 Hub inventory is registry-only—not availability, operational readiness, or publication policy.
 
 ## Current state
+
+**21 public Spaces, 46 models, 35 datasets.** Observed **2026-09-10T03:20:41Z** under the anonymous public-only `hf-public-author-membership/v1` predicate admitted by A11oy and bound in the GitHub organization profile. Kernels count once as model repositories; private assets, collections, and buckets are outside these totals. This is inventory evidence, not model quality, runtime readiness, or production authorization.
+
+[**Inventory binding**](https://github.com/szl-holdings/.github/blob/main/profile/public-inventory.json) · [**Admitted source manifest**](https://github.com/szl-holdings/a11oy/blob/4c6621b17ba452d5af7aa2460462fdfbe513509f/docs/huggingface-ecosystem-manifest.json)
 
 Killinchu public actuation is **SIMULATED**. `SZLHOLDINGS/SZLHOLDINGS` is **HISTORICAL**. Λ uniqueness remains **Conjecture 1**. HTTP 200 is not a production certificate.
 


### PR DESCRIPTION
## Alignment repair

Projects the already-admitted public inventory observation into the canonical Hugging Face organization-card source without rewriting the historical estate contract. Current observation remains **21 public Spaces / 46 models / 35 datasets at 2026-09-10T03:20:41Z** under `hf-public-author-membership/v1`; the older `17 / 45 / 34` estate-alignment v1 values are explicitly labeled HISTORICAL.

This branch starts from protected `.github/main` after #729 merged as `a61cb238b71d1852d84ce6394a208d0ab0110796`. Because `huggingface/org-card/README.md` is owned by the central exact-source publisher, a normal protected-main merge will invoke the existing organization-card publication/readback workflow rather than patching Hugging Face directly.

## Bounds

No inventory policy, keep-list, visibility, provider/model authorization, production readiness, DNS, secrets, branch protection, or historical topology is changed. Current counts are registry evidence only and do not imply model quality/runtime readiness. Production and broader estate disposition remain governed by their existing controls.