### PR TITLE
docs(estate): declare incomparable inventory predicates and kernel-kind HOLD

### DIFF
--- a/estate/INVENTORY_SCOPE.md
+++ b/estate/INVENTORY_SCOPE.md
@@ -1,0 +1,45 @@
+# Inventory scope declaration (2026-09-11)
+
+Status: **HOLD**. Tracking: [.github#728](https://github.com/szl-holdings/.github/issues/728).
+
+This directory already carries estate alignment. This note does not replace
+`https://a11oy.net/public-membership.json` or
+`https://a11oy.net/public-inventory.json`. It records why those two public
+files, plus a historical estate-upgrade report, cannot be added or compared
+as current totals.
+
+## Incomparable predicates
+
+| Snapshot | Observed | Schema | Counts | Kernel treatment |
+| --- | --- | --- | --- | --- |
+| Public membership | 2026-09-10T03:20:41Z | `szl.public-profile-inventory/v1` | models 46, datasets 35, spaces 21 | counted once as a model repository |
+| Public inventory | 2026-08-31T18:59:11Z | `szl.public-hf-inventory/v3` | models 44, datasets 30, spaces 48, collections 21, buckets 1 | `szl-kernels` listed as a model |
+| Estate-upgrade report | 2026-07-22T06:34:06Z | `szl.hf-estate-upgrade-report/v1` | models 15, datasets 32, spaces 26, kernels 10 | historical dry-run |
+
+Identical cardinality can hide missing and unexpected assets. These rows are
+not the same scope.
+
+## Kernel kind (separate scope)
+
+Unauthenticated `GET https://huggingface.co/api/kernels?author=SZLHOLDINGS`
+on 2026-09-11 listed **14** kernel-type repositories. Scope id:
+`hf-public-author-kernels/v1`. That number is not a membership count and is
+not the July 22 report's 10.
+
+`SZLHOLDINGS/szl-kernels` still also appears in a model search. `SZLHOLDINGS/szl-khipu-kernels`
+appeared in the model search and not in the kernels API list. Dual listing is
+not deletion authority.
+
+Hugging Face kernels >= 0.14 load only `kernel` repositories. Retained
+legacy model-type kernel repositories begin removal 2026-09-13. Stable pin:
+`huggingface/kernels@1dc5c9d05683e8a594bb6d7a1ab18318b89e2caa` (`v0.16.1`).
+
+Still HOLD until:
+
+1. same-scope item-level membership enumeration exists,
+2. every production-relevant projection is a first-class kernel repository
+   with exact main and v1 revisions,
+3. legacy model-type loaders fail closed,
+4. remote-code trust is an explicit decision.
+
+Do not create a kernel repository by publishing a model repository as a bypass.

--- a/estate/inventory-scope-declaration-2026-09-11.json
+++ b/estate/inventory-scope-declaration-2026-09-11.json
@@ -1,0 +1,96 @@
+{
+  "schema": "szl.public-inventory-scope-declaration/v1",
+  "observed_at": "2026-09-11T19:05:00Z",
+  "disposition": "HOLD",
+  "evidence_class": "LIVE_READBACK",
+  "production_authorization": false,
+  "automatic_promotion_authorized": false,
+  "issue": "https://github.com/szl-holdings/.github/issues/728",
+  "note": "A date-stamped declaration of incomparable predicates. Not a replacement for public-membership.json or public-inventory.json. Not an item-level membership sweep.",
+  "predicates": {
+    "membership_v1": {
+      "schema": "szl.public-profile-inventory/v1",
+      "observed_at": "2026-09-10T03:20:41Z",
+      "origin": "https://a11oy.net/public-membership.json",
+      "scope_id": "hf-public-author-membership/v1",
+      "counts": { "models": 46, "datasets": 35, "spaces": 21 },
+      "kernel_policy": "count-once-as-model-repository-not-a-fourth-kind",
+      "kinds": ["models", "datasets", "spaces"],
+      "comparable_to": []
+    },
+    "inventory_v3": {
+      "schema": "szl.public-hf-inventory/v3",
+      "observed_at": "2026-08-31T18:59:11Z",
+      "origin": "https://a11oy.net/public-inventory.json",
+      "counts": { "models": 44, "datasets": 30, "spaces": 48, "collections": 21, "buckets": 1 },
+      "kernel_note": "szl-kernels counted as a model repository in this historical snapshot",
+      "comparable_to": []
+    },
+    "estate_upgrade_report_2026_07_22": {
+      "schema": "szl.hf-estate-upgrade-report/v1",
+      "observed_at": "2026-07-22T06:34:06Z",
+      "origin": "https://github.com/szl-holdings/.github/blob/main/reports/hf-estate-upgrade-latest.json",
+      "counts": { "models": 15, "datasets": 32, "spaces": 26, "kernels": 10, "collections": 0, "buckets": 0 },
+      "note": "Historical dry-run report. Third predicate. Do not use as current totals.",
+      "comparable_to": []
+    }
+  },
+  "kernel_kind": {
+    "required_before": "2026-09-13T00:00:00Z",
+    "membership_v1_policy": "count-once-as-model-repository-not-a-fourth-kind",
+    "first_class_hub_type": "kernel",
+    "loader": {
+      "package": "huggingface/kernels",
+      "version": "v0.16.1",
+      "revision": "1dc5c9d05683e8a594bb6d7a1ab18318b89e2caa",
+      "loads_model_type_kernels": false
+    },
+    "scope": {
+      "id": "hf-public-author-kernels/v1",
+      "method": "GET",
+      "url": "https://huggingface.co/api/kernels?author=SZLHOLDINGS",
+      "authentication": "none",
+      "observed_at": "2026-09-11T19:05:00Z"
+    },
+    "listed": [
+      "SZLHOLDINGS/szl-govsign",
+      "SZLHOLDINGS/szl-kernels",
+      "SZLHOLDINGS/szl-lambda-gate",
+      "SZLHOLDINGS/szl-governed-norm",
+      "SZLHOLDINGS/governed-inference-meter",
+      "SZLHOLDINGS/szl-blocked",
+      "SZLHOLDINGS/szl-provctl",
+      "SZLHOLDINGS/szl-invariants",
+      "SZLHOLDINGS/szl-ouroboros",
+      "SZLHOLDINGS/szl-formulas",
+      "SZLHOLDINGS/szl-maskmod",
+      "SZLHOLDINGS/szl-block-kv",
+      "SZLHOLDINGS/szl-receipt-attn",
+      "SZLHOLDINGS/YARQA-ATTN"
+    ],
+    "listed_count": 14,
+    "listed_count_meaning": "cardinality of unauthenticated Hub kernels API for author SZLHOLDINGS at observed_at; not membership; not inventory v3; not projection closure",
+    "dual_listed_as_model_search_hits": [
+      "SZLHOLDINGS/szl-kernels",
+      "SZLHOLDINGS/szl-khipu-kernels"
+    ],
+    "model_search_only_not_in_kernels_api": [
+      "SZLHOLDINGS/szl-khipu-kernels"
+    ],
+    "count_for_membership_v1": null,
+    "count_reason": "KERNEL_KIND_DISTINCT_SCOPE",
+    "production_relevant_projections_verified": false,
+    "exact_main_and_v1_revisions_bound": false,
+    "legacy_model_type_fail_closed_verified": false,
+    "remote_code_trust_decided": false
+  },
+  "item_level_membership_enumeration": "UNAVAILABLE",
+  "forbidden": [
+    "mix membership 46/35/21 with inventory 44/30/48",
+    "treat kernels API 14 as the membership model count",
+    "treat July 22 report 15/32/26/10 as current",
+    "delete assets to force a number",
+    "claim first-class kernel kind is already in public-membership.json",
+    "treat Hub listing as runtime readiness or production admission"
+  ]
+}

--- a/tests/test_inventory_scope_declaration.py
+++ b/tests/test_inventory_scope_declaration.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Same-scope inventory declaration must not mix predicates."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "estate" / "inventory-scope-declaration-2026-09-11.json"
+
+
+def test_declaration_exists_and_is_hold() -> None:
+    payload = json.loads(DOC.read_text(encoding="utf-8"))
+    assert payload["schema"] == "szl.public-inventory-scope-declaration/v1"
+    assert payload["disposition"] == "HOLD"
+    assert payload["production_authorization"] is False
+    assert payload["automatic_promotion_authorized"] is False
+    assert payload["item_level_membership_enumeration"] == "UNAVAILABLE"
+
+
+def test_membership_and_inventory_counts_are_not_the_same_predicate() -> None:
+    payload = json.loads(DOC.read_text(encoding="utf-8"))
+    membership = payload["predicates"]["membership_v1"]["counts"]
+    inventory = payload["predicates"]["inventory_v3"]["counts"]
+    assert membership != {k: inventory[k] for k in ("models", "datasets", "spaces")}
+    assert payload["predicates"]["membership_v1"]["comparable_to"] == []
+    assert payload["predicates"]["inventory_v3"]["comparable_to"] == []
+
+
+def test_july_report_is_historical_and_incomparable() -> None:
+    payload = json.loads(DOC.read_text(encoding="utf-8"))
+    report = payload["predicates"]["estate_upgrade_report_2026_07_22"]
+    assert report["counts"]["kernels"] == 10
+    assert report["comparable_to"] == []
+    assert report["counts"]["kernels"] != payload["kernel_kind"]["listed_count"]
+
+
+def test_kernel_kind_list_is_scoped_and_not_a_membership_count() -> None:
+    payload = json.loads(DOC.read_text(encoding="utf-8"))
+    kind = payload["kernel_kind"]
+    assert kind["scope"]["id"] == "hf-public-author-kernels/v1"
+    assert kind["listed_count"] == 14
+    assert len(kind["listed"]) == 14
+    assert kind["count_for_membership_v1"] is None
+    assert kind["production_relevant_projections_verified"] is False
+    assert "SZLHOLDINGS/szl-kernels" in kind["listed"]
+    assert "SZLHOLDINGS/szl-khipu-kernels" in kind["model_search_only_not_in_kernels_api"]
+    assert kind["listed_count"] != payload["predicates"]["membership_v1"]["counts"]["models"]
+
+
+def test_forbidden_mix_rules_are_explicit() -> None:
+    payload = json.loads(DOC.read_text(encoding="utf-8"))
+    forbidden = " ".join(payload["forbidden"])
+    assert "46/35/21" in forbidden
+    assert "44/30/48" in forbidden
+    assert "14" in forbidden


### PR DESCRIPTION
## Why

[.github#728](https://github.com/szl-holdings/.github/issues/728) cannot close on mixed cardinality. Three existing snapshots use different predicates:

- public membership 2026-09-10 `szl.public-profile-inventory/v1` — 46 / 35 / 21, kernel counted as a model
- public inventory 2026-08-31 `szl.public-hf-inventory/v3` — 44 / 30 / 48 + collections 21 + buckets 1
- historical estate-upgrade report 2026-07-22 — 15 / 32 / 26 / kernels 10

Those numbers must not be summed or treated as current totals.

## What this PR is

A dated **scope declaration** plus a contract test. It does **not** rewrite `public-membership.json` or `public-inventory.json`. It does **not** delete Hub assets. It does **not** admit production.

## Kernel kind (separate scope)

Unauthenticated `GET https://huggingface.co/api/kernels?author=SZLHOLDINGS` on 2026-09-11 listed 14 kernel-type repositories under scope `hf-public-author-kernels/v1`. That 14 is not the membership model count and is not the July 22 report's 10.

`SZLHOLDINGS/szl-kernels` is also still reachable as a model-search hit. `SZLHOLDINGS/szl-khipu-kernels` appeared in the model search and not in the kernels API list.

Legacy model-type kernel repositories begin removal **2026-09-13**. Loader pin remains `huggingface/kernels@1dc5c9d05683e8a594bb6d7a1ab18318b89e2caa` (`v0.16.1`). Listing is not projection closure.

## Remaining HOLD

- item-level same-scope membership enumeration is UNAVAILABLE
- production-relevant kernel projections are not revision-bound here
- remote-code trust is not decided by this file

Issue #728 stays open until a same-scope item-level observation exists.

Signed-off-by: Stephen P. Lutar Jr. <stephenlutar2@gmail.com>