### PR TITLE
feat(provenance): advisory szl/provenance gate for solo-maintainer mode

### DIFF
--- a/.github/workflows/solo-provenance.yml
+++ b/.github/workflows/solo-provenance.yml
@@ -1,0 +1,31 @@
+name: szl/provenance
+
+# Advisory solo-maintainer provenance gate.
+# Not a required check. Does not disable DCO rulesets. Does not push to main.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: szl-provenance-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  provenance:
+    name: szl/provenance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Unit tests
+        run: python3 provenance/test_check.py
+      - name: Evaluate pull request
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: python3 provenance/check.py provenance/solo-maintainer-policy.v1.json

--- a/provenance/check.py
+++ b/provenance/check.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Advisory szl/provenance gate. Records identifiers and SHAs, never secrets."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+SCHEMA = "szl.solo-maintainer-provenance/v1"
+HEADINGS = [
+    "Origin",
+    "Rights",
+    "Agents and tools",
+    "Tests",
+    "Security",
+    "Rollback",
+    "Known limits",
+]
+
+
+def load_policy(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema") != SCHEMA:
+        raise SystemExit("policy schema mismatch")
+    if data.get("credential_value_recorded") is not False:
+        raise SystemExit("policy must forbid credential recording")
+    return data
+
+
+def heading_present(body: str, heading: str) -> bool:
+    pattern = rf"^##\s+{re.escape(heading)}\s*$"
+    return re.search(pattern, body, re.MULTILINE) is not None
+
+
+def evaluate(policy: dict, event: dict) -> dict:
+    pr = event.get("pull_request") or {}
+    repo = event.get("repository") or {}
+    sender = event.get("sender") or {}
+    body = pr.get("body") or ""
+    head = (pr.get("head") or {}).get("sha")
+    base_ref = (pr.get("base") or {}).get("ref")
+    default_branch = repo.get("default_branch") or "main"
+    owner = ((pr.get("head") or {}).get("repo") or {}).get("full_name", "")
+    actor = sender.get("login") or ""
+    headings = {name: heading_present(body, name) for name in HEADINGS}
+    internal = owner.startswith(f"{policy['organization']}/")
+    actor_ok = actor in set(policy.get("allowed_human_actors") or []) or actor.endswith("[bot]")
+    checks = {
+        "exact_head_sha": bool(head) and len(str(head)) == 40,
+        "internal_head_repository": internal,
+        "allowed_actor": actor_ok,
+        "protected_base": base_ref == default_branch,
+        "pr_body_headings": all(headings.values()),
+        "not_direct_default_branch_push": True,
+    }
+    failed = [name for name, ok in checks.items() if not ok]
+    return {
+        "schema": "szl.provenance-check/v1",
+        "enforcement": policy.get("enforcement", "advisory"),
+        "required_check": policy.get("required_check"),
+        "head_sha": head,
+        "base_ref": base_ref,
+        "head_repository": owner,
+        "actor": actor,
+        "headings": headings,
+        "checks": checks,
+        "failed": failed,
+        "pass": not failed,
+        "credential_value_recorded": False,
+        "known_limits": [
+            "advisory until added as a required check",
+            "does not verify GitHub merge provenance after merge",
+            "allowed_app_slugs are illustrative until resolved from the Apps API",
+        ],
+    }
+
+
+def main(argv: list[str]) -> int:
+    policy_path = Path(argv[1] if len(argv) > 1 else "provenance/solo-maintainer-policy.v1.json")
+    event_path = Path(os.environ.get("GITHUB_EVENT_PATH") or (argv[2] if len(argv) > 2 else ""))
+    policy = load_policy(policy_path)
+    if not event_path or not event_path.exists():
+        print(json.dumps({"schema": "szl.provenance-check/v1", "pass": False, "failed": ["missing_event"]}, indent=2))
+        return 1
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    report = evaluate(policy, event)
+    print(json.dumps(report, indent=2))
+    if report["enforcement"] == "advisory":
+        return 0 if report["pass"] else 2
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/provenance/solo-maintainer-policy.v1.json
+++ b/provenance/solo-maintainer-policy.v1.json
@@ -1,0 +1,34 @@
+{
+  "schema": "szl.solo-maintainer-provenance/v1",
+  "organization": "szl-holdings",
+  "internal_dco_required": false,
+  "external_dco_or_cla_required": true,
+  "required_check": "szl/provenance",
+  "enforcement": "advisory",
+  "allowed_human_actors": ["stephenlutar2-hash"],
+  "allowed_app_slugs": [
+    "web-flow",
+    "dependabot",
+    "chatgpt-codex-connector"
+  ],
+  "merge_modes": ["squash"],
+  "direct_default_branch_push": false,
+  "required_evidence": [
+    "exact_head_sha",
+    "tests",
+    "security_checks",
+    "rights_attestation",
+    "rollback",
+    "known_limits"
+  ],
+  "pr_body_headings": [
+    "Origin",
+    "Rights",
+    "Agents and tools",
+    "Tests",
+    "Security",
+    "Rollback",
+    "Known limits"
+  ],
+  "credential_value_recorded": false
+}

--- a/provenance/test_check.py
+++ b/provenance/test_check.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check
+
+POLICY = Path(__file__).with_name("solo-maintainer-policy.v1.json")
+BODY = """## Origin
+Founder-authored / approved agent-assisted work.
+
+## Rights
+I own this change or have the right to contribute every included component.
+
+## Agents and tools
+Grok 4.6 terminal controller.
+
+## Tests
+python3 provenance/test_check.py
+
+## Security
+No secrets. Policy JSON only. Advisory workflow.
+
+## Rollback
+Revert the squash merge commit on .github.
+
+## Known limits
+Does not add szl/provenance as a required ruleset check.
+"""
+
+
+class ProvenanceCheckTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy = check.load_policy(POLICY)
+
+    def event(self, **over) -> dict:
+        payload = {
+            "pull_request": {
+                "body": BODY,
+                "head": {
+                    "sha": "a" * 40,
+                    "repo": {"full_name": "szl-holdings/.github"},
+                },
+                "base": {"ref": "main"},
+            },
+            "repository": {"default_branch": "main"},
+            "sender": {"login": "stephenlutar2-hash"},
+        }
+        payload.update(over)
+        return payload
+
+    def test_policy_forbids_credential_recording(self) -> None:
+        self.assertIs(self.policy["credential_value_recorded"], False)
+
+    def test_founder_internal_pr_passes(self) -> None:
+        report = check.evaluate(self.policy, self.event())
+        self.assertTrue(report["pass"], report["failed"])
+
+    def test_missing_heading_fails(self) -> None:
+        event = self.event()
+        event["pull_request"]["body"] = BODY.replace("## Rollback\nRevert the squash merge commit on .github.\n", "")
+        report = check.evaluate(self.policy, event)
+        self.assertFalse(report["pass"])
+        self.assertIn("pr_body_headings", report["failed"])
+
+    def test_http_success_is_not_modeled_as_live(self) -> None:
+        report = check.evaluate(self.policy, self.event())
+        self.assertNotIn("live", report)
+        self.assertIn("advisory until added as a required check", report["known_limits"])
+
+    def test_fork_head_fails_internal_mode(self) -> None:
+        event = self.event()
+        event["pull_request"]["head"]["repo"]["full_name"] = "other/.github"
+        report = check.evaluate(self.policy, event)
+        self.assertIn("internal_head_repository", report["failed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Origin
Founder-authored / approved agent-assisted work. Grok 4.6 estate controller, session 2026-09-12.

## Rights
I own this change or have the right to contribute every included component.

## Agents and tools
Grok 4.6 terminal via GitHub connector. No third-party source copied into these files.

## Tests
```
python3 provenance/test_check.py
Ran 5 tests. OK.
```
Local execution from repository-root path after inserting `provenance/` on sys.path. CI re-runs the same file.

## Security
- Advisory workflow only. Not a required check.
- Does not disable DCO rulesets.
- Does not grant write permissions beyond `contents: read` and `pull-requests: read`.
- `actions/checkout` pinned to `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2).
- Policy forbids recording credential values.
- Allowed app slugs are illustrative until resolved from the Apps API.

## Rollback
Revert the squash merge on `szl-holdings/.github`. Delete `.github/workflows/solo-provenance.yml` and `provenance/` if the check must be withdrawn. No production publisher is attached.

## Known limits
- Does not add `szl/provenance` as a required ruleset check.
- Does not remove DCO from any required-check set.
- Does not verify GitHub merge-commit provenance after merge.
- Does not enumerate every GitHub App actor.
- Does not close `.github#728` or certify production HOLD as lifted.
- HTTP 200 from this workflow is not live product admission.

## Objective
Start Wave 0 provenance migration in advisory mode.

## Root cause
Internal solo-maintainer work is still described against DCO ceremony. CONTRIBUTING already drops sign-off trailers; no replacement check existed.

## Scope
`.github` only: policy JSON, evaluator, unit tests, advisory workflow.

## Deployment impact
None. Not a publisher. Advisory check on pull requests to this repository.

## Non-claims
Not estate-complete. Not ruleset-migrated. Not a DCO deletion.