### PR TITLE
chore: refresh attic index

### DIFF
--- a/ATTIC.md
+++ b/ATTIC.md
@@ -11,12 +11,12 @@ Every public archived repository in the `szl-holdings` organization, mapped to t
 
 | Metric | Count |
 |---|---:|
-| Public repositories total | 95 |
-| Active public repositories | 60 |
-| Archived public repositories (tombstones) | 35 |
-| Tombstones with a resolved successor | 28 |
+| Public repositories total | 117 |
+| Active public repositories | 89 |
+| Archived public repositories (tombstones) | 28 |
+| Tombstones with a resolved successor | 22 |
 | Tombstones terminal by design | 6 |
-| Tombstones with UNKNOWN successor | 1 |
+| Tombstones with UNKNOWN successor | 0 |
 | Structural defects | 0 |
 
 ## Resolved tombstones
@@ -25,13 +25,11 @@ Every public archived repository in the `szl-holdings` organization, mapped to t
 |---|---|---|---|
 | `cosmos` | [`anatomy`](https://github.com/szl-holdings/anatomy) | JavaScript | 2026-08-29 |
 | `counsel` | [`ayllu`](https://github.com/szl-holdings/ayllu) | Python | 2026-08-29 |
-| `david-leads` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-28 |
 | `developers` | [`a11oy-net`](https://github.com/szl-holdings/a11oy-net) | HTML | 2026-07-29 |
 | `docs-site` | [`a11oy-net`](https://github.com/szl-holdings/a11oy-net) | JavaScript | 2026-08-28 |
 | `energy-attest-holo` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest) | Python | 2026-08-18 |
 | `governed-inference-meter` | [`szl-energy-attest`](https://github.com/szl-holdings/szl-energy-attest) | Python | 2026-08-30 |
 | `governed-norm-holo` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Python | 2026-08-29 |
-| `holographic-unify` | [`a11oy`](https://github.com/szl-holdings/a11oy) | TypeScript | 2026-08-29 |
 | `immune-lattice` | [`immune`](https://github.com/szl-holdings/immune) | TypeScript | 2026-08-29 |
 | `khipu-lab` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | TypeScript | 2026-08-29 |
 | `khipu-pages` | [`szl-khipu`](https://github.com/szl-holdings/szl-khipu) | HTML | 2026-08-29 |
@@ -39,18 +37,14 @@ Every public archived repository in the `szl-holdings` organization, mapped to t
 | `lean-kernel` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) | Python | 2026-08-28 |
 | `ouroboros` | [`platform`](https://github.com/szl-holdings/platform) | TypeScript | 2026-08-28 |
 | `receipt-chain-live` | [`szl-receipt`](https://github.com/szl-holdings/szl-receipt) | Python | 2026-08-26 |
-| `szl-build-env` | [`szl-forge`](https://github.com/szl-holdings/szl-forge) | Python | 2026-08-28 |
 | `szl-cookbook` | [`szl-forge`](https://github.com/szl-holdings/szl-forge) | TypeScript | 2026-08-31 |
 | `szl-experiments` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-29 |
 | `szl-formula-ledger` | [`lutar-lean`](https://github.com/szl-holdings/lutar-lean) | Python | 2026-07-22 |
 | `szl-governed-norm` | [`szl-lambda-gate`](https://github.com/szl-holdings/szl-lambda-gate) | Python | 2026-08-08 |
 | `szl-kernels-live` | [`szl-kernels`](https://github.com/szl-holdings/szl-kernels) | Python | 2026-08-18 |
-| `szl-mesh` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | Python | 2026-08-26 |
 | `szl-organ-integrity` | [`a11oy`](https://github.com/szl-holdings/a11oy) | HTML | 2026-08-29 |
 | `szl-provctl-live` | [`szl-provctl`](https://github.com/szl-holdings/szl-provctl) | Python | 2026-08-18 |
-| `szl-router` | [`a11oy`](https://github.com/szl-holdings/a11oy) | Python | 2026-08-26 |
 | `szl-telemetry` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | Python | 2026-08-29 |
-| `vsp-otel` | [`szl-substrate`](https://github.com/szl-holdings/szl-substrate) | TypeScript | 2026-08-26 |
 
 ## Terminal by design (no successor)
 
@@ -62,14 +56,6 @@ Every public archived repository in the `szl-holdings` organization, mapped to t
 | `szl-otel-mesh` | Published OpenTelemetry/DSSE research artifact with DOI 10.5281/zenodo.20434276. Immutable archival evidence by design. |
 | `szl-uds-deployment` | Frozen WarHacker-2026 UDS deployment evidence snapshot. Retained for reproducibility; it has no active software successor. |
 | `warhacker-demo` | One-off WarHacker-2026 hardware and air-gap dry-run snapshot. The archived demonstration is retained as evidence, not a maintained product. |
-
-## ⚠️ UNKNOWN successor — owner decision required
-
-These archived repositories carry no `Canonical:` pointer and are not declared terminal. Each needs one of: a successor pointer added to its description, or an entry in `TERMINAL_BY_DESIGN` in the generator explaining why it is terminal. **They are reported, not guessed.**
-
-| Archived repo | Description | Last push |
-|---|---|---|
-| `uds-bundles` | SZL UDS Zarf bundles for the two products (a11oy + killinchu) and their capability services — airgap-deploy... | 2026-06-30 |
 
 ---
 


### PR DESCRIPTION
## Root cause

The generated attic index drifted from the live organization inventory, causing the scheduled Attic Index workflow to fail on exact main.

## Repair

Regenerate `ATTIC.md` with `scripts/build_attic_index.py --write` from the current live estate. The result records 28 tombstones and zero `UNKNOWN` entries.

## Evidence

- Generator write completed.
- Generator check mode passed.
- Diff check passed.
- Exactly one generated file changed.
- The pull-request Attic Index check passed on exact head `5ddeed643df183b54a7969a60d942b883bac492b`.

## Origin

The repository-owned generator produced this change from the live public `szl-holdings` organization inventory on 2026-09-12. The exact parent is `348b779f04f598acca23e83f59462307b2188866`.

## Rights

This change contains repository-generated organization inventory metadata and no imported third-party source or model weights.

## Agents and tools

Codex performed the bounded audit and repair using the repository generator, Git, GitHub CLI, and protected GitHub Actions.

## Tests

`python -B scripts/build_attic_index.py --check` passed after generation. The protected Attic Index, test, doctrine, lint, provenance-gate, secret-scan, vulnerability-scan, and completed CodeQL checks passed on the exact signed head.

## Security

No credentials, permissions, workflows, executable runtime paths, or release authority were changed. The commit has a valid GitHub-verified SSH signature.

## Rollback

Revert the squash merge through a new protected pull request, then regenerate the index from the authoritative live inventory rather than editing generated entries manually.

## Known limits

The index is a timestamped public-inventory snapshot and can drift when repository archive state changes. This repair closes the current generated-index failure; it does not claim unrelated estate workflows, providers, deployments, models, or runtimes are healthy.